### PR TITLE
ci(FR-3659): deploy a per-PR Storybook preview and post a PR analysis report

### DIFF
--- a/.github/scripts/pr-preview/analyze-pr.mjs
+++ b/.github/scripts/pr-preview/analyze-pr.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Work out what a PR changed inside `packages/backend.ai-ui`, and map each
+// changed component onto the story entries that Storybook actually built for
+// it. The mapping is read out of the built `index.json` rather than guessed, so
+// a component whose stories live under a different title still resolves.
+//
+// Usage:
+//   node analyze-pr.mjs --base origin/main --head HEAD \
+//     --storybook-index <storybook-static/index.json> --output analysis.json
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const PKG_PREFIX = "packages/backend.ai-ui/";
+const SRC_PREFIX = `${PKG_PREFIX}src/`;
+const COMPONENT_PREFIX = `${SRC_PREFIX}components/`;
+
+const getArg = (name) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+};
+
+const base = getArg("base") ?? "origin/main";
+const head = getArg("head") ?? "HEAD";
+const indexPath = getArg("storybook-index");
+const output = getArg("output") ?? "analysis.json";
+
+const git = (args) =>
+  execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+
+// A three-dot diff reports only what the PR branch changed, ignoring commits
+// that landed on base meanwhile — that is the list we want. It needs a merge
+// base, which a shallow clone may not have once base has advanced past the
+// fetch window; deepen and retry before degrading. The two-dot fallback needs
+// no merge base but compares two trees, so it can both over-report base churn
+// and under-report a change that also exists on base. Callers get `diffMode` so
+// the report can say when the list is approximate.
+function changedFiles() {
+  // `--name-status` so a newly ADDED component can be told apart from a
+  // modified one; the report only flags missing stories for the former.
+  const parse = (raw) =>
+    raw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [status, ...rest] = line.split("\t");
+        // Renames are `R100\told\tnew` — the new path is what we care about.
+        return { status: status[0], file: rest[rest.length - 1] };
+      });
+
+  const threeDot = () =>
+    parse(git(["diff", "--name-status", `${base}...${head}`]));
+
+  try {
+    return { files: threeDot(), diffMode: "three-dot" };
+  } catch {
+    /* fall through to the deepen retry */
+  }
+
+  try {
+    const bareBase = base.replace(/^origin\//, "");
+    git([
+      "fetch",
+      "--deepen=200",
+      "origin",
+      `+refs/heads/${bareBase}:refs/remotes/origin/${bareBase}`,
+    ]);
+    return { files: threeDot(), diffMode: "three-dot" };
+  } catch {
+    /* fall through to the two-dot fallback */
+  }
+
+  try {
+    return {
+      files: parse(git(["diff", "--name-status", `${base}..${head}`])),
+      diffMode: "two-dot",
+    };
+  } catch (error) {
+    // A failed diff is not the same as "nothing changed" — publishing an empty
+    // analysis here would look legitimate and silently drop the whole report.
+    console.error(`::error::Could not diff ${base}..${head}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+const isGenerated = (file) => file.includes("/__generated__/");
+const isStory = (file) => file.endsWith(".stories.tsx");
+const isTest = (file) =>
+  file.endsWith(".test.tsx") || file.endsWith(".test.ts");
+
+/** `packages/backend.ai-ui/src/components/Foo.tsx` -> `./src/components/Foo.stories.tsx` */
+const storyImportPathFor = (file) =>
+  `./${file.slice(PKG_PREFIX.length).replace(/\.tsx$/, ".stories.tsx")}`;
+
+/** `./src/components/Foo.stories.tsx` -> `packages/backend.ai-ui/src/components/Foo.stories.tsx` */
+const repoPathForImport = (importPath) =>
+  `${PKG_PREFIX}${importPath.replace(/^\.\//, "")}`;
+
+function loadStoryEntries() {
+  if (!indexPath || !existsSync(indexPath)) return [];
+  const parsed = JSON.parse(readFileSync(indexPath, "utf8"));
+  return Object.values(parsed.entries ?? {});
+}
+
+const { files, diffMode } = changedFiles();
+const storyEntries = loadStoryEntries();
+const entriesByImportPath = new Map();
+for (const entry of storyEntries) {
+  const list = entriesByImportPath.get(entry.importPath) ?? [];
+  list.push(entry);
+  entriesByImportPath.set(entry.importPath, list);
+}
+
+// One row per changed component source file. A changed `*.stories.tsx` with no
+// matching component change gets its own row too, so a stories-only PR still
+// links into the preview.
+const rows = new Map();
+
+const addRow = (componentFile) => {
+  if (rows.has(componentFile)) return rows.get(componentFile);
+  const storyImportPath = storyImportPathFor(componentFile);
+  const entries = entriesByImportPath.get(storyImportPath) ?? [];
+  // Prefer the autodocs page — it shows every story of the component on one
+  // page, which is what a reviewer wants first. Fall back to the first story.
+  const preferred = entries.find((e) => e.type === "docs") ?? entries[0];
+  const row = {
+    name: componentFile
+      .split("/")
+      .pop()
+      .replace(/\.tsx$/, ""),
+    file: componentFile,
+    storyFile: entries.length > 0 ? repoPathForImport(storyImportPath) : null,
+    hasStories: entries.length > 0,
+    storyCount: entries.filter((e) => e.type === "story").length,
+    deepLink: preferred ? `?path=/${preferred.type}/${preferred.id}` : null,
+    sourceChanged: false,
+    storiesChanged: false,
+    isNew: false,
+  };
+  rows.set(componentFile, row);
+  return row;
+};
+
+for (const { status, file } of files) {
+  if (!file.startsWith(COMPONENT_PREFIX) || isGenerated(file) || isTest(file))
+    continue;
+  if (isStory(file)) {
+    addRow(file.replace(/\.stories\.tsx$/, ".tsx")).storiesChanged = true;
+  } else if (file.endsWith(".tsx")) {
+    const row = addRow(file);
+    row.sourceChanged = true;
+    row.isNew = status === "A";
+  }
+}
+
+const components = [...rows.values()].sort((a, b) =>
+  a.name.localeCompare(b.name),
+);
+
+// Every changed package file already represented by a component row.
+const accounted = new Set();
+for (const row of rows.values()) {
+  if (row.sourceChanged) accounted.add(row.file);
+  if (row.storiesChanged)
+    accounted.add(row.file.replace(/\.tsx$/, ".stories.tsx"));
+}
+
+const analysis = {
+  diffMode,
+  base,
+  head,
+  changedFileCount: files.length,
+  packageFileCount: files.filter(({ file }) => file.startsWith(PKG_PREFIX))
+    .length,
+  // A locale-only or hook-only change still deploys a preview; the report says
+  // so rather than pretending nothing happened.
+  otherPackageFiles: files
+    .map(({ file }) => file)
+    .filter(
+      (f) => f.startsWith(PKG_PREFIX) && !accounted.has(f) && !isGenerated(f),
+    ),
+  components,
+  summary: {
+    componentsChanged: components.filter((c) => c.sourceChanged).length,
+    // Only NEW components are counted as a gap. Plenty of pre-existing
+    // components — the Relay `fragments/` ones especially — have never had a
+    // story, and nagging about them on every unrelated edit trains reviewers to
+    // ignore the report.
+    newWithoutStories: components.filter((c) => c.isNew && !c.hasStories)
+      .length,
+    totalStories: storyEntries.filter((e) => e.type === "story").length,
+  },
+};
+
+writeFileSync(output, `${JSON.stringify(analysis, null, 2)}\n`);
+console.log(
+  `Analyzed ${files.length} changed files (${diffMode}); ` +
+    `${analysis.summary.componentsChanged} BUI components changed, ` +
+    `${analysis.summary.newWithoutStories} new one(s) without stories.`,
+);

--- a/.github/scripts/pr-preview/compact-gh-pages-history.sh
+++ b/.github/scripts/pr-preview/compact-gh-pages-history.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Squash gh-pages down to a single orphan commit.
+#
+# Every preview deploy and every cleanup adds a commit whose tree carries ~18 MB
+# of Storybook output per live PR. The history of those trees is worthless — only
+# the current tree is ever served — but it is what makes the branch grow without
+# bound in a repository that is already ~800 MB. Rewriting to one orphan commit
+# lets git drop every unreferenced blob on the next gc.
+#
+# Force-pushing a branch is normally off-limits here. gh-pages is the exception:
+# it holds no reviewed history, nobody branches from it, and the tree is
+# reproducible from CI. The rewrite keeps the tree byte-identical — it only
+# discards ancestry.
+set -euo pipefail
+
+BRANCH="${BRANCH:-gh-pages}"
+WORK="${WORK:-${RUNNER_TEMP:-/tmp}/gh-pages-compact}"
+# Below this, the rewrite costs more (a full force-push of the tree) than the
+# history it reclaims.
+MIN_COMMITS="${MIN_COMMITS:-10}"
+# REPO_URL is overridable so the logic can be exercised against a local bare
+# repository; CI leaves it unset and gets the token URL.
+if [ -z "${REPO_URL:-}" ]; then
+  REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+  REPO_URL="https://x-access-token:${TOKEN}@github.com/${REPO}.git"
+fi
+
+rm -rf "$WORK"
+git clone --branch "$BRANCH" "$REPO_URL" "$WORK" \
+  || { echo "No ${BRANCH} branch yet — nothing to compact."; exit 0; }
+
+cd "$WORK"
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+COMMITS="$(git rev-list --count HEAD)"
+echo "${BRANCH} has ${COMMITS} commit(s)."
+if [ "$COMMITS" -lt "$MIN_COMMITS" ]; then
+  echo "Fewer than ${MIN_COMMITS} — leaving history alone."
+  exit 0
+fi
+
+BEFORE="$(git count-objects -vH | awk '/size-pack/ {print $2 $3}')"
+
+git checkout --orphan compacted
+git add -A
+git commit -m "Compact ${BRANCH} history ($(date -u +%Y-%m-%d), was ${COMMITS} commits)"
+
+# The tree must be identical to what we cloned; a mismatch means the orphan
+# commit lost content and must not be pushed.
+if [ "$(git rev-parse compacted^{tree})" != "$(git rev-parse "origin/${BRANCH}^{tree}")" ]; then
+  echo "::error::Compacted tree differs from ${BRANCH} — refusing to force-push."
+  exit 1
+fi
+
+git push --force origin "compacted:${BRANCH}"
+echo "Compacted ${COMMITS} commits into 1 (pack size before rewrite: ${BEFORE})."

--- a/.github/scripts/pr-preview/compact-gh-pages-history.sh
+++ b/.github/scripts/pr-preview/compact-gh-pages-history.sh
@@ -34,8 +34,13 @@ cd "$WORK"
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
+# The tip we cloned. Everything below is asserted against exactly this commit,
+# and the push is leased to it, so a deploy or cleanup that lands while we work
+# makes the push fail instead of being erased by it.
+CLONED_TIP="$(git rev-parse HEAD)"
+
 COMMITS="$(git rev-list --count HEAD)"
-echo "${BRANCH} has ${COMMITS} commit(s)."
+echo "${BRANCH} has ${COMMITS} commit(s) at ${CLONED_TIP}."
 if [ "$COMMITS" -lt "$MIN_COMMITS" ]; then
   echo "Fewer than ${MIN_COMMITS} — leaving history alone."
   exit 0
@@ -47,12 +52,20 @@ git checkout --orphan compacted
 git add -A
 git commit -m "Compact ${BRANCH} history ($(date -u +%Y-%m-%d), was ${COMMITS} commits)"
 
-# The tree must be identical to what we cloned; a mismatch means the orphan
-# commit lost content and must not be pushed.
-if [ "$(git rev-parse compacted^{tree})" != "$(git rev-parse "origin/${BRANCH}^{tree}")" ]; then
-  echo "::error::Compacted tree differs from ${BRANCH} — refusing to force-push."
+# The tree must be identical to the commit we cloned; a mismatch means the
+# orphan commit lost content and must not be pushed.
+if [ "$(git rev-parse compacted^{tree})" != "$(git rev-parse "${CLONED_TIP}^{tree}")" ]; then
+  echo "::error::Compacted tree differs from ${CLONED_TIP} — refusing to force-push."
   exit 1
 fi
 
-git push --force origin "compacted:${BRANCH}"
+# --force-with-lease pinned to the cloned tip, NOT a bare --force. The deploy and
+# cleanup jobs run in different concurrency groups, so one of them can land a new
+# preview between our clone and this push; a bare force would delete it, and the
+# tree check above would not notice because it only ever saw the stale tip.
+# Failing here is correct — the next weekly run compacts the newer history.
+if ! git push --force-with-lease="${BRANCH}:${CLONED_TIP}" origin "compacted:${BRANCH}"; then
+  echo "::warning::${BRANCH} moved since the clone (a deploy or cleanup landed) — skipping compaction this run."
+  exit 0
+fi
 echo "Compacted ${COMMITS} commits into 1 (pack size before rewrite: ${BEFORE})."

--- a/.github/scripts/pr-preview/generate-pr-comment.mjs
+++ b/.github/scripts/pr-preview/generate-pr-comment.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+// Render the "PR Analysis Report" comment body from the artifacts CI produced.
+// Writes markdown to stdout; the calling workflow posts or updates it.
+//
+// Usage:
+//   node generate-pr-comment.mjs --analysis analysis.json --meta pr-meta.json \
+//     [--bundle-head bundle-head.json] [--bundle-base bundle-base.json]
+
+import { existsSync, readFileSync } from "node:fs";
+
+const getArg = (name) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+};
+
+const readJson = (path) =>
+  path && existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : null;
+
+const analysis = readJson(getArg("analysis"));
+const meta = readJson(getArg("meta"));
+const bundleHead = readJson(getArg("bundle-head"));
+const bundleBase = readJson(getArg("bundle-base"));
+
+if (!analysis || !meta) {
+  console.error("Missing analysis.json or pr-meta.json");
+  process.exit(1);
+}
+
+const kb = (bytes) => `${(bytes / 1024).toFixed(1)} kB`;
+const signed = (bytes) =>
+  `${bytes > 0 ? "+" : bytes < 0 ? "−" : "±"}${kb(Math.abs(bytes))}`;
+
+const link = (text, href) =>
+  `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+
+const out = [];
+out.push("## PR Analysis Report");
+out.push("");
+
+// ── Storybook preview ────────────────────────────────────────────────────────
+out.push("### 📚 Storybook Preview");
+out.push("");
+if (meta.storybookUrl) {
+  out.push(`**${link("View Storybook for this PR", meta.storybookUrl)}**`);
+  out.push("");
+  out.push(
+    "_GitHub Pages may take up to a minute to hydrate after the deploy._",
+  );
+} else {
+  out.push("_No preview was deployed for this run._");
+}
+out.push("");
+
+// ── Changed components ───────────────────────────────────────────────────────
+out.push("### 🧩 Changed Components");
+out.push("");
+// The table is the actionable part, so it holds only the components a reviewer
+// can actually open. Everything else goes below it, out of the way — a wall of
+// "no story, nothing to open" rows is what makes a report like this get ignored.
+const previewable = analysis.components.filter(
+  (c) => c.deepLink && meta.storybookUrl,
+);
+const unpreviewable = analysis.components.filter(
+  (c) => !c.deepLink || !meta.storybookUrl,
+);
+const MAX_ROWS = 30;
+
+// `components/BAIVFolderDeleteButton.tsx` and
+// `components/fragments/BAIVFolderDeleteButton.tsx` both exist. Disambiguate by
+// subdirectory, but only when a PR actually touches both — otherwise the bare
+// name reads better.
+const nameCounts = new Map();
+for (const c of analysis.components) {
+  nameCounts.set(c.name, (nameCounts.get(c.name) ?? 0) + 1);
+}
+const label = (c) => {
+  if (nameCounts.get(c.name) === 1) return c.name;
+  const rel = c.file.replace("packages/backend.ai-ui/src/components/", "");
+  return rel.replace(/\.tsx$/, "");
+};
+
+if (analysis.components.length === 0) {
+  out.push(
+    "_No component files changed in `packages/backend.ai-ui/src/components/`._",
+  );
+} else if (previewable.length === 0) {
+  out.push(
+    `_${analysis.components.length} component(s) changed, none of which has a ` +
+      "`*.stories.tsx` — nothing to open in the preview._",
+  );
+} else {
+  out.push("| Component | Changed | Stories | Open |");
+  out.push("|---|---|---|---|");
+  for (const c of previewable.slice(0, MAX_ROWS)) {
+    const changed = [
+      c.isNew ? "new" : c.sourceChanged && "source",
+      c.storiesChanged && "stories",
+    ]
+      .filter(Boolean)
+      .join(" + ");
+    out.push(
+      `| \`${label(c)}\` | ${changed} | ${c.storyCount} | ` +
+        `${link("Storybook ↗", `${meta.storybookUrl}${c.deepLink}`)} |`,
+    );
+  }
+  if (previewable.length > MAX_ROWS) {
+    out.push(`| _…and ${previewable.length - MAX_ROWS} more_ | | | |`);
+  }
+}
+out.push("");
+
+if (analysis.summary.newWithoutStories > 0) {
+  const names = analysis.components
+    .filter((c) => c.isNew && !c.hasStories)
+    .map((c) => `\`${label(c)}\``)
+    .join(", ");
+  out.push(
+    `> ⚠️ New component(s) without a \`*.stories.tsx\`: ${names}. They cannot appear ` +
+      "in the preview, and a story is the cheapest way to make a new component " +
+      "reviewable.",
+  );
+  out.push("");
+}
+
+if (unpreviewable.length > 0) {
+  out.push(
+    `<details><summary>${unpreviewable.length} changed component(s) with no story ` +
+      "to open</summary>",
+  );
+  out.push("");
+  for (const c of unpreviewable) out.push(`- \`${c.name}\` — \`${c.file}\``);
+  out.push("");
+  out.push("</details>");
+  out.push("");
+}
+
+if (analysis.otherPackageFiles.length > 0) {
+  const shown = analysis.otherPackageFiles.slice(0, 10);
+  out.push(
+    `<details><summary>${analysis.otherPackageFiles.length} other changed file(s) in ` +
+      "<code>packages/backend.ai-ui/</code></summary>",
+  );
+  out.push("");
+  for (const f of shown) out.push(`- \`${f}\``);
+  if (analysis.otherPackageFiles.length > shown.length) {
+    out.push(`- …and ${analysis.otherPackageFiles.length - shown.length} more`);
+  }
+  out.push("");
+  out.push("</details>");
+  out.push("");
+}
+
+// ── Bundle size ──────────────────────────────────────────────────────────────
+out.push("### 📦 Bundle Size");
+out.push("");
+if (!bundleHead) {
+  out.push("_Bundle was not measured for this run._");
+} else {
+  const baseByFile = new Map(
+    (bundleBase?.entries ?? []).map((e) => [e.file, e]),
+  );
+  const rows = bundleHead.entries.filter((e) => e.bytes >= 20 * 1024);
+  out.push(`| File | Size | Gzip |${bundleBase ? " Δ Gzip vs base |" : ""}`);
+  out.push(`|---|---|---|${bundleBase ? "---|" : ""}`);
+  for (const e of rows) {
+    const prev = baseByFile.get(e.file);
+    const delta = bundleBase
+      ? prev
+        ? ` ${prev.hash === e.hash ? "—" : signed(e.gzipBytes - prev.gzipBytes)} |`
+        : " 🆕 new |"
+      : "";
+    out.push(`| \`${e.file}\` | ${kb(e.bytes)} | ${kb(e.gzipBytes)} |${delta}`);
+  }
+  if (bundleBase) {
+    const totalHead = bundleHead.entries.reduce((n, e) => n + e.gzipBytes, 0);
+    const totalBase = bundleBase.entries.reduce((n, e) => n + e.gzipBytes, 0);
+    out.push("");
+    out.push(
+      `**Total gzip:** ${kb(totalHead)} (${signed(totalHead - totalBase)} vs \`${analysis.base}\`)`,
+    );
+  } else {
+    out.push("");
+    out.push(
+      "_No base measurement — the merge-base build was skipped " +
+        "(dependency changes, or the base build failed)._",
+    );
+  }
+}
+out.push("");
+
+if (analysis.diffMode === "two-dot") {
+  out.push(
+    "> ℹ️ The changed-file list came from a two-dot diff (no merge base was " +
+      "reachable in the shallow clone), so it may over- or under-report.",
+  );
+  out.push("");
+}
+
+out.push("---");
+out.push("");
+out.push(
+  `<sub>Generated by the PR Preview workflow · ${
+    meta.storybookUrl ? `${link("Storybook", meta.storybookUrl)} · ` : ""
+  }${link("CI run", meta.runUrl)}</sub>`,
+);
+
+console.log(out.join("\n"));

--- a/.github/scripts/pr-preview/measure-dist.mjs
+++ b/.github/scripts/pr-preview/measure-dist.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Measure the built `backend.ai-ui` bundle: raw + gzip bytes per top-level dist
+// entry. Run once for the PR head and once for the merge base; the PR comment
+// renders the delta between the two reports.
+//
+// Usage: node measure-dist.mjs --dist <dir> --output <file.json>
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const getArg = (name) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+};
+
+const distDir = getArg("dist");
+const output = getArg("output");
+if (!distDir || !output) {
+  console.error("usage: measure-dist.mjs --dist <dir> --output <file.json>");
+  process.exit(1);
+}
+
+// Only top-level emitted JS. Source maps and .d.ts do not ship to consumers,
+// and the per-locale chunks are noise next to the main bundle.
+const entries = readdirSync(distDir)
+  .filter((name) => name.endsWith(".js"))
+  .map((name) => {
+    const buf = readFileSync(join(distDir, name));
+    return {
+      file: name,
+      bytes: statSync(join(distDir, name)).size,
+      gzipBytes: gzipSync(buf, { level: 9 }).length,
+      hash: createHash("sha256").update(buf).digest("hex").slice(0, 12),
+    };
+  })
+  .sort((a, b) => b.bytes - a.bytes);
+
+writeFileSync(output, `${JSON.stringify({ entries }, null, 2)}\n`);
+console.log(`Measured ${entries.length} dist entries -> ${output}`);

