### PR TITLE
fix(FR-3658): render the statusline Portless and Jira segments reliably

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -7,6 +7,9 @@
 #     debounce), so a run must finish well under 300ms or it never renders while the
 #     user is working. That budget is the whole design: exactly one python3 spawn
 #     (this shim calls no coreutils — each is ~9ms on uutils) plus at most two git calls.
+#     A healthy tick lands near 210ms. A repo whose git is pathologically slow is the
+#     one case that overshoots, bounded by GIT_TOTAL_BUDGET and self-healing through
+#     spawn_git_warm; that tick is aborted, which costs a frame, not correctness.
 #   * Portless state is read straight from ~/.portless/{routes.json,proxy.port,proxy.tls};
 #     the `portless` CLI is a workspace devDependency and is never on the statusline's
 #     PATH. Route ownership is /proc/<pid>/cwd, which is also the liveness check.
@@ -41,11 +44,14 @@ T0 = time.monotonic()
 CACHE_TTL = 300.0      # Jira cache freshness
 ATTEMPT_TTL = 60.0     # floor between two refresher spawns for the same key
 JIRA_BASE = "https://lablup.atlassian.net"
-# The foreground budget is 300ms (the refresh debounce). These two are the only
-# blocking calls, so their sum is the script's hard ceiling: keep it near 1s so a
-# pathological repo degrades fast instead of guaranteeing an abort.
+# git is the only thing that blocks, so its budget IS the script's worst case. The two
+# calls share one deadline rather than each getting its own: sequential per-call
+# timeouts sum, and a 0.4+0.6 worst case would overshoot the 300ms refresh debounce by
+# more than 3x on exactly the pathological repo the timeouts exist for.
+GIT_TOTAL_BUDGET = 0.8
 GIT_REVPARSE_TIMEOUT = 0.4
 GIT_STATUS_TIMEOUT = 0.6
+GIT_MIN_TIMEOUT = 0.15
 HOSTNAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]{0,252}[A-Za-z0-9])?$")
 
 LINE2 = ""
@@ -135,6 +141,7 @@ def git_facts(workspace, cache_dir=""):
     if not git:
         return None
     base = [git, "-C", workspace]
+    started = time.monotonic()
     top = run(base + ["rev-parse", "--show-toplevel"], GIT_REVPARSE_TIMEOUT)
     if top is None:
         return None
@@ -161,7 +168,8 @@ def git_facts(workspace, cache_dir=""):
         stamp(inflight)
     st, timed_out = run_ex(
         base + ["status", "--porcelain=v2", "--branch", "--untracked-files=normal"],
-        GIT_STATUS_TIMEOUT)
+        max(GIT_MIN_TIMEOUT,
+            min(GIT_STATUS_TIMEOUT, GIT_TOTAL_BUDGET - (time.monotonic() - started))))
     if inflight:
         try:
             os.unlink(inflight)
@@ -250,17 +258,57 @@ def portless_state_dir():
             or os.path.join(os.path.expanduser("~"), ".portless"))
 
 
-def pid_cwd(pid):
+def resolve_cwds(pids):
+    """pid -> cwd, for the whole route table at once.
+
+    On Linux each entry is a readlink, and a dead pid simply raises, so this doubles
+    as the liveness check a stale routes.json needs. Everywhere else it is ONE lsof
+    for the entire set (it takes a comma-separated pid list): one subprocess per route
+    is the bottleneck this rewrite exists to remove, and macOS is where lsof is the
+    only option."""
+    found = {}
+    if not pids:
+        return found
     if os.path.isdir("/proc"):
-        # A dead pid raises here, so the readlink doubles as the liveness check.
-        return os.path.realpath(os.readlink("/proc/%d/cwd" % pid))
-    out = run(["lsof", "-p", str(pid), "-a", "-d", "cwd", "-Fn"], 1.0)  # macOS only
+        for pid in pids:
+            try:
+                found[pid] = os.path.realpath(os.readlink("/proc/%d/cwd" % pid))
+            except Exception:
+                pass
+        return found
+    out = run(["lsof", "-p", ",".join(str(p) for p in pids), "-a", "-d", "cwd", "-Fn"], 1.5)
     if not out:
-        raise OSError("no cwd")
+        return found
+    pid = None
     for ln in out.split("\n"):
-        if ln.startswith("n"):
-            return os.path.realpath(ln[1:])
+        if ln.startswith("p"):
+            try:
+                pid = int(ln[1:])
+            except ValueError:
+                pid = None
+        elif ln.startswith("n") and pid is not None:
+            found.setdefault(pid, os.path.realpath(ln[1:]))
+    return found
     raise OSError("no cwd")
+
+
+def leaf_label(name):
+    """The leading subdomain — `fr-3658` out of `fr-3658.backend-ai-webui.localhost`."""
+    return (name or "").split(".")[0]
+
+
+def delta_label(primary_leaf, leaf):
+    """What distinguishes a second dev server from the representative one.
+
+    Portless derives a route name from the app name or the worktree, so extra servers
+    on the same tree are usually the primary plus a suffix (`fr-3658`, `fr-3658-alt`).
+    Show just the suffix when that holds, and the whole name when it does not — an
+    unrelated name carries no useful delta."""
+    for sep in ("-", "_"):
+        prefix = primary_leaf + sep
+        if leaf.startswith(prefix) and len(leaf) > len(prefix):
+            return leaf[len(prefix):]
+    return leaf
 
 
 def sub_label(rel, hostname):
@@ -299,13 +347,10 @@ def portless_links(claim_root):
             port = v
     except Exception:
         pass
-    scheme = "https"
-    try:
-        with open(os.path.join(state, "proxy.tls")) as f:
-            if f.read().strip() == "0":
-                scheme = "http"
-    except Exception:
-        pass
+    # proxy.tls is an EXISTENCE marker, not a value: portless writes "1" when TLS is on
+    # and unlinks the file when it is off (readTlsMarker/writeTlsMarker, pinned 0.15.5).
+    # Reading its contents would hand `proxy start --no-tls` an https link that is dead.
+    scheme = "https" if os.path.exists(os.path.join(state, "proxy.tls")) else "http"
 
     stats = {"routes": len(routes), "matched": 0}
     if not claim_root or not port:
@@ -313,7 +358,8 @@ def portless_links(claim_root):
     root = claim_root.rstrip("/")
     root_prefix = root + "/"
     worktrees_prefix = root + "/.claude/worktrees/"
-    primary, subs = [], []
+
+    candidates = []
     for r in routes:
         if not isinstance(r, dict):
             continue
@@ -328,19 +374,38 @@ def portless_links(claim_root):
             continue
         if pid <= 0:
             continue  # alias route: no owning process, so there is no cwd to match
-        try:
-            cwd = pid_cwd(pid)
-        except Exception:
+        candidates.append((hostname, pid))
+
+    cwds = resolve_cwds([pid for _, pid in candidates])
+
+    roots, subs = [], []
+    for hostname, pid in candidates:
+        cwd = cwds.get(pid)
+        if not cwd:
             continue
         # The route's own `port` is the upstream app port; only the proxy port routes.
         url = "%s://%s:%s" % (scheme, hostname, port)
         if cwd == root:
-            primary.append(("Portless", url))
+            roots.append((hostname, url))
         elif cwd.startswith(root_prefix) and not cwd.startswith(worktrees_prefix):
             # Sibling worktrees live under .claude/worktrees/ and belong to their own
             # sessions; without that exclusion a root session claims all of them.
             subs.append((sub_label(cwd[len(root_prefix):], hostname), url))
-    matches = primary + subs
+
+    # Sub-project routes already say what they are (Storybook / Docs / Release). Root
+    # routes are all "the dev server", so n of them would render as n identical
+    # "Portless" links: name the representative one, and reduce the rest to the part
+    # of their subdomain that differs from it.
+    roots.sort()
+    matches = []
+    if roots:
+        want = leaf_label(os.path.basename(root))
+        pick = next((i for i, (h, _) in enumerate(roots) if leaf_label(h) == want), 0)
+        primary_host, primary_url = roots.pop(pick)
+        matches.append(("Portless", primary_url))
+        primary_leaf = leaf_label(primary_host)
+        matches.extend(("+" + delta_label(primary_leaf, leaf_label(h)), u) for h, u in roots)
+    matches.extend(subs)
     stats["matched"] = len(matches)
     return matches, stats
 
