### PR TITLE
fix(FR-3611): converge every bare-svg tooltip trigger onto the BAI trigger components

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAlertIconWithTooltip.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAlertIconWithTooltip.tsx
@@ -15,7 +15,7 @@
  `colorWarning` / `colorError` resolved to, so the hue is legacy-identical in
  both modes (P19: names checked against the built theme).
 */
-import { Tooltip } from '@astryxdesign/core/Tooltip';
+import BAIIconWithTooltip from './BAIIconWithTooltip';
 import { CircleAlertIcon } from 'lucide-react';
 import React from 'react';
 import type { ReactNode } from 'react';
@@ -35,20 +35,23 @@ const BAIAlertIconWithTooltip = ({
   placement,
 }: BAIAlertIconWithTooltipProps) => {
   return (
-    <Tooltip content={title} placement={placement}>
-      <CircleAlertIcon
-        style={{
-          color:
-            type === 'warning'
-              ? 'var(--color-warning)'
-              : type === 'error'
-                ? 'var(--color-error)'
-                : undefined,
-          cursor: 'help',
-        }}
-        {...iconProps}
-      />
-    </Tooltip>
+    <BAIIconWithTooltip
+      content={title}
+      placement={placement}
+      icon={
+        <CircleAlertIcon
+          style={{
+            color:
+              type === 'warning'
+                ? 'var(--color-warning)'
+                : type === 'error'
+                  ? 'var(--color-error)'
+                  : undefined,
+          }}
+          {...iconProps}
+        />
+      }
+    />
   );
 };
 

--- a/packages/backend.ai-ui/src/components/BAIBoardItemTitle.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBoardItemTitle.tsx
@@ -1,8 +1,7 @@
+import BAIQuestionIconWithTooltip from './BAIQuestionIconWithTooltip';
 import { theme } from '../theme-shim';
 import BAIFlex from './BAIFlex';
 import { Heading } from '@astryxdesign/core/Text';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
