### PR TITLE
chore(FR-3657): use cached eslint and incremental tsc in verify.sh

### DIFF
--- a/.github/workflows/vitest-backend-ai-ui.yml
+++ b/.github/workflows/vitest-backend-ai-ui.yml
@@ -8,6 +8,10 @@ on:
       - packages/backend.ai-ui/package.json
       - packages/backend.ai-ui/vitest.config.ts
       - .github/workflows/vitest-backend-ai-ui.yml
+      # Config-only edits must run the i18n schema cache-tripwire test, and a
+      # schema-only PR must revalidate the locale files (PR #9016 review).
+      - packages/backend.ai-ui/eslint.config.js
+      - packages/backend.ai-ui/i18n.schema.json
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ typings/
 # Optional eslint cache
 .eslintcache
 
+# TypeScript incremental build info (verify.sh tsc --incremental)
+*.tsbuildinfo
+
 # Optional REPL history
 .node_repl_history
 

--- a/packages/backend.ai-agent-cli/package.json
+++ b/packages/backend.ai-agent-cli/package.json
@@ -51,6 +51,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "lint": "eslint ./src --max-warnings=0 --no-warn-ignored",
+    "lint:ci": "eslint ./src --max-warnings=0 --no-warn-ignored",
     "prepublishOnly": "pnpm lint && pnpm test && pnpm build"
   },
   "devDependencies": {

--- a/packages/backend.ai-client/package.json
+++ b/packages/backend.ai-client/package.json
@@ -47,7 +47,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "lint": "eslint ./src",
-    "lint:ci": "eslint ./src --cache --cache-strategy content --cache-location .eslintcache",
+    "lint:ci": "eslint ./src",
     "prepublishOnly": "pnpm lint && pnpm test && pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-client/package.json
+++ b/packages/backend.ai-client/package.json
@@ -47,7 +47,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "lint": "eslint ./src",
-    "lint:ci": "eslint ./src",
+    "lint:ci": "npm run lint --silent",
     "prepublishOnly": "pnpm lint && pnpm test && pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-client/package.json
+++ b/packages/backend.ai-client/package.json
@@ -47,6 +47,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "lint": "eslint ./src",
+    "lint:ci": "eslint ./src --cache --cache-strategy content --cache-location .eslintcache",
     "prepublishOnly": "pnpm lint && pnpm test && pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-client/package.json
+++ b/packages/backend.ai-client/package.json
@@ -47,7 +47,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "lint": "eslint ./src",
-    "lint:ci": "npm run lint --silent",
+    "lint:ci": "eslint ./src",
     "prepublishOnly": "pnpm lint && pnpm test && pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-ui/eslint.config.js
+++ b/packages/backend.ai-ui/eslint.config.js
@@ -3,6 +3,14 @@ import jsonSchemaValidator from "eslint-plugin-json-schema-validator";
 import storybookPlugin from "eslint-plugin-storybook";
 import jsoncParser from "jsonc-eslint-parser";
 import globals from "globals";
+import fs from "node:fs";
+
+// Embedded inline (not referenced by path) so the schema CONTENT is part of
+// the resolved config: editing i18n.schema.json then invalidates `--cache`d
+// lint results for the locale files, which a `$schema` path alone would not.
+const i18nSchema = JSON.parse(
+  fs.readFileSync(new URL("./i18n.schema.json", import.meta.url), "utf8"),
+);
 
 export default [
   ...base,
@@ -109,6 +117,14 @@ export default [
     },
     rules: {
       ...jsonSchemaValidator.configs.recommended.rules,
+      "json-schema-validator/no-invalid": [
+        "error",
+        {
+          schemas: [
+            { fileMatch: ["**/src/locale/*.json"], schema: i18nSchema },
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/backend.ai-ui/src/locale/__tests__/i18nSchemaCacheTripwire.test.ts
+++ b/packages/backend.ai-ui/src/locale/__tests__/i18nSchemaCacheTripwire.test.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Guards the lint-cache tripwire: eslint.config.js must inline i18n.schema.json's
+// CONTENT (not a path) so schema edits invalidate the locale files' eslint cache.
+describe('i18n schema lint-cache tripwire', () => {
+  it(
+    'inlines the schema content into the no-invalid rule options',
+    { timeout: 30_000 },
+    () => {
+      // jsdom gives this file a non-file import.meta.url; testPath is the real one.
+      const pkgRoot = path.resolve(
+        path.dirname(expect.getState().testPath ?? ''),
+        '../../..',
+      );
+      // Loaded in a subprocess: vitest's transform breaks the config's own
+      // `new URL(..., import.meta.url)`; native node import matches ESLint.
+      const configUrl = pathToFileURL(
+        path.join(pkgRoot, 'eslint.config.js'),
+      ).href;
+      const stdout = execFileSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '-e',
+          `const config = (await import(${JSON.stringify(configUrl)})).default;
+           const entry = config.find(
+             (e) =>
+               Array.isArray(e.files) &&
+               e.files.includes("src/locale/*.json") &&
+               e.rules?.["json-schema-validator/no-invalid"],
+           );
+           console.log(
+             JSON.stringify(
+               entry?.rules["json-schema-validator/no-invalid"]?.[1] ?? null,
+             ),
+           );`,
+        ],
+        { encoding: 'utf8' },
+      );
+      const options = JSON.parse(stdout);
+      expect(options).not.toBeNull();
+
+      const inline = options.schemas[0].schema;
+
+      // A "cleanup" back to a path string would silently restore the stale-cache
+      // bug: the rule validates via the files' own $schema either way, so only
+      // this inline copy makes the schema content part of the cache hash.
+      expect(inline).toBeTypeOf('object');
+      expect(inline).toEqual(
+        JSON.parse(
+          fs.readFileSync(path.join(pkgRoot, 'i18n.schema.json'), 'utf8'),
+        ),
+      );
+    },
+  );
+});

--- a/scripts/lint-ci-coverage-gate.mjs
+++ b/scripts/lint-ci-coverage-gate.mjs
@@ -1,0 +1,60 @@
+// Gate: every workspace package with a `lint` script must also define `lint:ci`.
+//
+// verify.sh lints with `pnpm -r lint:ci`, and pnpm `-r` silently skips (exit 0)
+// any package that lacks the script — so a new package that ships only `lint`
+// silently drops out of the Lint gate. This gate turns that silence into a
+// failure (PR #9016 review).
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+// pnpm-workspace.yaml `packages:` entries — a flat list of literal dirs and
+// single-level `dir/*` globs; parsed by hand to keep this dependency-free.
+const workspaceYaml = fs.readFileSync(
+  path.join(root, "pnpm-workspace.yaml"),
+  "utf8",
+);
+const packagesBlock = workspaceYaml.match(/^packages:\n((?:[ \t]+-[^\n]*\n)+)/m);
+if (!packagesBlock) {
+  console.error("Could not parse `packages:` from pnpm-workspace.yaml");
+  process.exit(1);
+}
+const globs = [...packagesBlock[1].matchAll(/^[ \t]+-[ \t]+["']?([^"'\n]+?)["']?[ \t]*$/gm)].map(
+  (m) => m[1],
+);
+
+const pkgDirs = globs.flatMap((glob) => {
+  if (glob.endsWith("/*")) {
+    const base = path.join(root, glob.slice(0, -2));
+    return fs
+      .readdirSync(base, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => path.join(base, e.name));
+  }
+  return [path.join(root, glob)];
+});
+
+const offenders = [];
+for (const dir of pkgDirs) {
+  const pkgJsonPath = path.join(dir, "package.json");
+  if (!fs.existsSync(pkgJsonPath)) continue;
+  const scripts = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")).scripts ?? {};
+  if (scripts.lint && !scripts["lint:ci"]) {
+    offenders.push(path.relative(root, dir));
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    `Packages with a \`lint\` script but no \`lint:ci\`: ${offenders.join(", ")}`,
+  );
+  console.error(
+    "`pnpm -r lint:ci` (the Lint gate) silently skips them — add a `lint:ci`",
+  );
+  console.error(
+    "script (uncached if the package uses type-aware rules; see scripts/verify.sh).",
+  );
+  process.exit(1);
+}
+console.log(`lint:ci coverage ok (${pkgDirs.length} workspace packages scanned)`);

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -208,6 +208,8 @@ check_z_index_ladder() {
 run_check "Relay" check_relay_drift
 # lint:ci = the cached eslint variant CI runs (content-hash cache; modified
 # files are always re-linted). Uncached equivalent: `pnpm -r lint`.
+# backend.ai-client's lint:ci is deliberately uncached: its type-aware
+# no-floating-promises rule can flag a caller whose own content is unchanged.
 run_check "Lint" pnpm -r --stream lint:ci
 run_check "Format" pnpm run format
 run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit --incremental

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -206,9 +206,11 @@ check_z_index_ladder() {
 }
 
 run_check "Relay" check_relay_drift
-run_check "Lint" pnpm -r --stream lint
+# lint:ci = the cached eslint variant CI runs (content-hash cache; modified
+# files are always re-linted). Uncached equivalent: `pnpm -r lint`.
+run_check "Lint" pnpm -r --stream lint:ci
 run_check "Format" pnpm run format
-run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
+run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit --incremental
 # The react lane reaches backend.ai-{ui,client} through tsconfig `paths`,
 # but nothing pulls in the agent CLI, so it gets its own lane.
 run_check "TypeScript (agent-cli)" pnpm --filter backend.ai-agent-cli exec tsc --noEmit

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -208,8 +208,11 @@ check_z_index_ladder() {
 run_check "Relay" check_relay_drift
 # lint:ci = the cached eslint variant CI runs (content-hash cache; modified
 # files are always re-linted). Uncached equivalent: `pnpm -r lint`.
-# backend.ai-client's lint:ci is deliberately uncached: its type-aware
-# no-floating-promises rule can flag a caller whose own content is unchanged.
+# backend.ai-client's and backend.ai-agent-cli's lint:ci are deliberately
+# uncached: their type-aware no-floating-promises rule can flag a caller whose
+# own content is unchanged. The coverage gate fails when a package defines
+# `lint` without `lint:ci`, because `pnpm -r` silently skips such packages.
+run_check "Lint script coverage" node scripts/lint-ci-coverage-gate.mjs
 run_check "Lint" pnpm -r --stream lint:ci
 run_check "Format" pnpm run format
 run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit --incremental


### PR DESCRIPTION
Resolves #9014 (FR-3657)

## What

`scripts/verify.sh` (the local/agent verification harness) took **~146s** per run; agents run it before every submit/push. Two changes cut warm runs to **~25–31s** (5x), plus three review-driven guards:

1. **Lint** — run the existing cached `lint:ci` scripts (`--cache --cache-strategy content`) instead of uncached `lint`. `backend.ai-client` and `backend.ai-agent-cli` gain `lint:ci` scripts so `pnpm -r lint:ci` keeps the same package coverage as `pnpm -r lint`.
2. **TypeScript** — add `--incremental` to the `tsc --noEmit` step (`react/tsconfig.tsbuildinfo`, gitignored via a new `*.tsbuildinfo` entry).
3. **Coverage gate** (review follow-up) — `scripts/lint-ci-coverage-gate.mjs`, run by verify.sh before Lint, fails when any workspace package defines `lint` without `lint:ci`. `pnpm -r` silently skips (exit 0) packages lacking the script, and `backend.ai-agent-cli` had already landed on main in exactly that state — without the gate, every future package would reopen the same hole.
4. **Schema-inline regression test** (review follow-up) — `packages/backend.ai-ui/src/locale/__tests__/i18nSchemaCacheTripwire.test.ts` pins the cache-tripwire below.
5. **Tripwire trigger paths** (review follow-up) — `.github/workflows/vitest-backend-ai-ui.yml` gains `packages/backend.ai-ui/eslint.config.js` and `i18n.schema.json` in its `paths:`. The suite's filter listed neither and verify.sh runs no vitest step, so a PR touching only the ESLint config — exactly the cleanup-to-a-path-reference item 4 guards against — would never have run that test. The schema entry also restores locale revalidation in CI for a schema-only PR.

## Why the caches are sound

ESLint's content-hash cache re-lints every modified file and invalidates on config/version changes; the one unsound case is a rule whose verdict on file A depends on the content of file B. Review found the places this repo hits that case; all are closed in this PR:

- **`backend.ai-client` and `backend.ai-agent-cli` are deliberately uncached** (their `lint:ci` repeats their plain `lint` command): both packages enable type-aware `@typescript-eslint/no-floating-promises` (`projectService`), so changing an imported function's return type to a Promise can make an unchanged caller invalid — which a content-hash cache would skip. CI already runs `backend.ai-client`'s lint uncached (`typecheck.yml`); the two cost ~5s each locally.
- **`backend.ai-ui`'s locale schema content is embedded in the ESLint config**: `src/locale/*.json` are validated against `i18n.schema.json` (`eslint-plugin-json-schema-validator`), and a schema-only edit does not touch the locale files' content. The schema's *content* is inlined into the `json-schema-validator/no-invalid` rule options, so editing the schema changes the locale files' config hash and invalidates exactly their cache entries. Verified empirically: with a warm cache, breaking the schema makes the next `lint:ci` fail with 11,156 violations; `.ts` cache entries stay valid because their config slice is unchanged.
  - Review caveat (agatha197): the rule resolves `$schema || options || catalog`, and every locale file carries `"$schema"` — so the inline copy is never used for *validation*; it works purely as a cache-hash tripwire. The new regression test asserts the rule options carry the schema **content** (an object deep-equal to the on-disk file, not a path string), so a later "cleanup" back to a path reference fails the test instead of silently restoring the stale-cache bug.

The remaining cached lint surfaces (react, backend.ai-ui) use single-file rules only, and this matches what the project already trusts: CI (`vitest-react.yml`, `vitest-backend-ai-ui.yml`) runs `lint:ci` with an actions cache keyed on the lockfile + eslint configs, and the pre-commit lint-staged hook runs `lint --cache`.

tsc `--incremental` tracks the type dependency graph itself, so a change in file A still surfaces type errors in dependent file B.

## Measurements (8-core dev box)

| Step | Before | After (warm) |
|---|---|---|
| react eslint | 71.9s | 3.6s |
| backend.ai-ui eslint | 30.3s | 3.9s |
| backend.ai-client eslint | ~5s | ~5s (deliberately uncached) |
| backend.ai-agent-cli eslint | ~5s (was covered by `pnpm -r lint`) | ~5s (deliberately uncached) |
| lint:ci coverage gate | — | <0.1s |
| tsc --noEmit | 36.8s | 8.8s |
| **verify.sh total** | **~146s** | **~30–41s** |

Cold runs (fresh caches) are unchanged (~142s). The warm total grew from the original ~25–31s only by the agent-cli lint/tsc lanes — coverage main already pays for, not new cost (the 41s upper bound was measured while a dev server shared the box). Parallelizing the independent checks is deliberately out of scope.

## Verification

- `bash scripts/verify.sh` — `=== ALL PASS ===` in **41s** warm (dev server sharing the box) after the rebase onto main and the review fixes.
- Coverage gate: removing `backend.ai-agent-cli`'s `lint:ci` makes the gate fail naming that package; restoring it returns green.
- Tripwire test: swapping the inline schema for a path string fails with `expected './i18n.schema.json' to be type of 'object'`; restoring the inline passes.
- Trigger paths: `packages/backend.ai-ui/eslint.config.js` and `i18n.schema.json` now appear in the `Vitest (backend.ai-ui)` `paths:` list, so a config-only or schema-only PR runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rDBVANzHZz7yupv4KL7X8
https://claude.ai/code/session_01SdS1y7NFyftDPZBWc2Cd59