--- a/.github/scripts/pr-preview/write-index.mjs
+++ b/.github/scripts/pr-preview/write-index.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Regenerate the gh-pages landing page from whatever `pr/<n>/` directories are
+// currently on disk. Both the deploy and the cleanup job call this after they
+// change the tree, so the index never claims a preview that is gone.
+//
+// Usage: node write-index.mjs --root <gh-pages checkout>
+
+import { existsSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const getArg = (name) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+};
+
+const root = getArg("root");
+if (!root) {
+  console.error("usage: write-index.mjs --root <dir>");
+  process.exit(1);
+}
+
+const prRoot = join(root, "pr");
+const previews = existsSync(prRoot)
+  ? readdirSync(prRoot)
+      .filter((name) => /^\d+$/.test(name))
+      .map(Number)
+      .sort((a, b) => b - a)
+  : [];
+
+const items = previews
+  .map(
+    (n) =>
+      `      <li><a href="./pr/${n}/storybook/">PR #${n}</a> ` +
+      `<a class="src" href="https://github.com/lablup/backend.ai-webui/pull/${n}">source ↗</a></li>`,
+  )
+  .join("\n");
+
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Backend.AI WebUI — PR previews</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        font: 16px/1.6 ui-sans-serif, system-ui, sans-serif;
+        margin: 0 auto; max-width: 42rem; padding: 3rem 1.5rem;
+      }
+      h1 { font-size: 1.4rem; margin-bottom: .25rem; }
+      p { color: color-mix(in srgb, currentColor 65%, transparent); margin-top: 0; }
+      ul { padding-left: 1.1rem; }
+      li { margin: .3rem 0; }
+      .src { font-size: .8em; opacity: .6; margin-left: .5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Backend.AI WebUI — Storybook previews</h1>
+    <p>
+      One build of <code>packages/backend.ai-ui</code> per open pull request.
+      Previews are removed when their PR is merged or closed.
+    </p>
+${previews.length > 0 ? `    <ul>\n${items}\n    </ul>` : "    <p>No live previews right now.</p>"}
+  </body>
+</html>
+`;
+
+writeFileSync(join(root, "index.html"), html);
+console.log(`Wrote index.html listing ${previews.length} preview(s).`);

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -137,9 +137,16 @@ jobs:
           exit 1
 
   compact:
+    # Sequenced after `cleanup`, never beside it. On a manual dispatch with
+    # compact=true the cleanup condition is also true, and two jobs cloning the
+    # same tip and pushing would race — the compaction would rewrite history
+    # that the cleanup had just changed. `always()` keeps this running on the
+    # weekly cron, where `cleanup` is skipped rather than run.
+    needs: [cleanup]
     if: >-
-      github.event.schedule == '17 9 * * 1' ||
-      github.event.inputs.compact == 'true'
+      always() &&
+      (needs.cleanup.result == 'success' || needs.cleanup.result == 'skipped') &&
+      (github.event.schedule == '17 9 * * 1' || github.event.inputs.compact == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,154 @@
+# Keep gh-pages bounded.
+#
+# Two independent chores, both cheap and both necessary because GitHub Pages has
+# a hard 1 GB published-site ceiling and this repository is already large:
+#
+#   cleanup  — delete `pr/<n>/` for every PR that is no longer open. At ~18 MB
+#              per preview and ~29% of PRs qualifying for one, the ~98 open PRs
+#              project to ~520 MB; without this the merged ones never leave.
+#   compact  — squash gh-pages history to a single orphan commit once a week, so
+#              the branch's *history* of those 18 MB trees stops growing the
+#              repository.
+#
+# The cleanup reconciles against the live open-PR list on every run, so it needs
+# no `closed` event to be correct — firing on any preview build (plus the daily
+# cron) is enough to garbage-collect.
+#
+# SAFETY: never checks out or runs PR-controlled code. It only edits gh-pages.
+
+name: PR Preview Cleanup
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily — reclaim closed PRs' previews
+    - cron: "17 9 * * 1" # Mondays — compact gh-pages history
+  workflow_run:
+    workflows: ["PR Preview"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be deleted without deleting it"
+        type: boolean
+        default: false
+      compact:
+        description: "Also squash gh-pages history"
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  # Deliberately its own group, not shared with the deploy: joining that group
+  # could cancel a pending deploy and leave the site stale. Races against a
+  # concurrent deploy are handled by the push retry instead.
+  group: pr-preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    # Skip on the weekly compaction cron — that fires the `compact` job instead.
+    if: >-
+      github.event_name != 'schedule' || github.event.schedule == '0 6 * * *'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Check out the maintenance scripts
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/pr-preview
+
+      - name: Remove previews for closed PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          WORK_DIR="$PWD"
+          PAGES_DIR="${RUNNER_TEMP}/gh-pages"
+          MAX_ATTEMPTS=5
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # One list for the whole run: an open PR that closes mid-run keeps its
+          # preview until tomorrow, which is the harmless direction to err in.
+          OPEN_PRS="$(gh pr list --repo "${{ github.repository }}" --state open --limit 500 --json number --jq '.[].number' | sort -u)"
+          echo "Open PRs: $(echo "$OPEN_PRS" | wc -w)"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt ${attempt} of ${MAX_ATTEMPTS}"
+            cd "$WORK_DIR"
+            rm -rf "$PAGES_DIR"
+
+            if ! git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" "$PAGES_DIR" 2>/dev/null; then
+              echo "No gh-pages branch — nothing to clean."
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            REMOVED=0
+            if [ -d "${PAGES_DIR}/pr" ]; then
+              for dir in "${PAGES_DIR}"/pr/*/; do
+                [ -d "$dir" ] || continue
+                n="$(basename "$dir")"
+                case "$n" in ''|*[!0-9]*) echo "Skipping non-numeric entry: $n"; continue ;; esac
+                if echo "$OPEN_PRS" | grep -qx "$n"; then continue; fi
+                SIZE="$(du -sh "$dir" | cut -f1)"
+                if [ "${DRY_RUN:-false}" = "true" ]; then
+                  echo "DRY RUN — would delete pr/${n} (${SIZE})"
+                else
+                  echo "Deleting pr/${n} (${SIZE}) — PR is not open."
+                  rm -rf "$dir"
+                  REMOVED=$((REMOVED + 1))
+                fi
+              done
+            fi
+
+            if [ "${DRY_RUN:-false}" = "true" ]; then
+              echo "Dry run complete; nothing was pushed."
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            node .github/scripts/pr-preview/write-index.mjs --root "$PAGES_DIR"
+
+            cd "$PAGES_DIR"
+            git add -A
+            git commit -m "Clean up ${REMOVED} stale PR preview(s)" \
+              || { echo "Nothing to clean up."; echo "::endgroup::"; exit 0; }
+
+            if git push origin gh-pages; then
+              echo "Removed ${REMOVED} preview(s) on attempt ${attempt}."
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push failed (likely a concurrent deploy); retrying in $((attempt * 2))s."
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to push the cleanup after ${MAX_ATTEMPTS} attempts."
+          exit 1
+
+  compact:
+    if: >-
+      github.event.schedule == '17 9 * * 1' ||
+      github.event.inputs.compact == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/pr-preview
+
+      - name: Compact gh-pages history
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/pr-preview/compact-gh-pages-history.sh

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -1,0 +1,236 @@
+# Publish what "PR Preview" built: deploy the Storybook preview to gh-pages and
+# post/update the PR Analysis Report comment.
+#
+# This is the PRIVILEGED half, and it runs on `workflow_run` rather than
+# `pull_request` on purpose. A `pull_request` workflow triggered from a fork gets
+# a read-only token: it cannot push to gh-pages and cannot comment, which is the
+# classic reason previews silently never appear for external contributors.
+# `workflow_run` runs from the base repository with the repo's own token, so fork
+# PRs and branch PRs go down one code path with no drift between them.
+#
+# SAFETY: nothing here checks out or executes PR-controlled code. It downloads
+# the static artifacts the build already produced and copies them into gh-pages.
+# Do not add a checkout of the PR head or a build step to this file.
+#
+# NOTE: `workflow_run` workflows only fire from the version on the default
+# branch, so this does nothing until it is merged to `main`.
+
+name: PR Preview Publish
+
+on:
+  workflow_run:
+    workflows: ["PR Preview"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  # Serialize per source branch (≈ per PR) so two pushes to the same PR don't
+  # race each other's gh-pages push. Cross-PR races are handled by the retry loop
+  # in the deploy step. Not cancel-in-progress: let an in-flight deploy finish.
+  group: pr-preview-publish-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      # On workflow_run, checkout defaults to the default branch — i.e. the
+      # reviewed copy of these scripts, never the PR's version of them.
+      - name: Check out the maintenance scripts
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/pr-preview
+
+      - name: Download analysis artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-preview-analysis
+          path: pr-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Parse PR metadata
+        id: parse
+        run: |
+          if [ ! -f pr-analysis/pr-meta.json ]; then
+            echo "No pr-meta.json — the build produced nothing to publish."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_NUMBER="$(jq -r '.prNumber // ""' pr-analysis/pr-meta.json)"
+          SHORT_HASH="$(jq -r '.shortHash // ""' pr-analysis/pr-meta.json)"
+
+          # These name a gh-pages path and an artifact. They come from a file the
+          # PR's own workflow wrote, so validate their shape before they reach a
+          # shell or a filesystem path.
+          echo "$PR_NUMBER" | grep -qE '^[0-9]+$' || { echo "::error::Bad PR number"; exit 1; }
+          echo "$SHORT_HASH" | grep -qE '^[0-9a-f]{7,40}$' || { echo "::error::Bad commit hash"; exit 1; }
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "short_hash=$SHORT_HASH" >> "$GITHUB_OUTPUT"
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Download Storybook artifact
+        if: steps.parse.outputs.deploy == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-preview-storybook-${{ steps.parse.outputs.short_hash }}
+          path: storybook-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # An expired or never-produced artifact is not a failure — a preview is
+        # best-effort. The check below turns it into a clean skip.
+        continue-on-error: true
+
+      - name: Verify the artifact is usable
+        id: verify
+        if: steps.parse.outputs.deploy == 'true'
+        run: |
+          if [ -d storybook-dist ] && [ -n "$(ls -A storybook-dist 2>/dev/null)" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Storybook artifact missing or empty — skipping the deploy for this run."
+          fi
+
+      - name: Deploy to gh-pages
+        if: steps.parse.outputs.deploy == 'true' && steps.verify.outputs.ready == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+        run: |
+          # A manual push with retry-on-conflict rather than a Pages action, so a
+          # concurrent cleanup or another PR's deploy just retries instead of
+          # failing the run.
+          set -euo pipefail
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          WORK_DIR="$PWD"
+          PAGES_DIR="${RUNNER_TEMP}/gh-pages"
+          MAX_ATTEMPTS=5
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt ${attempt} of ${MAX_ATTEMPTS}"
+            cd "$WORK_DIR"
+            rm -rf "$PAGES_DIR"
+
+            if git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" "$PAGES_DIR" 2>/dev/null; then
+              :
+            else
+              # First ever deploy: start the branch with no history to inherit.
+              echo "No gh-pages branch — creating it."
+              git init "$PAGES_DIR"
+              git -C "$PAGES_DIR" checkout -b gh-pages
+              git -C "$PAGES_DIR" remote add origin "$REPO_URL"
+              # Tell Pages not to run the content through Jekyll, which would
+              # drop Storybook's `_`-prefixed asset directories.
+              touch "$PAGES_DIR/.nojekyll"
+            fi
+
+            rm -rf "${PAGES_DIR}/pr/${PR_NUMBER}"
+            mkdir -p "${PAGES_DIR}/pr/${PR_NUMBER}/storybook"
+            cp -r storybook-dist/. "${PAGES_DIR}/pr/${PR_NUMBER}/storybook/"
+            touch "${PAGES_DIR}/.nojekyll"
+            node .github/scripts/pr-preview/write-index.mjs --root "$PAGES_DIR"
+
+            cd "$PAGES_DIR"
+            git add -A
+            git commit -m "Deploy PR #${PR_NUMBER} Storybook preview" \
+              || { echo "Nothing to commit."; echo "::endgroup::"; exit 0; }
+
+            if git push origin gh-pages; then
+              echo "Deployed on attempt ${attempt}."
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push failed (likely a concurrent update); retrying in $((attempt * 2))s."
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to deploy the PR preview after ${MAX_ATTEMPTS} attempts."
+          exit 1
+
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      # As above: default branch, and no setup-node — the report scripts use
+      # nothing beyond `node:fs` / `node:child_process`, so the runner image's
+      # preinstalled Node is enough and one fewer step has to go right.
+      - name: Check out the report scripts
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/pr-preview
+
+      - name: Download analysis artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-preview-analysis
+          path: pr-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Post or update the PR Analysis Report
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('node:fs');
+            const { execFileSync } = require('node:child_process');
+
+            if (!fs.existsSync('pr-analysis/analysis.json') ||
+                !fs.existsSync('pr-analysis/pr-meta.json')) {
+              core.info('No analysis artifact — nothing to report.');
+              return;
+            }
+
+            const meta = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
+            const prNumber = Number.parseInt(meta.prNumber, 10);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.warning('No usable PR number in the metadata — cannot comment.');
+              return;
+            }
+
+            const args = [
+              '.github/scripts/pr-preview/generate-pr-comment.mjs',
+              '--analysis', 'pr-analysis/analysis.json',
+              '--meta', 'pr-analysis/pr-meta.json',
+            ];
+            if (fs.existsSync('pr-analysis/bundle-head.json')) {
+              args.push('--bundle-head', 'pr-analysis/bundle-head.json');
+            }
+            if (fs.existsSync('pr-analysis/bundle-base.json')) {
+              args.push('--bundle-base', 'pr-analysis/bundle-base.json');
+            }
+
+            const body = execFileSync('node', args, { encoding: 'utf8' });
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes('PR Analysis Report'),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated the PR Analysis Report on #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              core.info(`Posted the PR Analysis Report on #${prNumber}.`);
+            }

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -12,6 +12,20 @@
 # the static artifacts the build already produced and copies them into gh-pages.
 # Do not add a checkout of the PR head or a build step to this file.
 #