@@ -436,19 +501,16 @@ def spawn_git_warm(git, top, cache_dir):
     was aborted mid-status. On a stat-dirty index that means git was killed before it
     could write the refreshed index back, so every following tick would re-hash the
     whole tree again, forever (1.6s a tick here, against 60ms once the index is
-    written). Finish the refresh out-of-band instead (setsid: the refresh abort is a
-    process-group SIGTERM), at most once a minute per repo."""
+    written). Finish the refresh out-of-band instead (start_new_session, because the
+    refresh abort is a process-group SIGTERM), at most once a minute per repo."""
     if not git or not top or not cache_dir:
-        return False
-    setsid = which("setsid")
-    if not setsid:
         return False
     attempt = os.path.join(cache_dir, "git-refresh-" + slug(top) + ".attempt")
     if age(attempt) < ATTEMPT_TTL or not stamp(attempt):
         return False
     try:
         subprocess.Popen(
-            [setsid, git, "-C", top, "update-index", "-q", "--refresh"],
+            [git, "-C", top, "update-index", "-q", "--refresh"],
             stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
@@ -458,9 +520,8 @@ def spawn_git_warm(git, top, cache_dir):
 
 
 def spawn_refresh(key, cache_path):
-    setsid = which("setsid")
     bash = which("bash")
-    if not setsid or not bash:
+    if not bash:
         return False
     # The attempt stamp is written before the spawn, so a hard failure costs one
     # curl per minute instead of one per tick.
@@ -468,11 +529,13 @@ def spawn_refresh(key, cache_path):
     if age(attempt) < ATTEMPT_TTL or not stamp(attempt):
         return False
     try:
-        # setsid: the refresh abort is a SIGTERM to the whole process group, which
-        # kills `&disown` children but not a new session. All fds to /dev/null so our
-        # exit closes the consumer's stdout pipe immediately.
+        # start_new_session calls setsid(2) in the child: the refresh abort is a SIGTERM
+        # to the whole process group, which kills `&disown` children but not a new
+        # session. Doing it here rather than through a setsid(1) binary keeps the path
+        # alive on macOS, which does not ship one. All fds to /dev/null so our exit
+        # closes the consumer's stdout pipe immediately.
         subprocess.Popen(
-            [setsid, bash, "-c", REFRESH, "_", key, cache_path],
+            [bash, "-c", REFRESH, "_", key, cache_path],
             stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             start_new_session=True,
         )

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -1,434 +1,690 @@
 #!/bin/bash
-# Claude Code statusline: Teams thread + Jira issue (single line)
-# Reads session JSON from stdin, extracts git branch, queries Jira with caching.
+# Claude Code statusline — line 1: worktree state + VS Code + Portless + Teams + Jira,
+# line 2: model + token usage. Reads the session JSON on stdin.
 #
-# Strategy: Stale-While-Revalidate
-#   - Never blocks on network calls; always serves from cache instantly
-#   - Stale cache → serve immediately + background refresh
-#   - No cache (new branch) → show nothing + background pre-warm
+# WHY IT LOOKS LIKE THIS
+#   * Claude Code aborts the in-flight statusline on every refresh (300ms trailing
+#     debounce), so a run must finish well under 300ms or it never renders while the
+#     user is working. That budget is the whole design: exactly one python3 spawn
+#     (this shim calls no coreutils — each is ~9ms on uutils) plus at most two git calls.
+#   * Portless state is read straight from ~/.portless/{routes.json,proxy.port,proxy.tls};
+#     the `portless` CLI is a workspace devDependency and is never on the statusline's
+#     PATH. Route ownership is /proc/<pid>/cwd, which is also the liveness check.
+#   * No network in the foreground. Jira is served from cache; a setsid-detached
+#     refresher warms it (setsid, because the abort is a process-group SIGTERM).
+#   * No `set -e`, and python3 runs as a CHILD (never `exec`): a run that COMPLETES
+#     with empty stdout clears the statusline, while an abort merely freezes it.
+#     Emitting something always beats exiting clean, so every python failure — even
+#     one that only shows up after the interpreter has started — falls through to the
+#     pure-bash tail at the bottom of this file.
+#   * git runs WITHOUT --no-optional-locks so it may write the refreshed index back;
+#     see the comment in git_facts() for the 25x this is worth on a stat-dirty tree.
 #
+# Requires (optional): ~/.config/atlassian/credentials with ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN.
+# Jira field customfield_10176 = Teams thread URL.
+# Env: CLAUDE_STATUSLINE_SSH_HOST (VS Code Remote-SSH host; prefer an ssh-config alias),
+#      CLAUDE_STATUSLINE_CACHE_DIR, CLAUDE_STATUSLINE_DEBUG=1|2, CLAUDE_STATUSLINE_DEBUG_LOG,
+#      PORTLESS_STATE_DIR / PORTLESS_HOME.
 # Docs: https://docs.anthropic.com/en/docs/claude-code/statusline
-# Requires: ~/.config/atlassian/credentials (ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN)
-# Jira fields: customfield_10176 = Teams thread URL
 
-set -euo pipefail
+IFS= read -r -d '' _PY <<'PYSRC'
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.parse
 
-CACHE_DIR="${HOME}/.cache/claude-statusline"
-CACHE_TTL=300  # 5 minutes
-mkdir -p "$CACHE_DIR"
+T0 = time.monotonic()
+CACHE_TTL = 300.0      # Jira cache freshness
+ATTEMPT_TTL = 60.0     # floor between two refresher spawns for the same key
+JIRA_BASE = "https://lablup.atlassian.net"
+# The foreground budget is 300ms (the refresh debounce). These two are the only
+# blocking calls, so their sum is the script's hard ceiling: keep it near 1s so a
+# pathological repo degrades fast instead of guaranteeing an abort.
+GIT_REVPARSE_TIMEOUT = 0.4
+GIT_STATUS_TIMEOUT = 0.6
+HOSTNAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]{0,252}[A-Za-z0-9])?$")
 
-# Cross-platform file modification time (seconds since epoch)
-file_mtime() {
-  if mt=$(stat -f %m "$1" 2>/dev/null); then echo "$mt"; return; fi  # macOS
-  stat -c %Y "$1" 2>/dev/null || echo 0                               # Linux
-}
+LINE2 = ""
+WROTE = False
 
-# OSC 8 clickable link: link <url> <text>
-link() { printf '\033]8;;%s\033\\%s\033]8;;\033\\' "$1" "$2"; }
 
-# Background PR cache refresh: _refresh_pr <branch> <cache_file> <gh_repo>
-_refresh_pr() {
-  ( _url=$(gh pr view "$1" --repo "$3" --json url -q .url 2>/dev/null) || true
-    echo "$_url" > "$2"
-  ) &disown 2>/dev/null
-}
+def scrub(value):
+    """Control characters would corrupt the OSC 8 sequences; data is never trusted."""
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"[\x00-\x1f\x7f]", " ", value)
 