-import { CircleHelp } from 'lucide-react';
 import React from 'react';
 
 export interface BAIBoardItemTitleProps {
@@ -51,14 +50,7 @@ const BAIBoardItemTitle: React.FC<BAIBoardItemTitleProps> = ({
         ) : (
           title
         )}
-        {tooltip ? (
-          <Tooltip content={tooltip}>
-            <CircleHelp
-              style={{ color: token.colorTextSecondary }}
-              size="1em"
-            />
-          </Tooltip>
-        ) : null}
+        {tooltip ? <BAIQuestionIconWithTooltip title={tooltip} /> : null}
       </BAIFlex>
 
       <BAIFlex

--- a/packages/backend.ai-ui/src/components/BAIIconWithTooltip.tsx
+++ b/packages/backend.ai-ui/src/components/BAIIconWithTooltip.tsx
@@ -19,44 +19,66 @@ export interface BAIIconWithTooltipProps
   extends Omit<TooltipProps, 'children' | 'anchorRef'> {
   /** The glyph the tooltip is attached to. */
   icon: ReactNode;
+  /**
+   * `false` renders the trigger as a plain `<span>` (hover-only) instead of a
+   * focusable `<button>` — required inside another interactive element (a
+   * link, a select option, a segmented-control label), where nesting a button
+   * is invalid.
+   */
+  focusable?: boolean;
   style?: CSSProperties;
   className?: string;
 }
 
 const BAIIconWithTooltip = ({
   icon,
+  focusable = true,
   style,
   className,
   ...tooltipProps
 }: BAIIconWithTooltipProps) => {
+  const label = nodeToAccessibleLabel(tooltipProps.content) || undefined;
+  const iconNode = (
+    <Text color="placeholder" style={{ display: 'inline-flex' }}>
+      {icon}
+    </Text>
+  );
   return (
     <Tooltip {...tooltipProps}>
-      {/* A real button (reset to inline glyph) keeps the hint focusable, so
-          keyboard users can reach the tooltip. Reset is explicit, not
-          `all: 'unset'`: on Chromium >= 151 `all` makes the anchor-name CSSOM
-          getter return 'unset', which poisons Astryx's addAnchorName list and
-          detaches the tooltip to the viewport top-left (FR-3589). */}
-      <button
-        type="button"
-        aria-label={nodeToAccessibleLabel(tooltipProps.content) || undefined}
-        className={className}
-        style={{
-          appearance: 'none',
-          background: 'none',
-          border: 0,
-          margin: 0,
-          padding: 0,
-          font: 'inherit',
-          color: 'inherit',
-          cursor: 'help',
-          display: 'inline-flex',
-          ...style,
-        }}
-      >
-        <Text color="placeholder" style={{ display: 'inline-flex' }}>
-          {icon}
-        </Text>
-      </button>
+      {focusable ? (
+        /* A real button (reset to inline glyph) keeps the hint focusable, so
+           keyboard users can reach the tooltip. Reset is explicit, not
+           `all: 'unset'`: on Chromium >= 151 `all` makes the anchor-name CSSOM
+           getter return 'unset', which poisons Astryx's addAnchorName list and
+           detaches the tooltip to the viewport top-left (FR-3589). */
+        <button
+          type="button"
+          aria-label={label}
+          className={className}
+          style={{
+            appearance: 'none',
+            background: 'none',
+            border: 0,
+            margin: 0,
+            padding: 0,
+            font: 'inherit',
+            color: 'inherit',
+            cursor: 'help',
+            display: 'inline-flex',
+            ...style,
+          }}
+        >
+          {iconNode}
+        </button>
+      ) : (
+        <span
+          aria-label={label}
+          className={className}
+          style={{ cursor: 'help', display: 'inline-flex', ...style }}
+        >
+          {iconNode}
+        </span>
+      )}
     </Tooltip>
   );
 };

--- a/packages/backend.ai-ui/src/components/BAIQuestionIconWithTooltip.tsx
+++ b/packages/backend.ai-ui/src/components/BAIQuestionIconWithTooltip.tsx
@@ -53,6 +53,8 @@ export interface BAIQuestionIconWithTooltipProps {
   style?: CSSProperties;
   className?: string;
   iconProps?: React.ComponentProps<typeof CircleHelp>;
+  /** See BAIIconWithTooltip — `false` for triggers nested in interactive elements. */
+  focusable?: boolean;
 }
 
 const BAIQuestionIconWithTooltip = ({
@@ -64,6 +66,7 @@ const BAIQuestionIconWithTooltip = ({
   style,
   className,
   iconProps,
+  focusable,
 }: BAIQuestionIconWithTooltipProps) => {
   const { placement: astryxPlacement, alignment } =
     splitAntdPlacement(placement);
@@ -78,6 +81,7 @@ const BAIQuestionIconWithTooltip = ({
       delay={mouseEnterDelay === undefined ? undefined : mouseEnterDelay * 1000}
       style={style}
       className={className}
+      focusable={focusable}
     />
   );
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
@@ -1,3 +1,4 @@
+import BAIQuestionIconWithTooltip from '../BAIQuestionIconWithTooltip';
 import { BAIDeleteArtifactRevisionsModalArtifactFragment$key } from '../../__generated__/BAIDeleteArtifactRevisionsModalArtifactFragment.graphql';
 import {
   BAIDeleteArtifactRevisionsModalArtifactRevisionFragment$data,
@@ -20,9 +21,7 @@ import BAIText from '../BAIText';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
 import { BAIColumnsType, BAITable } from '../Table';
 import BAIArtifactDescriptions from './BAIArtifactDescriptions';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
-import { CircleHelp } from 'lucide-react';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 type ArtifactRevision =
@@ -184,19 +183,13 @@ const BAIDeleteArtifactRevisionsModal = ({
           selectedArtifactRevision.length ? (
             <BAIAlert
               icon={
-                <Tooltip
-                  content={t(
+                <BAIQuestionIconWithTooltip
+                  title={t(
                     'comp:BAIDeleteArtifactModal.OnlyVersionsNotInPULLINGOrSCANNED',
                   )}
-                >
-                  <CircleHelp
-                    style={{
-                      color: token.colorInfo,
-                      marginRight: token.marginXS,
-                    }}
-                    size="1em"
-                  />
-                </Tooltip>
+                  iconProps={{ style: { color: token.colorInfo } }}
+                  style={{ marginRight: token.marginXS }}
+                />
               }
               showIcon
               title={t('comp:BAIDeleteArtifactModal.ExcludedVersions', {

--- a/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
@@ -1,3 +1,4 @@
+import BAIQuestionIconWithTooltip from '../BAIQuestionIconWithTooltip';
 import { BAIImportArtifactModalArtifactFragment$key } from '../../__generated__/BAIImportArtifactModalArtifactFragment.graphql';
 import {
   BAIImportArtifactModalArtifactRevisionFragment$data,
@@ -20,9 +21,7 @@ import BAIText from '../BAIText';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
 import { BAIColumnsType, BAITable } from '../Table';
 import BAIArtifactDescriptions from './BAIArtifactDescriptions';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
-import { CircleHelp } from 'lucide-react';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 type ArtifactRevision =
@@ -215,19 +214,13 @@ const BAIImportArtifactModal = ({
             selectedArtifactRevision.length && (
             <BAIAlert
               icon={
-                <Tooltip
-                  content={t(
+                <BAIQuestionIconWithTooltip
+                  title={t(
                     'comp:BAIImportArtifactModal.OnlySCANNEDVersionsCanBePulled',
                   )}
-                >
-                  <CircleHelp
-                    style={{
-                      color: token.colorInfo,
-                      marginRight: token.marginXS,
-                    }}
-                    size="1em"
-                  />
-                </Tooltip>
+                  iconProps={{ style: { color: token.colorInfo } }}
+                  style={{ marginRight: token.marginXS }}
+                />
               }
               showIcon
               title={t('comp:BAIImportArtifactModal.ExcludedVersions', {

--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
@@ -1,10 +1,10 @@
+import BAIQuestionIconWithTooltip from '../BAIQuestionIconWithTooltip';
 import {
   BAIRuntimeVariantPresetTableFragment$data,
   BAIRuntimeVariantPresetTableFragment$key,
 } from '../../__generated__/BAIRuntimeVariantPresetTableFragment.graphql';
 import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
-import { theme } from '../../theme-shim';
 import BAIFlex from '../BAIFlex';
 import BAIId from '../BAIId';
 import BAIText from '../BAIText';
@@ -16,10 +16,8 @@ import {
   BAITableProps,
 } from '../Table';
 import useConnectedBAIClient from '../provider/BAIClientProvider/hooks/useConnectedBAIClient';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { CircleHelp } from 'lucide-react';
 import { graphql, useFragment } from 'react-relay';
 
 export type RuntimeVariantPresetNodeInList = NonNullable<
@@ -60,7 +58,6 @@ const BAIRuntimeVariantPresetTable = ({
 }: BAIRuntimeVariantPresetTableProps) => {
   'use memo';
   const { t } = useBAIi18n();
-  const { token } = theme.useToken();
   const baiClient = useConnectedBAIClient();
   const isRequiredSupported = baiClient.supports(
     'runtime-variant-preset-required',
@@ -216,14 +213,9 @@ const BAIRuntimeVariantPresetTable = ({
         title: (
           <BAIFlex gap="xs" align="center">
             {t('comp:BAIRuntimeVariantPresetTable.Rank')}
-            <Tooltip
-              content={t('comp:BAIRuntimeVariantPresetTable.RankTooltip')}
-            >
-              <CircleHelp
-                style={{ color: token.colorTextDescription }}
-                size="1em"
-              />
-            </Tooltip>
+            <BAIQuestionIconWithTooltip
+              title={t('comp:BAIRuntimeVariantPresetTable.RankTooltip')}
+            />
           </BAIFlex>
         ),
         dataIndex: 'rank',

--- a/react/src/components/Chat/DeploymentTokenSelect.tsx
+++ b/react/src/components/Chat/DeploymentTokenSelect.tsx
@@ -12,9 +12,9 @@ import type { SelectorOptionData } from '@astryxdesign/core/Selector';
 import { Selector } from '@astryxdesign/core/Selector';
 import { Text } from '@astryxdesign/core/Text';
 import { TextInput } from '@astryxdesign/core/TextInput';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIFlex,
+  BAIIconWithTooltip,
   filterOutNullAndUndefined,
   toGlobalId,
   useControllableValue,
@@ -182,12 +182,16 @@ const DeploymentTokenSelectWithQuery: React.FC<
         aria-label={t('deployment.AccessTokenSettings')}
         style={{ flexShrink: 0, display: 'inline-flex' }}
       >
-        <Tooltip content={t('deployment.AccessTokenSettings')}>
-          <Settings
-            style={{ color: 'var(--color-text-secondary)' }}
-            size="1em"
-          />
-        </Tooltip>
+        <BAIIconWithTooltip
+          content={t('deployment.AccessTokenSettings')}
+          focusable={false}
+          icon={
+            <Settings
+              style={{ color: 'var(--color-text-secondary)' }}
+              size="1em"
+            />
+          }
+        />
       </WebUILink>
     </BAIFlex>
   );

--- a/react/src/components/FairShareItems/DomainResourceGroupWarningIcon.tsx
+++ b/react/src/components/FairShareItems/DomainResourceGroupWarningIcon.tsx
@@ -1,7 +1,7 @@
+import { BAIIconWithTooltip } from 'backend.ai-ui';
 import type { DomainResourceGroupWarningIconFragment$key } from '../../__generated__/DomainResourceGroupWarningIconFragment.graphql';
 import type { DomainResourceGroupWarningIconQuery } from '../../__generated__/DomainResourceGroupWarningIconQuery.graphql';
 import { theme } from '../../theme-shim';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
 import { TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -50,17 +50,12 @@ const DomainResourceGroupWarningIcon: React.FC<
   }
 
   return (
-    <Tooltip
+    <BAIIconWithTooltip
       content={t('fairShare.DomainNotAllowedInResourceGroup', {
         resourceGroup: resourceGroupName,
       })}
-    >
-      <TriangleAlert
-        style={{
-          color: token.colorWarning,
-        }}
-      />
-    </Tooltip>
+      icon={<TriangleAlert style={{ color: token.colorWarning }} />}
+    />
   );
 };
 

--- a/react/src/components/FairShareItems/ProjectResourceGroupWarningIcon.tsx
+++ b/react/src/components/FairShareItems/ProjectResourceGroupWarningIcon.tsx
@@ -1,7 +1,7 @@
+import { BAIIconWithTooltip } from 'backend.ai-ui';
 import type { ProjectResourceGroupWarningIconFragment$key } from '../../__generated__/ProjectResourceGroupWarningIconFragment.graphql';
 import type { ProjectResourceGroupWarningIconQuery } from '../../__generated__/ProjectResourceGroupWarningIconQuery.graphql';
 import { theme } from '../../theme-shim';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
 import { TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -60,17 +60,12 @@ const ProjectResourceGroupWarningIcon: React.FC<
   }
 
   return (
-    <Tooltip
+    <BAIIconWithTooltip
       content={t('fairShare.ProjectNotAllowedInResourceGroup', {
         resourceGroup: resourceGroupName,
       })}
-    >
-      <TriangleAlert
-        style={{
-          color: token.colorWarning,
-        }}
-      />
-    </Tooltip>
+      icon={<TriangleAlert style={{ color: token.colorWarning }} />}
+    />
   );
 };
 

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -20,13 +20,13 @@ import {
 } from './astryxFormControls';
 import { Divider } from '@astryxdesign/core/Divider';
 import { Skeleton } from '@astryxdesign/core/Skeleton';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
-  BAIQuestionIconWithTooltip,
   BAIButton,
   BAIFlex,
+  BAIIconWithTooltip,
   BAIModal,
   BAIModalProps,
+  BAIQuestionIconWithTooltip,
   ESMClientErrorResponse,
   useBAILogger,
   useErrorMessageResolver,
@@ -486,7 +486,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
                             'data-testid': 'project-type',
                             disabled: shouldDisableProject,
                             endContent: shouldDisableProject ? (
-                              <Tooltip
+                              <BAIIconWithTooltip
                                 content={
                                   usageMode === 'model'
                                     ? t(
@@ -496,9 +496,9 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
                                         'data.folders.ChangeTheVFolderTypeToCreateAutoMountFolder',
                                       )
                                 }
-                              >
-                                <TriangleAlertIcon />
-                              </Tooltip>
+                                focusable={false}
+                                icon={<TriangleAlertIcon />}
+                              />
                             ) : undefined,
                           },
                         ]
@@ -560,13 +560,13 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
                             'data-testid': 'rw-permission',
                             disabled: shouldDisableRWPermission,
                             endContent: shouldDisableRWPermission ? (
-                              <Tooltip
+                              <BAIIconWithTooltip
                                 content={t(
                                   'data.folders.ModelProjectFolderRestrictedToReadOnly',
                                 )}
-                              >
-                                <TriangleAlertIcon />
-                              </Tooltip>
+                                focusable={false}
+                                icon={<TriangleAlertIcon />}
+                              />
                             ) : undefined,
                           },
                         ]

--- a/react/src/components/FolderCreateModalV2.tsx
+++ b/react/src/components/FolderCreateModalV2.tsx
@@ -36,12 +36,12 @@ import { Button } from '@astryxdesign/core/Button';
 import { Divider } from '@astryxdesign/core/Divider';
 import { Skeleton } from '@astryxdesign/core/Skeleton';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
+  BAIIconWithTooltip,
   BAIModal,
-  type BAIModalProps,
   BAIQuestionIconWithTooltip,
   toLocalId,
+  type BAIModalProps,
   useBAILogger,
   useErrorMessageResolver,
   useMutationWithPromise,
@@ -742,7 +742,7 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
                               disabled: shouldDisableProject,
                               endContent:
                                 !isFolderTypeLocked && shouldDisableProject ? (
-                                  <Tooltip
+                                  <BAIIconWithTooltip
                                     content={
                                       usageMode === 'model'
                                         ? t(
@@ -752,9 +752,9 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
                                             'data.folders.ChangeTheVFolderTypeToCreateAutoMountFolder',
                                           )
                                     }
-                                  >
-                                    <TriangleAlertIcon />
-                                  </Tooltip>
+                                    focusable={false}
+                                    icon={<TriangleAlertIcon />}
+                                  />
                                 ) : undefined,
                             },
                           ]
@@ -816,13 +816,13 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
                         disabled: shouldDisableRWPermission,
                         endContent:
                           !isFolderTypeLocked && shouldDisableRWPermission ? (
-                            <Tooltip
+                            <BAIIconWithTooltip
                               content={t(
                                 'data.folders.ModelProjectFolderRestrictedToReadOnly',
                               )}
-                            >
-                              <TriangleAlertIcon />
-                            </Tooltip>
+                              focusable={false}
+                              icon={<TriangleAlertIcon />}
+                            />
                           ) : undefined,
                       },
                       {

--- a/react/src/components/KeypairResourcePolicyStoragePermissionTableV2.tsx
+++ b/react/src/components/KeypairResourcePolicyStoragePermissionTableV2.tsx
@@ -17,22 +17,17 @@ import { theme } from '../theme-shim';
 import StoragePermissionEditModal from './StoragePermissionEditModal';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
+  BAIAlertIconWithTooltip,
   BAIFlex,
   BAINameActionCell,
   BAITable,
-  type BAITableProps,
   BAITag,
-  BAIUnmountAfterClose,
   BAIText,
+  BAIUnmountAfterClose,
+  type BAITableProps,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import {
-  CircleCheck,
-  CircleX,
-  CircleAlert,
-  Info,
-  SquarePenIcon,
-} from 'lucide-react';
+import { CircleCheck, CircleX, Info, SquarePenIcon } from 'lucide-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -263,16 +258,11 @@ const KeypairResourcePolicyStoragePermissionTableV2: React.FC<
               // a user to scope the view.
               if (!selectedUserId) {
                 return (
-                  <Tooltip
-                    content={t(
-                      'storageHost.permission.SelectUserToSeeKeypairs',
-                    )}
-                  >
-                    <CircleAlert
-                      style={{ color: token.colorWarning }}
-                      size="1em"
-                    />
-                  </Tooltip>
+                  <BAIAlertIconWithTooltip
+                    title={t('storageHost.permission.SelectUserToSeeKeypairs')}
+                    type="warning"
+                    iconProps={{ size: '1em' }}
+                  />
                 );
               }
               const keypairNodes = _.compact(

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -6,8 +6,12 @@ import { useAccessibleProjects } from '../hooks/useAccessibleProjects';
 import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentUserProjectRoles } from '../hooks/useCurrentUserProjectRoles';
 import { theme } from '../theme-shim';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
-import { BAIFlex, BAISelect, BAISelectProps } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  BAIIconWithTooltip,
+  BAISelect,
+  BAISelectProps,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Info, ShieldUser } from 'lucide-react';
 import React, { useEffect, useEffectEvent } from 'react';
@@ -98,9 +102,11 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
             label: showBadge ? (
               <BAIFlex gap={token.marginXS} align="center">
                 <span>{project?.name}</span>
-                <Tooltip content={t('projectSelect.ProjectAdminBadge')}>
-                  <ShieldUser />
-                </Tooltip>
+                <BAIIconWithTooltip
+                  content={t('projectSelect.ProjectAdminBadge')}
+                  focusable={false}
+                  icon={<ShieldUser />}
+                />
               </BAIFlex>
             ) : (
               project?.name

--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -16,7 +16,6 @@ import {
   useSFTPProxyResourceGroupsQuery,
   useSFTPResourceGroups,
 } from '../hooks/useSFTPResourceGroups';
-import { theme } from '../theme-shim';
 import BAIFormItem from './BAIFormItem';
 import { ScalingGroupOpts } from './ResourceGroupList';
 import {
@@ -28,20 +27,19 @@ import {
   AstryxFormTextInput,
 } from './astryxFormControls';
 import { Grid } from '@astryxdesign/core/Grid';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
-  BAISkeleton,
+  BAICard,
+  BAIDomainSelect,
+  BAIFlex,
   BAIModal,
   BAIModalProps,
-  omitNullAndUndefinedFields,
-  BAICard,
-  BAIFlex,
-  BAIDomainSelect,
+  BAIQuestionIconWithTooltip,
+  BAISkeleton,
   BAIStorageProxySelect,
+  omitNullAndUndefinedFields,
   useBAILogger,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { CircleHelp } from 'lucide-react';
 import React, { Suspense, useDeferredValue, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
@@ -73,7 +71,6 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const baiClient = useSuspendedBackendaiClient();
@@ -519,16 +516,11 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
                 label={
                   <BAIFlex gap="xxs">
                     {t('resourceGroup.PendingTimeout')}
-                    <Tooltip
-                      content={newLineToBrElement(
+                    <BAIQuestionIconWithTooltip
+                      title={newLineToBrElement(
                         t('resourceGroup.PendingTimeoutDesc'),
                       )}
-                    >
-                      <CircleHelp
-                        style={{ color: token.colorTextSecondary }}
-                        size="1em"
-                      />
-                    </Tooltip>
+                    />
                   </BAIFlex>
                 }
                 name="pendingTimeout"

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -15,9 +15,9 @@ import type {
   SelectorOptionType,
 } from '@astryxdesign/core/Selector';
 import { Selector } from '@astryxdesign/core/Selector';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIFlex,
+  BAIIconWithTooltip,
   BAIResourceNumberWithIcon,
   useThrottleFn,
   useUpdatableState,
@@ -160,14 +160,13 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
       return (
         <BAIFlex gap={'xs'}>
           {t('session.launcher.MiniumAllocation')}
-          <Tooltip content={t('session.launcher.MiniumAllocationTooltip')}>
-            <Info
-              style={{
-                color: token.colorTextSecondary,
-              }}
-              size="1em"
-            />
-          </Tooltip>
+          <BAIIconWithTooltip
+            content={t('session.launcher.MiniumAllocationTooltip')}
+            focusable={false}
+            icon={
+              <Info style={{ color: token.colorTextSecondary }} size="1em" />
+            }
+          />
         </BAIFlex>
       );
     }

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -47,17 +47,18 @@ import {
 import { Tab, TabList } from '@astryxdesign/core/TabList';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
-  BAISkeleton,
   BAIFlex,
+  BAIIconWithTooltip,
   BAILink,
   BAISessionAgentIds,
   BAISessionClusterMode,
   BAISessionTypeTag,
+  BAISkeleton,
   BAIText,
-  INITIAL_FETCH_KEY,
-  UNSAFELazyUserEmailView,
   filterOutNullAndUndefined,
+  INITIAL_FETCH_KEY,
   toGlobalId,
+  UNSAFELazyUserEmailView,
   useMemoizedJSONParse,
   useToggle,
 } from 'backend.ai-ui';
@@ -501,12 +502,15 @@ const SessionDetailContent: React.FC<{
           <MetadataListItem label={t('session.launcher.ResourceAllocation')}>
             <BAIFlex gap={'sm'} wrap="wrap" align="center">
               {hasResourceAllocationDifference && (
-                <Tooltip content={t('session.AllocatedLessThanRequested')}>
-                  <TriangleAlert
-                    size="1em"
-                    style={{ color: 'var(--color-warning)' }}
-                  />
-                </Tooltip>
+                <BAIIconWithTooltip
+                  content={t('session.AllocatedLessThanRequested')}
+                  icon={
+                    <TriangleAlert
+                      size="1em"
+                      style={{ color: 'var(--color-warning)' }}
+                    />
+                  }
+                />
               )}
               <Tooltip content={t('session.ResourceGroup')}>
                 <Badge label={session.scaling_group} />

--- a/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
+++ b/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
@@ -12,12 +12,14 @@ import RemainingMark from './RemainingMark';
 // FRONTIER (ticket 17): the form ENGINE is self-hosted since ticket 34 (live
 // again since ticket 35). The CONTROLS are Astryx now.
 import { SegmentedControl } from '@astryxdesign/core/SegmentedControl';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { spacingVars } from '@astryxdesign/core/theme/tokens.stylex';
 import * as stylex from '@stylexjs/stylex';
-import { BAISegmentedControlItem, BAIFlex } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  BAIQuestionIconWithTooltip,
+  BAISegmentedControlItem,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { CircleHelp } from 'lucide-react';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -69,9 +71,10 @@ const ClusterModeSegmented: React.FC<{
           label={
             <span {...stylex.props(clusterModeSegmentedStyles.label)}>
               {item.label}
-              <Tooltip content={item.tooltip}>
-                <CircleHelp size="1em" />
-              </Tooltip>
+              <BAIQuestionIconWithTooltip
+                title={item.tooltip}
+                focusable={false}
+              />
             </span>
           }
         />

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -38,20 +38,20 @@ import { Card } from '@astryxdesign/core/Card';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { SegmentedControl } from '@astryxdesign/core/SegmentedControl';
 import { VStack } from '@astryxdesign/core/Stack';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { spacingVars } from '@astryxdesign/core/theme/tokens.stylex';
 import * as stylex from '@stylexjs/stylex';
 import {
-  BAISegmentedControlItem,
+  BAIDynamicUnitInputNumberWithSlider,
   BAIFlex,
+  BAIQuestionIconWithTooltip,
+  BAIProjectResourceGroupSelect,
+  BAISegmentedControlItem,
+  BAISelect,
   useEventNotStable,
   useUpdatableState,
-  BAIDynamicUnitInputNumberWithSlider,
-  BAIProjectResourceGroupSelect,
-  BAISelect,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { CircleHelp, RotateCw } from 'lucide-react';
+import { RotateCw } from 'lucide-react';
 import React, { Suspense, useEffect, useMemo, useTransition } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -219,9 +219,10 @@ const ClusterModeSegmented: React.FC<{
           label={
             <span {...stylex.props(clusterModeSegmentedStyles.label)}>
               {item.label}
-              <Tooltip content={item.tooltip}>
-                <CircleHelp size="1em" />
-              </Tooltip>
+              <BAIQuestionIconWithTooltip
+                title={item.tooltip}
+                focusable={false}
+              />
             </span>
           }
         />

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -11,8 +11,12 @@ import {
   MetadataListItem,
 } from '@astryxdesign/core/MetadataList';
 import { Spinner } from '@astryxdesign/core/Spinner';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  BAIIconWithTooltip,
+  BAIModal,
+  BAIModalProps,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { TriangleAlert } from 'lucide-react';
 import React from 'react';
@@ -150,9 +154,12 @@ const UserInfoModal: React.FC<Props> = ({
       <MetadataList label={{ position: 'start', width: '50%' }}>
         <MetadataListItem label={t('credential.ProjectAndGroup')}>
           {user && !user.projects ? (
-            <Tooltip content={t('credential.FailedToLoadProjects')}>
-              <TriangleAlert style={{ color: token.colorError }} size="1em" />
-            </Tooltip>
+            <BAIIconWithTooltip
+              content={t('credential.FailedToLoadProjects')}
+              icon={
+                <TriangleAlert style={{ color: token.colorError }} size="1em" />
+              }
+            />
           ) : (
             <BAIFlex gap="xs" wrap="wrap">
               {_.map(user?.projects?.edges, (edge) => {


### PR DESCRIPTION
Resolves #8930 (FR-3611)

Stacked on #8952 (FR-3589) — uses the `BAIIconWithTooltip` trigger base introduced there. Stack: #8929 → #8952 → this.

## Problem

A lucide `<svg>` passed directly as an Astryx `Tooltip` child never opens the tooltip: Astryx attaches its hover listeners to the svg itself, lucide renders `fill="none"`, and SVG hit-testing defaults to `visiblePainted` — so only the ~1.5px glyph stroke is hoverable. `isFocusable()` also rejects a bare `<svg>`, so there is no keyboard fallback. The hint text is unreachable by any input.

The original report counted 7 sites (bounded scan). An exhaustive scan — every `<Tooltip>` whose first JSX child is a lucide icon imported in the same file — found **20 sites in 16 files**.

## Change

Converge all 20 onto the trigger components from the stack below, preferring the named ones (the name-tells-you-the-icon convention stays the public API):

| Trigger | Sites |
|---|---|
| `BAIQuestionIconWithTooltip` (named) | `BAIBoardItemTitle` (6 dashboard board items), `BAIRuntimeVariantPresetTable` header, `ResourceGroupSettingModal`, the two artifact modals (`iconProps` tint), ClusterMode / ResourceAllocation FormItems segmented labels (`focusable={false}`) |
| `BAIAlertIconWithTooltip` (named, existing) | `KeypairResourcePolicyStoragePermissionTableV2`'s CircleAlert warning |
| `BAIIconWithTooltip` (generic, genuinely one-off glyphs) | TriangleAlert warnings (SessionDetailContent, UserInfoModal, FairShare Domain/Project warning icons, FolderCreateModal ×2, FolderCreateModalV2 ×2), Info (ResourcePresetSelect), Settings (DeploymentTokenSelect), ShieldUser (ProjectSelect) |

Every "?" glyph goes through the **named** question component — no call site passes a raw `CircleHelp` to a tooltip anymore. Raw `CircleHelp` remains only as `IconButton`/`Button` `icon` props (glyphs of real click actions — the help link, the idle-check modal button), which is the legitimate use of the bare icon. `BAIAlertIconWithTooltip` itself now renders through `BAIIconWithTooltip`, so the safe-trigger mechanics (focusable reset button, FR-3589 anchor-name note) live in exactly one file.

**New prop — `BAIIconWithTooltip.focusable?: boolean`** (default `true`), forwarded by `BAIQuestionIconWithTooltip`. `false` renders the trigger as a plain `<span>` (hover-only) instead of a `<button>`, for the nine sites nested inside another interactive element (a `WebUILink`, `Selector` option labels, segmented-control item labels, radio-item `endContent`) where nesting a button is invalid HTML. Those sites previously had no keyboard access either, so nothing regresses.

## Verification

- Chromium 151, dashboard: the six board-item "?" tooltips went from **0/6 opening at all** to **6/6 open and anchored**.
- Chromium 151, deployment detail: the stack's 13 tooltips remain 13/13 anchored (no regression).
- `bash scripts/verify.sh` → `=== ALL PASS ===`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