+# SAFETY, the part that is easy to get wrong: **which PR this run is about is
+# never read from an artifact.** The build workflow runs from the PR's own head,
+# so on a fork PR its file — and therefore anything it writes — is written by the
+# contributor. If this job took the PR number from there, a fork could name
+# someone else's open PR and have this write-enabled job overwrite that PR's
+# preview or post the report on it. So both jobs resolve the number themselves
+# from `workflow_run.head_sha`, which GitHub sets, and derive the preview URL
+# from that. The only artifact fields used are measurements the report renders.
+#
+# Residual risk, inherent to any Pages-hosted preview: the Storybook bundle is
+# PR-controlled content, so a fork PR can publish arbitrary static files under
+# ITS OWN `/pr/<n>/` path on the org's github.io origin. Previews are for
+# reviewers, not a trusted origin — do not host anything privileged there.
+#
 # NOTE: `workflow_run` workflows only fire from the version on the default
 # branch, so this does nothing until it is merged to `main`.
 
@@ -38,6 +52,7 @@ jobs:
     permissions:
       contents: write
       actions: read
+      pull-requests: read
     steps:
       # On workflow_run, checkout defaults to the default branch — i.e. the
       # reviewed copy of these scripts, never the PR's version of them.
@@ -46,36 +61,40 @@ jobs:
         with:
           sparse-checkout: .github/scripts/pr-preview
 