-# Background Jira cache refresh: _refresh_jira <jira_key> <cache_file>
-_refresh_jira() {
-  ( CRED_FILE="${ATLASSIAN_CRED_FILE:-$HOME/.config/atlassian/credentials}"
-    [[ -f "$CRED_FILE" ]] && source "$CRED_FILE"
-    if [[ -n "${ATLASSIAN_EMAIL:-}" && -n "${ATLASSIAN_API_TOKEN:-}" ]]; then
-      AUTH=$(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_API_TOKEN" | base64 | tr -d '\n')
-      RESP=$(curl -s --max-time 3 \
-        "https://lablup.atlassian.net/rest/api/3/issue/${1}?fields=summary,status,customfield_10176" \
-        -H "Authorization: Basic ${AUTH}" \
-        -H "Content-Type: application/json" 2>/dev/null) || RESP=""
-      if [[ -n "$RESP" ]] && echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert "fields" in d' 2>/dev/null; then
-        echo "$RESP" > "$2"
-      fi
-    fi
-  ) &disown 2>/dev/null
-}
 
-# ── Read all stdin once (can only be read once) ───────────
-SESSION_JSON=$(cat)
+def link(url, text):
+    return "\033]8;;%s\033\\%s\033]8;;\033\\" % (url, text)
 
-# ── Extract model + token info ───────────────────────────
-MODEL_PART=$(echo "$SESSION_JSON" | python3 -c '
-import json, sys
-try:
-    data = json.load(sys.stdin)
-    model = (data.get("model") or {}).get("display_name", "Unknown Model")
-    cw = data.get("context_window") or {}
-    used = cw.get("used_percentage")
-    inp = (cw.get("current_usage") or {}).get("input_tokens")
-    out = (cw.get("current_usage") or {}).get("output_tokens")
 
-    model_str = f"\033[36m{model}\033[0m"
+def run_ex(args, timeout):
+    """Every foreground subprocess is bounded here — timeout(1) costs ~110ms on uutils.
 
-    if used is not None:
-        used_int = round(used)
-        color = "\033[31m" if used_int >= 80 else "\033[33m" if used_int >= 50 else "\033[32m"
-        usage_str = f"{color}{used:.1f}% used\033[0m"
-        token_detail = f" \033[90m(in:{inp} out:{out})\033[0m" if inp is not None and out is not None else ""
-        print(f"{model_str} | Tokens: {usage_str}{token_detail}", end="")
+    Returns (stdout or None, timed_out): a timeout is not the same failure as a
+    non-zero exit, because only a timeout means the child was killed mid-work and
+    may need to be finished out-of-band (see spawn_git_warm)."""
+    try:
+        p = subprocess.run(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None, True
+    except Exception:
+        return None, False
+    if p.returncode != 0:
+        return None, False
+    return p.stdout.decode("utf-8", "replace"), False
+
+
+def run(args, timeout):
+    return run_ex(args, timeout)[0]
+
+
+# ── line 2: model + tokens ────────────────────────────────────────────────
+def render_line2(payload):
+    model = "Unknown Model"
+    try:
+        model = scrub((payload.get("model") or {}).get("display_name")) or "Unknown Model"
+    except Exception:
+        pass
+    model_str = "\033[36m%s\033[0m" % model
+    try:
+        cw = payload.get("context_window") or {}
+        used = cw.get("used_percentage")
+        cur = cw.get("current_usage") or {}
+        inp = cur.get("input_tokens")
+        out = cur.get("output_tokens")
+        if used is not None:
+            used_int = round(used)
+            color = "\033[31m" if used_int >= 80 else "\033[33m" if used_int >= 50 else "\033[32m"
+            detail = ""
+            if inp is not None and out is not None:
+                detail = " \033[90m(in:%s out:%s)\033[0m" % (inp, out)
+            return "%s | Tokens: %s%.1f%% used\033[0m%s" % (model_str, color, used, detail)
+    except Exception:
+        pass
+    return "%s | Tokens: \033[90mno data yet\033[0m" % model_str
+
+
+# ── git: one rev-parse for the claim root, one status for everything else ──
+def which(name):
+    """Resolve once, by stat: execvp's PATH walk would cost a failed execve per miss."""
+    for d in (os.environ.get("PATH") or "").split(os.pathsep):
+        if not d:
+            continue
+        p = os.path.join(d, name)
+        if os.access(p, os.X_OK) and not os.path.isdir(p):
+            return p
+    return None
+
+
+def git_facts(workspace, cache_dir=""):
+    if not workspace:
+        return None
+    git = which("git")
+    if not git:
+        return None
+    base = [git, "-C", workspace]
+    top = run(base + ["rev-parse", "--show-toplevel"], GIT_REVPARSE_TIMEOUT)
+    if top is None:
+        return None
+    top = top.strip()
+    if not top:
+        return None
+    facts = {"top": top, "branch": "", "ahead": 0, "dirty": False,
+             "untracked": False, "status_ok": False}
+    # porcelain=v2 --branch yields branch, upstream divergence and worktree state in
+    # ONE call, and (unlike diff-index) refreshes the index so a stat-dirty tree does
+    # not report a false "uncommitted".
+    #
+    # Deliberately NOT --no-optional-locks / GIT_OPTIONAL_LOCKS=0: those forbid
+    # writing the refreshed index back, so a stat-dirty tree re-hashes on every tick
+    # forever — 1507-1758ms here, against 60ms once the index may be written.
+    #
+    # The in-flight marker is what lets a repo whose status never finishes heal: an
+    # aborted tick dies ~300ms in, before this timeout, so it can schedule nothing
+    # itself — but it leaves the marker, and the next tick acts on it.
+    inflight = os.path.join(cache_dir, "git-inflight-" + slug(top)) if cache_dir else ""
+    if inflight and os.path.exists(inflight) and age(inflight) < 600.0:
+        spawn_git_warm(git, top, cache_dir)
+    if inflight:
+        stamp(inflight)
+    st, timed_out = run_ex(
+        base + ["status", "--porcelain=v2", "--branch", "--untracked-files=normal"],
+        GIT_STATUS_TIMEOUT)
+    if inflight:
+        try:
+            os.unlink(inflight)
+        except Exception:
+            pass
+    if st is None:
+        if timed_out:
+            spawn_git_warm(git, top, cache_dir)
+        return facts
+    for ln in st.split("\n"):
+        if ln.startswith("# branch.head "):
+            # Seeing this line is what proves the output really is porcelain v2, so
+            # a `git` shim that exits 0 with junk on stdout cannot render a green
+            # "clean" tick out of nothing.
+            facts["status_ok"] = True
+            head = ln[14:].strip()
+            facts["branch"] = "" if head == "(detached)" else head
+        elif ln.startswith("# branch.ab "):
+            m = re.search(r"\+(\d+)", ln)
+            if m:
+                facts["ahead"] = int(m.group(1))
+        elif ln[:2] in ("1 ", "2 ", "u "):
+            facts["dirty"] = True
+        elif ln.startswith("? "):
+            facts["untracked"] = True
+    return facts
+
+
+def render_indicator(facts):
+    if not facts:
+        return ""
+    if not facts["status_ok"]:
+        # A repo was found but its state could not be read. Rendering nothing here
+        # would fail OPEN — absent reads as "nothing to report" — so say unknown.
+        return "\033[90m?\033[0m"
+    if facts["dirty"]:
+        return "\033[91m⚠ uncommitted\033[0m"
+    if facts["untracked"]:
+        return "\033[91m⚠ untracked\033[0m"
+    if facts["ahead"] > 0:
+        return "\033[93m↑%d\033[0m" % facts["ahead"]
+    return "\033[32m✓\033[0m"
+
+
+# ── VS Code ────────────────────────────────────────────────────────────────
+def render_vscode(workspace):
+    if not workspace:
+        return ""
+    target = workspace
+    try:
+        names = sorted(e.name for e in os.scandir(workspace) if e.name.endswith(".code-workspace"))
+        if names:
+            target = os.path.join(workspace, names[0])
+    except Exception:
+        pass
+    quoted = urllib.parse.quote(target, safe="/")
+    host = os.environ.get("CLAUDE_STATUSLINE_SSH_HOST") or ""
+    if not host:
+        fields = (os.environ.get("SSH_CONNECTION") or "").split()
+        if len(fields) >= 3 and fields[2]:
+            user = os.environ.get("USER") or os.environ.get("LOGNAME") or ""
+            host = ("%s@%s" % (user, fields[2])) if user else fields[2]
+    if not host:
+        # cc-daemon strips SSH_CONNECTION from every Claude process, so without this
+        # the link would tell the user's laptop to open a path that only exists here.
+        # gethostname() first: it is a pure syscall, getfqdn() may hit DNS.
+        try:
+            name = socket.gethostname() or ""
+            if not name or name.startswith("localhost"):
+                name = socket.getfqdn() or ""
+        except Exception:
+            name = ""
+        if name and name not in ("localhost", "localhost.localdomain"):
+            host = name
+    if host:
+        url = "vscode://vscode-remote/ssh-remote+%s%s" % (scrub(host), quoted)
     else:
-        print(f"{model_str} | Tokens: \033[90mno data yet\033[0m", end="")
-except Exception:
+        url = "vscode://file%s" % quoted
+    return link(url, "⧉ VS Code")
+
+
+# ── Portless ───────────────────────────────────────────────────────────────
+def portless_state_dir():
+    return (os.environ.get("PORTLESS_STATE_DIR")
+            or os.environ.get("PORTLESS_HOME")
+            or os.path.join(os.path.expanduser("~"), ".portless"))
+
+
+def pid_cwd(pid):
+    if os.path.isdir("/proc"):
+        # A dead pid raises here, so the readlink doubles as the liveness check.
+        return os.path.realpath(os.readlink("/proc/%d/cwd" % pid))
+    out = run(["lsof", "-p", str(pid), "-a", "-d", "cwd", "-Fn"], 1.0)  # macOS only
+    if not out:
+        raise OSError("no cwd")
+    for ln in out.split("\n"):
+        if ln.startswith("n"):
+            return os.path.realpath(ln[1:])
+    raise OSError("no cwd")
+
+
+def sub_label(rel, hostname):
+    if rel.startswith("scripts/temp-releases/"):
+        return "Release"
+    if rel.startswith("packages/backend.ai-ui"):
+        return "Storybook"
+    if rel.startswith("packages/backend.ai-webui-docs"):
+        # Auto-named routes prefix the worktree slug, so the flavor can be any label.
+        labels = hostname.split(".")
+        if "docs-html" in labels:
+            return "Docs HTML"
+        if "docs-web" in labels:
+            return "Docs Web"
+        return "Docs"
+    return "Portless"
+
+
+def portless_links(claim_root):
+    state = portless_state_dir()
+    routes = []
+    try:
+        with open(os.path.join(state, "routes.json"), "rb") as f:
+            parsed = json.loads(f.read().decode("utf-8", "replace"))
+        if isinstance(parsed, list):
+            routes = parsed
+    except Exception:
+        pass
+    # No default port: a link to the wrong port renders green and live while being
+    # dead, which is worse than the gray placeholder.
+    port = ""
+    try:
+        with open(os.path.join(state, "proxy.port")) as f:
+            v = f.read().strip()
+        if v.isdigit() and 0 < int(v) < 65536:
+            port = v
+    except Exception:
+        pass
+    scheme = "https"
+    try:
+        with open(os.path.join(state, "proxy.tls")) as f:
+            if f.read().strip() == "0":
+                scheme = "http"
+    except Exception:
+        pass
+
+    stats = {"routes": len(routes), "matched": 0}
+    if not claim_root or not port:
+        return [], stats
+    root = claim_root.rstrip("/")
+    root_prefix = root + "/"
+    worktrees_prefix = root + "/.claude/worktrees/"
+    primary, subs = [], []
+    for r in routes:
+        if not isinstance(r, dict):
+            continue
+        hostname = scrub(r.get("hostname")).strip()
+        # A hostname is the only part of the link that comes from a file; anything
+        # that is not one would go into the URL verbatim, so require the shape.
+        if not hostname or not HOSTNAME_RE.match(hostname):
+            continue
+        try:
+            pid = int(r.get("pid"))
+        except Exception:
+            continue
+        if pid <= 0:
+            continue  # alias route: no owning process, so there is no cwd to match
+        try:
+            cwd = pid_cwd(pid)
+        except Exception:
+            continue
+        # The route's own `port` is the upstream app port; only the proxy port routes.
+        url = "%s://%s:%s" % (scheme, hostname, port)
+        if cwd == root:
+            primary.append(("Portless", url))
+        elif cwd.startswith(root_prefix) and not cwd.startswith(worktrees_prefix):
+            # Sibling worktrees live under .claude/worktrees/ and belong to their own
+            # sessions; without that exclusion a root session claims all of them.
+            subs.append((sub_label(cwd[len(root_prefix):], hostname), url))
+    matches = primary + subs
+    stats["matched"] = len(matches)
+    return matches, stats
+
+
+def render_portless(matches):
+    if not matches:
+        return "\033[90mPortless\033[0m"
+    return "  ".join(link(u, "\033[32m%s\033[0m" % lbl) for lbl, u in matches)
+
+
+def prune_cache(cache_dir):
+    """Sweep what previous versions left behind (the pid->cwd cache, whose pid reuse
+    silently mislinked worktrees; the gh PR summaries) and expire the attempt stamps,
+    which are one-per-key-forever otherwise."""
+    now = time.time()
+    try:
+        for e in os.scandir(cache_dir):
+            n = e.name
+            stale = ((n.startswith("portless-pid-") and n.endswith(".cwd"))
+                     or (n.startswith("pr-FR-") and n.endswith(".txt")))
+            if not stale and (n.endswith(".attempt") or n.startswith("git-inflight-")):
+                try:
+                    stale = abs(now - e.stat().st_mtime) > 86400.0
+                except Exception:
+                    stale = False
+            if stale:
+                try:
+                    os.unlink(e.path)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+
+# ── Jira / Teams ───────────────────────────────────────────────────────────
+REFRESH = r'''
+key=$1; cache=$2
+cred="${ATLASSIAN_CRED_FILE:-$HOME/.config/atlassian/credentials}"
+[ -f "$cred" ] && . "$cred"
+[ -n "${ATLASSIAN_EMAIL:-}" ] && [ -n "${ATLASSIAN_API_TOKEN:-}" ] || exit 0
+auth=$(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_API_TOKEN" | base64 | tr -d '\n')
+tmp="${cache}.tmp.$$"
+# The credential arrives on stdin via --config, never in argv: /proc is readable by
+# every other process on a dev box that runs dozens of agents.
+code=$(printf 'header = "Authorization: Basic %s"\n' "$auth" \
+  | curl -s -o "$tmp" -w '%{http_code}' --max-time 3 --config - \
+  "https://lablup.atlassian.net/rest/api/3/issue/${key}?fields=summary,status,customfield_10176" \
+  -H "Content-Type: application/json" 2>/dev/null) || code=000
+case "$code" in
+  200)
+    if python3 -c 'import json,sys; sys.exit(0 if "fields" in json.load(open(sys.argv[1])) else 1)' "$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$cache"
+    fi
+    ;;
+  401|403|404)
+    # Definitive failure: never clobber a good cache, just gate the next attempt.
+    if [ -s "$cache" ]; then touch "$cache"; else printf '{}' >"$tmp" && mv -f "$tmp" "$cache"; fi
+    ;;
+esac
+rm -f "$tmp" 2>/dev/null
+exit 0
+'''
+
+
+def mtime(path):
+    try:
+        return os.path.getmtime(path)
+    except Exception:
+        return 0.0
+
+
+def age(path):
+    """abs(): a future mtime — a clock step back after an NTP correction, a
+    suspend/resume, a restored snapshot — must not freeze a cache forever."""
+    return abs(time.time() - mtime(path))
+
+
+def stamp(path):
+    try:
+        with open(path, "w"):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+def slug(path):
+    return re.sub(r"[^A-Za-z0-9]+", "-", path or "").strip("-")[-100:]
+
+
+def spawn_git_warm(git, top, cache_dir):
+    """The foreground `git status` could not finish — it timed out, or an earlier tick
+    was aborted mid-status. On a stat-dirty index that means git was killed before it
+    could write the refreshed index back, so every following tick would re-hash the
+    whole tree again, forever (1.6s a tick here, against 60ms once the index is
+    written). Finish the refresh out-of-band instead (setsid: the refresh abort is a
+    process-group SIGTERM), at most once a minute per repo."""
+    if not git or not top or not cache_dir:
+        return False
+    setsid = which("setsid")
+    if not setsid:
+        return False
+    attempt = os.path.join(cache_dir, "git-refresh-" + slug(top) + ".attempt")
+    if age(attempt) < ATTEMPT_TTL or not stamp(attempt):
+        return False
+    try:
+        subprocess.Popen(
+            [setsid, git, "-C", top, "update-index", "-q", "--refresh"],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        return False
+    return True
+
+
+def spawn_refresh(key, cache_path):
+    setsid = which("setsid")
+    bash = which("bash")
+    if not setsid or not bash:
+        return False
+    # The attempt stamp is written before the spawn, so a hard failure costs one
+    # curl per minute instead of one per tick.
+    attempt = cache_path + ".attempt"
+    if age(attempt) < ATTEMPT_TTL or not stamp(attempt):
+        return False
+    try:
+        # setsid: the refresh abort is a SIGTERM to the whole process group, which
+        # kills `&disown` children but not a new session. All fds to /dev/null so our
+        # exit closes the consumer's stdout pipe immediately.
+        subprocess.Popen(
+            [setsid, bash, "-c", REFRESH, "_", key, cache_path],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        return False
+    return True
+
+
+def jira_segments(branch, cache_dir):
+    m = re.search(r"fr-(\d+)", branch or "", re.I)
+    if not m:
+        return "", ""
+    key = "FR-%s" % m.group(1)
+    cache_path = os.path.join(cache_dir, key + ".json")
+    if age(cache_path) >= CACHE_TTL:
+        spawn_refresh(key, cache_path)
+    # Whatever the cache state, render what is there and keep going: the key alone is
+    # already useful on tick 1, and an early return is what caused the three-tick warmup.
+    summary = status = teams = ""
+    try:
+        with open(cache_path, "rb") as f:
+            fields = (json.loads(f.read().decode("utf-8", "replace")) or {}).get("fields") or {}
+        summary = scrub(fields.get("summary"))
+        status = scrub((fields.get("status") or {}).get("name"))
+        teams = scrub(fields.get("customfield_10176")).strip()
+    except Exception:
+        pass
+    # https:// only: whoever can edit the field controls where a link labelled
+    # "Teams" points, so at least deny non-https schemes.
+    teams_part = link(teams, "Teams") if teams.startswith("https://") else ""
+    jira_part = link("%s/browse/%s" % (JIRA_BASE, key), key)
+    if status:
+        jira_part += " (%s)" % status
+    if summary:
+        if len(summary) > 45:
+            summary = summary[:42] + "..."
+        jira_part += ": %s" % summary
+    return teams_part, jira_part
+
+
+# ── debug ──────────────────────────────────────────────────────────────────
+def debug_log(level, payload, cache_dir, info):
+    # Not /tmp, and 0600: level 2 dumps the whole payload, which carries the session
+    # id, the transcript path, cost and rate-limit state.
+    path = (os.environ.get("CLAUDE_STATUSLINE_DEBUG_LOG")
+            or os.path.join(cache_dir or ".", "debug.log"))
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        if os.path.exists(path) and os.path.getsize(path) > 1048576:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        ws = payload.get("workspace") or {}
+        wt = payload.get("worktree") or {}
+        with os.fdopen(os.open(path, flags, 0o600), "a") as f:
+            f.write("%s sid=%s agent=%s cwd=%s wt=%s model=%s root=%s routes=%s matched=%s "
+                    "total_ms=%.1f git_ms=%.1f portless_ms=%.1f\n" % (
+                        time.strftime("%Y-%m-%dT%H:%M:%S"),
+                        str(payload.get("session_id") or "")[:8],
+                        payload.get("agent_type"), ws.get("current_dir"), wt.get("path"),
+                        (payload.get("model") or {}).get("id"),
+                        info.get("root"), info.get("routes"), info.get("matched"),
+                        info.get("total_ms", 0.0), info.get("git_ms", 0.0),
+                        info.get("portless_ms", 0.0)))
+            if level == "2":
+                f.write("  payload=%s\n" % json.dumps(payload, ensure_ascii=False))
+    except Exception:
+        pass
+
+
+# ── main ───────────────────────────────────────────────────────────────────
+def main():
+    global LINE2, WROTE
+    try:
+        payload = json.loads(sys.stdin.read()) or {}
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    LINE2 = render_line2(payload)  # computed first: it is the guaranteed fallback
+
+    workspace = ""
+    worktree = {}
+    try:
+        workspace = scrub((payload.get("workspace") or {}).get("current_dir")) or ""
+        wt = payload.get("worktree")
+        worktree = wt if isinstance(wt, dict) else {}
+    except Exception:
+        pass
+
+    cache_dir = (os.environ.get("CLAUDE_STATUSLINE_CACHE_DIR")
+                 or os.path.join(os.path.expanduser("~"), ".cache", "claude-statusline"))
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+    except Exception:
+        pass
+    prune_cache(cache_dir)
+
+    t = time.monotonic()
+    facts = None
+    try:
+        facts = git_facts(workspace, cache_dir)
+    except Exception:
+        pass
+    git_ms = (time.monotonic() - t) * 1000.0
+
+    claim_root = ""
+    try:
+        # Inside a linked worktree --show-toplevel returns the worktree path, so this
+        # one expression covers main checkout, worktree and any subdirectory of either.
+        src = (facts or {}).get("top") or scrub(worktree.get("path")) or workspace
+        if src:
+            claim_root = os.path.realpath(src)
+    except Exception:
+        pass
+
+    t = time.monotonic()
+    try:
+        matches, pstats = portless_links(claim_root)
+    except Exception:
+        matches, pstats = [], {"routes": 0, "matched": 0}
+    portless_ms = (time.monotonic() - t) * 1000.0
+
+    segments = []
+    for producer in (
+        lambda: render_indicator(facts),
+        lambda: render_vscode(workspace),
+        lambda: render_portless(matches),
+    ):
+        try:
+            part = producer()
+        except Exception:
+            part = ""
+        if part:
+            segments.append(part)
+
+    try:
+        branch = (facts or {}).get("branch") or scrub(worktree.get("branch")) or ""
+        teams_part, jira_part = jira_segments(branch, cache_dir)
+        if teams_part:
+            segments.append(teams_part)
+        if jira_part:
+            segments.append(jira_part)
+    except Exception:
+        pass
+
+    line1 = "  ".join(segments)
+    out = (line1 + "\n" + LINE2) if line1 else LINE2
+    sys.stdout.write(out)
+    WROTE = True
+
+    level = os.environ.get("CLAUDE_STATUSLINE_DEBUG")
+    if level in ("1", "2"):
+        debug_log(level, payload, cache_dir, {
+            "root": claim_root, "routes": pstats.get("routes"),
+            "matched": pstats.get("matched"),
+            "total_ms": (time.monotonic() - T0) * 1000.0,
+            "git_ms": git_ms, "portless_ms": portless_ms,
+        })
+
+
+try:
+    main()
+except BaseException:
     pass
-' 2>/dev/null) || true
+finally:
+    try:
+        if not WROTE:
+            sys.stdout.write(LINE2 or "\033[36mUnknown Model\033[0m | Tokens: \033[90mno data yet\033[0m")
+        sys.stdout.flush()
+    except BaseException:
+        pass
+PYSRC
 
-# ── Extract workspace from session JSON ──────────────────
-WORKSPACE=$(echo "$SESSION_JSON" | python3 -c '
-import json, sys
-try:
-    data = json.load(sys.stdin)
-    print(data.get("workspace", {}).get("current_dir", ""))
-except Exception: pass
-' 2>/dev/null) || true
+# Read the payload here, not in python: the fallback below needs it too, and it is
+# a builtin, so it costs no process.
+IFS= read -r -d '' _payload
 
-# ── VS Code link (⧉ VS Code → opens workspace in VS Code) ──
-# URL scheme:
-#   Remote (SSH): vscode://vscode-remote/ssh-remote+<host><path>
-#     Host resolution (first match wins):
-#       1. $CLAUDE_STATUSLINE_SSH_HOST — explicit override (ssh-config alias or public hostname).
-#          Honored even when SSH_CONNECTION is unset (tmux/screen detach, systemd, sudo -i,
-#          background jobs, etc. all drop SSH_CONNECTION but the host is still remote).
-#          Prefer an ssh-config alias (e.g. `jongeun2`) over a bare IP — VS Code Remote-SSH
-#          invokes ssh which only matches `Host <alias>` blocks against the literal string,
-#          so an alias keeps your IdentityFile, ControlMaster, keepalive, etc.
-#       2. `<whoami>@<server-ip>` from SSH_CONNECTION — zero-config default; the third field is
-#          the server-side address of the SSH TCP connection. It is usually reachable from the
-#          client, but on NATed / multi-homed / DNAT'd hosts it may be an internal address that
-#          the client cannot route back to — set CLAUDE_STATUSLINE_SSH_HOST in that case.
-#   Local (no SSH and no override): vscode://file<path>
-VSCODE_PART=""
-if [[ -n "$WORKSPACE" ]]; then
-  VSCODE_WS=$(find "$WORKSPACE" -maxdepth 1 -name '*.code-workspace' -print -quit 2>/dev/null) || true
-  VSCODE_TARGET_RAW="${VSCODE_WS:-$WORKSPACE}"
-  # %-encode path segments (preserve /) so spaces and reserved chars survive OSC 8 / URI parsing.
-  VSCODE_TARGET=$(python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1], safe="/"))' "$VSCODE_TARGET_RAW" 2>/dev/null) || VSCODE_TARGET="$VSCODE_TARGET_RAW"
-  VSCODE_URL=""
-  VSCODE_HOST=""
-  if [[ -n "${CLAUDE_STATUSLINE_SSH_HOST:-}" ]]; then
-    VSCODE_HOST="$CLAUDE_STATUSLINE_SSH_HOST"
-  elif [[ -n "${SSH_CONNECTION:-}" ]]; then
-    VSCODE_IP=$(awk '{print $3}' <<< "$SSH_CONNECTION")
-    [[ -n "$VSCODE_IP" ]] && VSCODE_HOST="$(whoami)@${VSCODE_IP}"
-  fi
-  if [[ -n "$VSCODE_HOST" ]]; then
-    VSCODE_URL="vscode://vscode-remote/ssh-remote+${VSCODE_HOST}${VSCODE_TARGET}"
+# NOT `exec python3`: exec only falls through when the binary cannot be launched at
+# all, so a python3 that starts and THEN dies (stale PYTHONHOME, a sitecustomize that
+# raises) would have replaced this shell already — zero bytes out, and Claude Code
+# keeps stale text on screen forever. Run it as a child and check what came back.
+#   -I       isolated: ignore PYTHON* and user site-packages. Program is stdlib-only.
+#   -X utf8  the program travels on argv and carries non-ASCII glyphs (⚠ ⧉ ✓), which
+#            a C/POSIX LC_CTYPE can decode into neither argv nor stdout.
+# `command -v` is a builtin: the guard costs no process and keeps stderr silent on a
+# box without python3.
+_out=""
+if command -v python3 >/dev/null 2>&1; then
+  if [ -n "${CLAUDE_STATUSLINE_DEBUG:-}" ]; then
+    _out=$(printf '%s' "$_payload" | python3 -I -X utf8 -c "$_PY")
   else
-    VSCODE_URL="vscode://file${VSCODE_TARGET}"
-  fi
-  [[ -n "$VSCODE_URL" ]] && VSCODE_PART=$(link "$VSCODE_URL" "⧉ VS Code")
-fi
-
-# ── Portless URL detection ─────────────────────────────────
-# Maps the current workspace to its Portless route by checking each route
-# process's cwd. Subdomain-based guessing breaks when multiple worktrees
-# run dev servers concurrently (e.g. one auto-named route can match a
-# different worktree's slug). cwd is the source of truth — `dev.mjs` is
-# spawned from the workspace, so its portless child's cwd equals it.
-#
-# Cache: pid → cwd in CACHE_DIR for 30s. Portless restarts cycle pids
-# quickly, so a short TTL trades minimal staleness for avoiding lsof per
-# tick (lsof on macOS spawns ~30–100ms per call).
-PORTLESS_PART=""
-if [[ -n "$WORKSPACE" ]] && command -v portless >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1; then
-  PORTLESS_TTL=30
-  WS_REAL=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$WORKSPACE" 2>/dev/null || printf '%s' "$WORKSPACE")
-  PORTLESS_LIST=$(portless list 2>/dev/null || true)
-
-  # Collect every portless route that belongs to this workspace, matched by the
-  # route process's cwd:
-  #   - exact match (cwd == workspace root) is the main dev server (dev.mjs) —
-  #     the primary, rendered first as "Portless".
-  #   - a cwd *under* the workspace root is a sub-project server launched from a
-  #     subdir: storybook (packages/backend.ai-ui), the docs preview/serve
-  #     servers (packages/backend.ai-webui-docs), serve-release
-  #     (scripts/temp-releases/webui-*), etc. Each is rendered as its own labeled
-  #     link after the primary, so a single root session can see and click all of
-  #     the servers it is currently running.
-  #   - exclude the worktrees subtree (<root>/.claude/worktrees/*): those routes
-  #     belong to their own worktree sessions, so a root session must not claim
-  #     them (this preserves the cwd-is-source-of-truth guarantee).
-  WS_WORKTREES="${WS_REAL}/.claude/worktrees/"
-  PORTLESS_PRIMARY=""   # url of the exact-root (main dev) match
-  PORTLESS_SUBS=()      # "<label>\t<url>" for each sub-project route
-  PORTLESS_NOTE=""
-  if [[ -n "$PORTLESS_LIST" ]]; then
-    while IFS= read -r _line; do
-      [[ "$_line" =~ pid\ ([0-9]+) ]] || continue
-      _pid="${BASH_REMATCH[1]}"
-      _pid_cache="${CACHE_DIR}/portless-pid-${_pid}.cwd"
-      _cwd=""
-      if [[ -f "$_pid_cache" ]]; then
-        _age=$(( $(date +%s) - $(file_mtime "$_pid_cache") ))
-        if (( _age < PORTLESS_TTL )); then
-          _cwd=$(cat "$_pid_cache" 2>/dev/null) || _cwd=""
-        fi
-      fi
-      if [[ -z "$_cwd" ]]; then
-        _cwd=$(lsof -p "$_pid" -a -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2); exit}' || true)
-        if [[ -n "$_cwd" ]]; then
-          printf '%s' "$_cwd" > "$_pid_cache" 2>/dev/null || true
-        fi
-      fi
-      [[ -z "$_cwd" ]] && continue
-      _cwd_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$_cwd" 2>/dev/null || printf '%s' "$_cwd")
-      # Multi-level subdomains (worktree prefix, e.g. branch.app.localhost) contain
-      # dots, so the host class must allow '.' as well as '-'.
-      _url=$(printf '%s' "$_line" | grep -oE 'https?://[a-z0-9.-]+\.localhost:[0-9]+' | head -1 || true)
-      [[ -z "$_url" ]] && continue
-      if [[ "$_cwd_real" == "$WS_REAL" ]]; then
-        PORTLESS_PRIMARY="$_url"
-      elif [[ "$_cwd_real" == "$WS_REAL"/* && "$_cwd_real" != "$WS_WORKTREES"* ]]; then
-        case "$_cwd_real" in
-          "$WS_REAL"/scripts/temp-releases/*) _sub_label="Release" ;;
-          "$WS_REAL"/packages/backend.ai-ui*) _sub_label="Storybook" ;;
-          "$WS_REAL"/packages/backend.ai-webui-docs*)
-            # The docs package runs several concurrent route flavors that each
-            # claim their own portless subdomain (docs-preview / docs-html /
-            # docs-web). Derive the label from the route's leading subdomain so
-            # they render as distinguishable links instead of identical "Docs".
-            _host="${_url#*://}"; _host="${_host%%.*}"
-            case "$_host" in
-              docs-html) _sub_label="Docs HTML" ;;
-              docs-web) _sub_label="Docs Web" ;;
-              *) _sub_label="Docs" ;;
-            esac
-            ;;
-          *) _sub_label="Portless" ;;
-        esac
-        PORTLESS_SUBS+=("${_sub_label}"$'\t'"${_url}")
-      fi
-    done <<< "$PORTLESS_LIST"
-  fi
-
-  # Fallback: portless route not registered (e.g. lost via the 0.10.x race
-  # where a dying prior owner's onCleanup wipes the new owner's entry).
-  # Scan for any `portless` CLI process whose cwd matches this workspace —
-  # if found, the dev server IS running, just unrouted. Derive subdomain
-  # from argv (explicit `portless <name>`) or package.json (auto-name).
-  if [[ -z "$PORTLESS_PRIMARY" && ${#PORTLESS_SUBS[@]} -eq 0 ]]; then
-    for _pid in $(pgrep -f 'portless/dist/cli\.js' 2>/dev/null || true); do
-      _cwd=$(lsof -p "$_pid" -a -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2); exit}' || true)
-      [[ -z "$_cwd" ]] && continue
-      _cwd_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$_cwd" 2>/dev/null || printf '%s' "$_cwd")
-      [[ "$_cwd_real" != "$WS_REAL" ]] && continue
-      _argv=$(ps -o command= -p "$_pid" 2>/dev/null || true)
-      # Skip the proxy daemon itself (`portless proxy start ...`)
-      [[ "$_argv" =~ cli\.js[[:space:]]+proxy ]] && continue
-      _sub=$(printf '%s' "$_argv" | grep -oE 'cli\.js[[:space:]]+[a-zA-Z0-9_.-]+' | awk '{print $2}' | head -1 || true)
-      if [[ -z "$_sub" || "$_sub" == "run" ]]; then
-        if [[ -f "$WS_REAL/package.json" ]]; then
-          _sub=$(python3 - "$WS_REAL/package.json" <<'PYEOF' 2>/dev/null || true
-import json, re, sys
-try:
-    name = json.load(open(sys.argv[1])).get("name", "") or ""
-    name = re.sub(r"[^a-z0-9-]+", "-", name.lower())
-    name = re.sub(r"-+", "-", name).strip("-")
-    print(name)
-except Exception:
-    print("")
-PYEOF
-)
-        fi
-      fi
-      if [[ -n "$_sub" ]]; then
-        PORTLESS_PRIMARY="https://${_sub}.localhost:1355"
-        PORTLESS_NOTE=" (route lost)"
-        break
-      fi
-    done
-  fi
-
-  # Render: primary (main dev) first as "Portless", then each sub-project link.
-  PORTLESS_PART=""
-  if [[ -n "$PORTLESS_PRIMARY" ]]; then
-    PORTLESS_PART=$(link "$PORTLESS_PRIMARY" "$(printf '\033[32mPortless%s\033[0m' "$PORTLESS_NOTE")")
-  fi
-  if [[ ${#PORTLESS_SUBS[@]} -gt 0 ]]; then
-    for _entry in "${PORTLESS_SUBS[@]}"; do
-      _e_label="${_entry%%$'\t'*}"
-      _e_url="${_entry#*$'\t'}"
-      _e_link=$(link "$_e_url" "$(printf '\033[32m%s\033[0m' "$_e_label")")
-      if [[ -n "$PORTLESS_PART" ]]; then
-        PORTLESS_PART+="  $_e_link"
-      else
-        PORTLESS_PART="$_e_link"
-      fi
-    done
-  fi
-  if [[ -z "$PORTLESS_PART" ]]; then
-    PORTLESS_PART=$(printf '\033[90mPortless\033[0m')
+    _out=$(printf '%s' "$_payload" | python3 -I -X utf8 -c "$_PY" 2>/dev/null)
   fi
 fi
-
-# Fallback output when there is no Jira/Teams context:
-#   line 1 = worktree info + VS Code link (if available), line 2 = model/tokens.
-emit_fallback() {
-  local line1=""
-  if [[ -n "${WORKTREE_PART:-}" ]]; then
-    line1+="$WORKTREE_PART"
-  fi
-  if [[ -n "$VSCODE_PART" ]]; then
-    [[ -n "$line1" ]] && line1+="  "
-    line1+="$VSCODE_PART"
-  fi
-  if [[ -n "${PORTLESS_PART:-}" ]]; then
-    [[ -n "$line1" ]] && line1+="  "
-    line1+="$PORTLESS_PART"
-  fi
-  if [[ -n "$line1" ]]; then
-    printf '%b\n%b' "$line1" "$MODEL_PART"
-  else
-    printf '%b' "$MODEL_PART"
-  fi
-}
-
-# ── If no workspace, show only model/token ───────────────
-if [[ -z "$WORKSPACE" ]]; then
-  emit_fallback
+if [ -n "$_out" ]; then
+  printf '%s' "$_out"
   exit 0
 fi
 
-# ── Worktree & git safety indicator ──────────────────────
-# Detects: worktree name, uncommitted changes, unpushed commits
-# Output: WORKTREE_PART = colored string for status line
-WORKTREE_PART=""
-if [[ -n "$WORKSPACE" ]] && git -C "$WORKSPACE" rev-parse --git-dir >/dev/null 2>&1; then
-  # Safety check: uncommitted changes or unpushed commits
-  WT_DIRTY=0
-  WT_DETAIL=""
-  if ! git -C "$WORKSPACE" diff-index --quiet HEAD -- 2>/dev/null; then
-    WT_DIRTY=1
-    WT_DETAIL="uncommitted"
-  elif [[ -n "$(git -C "$WORKSPACE" ls-files --others --exclude-standard 2>/dev/null | head -1)" ]]; then
-    WT_DIRTY=1
-    WT_DETAIL="untracked"
-  fi
-
-  WT_UNPUSHED=0
-  if git -C "$WORKSPACE" rev-parse '@{u}' >/dev/null 2>&1; then
-    WT_UNPUSHED=$(git -C "$WORKSPACE" rev-list --count '@{u}..HEAD' 2>/dev/null) || WT_UNPUSHED=0
-  fi
-
-  # Build indicator
-  if (( WT_DIRTY )); then
-    WT_ICON="\033[91m⚠ ${WT_DETAIL}\033[0m"  # red
-  elif (( WT_UNPUSHED > 0 )); then
-    WT_ICON="\033[93m↑${WT_UNPUSHED}\033[0m"  # yellow
-  else
-    WT_ICON="\033[32m✓\033[0m"  # green = safe to delete
-  fi
-
-  # Compose: safety indicator only (✓/⚠/↑N)
-  WORKTREE_PART="$WT_ICON"
-fi
-
-# ── Extract branch and repo info ──────────────────────────
-BRANCH=$(git -C "$WORKSPACE" rev-parse --abbrev-ref HEAD 2>/dev/null) || { emit_fallback; exit 0; }
-JIRA_KEY=$(echo "$BRANCH" | grep -oiE 'fr-[0-9]+' | head -1 | tr '[:lower:]' '[:upper:]') || true
-
-# No Jira key on this branch → show only VS Code + model/token
-if [[ -z "$JIRA_KEY" ]]; then
-  emit_fallback
-  exit 0
-fi
-
-# Derive GitHub owner/repo from origin remote
-GH_REPO=$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null \
-  | sed -E 's#.*github\.com[:/]##; s/\.git$//' ) || true
-[[ -z "$GH_REPO" ]] && { emit_fallback; exit 0; }
-
-# ── PR check (non-blocking, stale-while-revalidate) ──────
-PR_CACHE_FILE="${CACHE_DIR}/pr-${JIRA_KEY}.txt"
-
-if [[ -f "$PR_CACHE_FILE" ]]; then
-  PR_URL=$(cat "$PR_CACHE_FILE" 2>/dev/null) || true
-  PR_CACHE_AGE=$(( $(date +%s) - $(file_mtime "$PR_CACHE_FILE") ))
-  (( PR_CACHE_AGE >= CACHE_TTL )) && _refresh_pr "$BRANCH" "$PR_CACHE_FILE" "$GH_REPO"
-else
-  # No cache → background pre-warm, show VS Code + model/token this cycle
-  _refresh_pr "$BRANCH" "$PR_CACHE_FILE" "$GH_REPO"
-  emit_fallback
-  exit 0
-fi
-
-if [[ -z "$PR_URL" ]]; then
-  emit_fallback
-  exit 0
-fi
-
-# ── Jira fetch (non-blocking, stale-while-revalidate) ────
-CACHE_FILE="${CACHE_DIR}/${JIRA_KEY}.json"
-
-if [[ -f "$CACHE_FILE" ]]; then
-  JIRA_CACHE_AGE=$(( $(date +%s) - $(file_mtime "$CACHE_FILE") ))
-  (( JIRA_CACHE_AGE >= CACHE_TTL )) && _refresh_jira "$JIRA_KEY" "$CACHE_FILE"
-else
-  # No Jira cache → background pre-warm, show VS Code + model/token this cycle
-  _refresh_jira "$JIRA_KEY" "$CACHE_FILE"
-  emit_fallback
-  exit 0
-fi
-
-# ── Parse all fields in a single python3 call ────────────
-# Outputs tab-separated: summary \t status \t teams_url
-PARSED=$(python3 -c '
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    f = d.get("fields", {})
-    summary = f.get("summary", "")
-    status = (f.get("status") or {}).get("name", "")
-    teams = f.get("customfield_10176", "") or ""
-    summary = summary.replace("\t", " ")
-    print(f"{summary}\t{status}\t{teams}")
-except Exception:
-    print("\t\t")
-' < "$CACHE_FILE" 2>/dev/null) || true
-
-IFS=$'\t' read -r JIRA_SUMMARY JIRA_STATUS TEAMS_URL <<< "$PARSED"
-
-# ── Line 1: Worktree + Links (VS Code + Teams + Jira) ────
-LINE1=""
-
-if [[ -n "$WORKTREE_PART" ]]; then
-  LINE1+="$WORKTREE_PART"
-  LINE1+="  "
-fi
-
-if [[ -n "$VSCODE_PART" ]]; then
-  LINE1+="$VSCODE_PART"
-  LINE1+="  "
-fi
-
-if [[ -n "${PORTLESS_PART:-}" ]]; then
-  LINE1+="$PORTLESS_PART"
-  LINE1+="  "
-fi
-
-if [[ -n "$TEAMS_URL" ]]; then
-  LINE1+=$(link "$TEAMS_URL" "Teams")
-  LINE1+="  "
-fi
-
-JIRA_URL="https://lablup.atlassian.net/browse/${JIRA_KEY}"
-LINE1+=$(link "$JIRA_URL" "$JIRA_KEY")
-
-if [[ -n "$JIRA_STATUS" ]]; then
-  LINE1+=" (${JIRA_STATUS})"
-fi
-
-if [[ -n "$JIRA_SUMMARY" ]]; then
-  if (( ${#JIRA_SUMMARY} > 45 )); then
-    JIRA_SUMMARY="${JIRA_SUMMARY:0:42}..."
-  fi
-  LINE1+=": ${JIRA_SUMMARY}"
-fi
-
-# ── Line 2: Model + token info ────────────────────────────
-printf '%b\n%b' "$LINE1" "$MODEL_PART"
+# Last resort: no python3, or python3 died without producing anything. Pull the model
+# name out of the payload with parameter expansion only — no subprocess, so this can
+# never be the thing that breaks.
+_model=""
+case "$_payload" in
+  *'"display_name"'*)
+    _model="${_payload#*\"display_name\"}"          # ": "Opus 5 …", …
+    _model="${_model#*:}"                            #  "Opus 5 …", …
+    _model="${_model#"${_model%%[![:space:]]*}"}"    # drop leading whitespace
+    case "$_model" in
+      '"'*) _model="${_model#\"}"; _model="${_model%%\"*}" ;;
+      *)    _model="" ;;
+    esac
+    ;;
+esac
+printf '\033[36m%s\033[0m | Tokens: \033[90mno data yet\033[0m' "${_model:-Unknown Model}"


### PR DESCRIPTION
Resolves #9018 (FR-3658)

The Portless links (FR-2900 / FR-2942) and the Jira + Teams links (FR-2122 / FR-2126) in the Claude Code statusline rendered only while the session was idle, and disappeared as soon as Claude was working. Three causes, each reproduced live on a dev box.

## Root causes

**1. The Portless block was gated behind `command -v portless`, which never succeeds.**
`portless` is a workspace devDependency (`node_modules/.bin/portless`), and that directory is not on the PATH Claude Code runs the statusline with. Captured from the real runtime environment of a live session:

```
PORTLESS=MISSING
PATH=/home/linuxbrew/.linuxbrew/bin:…:/home/ubuntu/.nvm/versions/node/v24.18.1/bin:…
```

The gray `Portless` placeholder was assigned *inside* the failing gate, so the segment vanished completely rather than degrading to "no server here".

**2. When the gate did pass, a tick cost ~1.9s.**
`portless list` is a node spawn (254 ms), route ownership was one `lsof` per route (10 × 39 ms), and parsing used ~14 separate `python3` spawns at ~57 ms each — roughly 25 processes per tick.

**3. Claude Code aborts the in-flight statusline on every refresh.**
The refresh callback aborts the previous `AbortController` before starting the next run, behind a 300 ms trailing debounce, and an aborted run returns before emitting. Measured refresh cadence during active work is about once per second, settling to `refreshInterval` only when idle. A 1.9 s script is therefore killed every time, and the previously rendered line stays frozen on screen — which is exactly what "works sometimes" looked like.

## Fix

Read the Portless state straight from `~/.portless/routes.json` plus `proxy.port` / `proxy.tls`, so the CLI is never needed, and resolve route ownership through `/proc/<pid>/cwd` — which doubles as the liveness check a stale `routes.json` entry needs. The whole script collapses to one `python3` pass plus at most two `git` calls, and nothing touches the network in the foreground.

| | before | after |
|---|---|---|
| p50 | 1894 ms | **211 ms** |
| p95 | 1982 ms | **241 ms** |
| processes per tick | ~25 | 4 |

Same payload, same live system, n=25. A healthy tick now finishes inside the 300 ms debounce window instead of being killed at 1.9 s.

To be precise about the limit rather than overclaiming it: the two `git` calls share one 0.8 s deadline, so a repo whose `git` is pathologically slow still overshoots the debounce on the tick that discovers it. That tick is aborted — costing a frame, not correctness — and `spawn_git_warm` finishes the index refresh out of band so it does not recur.

Also fixed along the way:

- **The Jira and Teams segments no longer hang off a PR existing.** A failed `gh pr view` wrote an *empty* cache file, and the empty file then suppressed Jira and Teams for the full 300 s TTL while re-poisoning itself on every refresh. The PR lookup is gone; the Jira key renders on the first tick.
- **Background refreshers get their own session** via `start_new_session=True`. The abort is a SIGTERM to the whole process group, so the old `( … ) &disown` children died exactly when the cache needed warming. (Doing it in Python rather than through a `setsid(1)` binary keeps the path working on macOS, which does not ship one.)
- **The pid→cwd cache is gone.** It was keyed on pid alone with no liveness check, so pid reuse could point one worktree at another worktree's dev server.
- **The process-scan "route lost" fallback is removed, not ported.** It existed for the portless 0.10.x cleanup race, which is fixed upstream (FR-3443 / FR-3521); the failure we actually hit now is the opposite shape — `routes.json` is correct while the proxy's inode-bound `fs.watch` never picks the entry up, which a process scan cannot detect and `portless-doctor` already fixes. `routes.json` is the single source of truth, and a route missing from it renders the gray placeholder.
- `git` runs *without* `--no-optional-locks` so it may write the refreshed index back. Forbidding that made a stat-dirty tree re-hash on every tick forever — 1.6 s a tick against 60 ms once the index may be written.
- The Atlassian credential reaches `curl` through `--config` on stdin instead of argv.
- The worktree indicator renders an explicit dim `?` when a repo is found but its state cannot be read, instead of failing open as a green tick.
- The VS Code link falls back to the hostname when `SSH_CONNECTION` is absent (cc-daemon strips it), instead of emitting a `vscode://file` link telling the laptop to open a path that only exists on the dev box.
- Debug payload capture is opt-in via `CLAUDE_STATUSLINE_DEBUG`, off by default.

## Naming multiple dev servers

`n` servers started from the workspace root all rendered as the same green `Portless`, so nothing said which link went where. The representative route keeps the name; every extra one is reduced to the part of its subdomain that differs from it:

```
1 server    ✓  ⧉ VS Code  Portless  FR-3658 (In Review): …
3 servers   ⚠ uncommitted  ⧉ VS Code  Portless  +alt  +unrelated-preview  FR-3658 …
```

`+alt` is `fr-statusline-portless-alt` against a primary of `fr-statusline-portless`; a name that shares no prefix falls back to itself (`+unrelated-preview`). Sub-project routes keep their semantic labels (`Storybook` / `Docs` / `Release`). A session running a single server renders exactly as it did before, so the common case gains no ink.

The representative is the route whose subdomain matches the workspace directory — not whichever entry `routes.json` happens to list first, which was arbitrary.

Verified live with three real servers registered from one worktree:

| label | resolves to |
|---|---|
| `Portless` | `https://fr-statusline-portless.localhost:1357` |
| `+alt` | `https://fr-statusline-portless-alt.localhost:1357` |
| `+unrelated-preview` | `https://unrelated-preview.localhost:1357` |

## Verification

Everything below was run against the live system, with 10–11 real Portless routes registered across 9 different worktrees.

**End-to-end, same payload, same moment.** A real dev server was registered from this worktree (`statusline-probe`, owner cwd = the worktree) and confirmed serving (`curl` → HTTP 200):

```
old:  ✓  ⧉ VS Code
new:  ⚠ uncommitted  ⧉ VS Code  Portless→https://statusline-probe.localhost:1357  FR-3658 (To Do): …
```

- **No cross-worktree leakage.** With 10 live routes across 9 worktrees, a session in worktree A resolves exactly 1 URL — its own. A session in the main checkout resolves none of them and shows the gray placeholder.
- **Liveness.** Killing the probe flips the segment back to the gray placeholder on the next tick.
- **Jira path.** Tick 1 renders the key with no cache; the detached refresher fills status + summary by tick 2, proving it survives the process-group SIGTERM.
- **Graceful degradation.** `PORTLESS_STATE_DIR=/nonexistent` still prints both lines, rc=0, p95 232 ms.
- **No interference with the user's git.** 40 concurrent statusline ticks against the main checkout while 25 `git status` calls ran: 0 failures, 0 leftover `index.lock`.
- Independent agents re-ran a 16-row scenario matrix (16/16), fuzzed `routes.json` with 54 malformed shapes, attempted ANSI/OSC-8 injection through route hostnames and branch names, and killed `python3` six different ways — every path emits a non-empty two-line statusline at rc=0. 0 of 280 timed ticks exceeded 300 ms, including 8-way concurrency on an 8-core box.

## Copilot review

Copilot reviewed this as a draft and found five things, all of them real and all fixed in `1d575600d` — every one a defect that our Linux dev boxes could not have surfaced:

| Finding | Outcome |
|---|---|
| `proxy.tls` is an existence marker (`--no-tls` unlinks it), so reading its contents made every link `https` | Fixed; verified both ways against a synthetic state dir |
| `setsid(1)` is not on macOS, so the Jira and git-warm refreshers could never start there | Fixed; `start_new_session=True` already calls `setsid(2)` |
| The non-`/proc` path ran one `lsof` per route — the very bottleneck this PR removes | Fixed; one batched `lsof -p a,b,c` for the whole table |
| The two git timeouts were sequential, summing to 1.0 s against a stated 300 ms budget | Fixed; shared deadline, and the claim is now stated accurately |
| The route-lost fallback was removed but the description said it was kept | Description corrected — the removal is deliberate, see above |

Every thread is replied to and resolved. **Both these fixes and the multi-server naming above landed after that single review pass, so Copilot never saw them** — they are covered by the live verification below rather than by a second bot round.

## Note for reviewers

`.claude/scripts/statusline.sh` is read by each contributor's own Claude Code sessions, so this lands for everyone on merge. Sessions running in the main checkout keep the old script until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVhEwwuLyb529VUQo2LY67