-      - name: Download analysis artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: pr-preview-analysis
-          path: pr-analysis
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Parse PR metadata
+      - name: Resolve the PR from the trusted event payload
         id: parse
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ ! -f pr-analysis/pr-meta.json ]; then
-            echo "No pr-meta.json — the build produced nothing to publish."
+          set -euo pipefail
+          # `head_sha` is set by GitHub, not by the PR. Ask the API which pull
+          # request that commit belongs to; for a fork PR the commit is reachable
+          # in this repository via refs/pull/<n>/head, so this resolves there too.
+          echo "$HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || { echo "::error::Malformed head_sha"; exit 1; }
+
+          PRS="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" \
+                  --jq '[.[] | select(.state=="open") | .number] | unique')"
+          COUNT="$(echo "$PRS" | jq 'length')"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::warning::No open PR resolves from ${HEAD_SHA} — nothing to publish."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$COUNT" -gt 1 ]; then
+            # Two open PRs sharing a head commit: we cannot tell which preview
+            # this build was for, and guessing would write to the wrong one.
+            echo "::warning::${HEAD_SHA} resolves to multiple open PRs ($PRS) — refusing to guess."
             echo "deploy=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PR_NUMBER="$(jq -r '.prNumber // ""' pr-analysis/pr-meta.json)"
-          SHORT_HASH="$(jq -r '.shortHash // ""' pr-analysis/pr-meta.json)"
-
-          # These name a gh-pages path and an artifact. They come from a file the
-          # PR's own workflow wrote, so validate their shape before they reach a
-          # shell or a filesystem path.
-          echo "$PR_NUMBER" | grep -qE '^[0-9]+$' || { echo "::error::Bad PR number"; exit 1; }
-          echo "$SHORT_HASH" | grep -qE '^[0-9a-f]{7,40}$' || { echo "::error::Bad commit hash"; exit 1; }
-
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "short_hash=$SHORT_HASH" >> "$GITHUB_OUTPUT"
+          PR_NUMBER="$(echo "$PRS" | jq -r '.[0]')"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "short_hash=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
           echo "deploy=true" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${HEAD_SHA:0:7} to PR #${PR_NUMBER}."
 
       - name: Download Storybook artifact
         if: steps.parse.outputs.deploy == 'true'
@@ -192,23 +211,45 @@ jobs:
             const fs = require('node:fs');
             const { execFileSync } = require('node:child_process');
 
-            if (!fs.existsSync('pr-analysis/analysis.json') ||
-                !fs.existsSync('pr-analysis/pr-meta.json')) {
+            if (!fs.existsSync('pr-analysis/analysis.json')) {
               core.info('No analysis artifact — nothing to report.');
               return;
             }
 
-            const meta = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
-            const prNumber = Number.parseInt(meta.prNumber, 10);
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.warning('No usable PR number in the metadata — cannot comment.');
+            const { owner, repo } = context.repo;
+            const headSha = context.payload.workflow_run.head_sha;
+
+            // Same rule as the deploy job: the PR this run belongs to is
+            // resolved from the event's head SHA, never read out of an artifact
+            // the PR's own workflow wrote. Otherwise a fork could make this
+            // write-enabled job post its report on somebody else's PR.
+            const resolved = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: headSha,
+            });
+            const open = [...new Set(
+              resolved.data.filter((pr) => pr.state === 'open').map((pr) => pr.number),
+            )];
+            if (open.length !== 1) {
+              core.warning(
+                `${headSha} resolves to ${open.length} open PRs — not commenting.`,
+              );
               return;
             }
+            const prNumber = open[0];
+
+            // Everything the report needs that is not a measurement is derived
+            // here, from trusted values.
+            fs.writeFileSync('pr-meta.json', JSON.stringify({
+              prNumber: String(prNumber),
+              shortHash: headSha.slice(0, 7),
+              storybookUrl: `https://${owner}.github.io/${repo}/pr/${prNumber}/storybook/`,
+              runUrl: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.payload.workflow_run.id}`,
+            }));
 
             const args = [
               '.github/scripts/pr-preview/generate-pr-comment.mjs',
               '--analysis', 'pr-analysis/analysis.json',
-              '--meta', 'pr-analysis/pr-meta.json',
+              '--meta', 'pr-meta.json',
             ];
             if (fs.existsSync('pr-analysis/bundle-head.json')) {
               args.push('--bundle-head', 'pr-analysis/bundle-head.json');
@@ -219,7 +260,6 @@ jobs:
 
             const body = execFileSync('node', args, { encoding: 'utf8' });
 
-            const { owner, repo } = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: prNumber, per_page: 100,
             });

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,130 @@
+# Build the per-PR Storybook preview and the data behind the PR Analysis Report.
+#
+# This is the UNPRIVILEGED half. It runs on `pull_request`, so on a fork PR it
+# gets a read-only token and can neither push to gh-pages nor comment — which is
+# exactly why it does neither. It only produces artifacts; `pr-preview-publish.yml`
+# picks them up from the trusted `workflow_run` context and does the writing.
+#
+# Gated on `packages/backend.ai-ui/**` at event level: measured over the last 120
+# PRs, 35 (29%) touch it, so the other ~71% never start a runner.
+
+name: PR Preview
+
+on:
+  pull_request:
+    paths:
+      - packages/backend.ai-ui/**
+      - .github/workflows/pr-preview.yml
+      - .github/scripts/pr-preview/**
+
+permissions:
+  contents: read
+
+concurrency:
+  # Keyed by PR number, not branch name: branch names are unique only within a
+  # repository, so two fork PRs both using e.g. `patch-1` would share a group and
+  # cancel each other's runs.
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=6144
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Enough history for a three-dot diff against the base in the common
+          # case; analyze-pr.mjs deepens on its own when the base has moved past
+          # this window.
+          fetch-depth: 50
+
+      - name: Fetch base branch
+        run: git fetch --depth=50 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Build Storybook
+        working-directory: ./packages/backend.ai-ui
+        run: pnpm run build-storybook
+
+      - name: Compute preview paths
+        id: urls
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          SHORT_HASH="$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)"
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+
+          echo "short_hash=${SHORT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "storybook_url=https://${OWNER}.github.io/${REPO}/pr/${PR_NUMBER}/storybook/" >> "$GITHUB_OUTPUT"
+
+      - name: Analyze changed components
+        run: |
+          node .github/scripts/pr-preview/analyze-pr.mjs \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --storybook-index packages/backend.ai-ui/storybook-static/index.json \
+            --output analysis.json
+
+      - name: Build and measure the package bundle (head)
+        run: |
+          pnpm --filter backend.ai-ui build
+          node .github/scripts/pr-preview/measure-dist.mjs \
+            --dist packages/backend.ai-ui/dist \
+            --output bundle-head.json
+
+      # Rebuild the same package from the base's sources to get a comparable
+      # number. Only `src/` is swapped, so node_modules and the lockfile-resolved
+      # dependency graph stay put — which is also why this is skipped outright
+      # when the PR changes the lockfile: the two builds would not be comparable.
+      # Runs LAST, and best-effort: a failure here costs the delta column, nothing
+      # else.
+      - name: Build and measure the package bundle (base)
+        id: bundle-base
+        continue-on-error: true
+        run: |
+          if ! git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- pnpm-lock.yaml; then
+            echo "Lockfile changed — skipping the base build (not comparable)."
+            exit 0
+          fi
+          rm -rf packages/backend.ai-ui/src
+          git checkout "origin/${{ github.base_ref }}" -- packages/backend.ai-ui/src
+          pnpm --filter backend.ai-ui build
+          node .github/scripts/pr-preview/measure-dist.mjs \
+            --dist packages/backend.ai-ui/dist \
+            --output bundle-base.json
+
+      - name: Write PR metadata for the trusted jobs
+        run: |
+          # pr-preview-publish.yml runs on workflow_run, where the PR number and
+          # the preview URL are not in the event payload. Persist them here.
+          cat > pr-meta.json <<EOF
+          {
+            "prNumber": "${{ github.event.pull_request.number }}",
+            "shortHash": "${{ steps.urls.outputs.short_hash }}",
+            "storybookUrl": "${{ steps.urls.outputs.storybook_url }}",
+            "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+          EOF
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-preview-storybook-${{ steps.urls.outputs.short_hash }}
+          path: packages/backend.ai-ui/storybook-static/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload analysis artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-preview-analysis
+          path: |
+            analysis.json
+            pr-meta.json
+            bundle-head.json
+            bundle-base.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -49,16 +49,14 @@ jobs:
         working-directory: ./packages/backend.ai-ui
         run: pnpm run build-storybook
 
-      - name: Compute preview paths
+      # Only the artifact NAME is derived here, and only from the head SHA. The
+      # PR number and the preview URL are deliberately NOT passed downstream:
+      # this workflow runs from the PR's own head, so anything it writes is
+      # attacker-controlled on a fork PR. pr-preview-publish.yml re-derives both
+      # from the trusted `workflow_run` payload instead — see its header.
+      - name: Compute the artifact suffix
         id: urls
-        run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          SHORT_HASH="$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)"
-          OWNER="${{ github.repository_owner }}"
-          REPO="${{ github.event.repository.name }}"
-
-          echo "short_hash=${SHORT_HASH}" >> "$GITHUB_OUTPUT"
-          echo "storybook_url=https://${OWNER}.github.io/${REPO}/pr/${PR_NUMBER}/storybook/" >> "$GITHUB_OUTPUT"
+        run: echo "short_hash=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Analyze changed components
         run: |
@@ -76,17 +74,29 @@ jobs:
             --output bundle-head.json
 
       # Rebuild the same package from the base's sources to get a comparable
-      # number. Only `src/` is swapped, so node_modules and the lockfile-resolved
-      # dependency graph stay put — which is also why this is skipped outright
-      # when the PR changes the lockfile: the two builds would not be comparable.
-      # Runs LAST, and best-effort: a failure here costs the delta column, nothing
-      # else.
+      # number. Only `src/` is swapped, so node_modules stays put — which is also
+      # why the delta is abandoned outright when the PR touches anything else
+      # that feeds the build. Swapping only `src/` under a changed vite config or
+      # a changed dependency set would build the "base" with the HEAD's bundling,
+      # and report a delta (often a reassuring zero) that describes no real
+      # comparison. Runs LAST, and best-effort: a failure costs the delta column
+      # and nothing else.
       - name: Build and measure the package bundle (base)
         id: bundle-base
         continue-on-error: true
         run: |
-          if ! git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- pnpm-lock.yaml; then
-            echo "Lockfile changed — skipping the base build (not comparable)."
+          BUILD_INPUTS=(
+            pnpm-lock.yaml
+            pnpm-workspace.yaml
+            package.json
+            packages/backend.ai-ui/package.json
+            packages/backend.ai-ui/vite.config.ts
+            packages/backend.ai-ui/tsconfig.json
+            relay.config.js
+          )
+          if ! git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- "${BUILD_INPUTS[@]}"; then
+            echo "A build input outside src/ changed — skipping the base build (not comparable)."
+            git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- "${BUILD_INPUTS[@]}"
             exit 0
           fi
           rm -rf packages/backend.ai-ui/src
@@ -95,19 +105,6 @@ jobs:
           node .github/scripts/pr-preview/measure-dist.mjs \
             --dist packages/backend.ai-ui/dist \
             --output bundle-base.json
-
-      - name: Write PR metadata for the trusted jobs
-        run: |
-          # pr-preview-publish.yml runs on workflow_run, where the PR number and
-          # the preview URL are not in the event payload. Persist them here.
-          cat > pr-meta.json <<EOF
-          {
-            "prNumber": "${{ github.event.pull_request.number }}",
-            "shortHash": "${{ steps.urls.outputs.short_hash }}",
-            "storybookUrl": "${{ steps.urls.outputs.storybook_url }}",
-            "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }
-          EOF
 
       - name: Upload Storybook artifact
         uses: actions/upload-artifact@v7
@@ -123,7 +120,6 @@ jobs:
           name: pr-preview-analysis
           path: |
             analysis.json
-            pr-meta.json
             bundle-head.json
             bundle-base.json
           if-no-files-found: error


### PR DESCRIPTION
Resolves #9035 (FR-3659)

Ports the PR-preview / PR-analysis-report pattern from [`facebook/astryx`'s CI](https://github.com/facebook/astryx/blob/main/.github/workflows/ci.yml) to this repository.

## What a reviewer gets

Every PR that touches `packages/backend.ai-ui/**` now gets:

1. **A Storybook preview** at `https://lablup.github.io/backend.ai-webui/pr/<n>/storybook/`.
2. **A "PR Analysis Report" comment** — posted once and updated in place on every push — with the preview link, a table of changed BUI components that deep-links each one straight to its story, a flag for **new** components shipped without a `*.stories.tsx`, and the `backend.ai-ui` bundle size with a gzip delta against the merge base.

Today, seeing a BUI component change means checking the branch out and running `pnpm storybook`. This removes that step, including for fork PRs.

Sample rendering (generated locally against a real 3-commit range):

```
## PR Analysis Report

### 📚 Storybook Preview
**View Storybook for this PR**

### 🧩 Changed Components
| Component | Changed | Stories | Open |
|---|---|---|---|
| `BAIComplexSelect`  | stories          | 6 | Storybook ↗ |
| `BAITable`          | source           | 9 | Storybook ↗ |
| `BAIUserSelect`     | source + stories | 4 | Storybook ↗ |

<details><summary>29 changed component(s) with no story to open</summary> … </details>

### 📦 Bundle Size
| File | Size | Gzip | Δ Gzip vs base |
|---|---|---|---|
| `backend.ai-ui.js` | 1912.5 kB | 466.8 kB | +1.2 kB |
```

## Where it runs, and what it costs

Nothing is self-hosted. Both halves ride GitHub's free tier for public repositories:

- **Compute** — GitHub-hosted standard runners. Per GitHub's billing docs: *"GitHub Actions usage is free for self-hosted runners and for public repositories that use standard GitHub-hosted runners."* Artifact and cache storage are free for public repositories too. This repository is public, so the added CI costs **$0**.
- **Hosting** — GitHub Pages from a `gh-pages` branch. Free; no origin server, no CDN bill.

Measured on this repository (2026-08-24), not estimated:

| Quantity | Measured |
|---|---|
| `pnpm build-storybook` | **1m 26s** wall, peak RSS 3.0 GB |
| Storybook output | **18 MB**, 853 files |
| `backend.ai-ui` `pnpm build` | **44s** (run twice: head + merge base) |
| Added wall time per qualifying PR | **≈ 3.5 min**, on its own runner, off the critical path |
| PRs opened in the last 7 days | 94 |
| Open PRs at time of writing | 98 |
| Of the last 120 PRs, touching `packages/backend.ai-ui/src/**` | **35 (29%)** |

The binding constraints are GitHub Pages' soft limits — **1 GB published site**, 100 GB/month bandwidth, 10 builds/hour — not money. At 18 MB per preview with ~29% of PRs qualifying, the ~98 open PRs project to **≈ 29 live previews ≈ 520 MB**: inside the 1 GB ceiling, but not with room to be careless. So the cost controls are part of this PR rather than a follow-up:

- **Event-level `paths:` gate** on `packages/backend.ai-ui/**`, so the other ~71% of PRs never start a runner.
- **Cleanup** reconciles the on-disk `pr/<n>/` directories against the live open-PR list, daily and after every preview build — a merged PR's 18 MB is reclaimed without needing a `closed` event.
- **Weekly compaction** squashes `gh-pages` to a single orphan commit, so the *history* of those trees stops growing an already ~800 MB repository.
- The build's concurrency group is `cancel-in-progress`, so rapid pushes to one PR produce **one** deploy, not one per push — which is also what keeps us clear of the 10-builds/hour Pages limit on a busy afternoon.

## How it is wired

```
pull_request  ──▶ PR Preview (build)          read-only token, may run PR code
                    ├─ storybook-static/      ─┐
                    ├─ analysis.json          ─┤ artifacts
                    └─ bundle-{head,base}.json─┘
                              │
workflow_run  ──▶ PR Preview Publish          write token, never runs PR code
                    ├─ deploy  → gh-pages/pr/<n>/storybook/
                    └─ comment → PR Analysis Report

schedule/workflow_run ──▶ PR Preview Cleanup
                    ├─ cleanup (daily)  → drop previews of non-open PRs
                    └─ compact (Mondays) → squash gh-pages history
```

The split is the important part. A `pull_request` workflow triggered from a fork gets a **read-only** token, so it can neither push to `gh-pages` nor comment — the classic reason previews silently never appear for external contributors. Everything privileged therefore runs on `workflow_run`, from the base repository with the repo's own token, and **never checks out or executes PR-controlled code**: it only downloads the static artifacts the build already produced. Fork PRs and branch PRs go down one code path with no drift between them.

**Which PR a run is about is never read from an artifact.** The build workflow runs from the PR's own head, so on a fork PR its file — and anything it writes — is written by the contributor; a PR number taken from there could name someone *else's* open PR and have the write-enabled jobs overwrite that preview or post the report on it. Both jobs therefore resolve the number themselves from `workflow_run.head_sha` (which GitHub sets) via `commits/{sha}/pulls`, and derive the preview URL from the result. A SHA mapping to zero or several open PRs is skipped, not guessed at. The artifacts carry only measurements.

Residual risk, inherent to any Pages-hosted preview and worth stating plainly: the Storybook bundle is PR-controlled content, so a fork PR can publish arbitrary static files under **its own** `/pr/<n>/` path on the org's `github.io` origin. Previews are for reviewers; nothing privileged should be hosted on that origin.

## Deliberately out of scope

**No sandbox preview** (astryx's second preview — a deployment of the app itself). `react/vite.config.ts` hardcodes `base: '/'`, and the app's assets are assembled outside Vite's control by the root `copyresource` / `copymonaco` / `copyconfig` scripts, all emitting root-absolute paths. Serving from `/backend.ai-webui/pr/<n>/app/` needs every one of those made base-path aware, plus a decision about which API endpoint a public preview may point at. That is its own ticket, not a CI change.

**No docs preview**, rejected on measured size: `packages/backend.ai-webui-docs/` is 167 MB across 1549 images, so ~22 concurrent docs previews would be ~3.3 GB — over the Pages ceiling on their own.

## ⚠️ Manual prerequisites (a maintainer must do these)

1. **Enable GitHub Pages** on this repository: Settings → Pages → Source = *Deploy from a branch* → `gh-pages` / `/` (root). The branch does not exist yet; the first deploy creates it, so Pages can be pointed at it either before or right after the first preview build.
2. Merging is what activates it. `workflow_run` workflows only fire from the copy on the **default branch**, so `PR Preview Publish` and `PR Preview Cleanup` do nothing until this lands on `main`. The build half (`PR Preview`) will run on this PR and upload its artifacts, but no preview is deployed and no comment is posted until then.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, StyleX cssInjectionTarget, Astryx theme build, z-index ladder mirrors, Terminology).
- **The build half ran green on this very PR** — [run 32789270929](https://github.com/lablup/backend.ai-webui/actions/runs/32789270929), `build` in **2m 1s**, every step ✓ including the head *and* base bundle measurements. The PR's own `paths:` gate caught it because it touches `.github/workflows/pr-preview.yml` and `.github/scripts/pr-preview/**`. `PR Preview Publish` correctly did **not** fire: `workflow_run` needs the workflow on `main` first, as documented above.
- The uploaded artifacts were downloaded and fed back through `generate-pr-comment.mjs`. It renders `prNumber: 9036`, the right preview URL, "No component files changed" (correct — this PR touches no BUI source), and a `—` bundle delta because the head and base builds hashed identically (also correct, and it exercises the hash-equality path).
- `prettier --check` clean on every added file.
- The two shell surfaces were smoke-tested locally against a bare repository standing in for `origin`, covering: first-ever deploy (branch creation), a second PR's deploy, an idempotent redeploy, index regeneration, cleanup reconciliation, repeat cleanup, the below-threshold compaction no-op, and a real compaction — asserting that the squashed tree is **byte-identical** to the pre-rewrite tree.
- `analyze-pr.mjs` and `generate-pr-comment.mjs` were run end to end against real repository history and a real `storybook-static/index.json` (579 entries), which is where the sample above comes from. The component → story mapping is read out of the built index rather than guessed, so it survives components whose stories sit under a different title; spot-checked against `BAIBadgeCount` / `BAIPopconfirm` / `BAIDrawer`, which genuinely have no stories and are correctly reported as such.

## Review

Copilot reviewed this as a draft and raised 5 findings. All 5 were correct and all 5 are fixed in `67b59f7e4`; every thread has a reply saying what changed, and none is left open.

| Finding | Fix |
|---|---|
| The publish jobs trusted the PR number from `pr-meta.json`, which a fork PR writes — so a fork could overwrite another PR's preview, or post the report on it (2 threads) | Deleted the hand-off. Both jobs resolve the PR from `workflow_run.head_sha`; artifacts carry only measurements |
| Compaction's bare `git push --force` erased a deploy that landed after the clone, and the tree assertion could not notice because it only ever saw the stale tip | `--force-with-lease` pinned to the cloned tip; a moved branch skips the run with a warning |
| A manual dispatch with `compact=true` also satisfies the cleanup condition, so both jobs raced the same tip | `compact` now `needs: [cleanup]`, gated with `always()` so the weekly cron still works |
| The base bundle build swapped only `src/`, so a PR changing vite config or dependencies built its "base" with the head's bundling and reported a delta that compared nothing | The delta is abandoned when any of 7 build inputs outside `src/` changed, not just the lockfile |

The fixes landed **after** the review, so Copilot never saw them; they are covered by `verify.sh` and by a new smoke-test case instead — with a concurrent deploy landing after the clone, the compaction push is refused and that deploy survives, and the next clean run still squashes to one commit with a byte-identical tree.
