### PR TITLE
feat(FR-3668): redesign scheduling-history sub-steps as a compact inline table and open the modals full screen

### DIFF
--- a/e2e/session/session-scheduling-history-modal.spec.ts
+++ b/e2e/session/session-scheduling-history-modal.spec.ts
@@ -715,7 +715,9 @@ test.describe(
       // 3. Click the expand icon/arrow on that row
       await expandableRow.getByLabel('Expand row').click();
 
-      // 4. Verify the sub-steps table columns are visible
+      // 4. Verify the sub-steps table columns are visible.
+      // The sub-step panel carries one Time column (the step's start) plus a
+      // Duration, not the Started At / Ended At pair it used to show.
       await expect(
         modal.getByRole('columnheader', { name: 'Step' }),
       ).toBeVisible();
@@ -729,10 +731,10 @@ test.describe(
         modal.getByRole('columnheader', { name: 'Error Code' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'Started At' }),
+        modal.getByRole('columnheader', { name: 'Duration' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'Ended At' }),
+        modal.getByRole('columnheader', { name: 'Time' }),
       ).toBeVisible();
 
       // 5. Verify at least one sub-step row is visible.
@@ -903,10 +905,10 @@ test.describe(
         modal.getByRole('columnheader', { name: 'Step' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'Started At' }),
+        modal.getByRole('columnheader', { name: 'Duration' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'Ended At' }),
+        modal.getByRole('columnheader', { name: 'Time' }),
       ).toBeVisible();
 
       // 7. Verify sub-step data is displayed.

--- a/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f04a8d6c2c26a9be4969f98eb55bd6f7>>
+ * @generated SignedSource<<e257031e6c51a22bec3ff54d78bd9dda>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,8 +13,10 @@ export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" 
 import { FragmentRefs } from "relay-runtime";
 export type BAIDeploymentSchedulingHistoryTableFragment$data = ReadonlyArray<{
   readonly id: string;
+  readonly phase: string;
   readonly result: SchedulingResult;
   readonly subSteps: ReadonlyArray<{
+    readonly step: string;
     readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
   }>;
   readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentSchedulingHistoryNodesFragment">;
@@ -44,6 +46,13 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "phase",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "result",
       "storageKey": null
     },
@@ -55,6 +64,13 @@ const node: ReaderFragment = {
       "name": "subSteps",
       "plural": true,
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "step",
+          "storageKey": null
+        },
         {
           "args": null,
           "kind": "FragmentSpread",
@@ -73,6 +89,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "72a9b8118e4f52a97c2ab8996996098d";
+(node as any).hash = "79396228ec9d200868dba2c92535e4b0";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<62e9f5ee291e0755eee6a0c3ad8898e4>>
+ * @generated SignedSource<<dbec63862c8e832e12c816fb9071797b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,8 +13,10 @@ export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" 
 import { FragmentRefs } from "relay-runtime";
 export type BAIRouteSchedulingHistoryTableFragment$data = ReadonlyArray<{
   readonly id: string;
+  readonly phase: string;
   readonly result: SchedulingResult;
   readonly subSteps: ReadonlyArray<{
+    readonly step: string;
     readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
   }>;
   readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodeTableFragment">;
@@ -44,6 +46,13 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "phase",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "result",
       "storageKey": null
     },
@@ -55,6 +64,13 @@ const node: ReaderFragment = {
       "name": "subSteps",
       "plural": true,
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "step",
+          "storageKey": null
+        },
         {
           "args": null,
           "kind": "FragmentSpread",
@@ -73,6 +89,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "7f5f32e6a4ea10ddfc54ff01c8b260b2";
+(node as any).hash = "fb72214c9f69e04160057fd7338e8ea7";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<78437bb97e2f6f7f9ff2eadc98f408cd>>
+ * @generated SignedSource<<fab0436457253611a585c705dff3f5f6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,8 +13,10 @@ export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" 
 import { FragmentRefs } from "relay-runtime";
 export type BAISchedulingHistoryTableFragment$data = ReadonlyArray<{
   readonly id: string;
+  readonly phase: string;
   readonly result: SchedulingResult;
   readonly subSteps: ReadonlyArray<{
+    readonly step: string;
     readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
   }>;
   readonly " $fragmentSpreads": FragmentRefs<"BAISchedulingHistoryNodesFragment">;
@@ -44,6 +46,13 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "phase",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "result",
       "storageKey": null
     },
@@ -55,6 +64,13 @@ const node: ReaderFragment = {
       "name": "subSteps",
       "plural": true,
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "step",
+          "storageKey": null
+        },
         {
           "args": null,
           "kind": "FragmentSpread",
@@ -73,6 +89,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "cc812aab73e7155ba3bc061806f997dd";
+(node as any).hash = "e369227c362b363c91d9f366ac98634d";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -271,6 +271,12 @@ export interface BAIModalProps {
   /* ------------------------------------------------------------ dimensions */
   width?: number | string | BAIModalResponsiveWidth;
   maxHeight?: number | string;
+  /**
+   * `'fullscreen'` fills the viewport and makes `width` / `maxHeight` inert.
+   * It is the only way to reach edge-to-edge: Astryx caps the standard dialog
+   * at `maxWidth: 90vw`, so `width="90%"` and `width="100%"` render alike.
+   */
+  variant?: 'standard' | 'fullscreen';
 
   /* -------------------------------------------------------- window actions */
   /** When non-empty, window controls are rendered in the header. */
@@ -377,6 +383,7 @@ const BAIModal: React.FC<BAIModalProps> = ({
   mask,
   width = 520,
   maxHeight,
+  variant,
   windowActions,
   onWindowStateChange,
   minimizedPlacement = 'bottomRight',
@@ -487,7 +494,8 @@ const BAIModal: React.FC<BAIModalProps> = ({
   const showClose = closable !== false && closeIcon !== false;
 
   // ----------------------------------------------------------- window sizing
-  const isFullscreen = effectiveWindowState === 'fullscreen';
+  const isFullscreen =
+    variant === 'fullscreen' || effectiveWindowState === 'fullscreen';
   const isMaximized = effectiveWindowState === 'maximized';
   const isMinimized = effectiveWindowState === 'minimized';
 

--- a/packages/backend.ai-ui/src/components/BAISchedulingResultBadge.tsx
+++ b/packages/backend.ai-ui/src/components/BAISchedulingResultBadge.tsx
@@ -18,7 +18,12 @@ export interface BAISchedulingResultBadgeProps extends Omit<
   result: SchedulingResult | null;
 }
 
-const resultSemanticMap: Record<SchedulingResult, SemanticColor> = {
+/**
+ * The one semantic mapping for a scheduling result. Exported so anything that
+ * draws a result alongside the badge (the sub-step timeline's rail dots) picks
+ * the same colour instead of inventing a second language.
+ */
+export const resultSemanticColorMap: Record<SchedulingResult, SemanticColor> = {
   SUCCESS: 'success',
   FAILURE: 'error',
   STALE: 'default',
@@ -33,7 +38,9 @@ const BAISchedulingResultBadge = ({
   ...badgeProps
 }: BAISchedulingResultBadgeProps) => {
   'use memo';
-  const semanticColor = result ? _.get(resultSemanticMap, result) : undefined;
+  const semanticColor = result
+    ? _.get(resultSemanticColorMap, result)
+    : undefined;
 
   return (
     <BAIBadge

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -682,6 +682,15 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   const expandedKeySet = new Set(_.map(expandedKeys, String));
 
   const hasExpandable = !!expandable?.expandedRowRender;
+  const expandColumnWidth =
+    expandable?.columnWidth ??
+    (rowSelection
+      ? EXPAND_COLUMN_WIDTH_AFTER_SELECTION
+      : EXPAND_COLUMN_WIDTH_FIRST);
+  /** Detail rows start where the first data column does: past the selection
+   * and chevron columns. */
+  const detailInsetStart =
+    (rowSelection ? SELECTION_COLUMN_WIDTH : 0) + expandColumnWidth;
 
   const toggleExpanded = (key: string) => {
     const next = expandedKeySet.has(key)
@@ -733,12 +742,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
       built.push({
         key: EXPAND_COLUMN_KEY,
         header: expandable?.columnTitle ?? '',
-        width: pixel(
-          expandable?.columnWidth ??
-            (rowSelection
-              ? EXPAND_COLUMN_WIDTH_AFTER_SELECTION
-              : EXPAND_COLUMN_WIDTH_FIRST),
-        ),
+        width: pixel(expandColumnWidth),
         resizable: false,
         renderCell: (item) => {
           if (isDetailRow(item)) return null;
@@ -1135,7 +1139,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
             colSpan={renderedColumnCount}
             style={{
               padding: token.paddingSM,
-              background: token.colorFillQuaternary,
+              paddingInlineStart: detailInsetStart,
             }}
           >
             {expandable?.expandedRowRender?.(record, index)}

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryTable.tsx
@@ -8,8 +8,7 @@ import BAIDeploymentSchedulingHistoryNodes, {
   BAIDeploymentSchedulingHistoryNodesProps,
   DeploymentSchedulingHistoryNodeInList,
 } from './BAIDeploymentSchedulingHistoryNodes';
-import BAISubStepNodes from './BAISubStepNodes';
-import * as _ from 'lodash-es';
+import BAISubStepNodes, { countExecutedSubSteps } from './BAISubStepNodes';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAIDeploymentSchedulingHistoryTableProps extends Omit<
@@ -40,8 +39,12 @@ const BAIDeploymentSchedulingHistoryTable = ({
       fragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory
       @relay(plural: true) {
         id
+        phase
         result
         subSteps {
+          # Read alongside the spread so the table can tell a row that holds
+          # only the trailing lifecycle marker from one with real sub-steps.
+          step
           ...BAISubStepNodesFragment
         }
         ...BAIDeploymentSchedulingHistoryNodesFragment
@@ -55,6 +58,8 @@ const BAIDeploymentSchedulingHistoryTable = ({
     useSchedulingHistoryExpandable(dataSource, {
       mode: expandMode,
       onModeChange: onExpandModeChange,
+      isExpandable: (record) =>
+        countExecutedSubSteps(record.subSteps ?? [], record.phase) > 0,
     });
 
   return (
@@ -65,12 +70,16 @@ const BAIDeploymentSchedulingHistoryTable = ({
         expandedRowKeys,
         onExpandedRowsChange,
         rowExpandable: (record: DeploymentSchedulingHistoryNodeInList) =>
-          !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
+          countExecutedSubSteps(
+            dataSource.find((h) => h.id === record.id)?.subSteps ?? [],
+            record.phase,
+          ) > 0,
         expandedRowRender: (record: DeploymentSchedulingHistoryNodeInList) => (
           <BAISubStepNodes
             subStepsFrgmt={
               dataSource.find((h) => h.id === record.id)?.subSteps ?? []
             }
+            parentPhase={record.phase}
           />
         ),
       }}

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryTable.tsx
@@ -68,11 +68,9 @@ const BAIDeploymentSchedulingHistoryTable = ({
           !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
         expandedRowRender: (record: DeploymentSchedulingHistoryNodeInList) => (
           <BAISubStepNodes
-            resizable
             subStepsFrgmt={
               dataSource.find((h) => h.id === record.id)?.subSteps ?? []
             }
-            pagination={false}
           />
         ),
       }}

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryTable.tsx
@@ -68,11 +68,9 @@ const BAIRouteSchedulingHistoryTable = ({
           !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
         expandedRowRender: (record: RouteSchedulingHistoryNodeInList) => (
           <BAISubStepNodes
-            resizable
             subStepsFrgmt={
               dataSource.find((h) => h.id === record.id)?.subSteps ?? []
             }
-            pagination={false}
           />
         ),
       }}

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryTable.tsx
@@ -8,8 +8,7 @@ import BAIRouteSchedulingHistoryNodeTable, {
   BAIRouteSchedulingHistoryNodesProps,
   RouteSchedulingHistoryNodeInList,
 } from './BAIRouteSchedulingHistoryNodeTable';
-import BAISubStepNodes from './BAISubStepNodes';
-import * as _ from 'lodash-es';
+import BAISubStepNodes, { countExecutedSubSteps } from './BAISubStepNodes';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAIRouteSchedulingHistoryTableProps extends Omit<
@@ -40,8 +39,12 @@ const BAIRouteSchedulingHistoryTable = ({
       fragment BAIRouteSchedulingHistoryTableFragment on RouteHistory
       @relay(plural: true) {
         id
+        phase
         result
         subSteps {
+          # Read alongside the spread so the table can tell a row that holds
+          # only the trailing lifecycle marker from one with real sub-steps.
+          step
           ...BAISubStepNodesFragment
         }
         ...BAIRouteSchedulingHistoryNodeTableFragment
@@ -55,6 +58,8 @@ const BAIRouteSchedulingHistoryTable = ({
     useSchedulingHistoryExpandable(dataSource, {
       mode: expandMode,
       onModeChange: onExpandModeChange,
+      isExpandable: (record) =>
+        countExecutedSubSteps(record.subSteps ?? [], record.phase) > 0,
     });
 
   return (
@@ -65,12 +70,16 @@ const BAIRouteSchedulingHistoryTable = ({
         expandedRowKeys,
         onExpandedRowsChange,
         rowExpandable: (record: RouteSchedulingHistoryNodeInList) =>
-          !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
+          countExecutedSubSteps(
+            dataSource.find((h) => h.id === record.id)?.subSteps ?? [],
+            record.phase,
+          ) > 0,
         expandedRowRender: (record: RouteSchedulingHistoryNodeInList) => (
           <BAISubStepNodes
             subStepsFrgmt={
               dataSource.find((h) => h.id === record.id)?.subSteps ?? []
             }
+            parentPhase={record.phase}
           />
         ),
       }}

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
@@ -160,7 +160,7 @@ const BAISchedulingHistoryNodes = ({
   return (
     // to-astryx ticket 25: migrated to the Astryx engine — this is the
     // expandable-row proving ground (`expandable` arrives from
-    // `BAISchedulingHistoryTable` and renders a nested `BAISubStepNodes`).
+    // `BAISchedulingHistoryTable` and renders the `BAISubStepNodes` timeline).
     <BAITable
       rowKey={'id'}
       dataSource={filterOutNullAndUndefined(histories)}

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryTable.tsx
@@ -8,8 +8,7 @@ import BAISchedulingHistoryNodes, {
   BAISchedulingHistoryNodesProps,
   SchedulingHistoryNodeInList,
 } from './BAISchedulingHistoryNodes';
-import BAISubStepNodes from './BAISubStepNodes';
-import * as _ from 'lodash-es';
+import BAISubStepNodes, { countExecutedSubSteps } from './BAISubStepNodes';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAISchedulingHistoryTableProps extends Omit<
@@ -40,8 +39,12 @@ const BAISchedulingHistoryTable = ({
       fragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory
       @relay(plural: true) {
         id
+        phase
         result
         subSteps {
+          # Read alongside the spread so the table can tell a row that holds
+          # only the trailing lifecycle marker from one with real sub-steps.
+          step
           ...BAISubStepNodesFragment
         }
         ...BAISchedulingHistoryNodesFragment
@@ -55,6 +58,8 @@ const BAISchedulingHistoryTable = ({
     useSchedulingHistoryExpandable(dataSource, {
       mode: expandMode,
       onModeChange: onExpandModeChange,
+      isExpandable: (record) =>
+        countExecutedSubSteps(record.subSteps ?? [], record.phase) > 0,
     });
 
   return (
@@ -65,12 +70,16 @@ const BAISchedulingHistoryTable = ({
         expandedRowKeys,
         onExpandedRowsChange,
         rowExpandable: (record: SchedulingHistoryNodeInList) =>
-          !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
+          countExecutedSubSteps(
+            dataSource.find((h) => h.id === record.id)?.subSteps ?? [],
+            record.phase,
+          ) > 0,
         expandedRowRender: (record: SchedulingHistoryNodeInList) => (
           <BAISubStepNodes
             subStepsFrgmt={
               dataSource.find((h) => h.id === record.id)?.subSteps ?? []
             }
+            parentPhase={record.phase}
           />
         ),
       }}

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryTable.tsx
@@ -68,11 +68,9 @@ const BAISchedulingHistoryTable = ({
           !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
         expandedRowRender: (record: SchedulingHistoryNodeInList) => (
           <BAISubStepNodes
-            resizable
             subStepsFrgmt={
               dataSource.find((h) => h.id === record.id)?.subSteps ?? []
             }
-            pagination={false}
           />
         ),
       }}

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -88,10 +88,9 @@
   overflow: hidden;
 }
 
+/* Typography lives on the header's `Text` (which also brings the ellipsis and
+   the truncate tooltip the fixed column widths need); only the band is here. */
 .bai-substep-table thead th {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-secondary);
   background: var(--color-background-muted);
 }
 

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -4,178 +4,216 @@
 
  Co-located styles for <BAISubStepNodes> (P17). Imported by the component.
 
- The sub-steps of a scheduling-history row are a flat, time-ordered list, so
- they are drawn as a vertical timeline instead of a nested table: a table
- inside an expanded row has to invent its own column widths, which never line
- up with the parent's and fight it for horizontal space.
+ Design 3a — the sub-steps of a scheduling-history row as a compact inline
+ table, one 32px row per step, with an order connector in a narrow rail column.
 
- Geometry only — every colour and every font size/weight comes from the theme
- (Astryx `Text` semantic types and `--color-*` tokens); nothing here sets one.
+ Deliberately UNLAYERED. Wrapped in `@layer`, `BAITable.css`'s unguarded
+ `.bai-table-astryx-no-header thead` / dim-layer `thead th` rules would outrank
+ the nested header's own tint.
+
+ Geometry only — every colour and every font size comes from the theme.
 */
-.bai-substep-timeline {
-  /* Rail drawing. These are a figure, not spacing rungs, so no theme token
-     carries them; the values are the design's (2a). */
-  --bai-substep-rail-width: 18px;
-  --bai-substep-rail-gap: 14px;
-  --bai-substep-dot-size: 9px;
+.bai-substep-panel {
+  /* 3a's table figure. The column widths, the 26px rail and the 7px/11px rail
+     nodes are a drawing, not spacing rungs, so no theme token carries them. */
+  --bai-substep-rail-col: 26px;
+  --bai-substep-col-step: 200px;
+  --bai-substep-col-result: 116px;
+  --bai-substep-col-duration: 74px;
+  --bai-substep-col-time: 150px;
+  --bai-substep-col-code: 96px;
+  --bai-substep-cell-inline: 10px;
+  --bai-substep-dot-size: 7px;
   --bai-substep-marker-size: 11px;
-  /* The larger marker ring needs 1px less top offset than the solid dot to
-     sit on the same text line. */
-  --bai-substep-marker-offset: 5px;
-  --bai-substep-node-gap: 18px;
-  --bai-substep-header-gap: 10px;
-  --bai-substep-detail-gap: 5px;
-  --bai-substep-chip-inset-block: 1px;
-  /* Wide enough for a full error message line, narrow enough that the eye
-     still tracks the rail. */
-  --bai-substep-list-max-width: 660px;
+  --bai-substep-panel-inset-block: 14px;
 
   /* `BAITable` pads the detail cell uniformly with `paddingSM` through an
-     INLINE style, which no stylesheet rule can override — so cancel it with a
-     matching negative margin and re-apply the design's asymmetric inset:
-     flush to the row above, 20px below, 24px right. The start inset is
-     BAITable's own `EXPAND_COLUMN_WIDTH_FIRST`, which is what left-aligns the
-     timeline with the parent's first data column. */
+     INLINE style, which no stylesheet rule can override — cancel it and
+     re-apply 3a's inset. The start inset is BAITable's own
+     `EXPAND_COLUMN_WIDTH_FIRST`, which lines the card's leading edge up with
+     the parent's first data column. */
   --bai-substep-cell-padding: var(--spacing-3);
   --bai-substep-inset-start: 56px;
 
   margin: calc(-1 * var(--bai-substep-cell-padding));
-  padding-block: 0 var(--spacing-5);
+  padding-block: var(--bai-substep-panel-inset-block);
   padding-inline: var(--bai-substep-inset-start) var(--spacing-6);
 
-  /* Nothing in here should inherit the PAGE's text metrics. Bare wrappers and
-     the badge's own root box take their line box from whatever they inherit —
-     16px/24px — so 12px and 14px `Text` still sat in a 24px line, which both
-     stretched the rows and, under `align-items: baseline`, staggered the
-     header items by a pixel each. Anchoring the subtree on the theme's body
-     metrics makes the inherited line box agree with the text in it. */
+  /* Nothing in here should inherit the PAGE's text metrics: bare cells take
+     their line box from whatever they inherit — 16px/24px — which both
+     stretched the rows and staggered inline items against each other. */
   font-size: var(--text-body-size);
   line-height: var(--text-body-leading);
 }
 
-.bai-substep-list {
-  display: flex;
-  flex-direction: column;
-  max-width: var(--bai-substep-list-max-width);
+.bai-substep-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--color-background-card);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-element);
+  /* Clips the header tint into the rounded corners. */
+  overflow: hidden;
 }
 
-.bai-substep-item {
-  display: grid;
-  grid-template-columns: var(--bai-substep-rail-width) 1fr;
-  gap: var(--bai-substep-rail-gap);
+.bai-substep-col-rail {
+  width: var(--bai-substep-rail-col);
+}
+.bai-substep-col-step {
+  width: var(--bai-substep-col-step);
+}
+.bai-substep-col-result {
+  width: var(--bai-substep-col-result);
+}
+.bai-substep-col-duration {
+  width: var(--bai-substep-col-duration);
+}
+.bai-substep-col-time {
+  width: var(--bai-substep-col-time);
+}
+.bai-substep-col-code {
+  width: var(--bai-substep-col-code);
 }
 
-.bai-substep-rail {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+.bai-substep-table th,
+.bai-substep-table td {
+  height: var(--spacing-8);
+  padding: 0 var(--bai-substep-cell-inline);
+  text-align: start;
+  vertical-align: middle;
+  /* The cell is width-bounded by `table-layout: fixed`, so a `Text maxLines`
+     child ellipsises instead of widening the column. */
+  overflow: hidden;
 }
 
-.bai-substep-dot {
-  flex: none;
+.bai-substep-table thead th {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  background: var(--color-background-muted);
+}
+
+.bai-substep-table tbody td {
+  border-top: var(--border-width) solid var(--color-border);
+}
+
+/* Both selectors carry the table class: the `th, td` rule above is (0,2,0), so
+   a bare `.bai-substep-num` would lose to it and the column would stay
+   start-aligned (measured). */
+.bai-substep-table th.bai-substep-num,
+.bai-substep-table td.bai-substep-num {
+  text-align: end;
+}
+
+.bai-substep-row--marker > td {
+  background: var(--color-background-muted);
+}
+
+/* ---- rail ---------------------------------------------------------------
+   A hand-rolled table, so the rail cell may overflow its box; an Astryx
+   `TableCell` sets `overflow: hidden` unconditionally and would clip the
+   connector at every row boundary. */
+.bai-substep-table td.bai-substep-rail-cell {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+}
+
+/* The connector runs the full row height, and is trimmed to a half at the two
+   ends so the line starts and stops at a node rather than at the card edge. */
+.bai-substep-rail-cell::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 50%;
+  width: var(--border-width);
+  transform: translateX(-50%);
+  background: var(--color-border-emphasized);
+}
+.bai-substep-table tbody tr:first-child .bai-substep-rail-cell::before {
+  inset-block-start: 50%;
+}
+.bai-substep-table tbody tr:last-child .bai-substep-rail-cell::before {
+  inset-block-end: 50%;
+}
+.bai-substep-table tbody tr:only-child .bai-substep-rail-cell::before {
+  display: none;
+}
+
+.bai-substep-rail-cell::after {
+  content: '';
+  position: absolute;
+  inset-inline-start: 50%;
+  inset-block-start: 50%;
   width: var(--bai-substep-dot-size);
   height: var(--bai-substep-dot-size);
-  /* Sits the dot on the first text line rather than on the box top. */
-  margin-top: var(--spacing-1-5);
+  transform: translate(-50%, -50%);
   border-radius: var(--radius-full);
-  background: var(--bai-substep-dot-color);
+  background: var(--bai-substep-node-color);
 }
 
-/* The trailing lifecycle entry is a RESULT MARKER, not an executed step
-   (`_build_history_sub_steps` appends it with started_at == ended_at), so it
-   reads as an open, dashed node instead of a solid one. */
-.bai-substep-dot--marker {
+/* The trailing lifecycle entry is a RESULT MARKER, not executed work. */
+.bai-substep-row--marker .bai-substep-rail-cell::after {
   width: var(--bai-substep-marker-size);
   height: var(--bai-substep-marker-size);
-  margin-top: var(--bai-substep-marker-offset);
-  border: calc(2 * var(--border-width)) dashed var(--bai-substep-dot-color);
+  border: calc(2 * var(--border-width)) dashed var(--bai-substep-node-color);
   background: var(--color-background-card);
 }
 
-.bai-substep-dot[data-variant='success'] {
-  --bai-substep-dot-color: var(--color-success);
+/* ---- semantic colour ----------------------------------------------------
+   One `data-variant` per row drives the rail node and the result chip, so the
+   two can never disagree. The tinted triples are the theme's own hue ramps,
+   which are built to be used together. */
+.bai-substep-row {
+  --bai-substep-node-color: var(--color-border-emphasized);
+  --bai-substep-chip-bg: var(--color-background-muted);
+  --bai-substep-chip-border: var(--color-border-emphasized);
+  --bai-substep-chip-ink: var(--color-text-secondary);
 }
-.bai-substep-dot[data-variant='error'] {
-  --bai-substep-dot-color: var(--color-error);
+.bai-substep-row[data-variant='success'] {
+  --bai-substep-node-color: var(--color-success);
+  --bai-substep-chip-bg: var(--color-background-green);
+  --bai-substep-chip-border: var(--color-border-green);
+  --bai-substep-chip-ink: var(--color-text-green);
 }
-.bai-substep-dot[data-variant='warning'] {
-  --bai-substep-dot-color: var(--color-warning);
+.bai-substep-row[data-variant='error'] {
+  --bai-substep-node-color: var(--color-error);
+  --bai-substep-chip-bg: var(--color-background-red);
+  --bai-substep-chip-border: var(--color-border-red);
+  --bai-substep-chip-ink: var(--color-text-red);
 }
-.bai-substep-dot[data-variant='info'] {
-  --bai-substep-dot-color: var(--color-text-accent);
+.bai-substep-row[data-variant='warning'] {
+  --bai-substep-node-color: var(--color-warning);
+  --bai-substep-chip-bg: var(--color-background-orange);
+  --bai-substep-chip-border: var(--color-border-orange);
+  --bai-substep-chip-ink: var(--color-text-orange);
 }
-.bai-substep-dot[data-variant='default'] {
-  --bai-substep-dot-color: var(--color-border-emphasized);
-}
-
-.bai-substep-connector {
-  flex: 1;
-  width: var(--border-width);
-  background: var(--color-border-emphasized);
-}
-
-.bai-substep-body {
-  /* Lets the message truncate instead of widening the grid column. */
-  min-width: 0;
-  padding-bottom: var(--bai-substep-node-gap);
-}
-
-.bai-substep-item:last-child .bai-substep-body {
-  padding-bottom: 0;
-}
-
-.bai-substep-body--marker {
-  padding-top: var(--spacing-0-5);
-}
-
-/* `center`, not the design's `baseline`. The row mixes plain text with two
-   boxed items (the result badge, the marker pill) whose own line boxes differ
-   from the step name's; baseline alignment then reads as each item sitting a
-   pixel or two off its neighbour. Centring is what actually looks aligned —
-   and at these sizes the two agree to within a pixel anyway. */
-.bai-substep-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--bai-substep-header-gap);
+.bai-substep-row[data-variant='info'] {
+  --bai-substep-node-color: var(--color-text-accent);
+  --bai-substep-chip-bg: var(--color-background-blue);
+  --bai-substep-chip-border: var(--color-border-blue);
+  --bai-substep-chip-ink: var(--color-text-blue);
 }
 
-/* `display: flex`, not `block`, on purpose. A block box lays its inline text
-   out against ITS OWN font as the strut, and these wrappers inherit the page's
-   16px/24px — so a 12px `Text` still produced a 24px line box and the three
-   detail rows sat further apart than the design. A flex container has no
-   strut: the row is exactly as tall as the text in it. Measured before/after
-   in the session scheduling-history modal. */
-.bai-substep-detail {
-  display: flex;
-  min-width: 0;
-  margin-top: var(--bai-substep-detail-gap);
-}
-
-.bai-substep-detail--time {
-  margin-top: var(--spacing-1);
-}
-
-.bai-substep-error-code {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  margin-top: var(--spacing-1-5);
-}
-
-.bai-substep-chip {
+.bai-substep-result {
   display: inline-flex;
   align-items: center;
-  padding: var(--bai-substep-chip-inset-block) var(--spacing-2);
+  max-width: 100%;
+  padding: 0 var(--spacing-1-5);
+  border: var(--border-width) solid var(--bai-substep-chip-border);
+  border-radius: var(--radius-inner);
+  background: var(--bai-substep-chip-bg);
+  color: var(--bai-substep-chip-ink);
+}
+
+.bai-substep-code {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 0 var(--spacing-1-5);
   border: var(--border-width) solid var(--color-border-emphasized);
   border-radius: var(--radius-inner);
   background: var(--color-background-card);
-}
-
-.bai-substep-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: var(--bai-substep-chip-inset-block) var(--spacing-2);
-  border-radius: var(--radius-full);
-  background: var(--color-background-muted);
 }

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -42,6 +42,15 @@
   margin: calc(-1 * var(--bai-substep-cell-padding));
   padding-block: 0 var(--spacing-5);
   padding-inline: var(--bai-substep-inset-start) var(--spacing-6);
+
+  /* Nothing in here should inherit the PAGE's text metrics. Bare wrappers and
+     the badge's own root box take their line box from whatever they inherit —
+     16px/24px — so 12px and 14px `Text` still sat in a 24px line, which both
+     stretched the rows and, under `align-items: baseline`, staggered the
+     header items by a pixel each. Anchoring the subtree on the theme's body
+     metrics makes the inherited line box agree with the text in it. */
+  font-size: var(--text-body-size);
+  line-height: var(--text-body-leading);
 }
 
 .bai-substep-list {
@@ -119,14 +128,27 @@
   padding-top: var(--spacing-0-5);
 }
 
+/* `center`, not the design's `baseline`. The row mixes plain text with two
+   boxed items (the result badge, the marker pill) whose own line boxes differ
+   from the step name's; baseline alignment then reads as each item sitting a
+   pixel or two off its neighbour. Centring is what actually looks aligned —
+   and at these sizes the two agree to within a pixel anyway. */
 .bai-substep-header {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   gap: var(--bai-substep-header-gap);
 }
 
+/* `display: flex`, not `block`, on purpose. A block box lays its inline text
+   out against ITS OWN font as the strut, and these wrappers inherit the page's
+   16px/24px — so a 12px `Text` still produced a 24px line box and the three
+   detail rows sat further apart than the design. A flex container has no
+   strut: the row is exactly as tall as the text in it. Measured before/after
+   in the session scheduling-history modal. */
 .bai-substep-detail {
+  display: flex;
+  min-width: 0;
   margin-top: var(--bai-substep-detail-gap);
 }
 

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -9,27 +9,51 @@
  inside an expanded row has to invent its own column widths, which never line
  up with the parent's and fight it for horizontal space.
 
- Only the rail geometry lives here — every colour, radius and gap is an Astryx
- token, and all typography is Astryx `Text`.
+ Geometry only — every colour and every font size/weight comes from the theme
+ (Astryx `Text` semantic types and `--color-*` tokens); nothing here sets one.
 */
 .bai-substep-timeline {
-  /* The rail column and the dots are fixed geometry; no token carries them. */
+  /* Rail drawing. These are a figure, not spacing rungs, so no theme token
+     carries them; the values are the design's (2a). */
   --bai-substep-rail-width: 18px;
+  --bai-substep-rail-gap: 14px;
   --bai-substep-dot-size: 9px;
   --bai-substep-marker-size: 11px;
+  /* The larger marker ring needs 1px less top offset than the solid dot to
+     sit on the same text line. */
+  --bai-substep-marker-offset: 5px;
+  --bai-substep-node-gap: 18px;
+  --bai-substep-header-gap: 10px;
+  --bai-substep-detail-gap: 5px;
+  --bai-substep-chip-inset-block: 1px;
   /* Wide enough for a full error message line, narrow enough that the eye
      still tracks the rail. */
-  --bai-substep-max-width: 660px;
+  --bai-substep-list-max-width: 660px;
 
+  /* `BAITable` pads the detail cell uniformly with `paddingSM` through an
+     INLINE style, which no stylesheet rule can override — so cancel it with a
+     matching negative margin and re-apply the design's asymmetric inset:
+     flush to the row above, 20px below, 24px right. The start inset is
+     BAITable's own `EXPAND_COLUMN_WIDTH_FIRST`, which is what left-aligns the
+     timeline with the parent's first data column. */
+  --bai-substep-cell-padding: var(--spacing-3);
+  --bai-substep-inset-start: 56px;
+
+  margin: calc(-1 * var(--bai-substep-cell-padding));
+  padding-block: 0 var(--spacing-5);
+  padding-inline: var(--bai-substep-inset-start) var(--spacing-6);
+}
+
+.bai-substep-list {
   display: flex;
   flex-direction: column;
-  max-width: var(--bai-substep-max-width);
+  max-width: var(--bai-substep-list-max-width);
 }
 
 .bai-substep-item {
   display: grid;
   grid-template-columns: var(--bai-substep-rail-width) 1fr;
-  gap: var(--spacing-3);
+  gap: var(--bai-substep-rail-gap);
 }
 
 .bai-substep-rail {
@@ -54,7 +78,7 @@
 .bai-substep-dot--marker {
   width: var(--bai-substep-marker-size);
   height: var(--bai-substep-marker-size);
-  margin-top: var(--spacing-1);
+  margin-top: var(--bai-substep-marker-offset);
   border: calc(2 * var(--border-width)) dashed var(--bai-substep-dot-color);
   background: var(--color-background-card);
 }
@@ -84,21 +108,29 @@
 .bai-substep-body {
   /* Lets the message truncate instead of widening the grid column. */
   min-width: 0;
-  padding-bottom: var(--spacing-4);
+  padding-bottom: var(--bai-substep-node-gap);
 }
 
 .bai-substep-item:last-child .bai-substep-body {
   padding-bottom: 0;
 }
 
+.bai-substep-body--marker {
+  padding-top: var(--spacing-0-5);
+}
+
 .bai-substep-header {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: var(--spacing-2);
+  gap: var(--bai-substep-header-gap);
 }
 
 .bai-substep-detail {
+  margin-top: var(--bai-substep-detail-gap);
+}
+
+.bai-substep-detail--time {
   margin-top: var(--spacing-1);
 }
 
@@ -112,7 +144,7 @@
 .bai-substep-chip {
   display: inline-flex;
   align-items: center;
-  padding: 0 var(--spacing-2);
+  padding: var(--bai-substep-chip-inset-block) var(--spacing-2);
   border: var(--border-width) solid var(--color-border-emphasized);
   border-radius: var(--radius-inner);
   background: var(--color-background-card);
@@ -121,7 +153,7 @@
 .bai-substep-pill {
   display: inline-flex;
   align-items: center;
-  padding: 0 var(--spacing-2);
+  padding: var(--bai-substep-chip-inset-block) var(--spacing-2);
   border-radius: var(--radius-full);
   background: var(--color-background-muted);
 }

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -1,0 +1,127 @@
+/*
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ Co-located styles for <BAISubStepNodes> (P17). Imported by the component.
+
+ The sub-steps of a scheduling-history row are a flat, time-ordered list, so
+ they are drawn as a vertical timeline instead of a nested table: a table
+ inside an expanded row has to invent its own column widths, which never line
+ up with the parent's and fight it for horizontal space.
+
+ Only the rail geometry lives here — every colour, radius and gap is an Astryx
+ token, and all typography is Astryx `Text`.
+*/
+.bai-substep-timeline {
+  /* The rail column and the dots are fixed geometry; no token carries them. */
+  --bai-substep-rail-width: 18px;
+  --bai-substep-dot-size: 9px;
+  --bai-substep-marker-size: 11px;
+  /* Wide enough for a full error message line, narrow enough that the eye
+     still tracks the rail. */
+  --bai-substep-max-width: 660px;
+
+  display: flex;
+  flex-direction: column;
+  max-width: var(--bai-substep-max-width);
+}
+
+.bai-substep-item {
+  display: grid;
+  grid-template-columns: var(--bai-substep-rail-width) 1fr;
+  gap: var(--spacing-3);
+}
+
+.bai-substep-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.bai-substep-dot {
+  flex: none;
+  width: var(--bai-substep-dot-size);
+  height: var(--bai-substep-dot-size);
+  /* Sits the dot on the first text line rather than on the box top. */
+  margin-top: var(--spacing-1-5);
+  border-radius: var(--radius-full);
+  background: var(--bai-substep-dot-color);
+}
+
+/* The trailing lifecycle entry is a RESULT MARKER, not an executed step
+   (`_build_history_sub_steps` appends it with started_at == ended_at), so it
+   reads as an open, dashed node instead of a solid one. */
+.bai-substep-dot--marker {
+  width: var(--bai-substep-marker-size);
+  height: var(--bai-substep-marker-size);
+  margin-top: var(--spacing-1);
+  border: calc(2 * var(--border-width)) dashed var(--bai-substep-dot-color);
+  background: var(--color-background-card);
+}
+
+.bai-substep-dot[data-variant='success'] {
+  --bai-substep-dot-color: var(--color-success);
+}
+.bai-substep-dot[data-variant='error'] {
+  --bai-substep-dot-color: var(--color-error);
+}
+.bai-substep-dot[data-variant='warning'] {
+  --bai-substep-dot-color: var(--color-warning);
+}
+.bai-substep-dot[data-variant='info'] {
+  --bai-substep-dot-color: var(--color-text-accent);
+}
+.bai-substep-dot[data-variant='default'] {
+  --bai-substep-dot-color: var(--color-border-emphasized);
+}
+
+.bai-substep-connector {
+  flex: 1;
+  width: var(--border-width);
+  background: var(--color-border-emphasized);
+}
+
+.bai-substep-body {
+  /* Lets the message truncate instead of widening the grid column. */
+  min-width: 0;
+  padding-bottom: var(--spacing-4);
+}
+
+.bai-substep-item:last-child .bai-substep-body {
+  padding-bottom: 0;
+}
+
+.bai-substep-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--spacing-2);
+}
+
+.bai-substep-detail {
+  margin-top: var(--spacing-1);
+}
+
+.bai-substep-error-code {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-1-5);
+}
+
+.bai-substep-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--spacing-2);
+  border: var(--border-width) solid var(--color-border-emphasized);
+  border-radius: var(--radius-inner);
+  background: var(--color-background-card);
+}
+
+.bai-substep-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--spacing-2);
+  border-radius: var(--radius-full);
+  background: var(--color-background-muted);
+}

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -25,19 +25,6 @@
   --bai-substep-cell-inline: 10px;
   --bai-substep-dot-size: 7px;
   --bai-substep-marker-size: 11px;
-  --bai-substep-panel-inset-block: 14px;
-
-  /* `BAITable` pads the detail cell uniformly with `paddingSM` through an
-     INLINE style, which no stylesheet rule can override — cancel it and
-     re-apply 3a's inset. The start inset is BAITable's own
-     `EXPAND_COLUMN_WIDTH_FIRST`, which lines the card's leading edge up with
-     the parent's first data column. */
-  --bai-substep-cell-padding: var(--spacing-3);
-  --bai-substep-inset-start: 56px;
-
-  margin: calc(-1 * var(--bai-substep-cell-padding));
-  padding-block: var(--bai-substep-panel-inset-block);
-  padding-inline: var(--bai-substep-inset-start) var(--spacing-6);
 
   /* Nothing in here should inherit the PAGE's text metrics: bare cells take
      their line box from whatever they inherit — 16px/24px — which both

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -46,16 +46,29 @@
   line-height: var(--text-body-leading);
 }
 
-.bai-substep-table {
-  width: 100%;
-  table-layout: fixed;
-  border-collapse: separate;
-  border-spacing: 0;
+/* The card is the scroller, so its border and radius stay put while the
+   columns slide underneath — the alternative, truncating, hides exactly the
+   values people open this panel to read (step names, error codes, and the
+   scheduler's placement-failure text all outrun any workable column width).
+   `overflow-y` must be stated: a `visible` axis next to a scrolling one
+   computes to `auto` and would add a stray vertical scrollbar. */
+.bai-substep-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
   background: var(--color-background-card);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-element);
-  /* Clips the header tint into the rounded corners. */
-  overflow: hidden;
+}
+
+.bai-substep-table {
+  /* `auto` + `max-content`: the `<col>` widths become the resting layout, and
+     any column whose content needs more takes it, widening the table past the
+     card and turning on the scrollbar. */
+  width: 100%;
+  min-width: max-content;
+  table-layout: auto;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .bai-substep-col-rail {
@@ -83,13 +96,13 @@
   padding: 0 var(--bai-substep-cell-inline);
   text-align: start;
   vertical-align: middle;
-  /* The cell is width-bounded by `table-layout: fixed`, so a `Text maxLines`
-     child ellipsises instead of widening the column. */
-  overflow: hidden;
+  /* Nothing wraps: a cell `height` is only a minimum, so a second line box
+     would push the row past 32px. Content that does not fit widens its column
+     and scrolls instead. */
+  white-space: nowrap;
 }
 
-/* Typography lives on the header's `Text` (which also brings the ellipsis and
-   the truncate tooltip the fixed column widths need); only the band is here. */
+/* Typography lives on the header's `Text`; only the band is here. */
 .bai-substep-table thead th {
   background: var(--color-background-muted);
 }
@@ -117,7 +130,6 @@
 .bai-substep-table td.bai-substep-rail-cell {
   position: relative;
   padding: 0;
-  overflow: visible;
 }
 
 /* The connector runs the full row height, and is trimmed to a half at the two
@@ -199,7 +211,6 @@
 .bai-substep-result {
   display: inline-flex;
   align-items: center;
-  max-width: 100%;
   padding: 0 var(--spacing-1-5);
   border: var(--border-width) solid var(--bai-substep-chip-border);
   border-radius: var(--radius-inner);
@@ -210,7 +221,6 @@
 .bai-substep-code {
   display: inline-flex;
   align-items: center;
-  max-width: 100%;
   padding: 0 var(--spacing-1-5);
   border: var(--border-width) solid var(--color-border-emphasized);
   border-radius: var(--radius-inner);

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.test.ts
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.test.ts
@@ -1,4 +1,8 @@
-import { formatElapsed, isResultMarkerEntry } from './BAISubStepNodes';
+import {
+  countExecutedSubSteps,
+  formatElapsed,
+  isLifecycleMarkerEntry,
+} from './BAISubStepNodes';
 
 describe('formatElapsed', () => {
   test('sub-second intervals read in milliseconds', () => {
@@ -25,6 +29,12 @@ describe('formatElapsed', () => {
     ).toBe('2h 07m');
   });
 
+  test('a zero-length interval is a real duration, not a missing one', () => {
+    expect(
+      formatElapsed('2026-08-19T09:32:55.524Z', '2026-08-19T09:32:55.524Z'),
+    ).toBe('0 ms');
+  });
+
   test('a missing or inverted timestamp yields no duration', () => {
     expect(formatElapsed(null, '2026-08-24T16:19:03.940Z')).toBeNull();
     expect(formatElapsed('2026-08-24T16:19:03.940Z', undefined)).toBeNull();
@@ -34,31 +44,83 @@ describe('formatElapsed', () => {
   });
 });
 
-describe('isResultMarkerEntry', () => {
-  const zeroLength = {
-    startedAt: '2026-08-24T16:19:05.031Z',
-    endedAt: '2026-08-24T16:19:05.031Z',
-  };
-  const realStep = {
-    startedAt: '2026-08-24T16:19:03.912Z',
-    endedAt: '2026-08-24T16:19:03.940Z',
-  };
+describe('isLifecycleMarkerEntry', () => {
+  const PHASE = 'deploying-rolling-back';
 
-  test('the trailing zero-length entry is the lifecycle marker', () => {
-    expect(isResultMarkerEntry(zeroLength, 2, 3)).toBe(true);
+  test('the trailing entry that restates the row phase is the marker', () => {
+    // The coordinator writes the phase with dashes and the sub-step with
+    // underscores; they name the same thing.
+    expect(
+      isLifecycleMarkerEntry({ step: 'deploying_rolling_back' }, 2, 3, PHASE),
+    ).toBe(true);
   });
 
-  test('an interior zero-length entry is a real (fast) step', () => {
-    expect(isResultMarkerEntry(zeroLength, 1, 3)).toBe(false);
+  test('the same name in an interior position is not the marker', () => {
+    expect(
+      isLifecycleMarkerEntry({ step: 'deploying_rolling_back' }, 1, 3, PHASE),
+    ).toBe(false);
   });
 
-  test('a trailing entry that took time is a real step', () => {
-    expect(isResultMarkerEntry(realStep, 2, 3)).toBe(false);
+  test('a trailing recorder step is not the marker', () => {
+    expect(
+      isLifecycleMarkerEntry({ step: 'setup_target_groups' }, 2, 3, PHASE),
+    ).toBe(false);
   });
 
-  test('missing timestamps never make a marker', () => {
-    expect(isResultMarkerEntry({ startedAt: null, endedAt: null }, 0, 1)).toBe(
-      false,
-    );
+  test('without the row phase nothing is a marker', () => {
+    expect(
+      isLifecycleMarkerEntry({ step: 'deploying_rolling_back' }, 0, 1, null),
+    ).toBe(false);
+  });
+
+  test('session rows never produce a marker', () => {
+    // Sessions and routes go through `extract_sub_steps_for_entity`, which
+    // appends nothing — and a real session step can still take 0 ms, which is
+    // why elapsed time cannot be the test.
+    expect(
+      isLifecycleMarkerEntry(
+        { step: 'All kernels ready for PREPARED' },
+        1,
+        2,
+        'schedule-sessions',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('countExecutedSubSteps', () => {
+  const PHASE = 'deploying-rolling-back';
+
+  test('a lone lifecycle marker counts as no detail to expand', () => {
+    expect(
+      countExecutedSubSteps([{ step: 'deploying_rolling_back' }], PHASE),
+    ).toBe(0);
+  });
+
+  test('real steps count, the trailing marker does not', () => {
+    expect(
+      countExecutedSubSteps(
+        [
+          { step: 'resolve_rollout_target' },
+          { step: 'setup_target_groups' },
+          { step: 'deploying_rolling_back' },
+        ],
+        PHASE,
+      ),
+    ).toBe(2);
+  });
+
+  test('every session sub-step counts', () => {
+    expect(
+      countExecutedSubSteps(
+        [{ step: 'check_and_pull_images' }, { step: 'All kernels ready' }],
+        'schedule-sessions',
+      ),
+    ).toBe(2);
+  });
+
+  test('an empty list has nothing to expand', () => {
+    expect(countExecutedSubSteps([], PHASE)).toBe(0);
+    expect(countExecutedSubSteps([null, undefined], PHASE)).toBe(0);
   });
 });

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.test.ts
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.test.ts
@@ -1,0 +1,64 @@
+import { formatElapsed, isResultMarkerEntry } from './BAISubStepNodes';
+
+describe('formatElapsed', () => {
+  test('sub-second intervals read in milliseconds', () => {
+    expect(
+      formatElapsed('2026-08-24T16:19:03.912Z', '2026-08-24T16:19:03.940Z'),
+    ).toBe('28 ms');
+  });
+
+  test('seconds keep two sub-second digits', () => {
+    expect(
+      formatElapsed('2026-08-24T16:19:03.940Z', '2026-08-24T16:19:05.031Z'),
+    ).toBe('1.09 s');
+    expect(
+      formatElapsed('2026-08-24T16:19:03.000Z', '2026-08-24T16:19:07.300Z'),
+    ).toBe('4.30 s');
+  });
+
+  test('a minute or more switches to m/s, an hour or more to h/m', () => {
+    expect(
+      formatElapsed('2026-08-24T16:19:00.000Z', '2026-08-24T16:20:05.000Z'),
+    ).toBe('1m 05s');
+    expect(
+      formatElapsed('2026-08-24T16:00:00.000Z', '2026-08-24T18:07:00.000Z'),
+    ).toBe('2h 07m');
+  });
+
+  test('a missing or inverted timestamp yields no duration', () => {
+    expect(formatElapsed(null, '2026-08-24T16:19:03.940Z')).toBeNull();
+    expect(formatElapsed('2026-08-24T16:19:03.940Z', undefined)).toBeNull();
+    expect(
+      formatElapsed('2026-08-24T16:19:05.031Z', '2026-08-24T16:19:03.940Z'),
+    ).toBeNull();
+  });
+});
+
+describe('isResultMarkerEntry', () => {
+  const zeroLength = {
+    startedAt: '2026-08-24T16:19:05.031Z',
+    endedAt: '2026-08-24T16:19:05.031Z',
+  };
+  const realStep = {
+    startedAt: '2026-08-24T16:19:03.912Z',
+    endedAt: '2026-08-24T16:19:03.940Z',
+  };
+
+  test('the trailing zero-length entry is the lifecycle marker', () => {
+    expect(isResultMarkerEntry(zeroLength, 2, 3)).toBe(true);
+  });
+
+  test('an interior zero-length entry is a real (fast) step', () => {
+    expect(isResultMarkerEntry(zeroLength, 1, 3)).toBe(false);
+  });
+
+  test('a trailing entry that took time is a real step', () => {
+    expect(isResultMarkerEntry(realStep, 2, 3)).toBe(false);
+  });
+
+  test('missing timestamps never make a marker', () => {
+    expect(isResultMarkerEntry({ startedAt: null, endedAt: null }, 0, 1)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -170,136 +170,132 @@ const BAISubStepNodes = ({
 
   return (
     <div className={classNames('bai-substep-panel', className)} {...divProps}>
-      <table className="bai-substep-table">
-        <colgroup>
-          <col className="bai-substep-col-rail" />
-          <col className="bai-substep-col-step" />
-          <col className="bai-substep-col-result" />
-          <col className="bai-substep-col-duration" />
-          <col className="bai-substep-col-time" />
-          <col className="bai-substep-col-code" />
-          <col />
-        </colgroup>
-        <thead>
-          <tr>
-            {/* The rail column is decoration, but the header cell has to exist
-                for the column count to line up. */}
-            <th scope="col" />
-            {(
-              [
-                ['Step', undefined],
-                ['Result', undefined],
-                ['Duration', 'bai-substep-num'],
-                ['Time', undefined],
-                ['ErrorCode', undefined],
-                ['Message', undefined],
-              ] as const
-            ).map(([key, cellClassName]) => (
-              <th scope="col" key={key} className={cellClassName}>
-                {/* `maxLines` for the ellipsis and the hover tooltip: the
-                    columns are fixed-width, and a one-word label like ru
-                    `Длительность` needs 103px in the 74px duration column. */}
-                <Text type="supporting" weight="medium" maxLines={1}>
-                  {t(`comp:BAISubStepNodes.${key}`)}
-                </Text>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {dataSource.map((record, index) => {
-            const result = toSchedulingResult(record.result);
-            const isResultMarker = isLifecycleMarkerEntry(
-              record,
-              index,
-              dataSource.length,
-              parentPhase,
-            );
-            const elapsed = formatElapsed(record.startedAt, record.endedAt);
+      {/* The card scrolls sideways rather than truncating: step names, error
+          codes and scheduler messages are all longer than any column width
+          that keeps six columns on screen. */}
+      <div className="bai-substep-scroll">
+        <table className="bai-substep-table">
+          <colgroup>
+            <col className="bai-substep-col-rail" />
+            <col className="bai-substep-col-step" />
+            <col className="bai-substep-col-result" />
+            <col className="bai-substep-col-duration" />
+            <col className="bai-substep-col-time" />
+            <col className="bai-substep-col-code" />
+            <col />
+          </colgroup>
+          <thead>
+            <tr>
+              {/* The rail column is decoration, but the header cell has to exist
+                  for the column count to line up. */}
+              <th scope="col" />
+              {(
+                [
+                  ['Step', undefined],
+                  ['Result', undefined],
+                  ['Duration', 'bai-substep-num'],
+                  ['Time', undefined],
+                  ['ErrorCode', undefined],
+                  ['Message', undefined],
+                ] as const
+              ).map(([key, cellClassName]) => (
+                <th scope="col" key={key} className={cellClassName}>
+                  <Text type="supporting" weight="medium">
+                    {t(`comp:BAISubStepNodes.${key}`)}
+                  </Text>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {dataSource.map((record, index) => {
+              const result = toSchedulingResult(record.result);
+              const isResultMarker = isLifecycleMarkerEntry(
+                record,
+                index,
+                dataSource.length,
+                parentPhase,
+              );
+              const elapsed = formatElapsed(record.startedAt, record.endedAt);
 
-            return (
-              <tr
-                key={`${record.step}-${index}`}
-                className={classNames(
-                  'bai-substep-row',
-                  isResultMarker && 'bai-substep-row--marker',
-                )}
-                data-variant={
-                  result ? resultSemanticColorMap[result] : 'default'
-                }
-              >
-                {/* No `aria-hidden`: hiding it would leave the row owning
-                    six cells against seven column headers. Empty is right —
-                    the header cell above it is empty too. */}
-                <td className="bai-substep-rail-cell" />
-                <td>
-                  <Text
-                    type="code"
-                    size="sm"
-                    maxLines={1}
-                    color={isResultMarker ? 'secondary' : 'primary'}
-                  >
-                    {record.step}
-                  </Text>
-                </td>
-                <td>
-                  {result ? (
-                    <span className="bai-substep-result">
-                      <Text type="supporting" color="inherit" maxLines={1}>
-                        {result}
-                      </Text>
-                    </span>
-                  ) : null}
-                </td>
-                <td className="bai-substep-num">
-                  {/* The marker is an instant, not work — it has no duration. */}
-                  {!isResultMarker && elapsed ? (
-                    <Text type="code" size="sm" color="secondary">
-                      {elapsed}
-                    </Text>
-                  ) : (
-                    <Text type="supporting" color="disabled">
-                      -
-                    </Text>
+              return (
+                <tr
+                  key={`${record.step}-${index}`}
+                  className={classNames(
+                    'bai-substep-row',
+                    isResultMarker && 'bai-substep-row--marker',
                   )}
-                </td>
-                <td>
-                  {record.startedAt ? (
-                    <Text type="code" size="sm" color="secondary">
-                      {dayjs(record.startedAt).format(TIME_FORMAT)}
+                  data-variant={
+                    result ? resultSemanticColorMap[result] : 'default'
+                  }
+                >
+                  {/* No `aria-hidden`: hiding it would leave the row owning
+                      six cells against seven column headers. Empty is right —
+                      the header cell above it is empty too. */}
+                  <td className="bai-substep-rail-cell" />
+                  <td>
+                    <Text
+                      type="code"
+                      size="sm"
+                      color={isResultMarker ? 'secondary' : 'primary'}
+                    >
+                      {record.step}
                     </Text>
-                  ) : null}
-                </td>
-                <td>
-                  {record.errorCode ? (
-                    <span className="bai-substep-code">
-                      <Text
-                        type="code"
-                        size="sm"
-                        color="secondary"
-                        maxLines={1}
-                      >
-                        {record.errorCode}
+                  </td>
+                  <td>
+                    {result ? (
+                      <span className="bai-substep-result">
+                        <Text type="supporting" color="inherit">
+                          {result}
+                        </Text>
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="bai-substep-num">
+                    {/* The marker is an instant, not work — it has no duration. */}
+                    {!isResultMarker && elapsed ? (
+                      <Text type="code" size="sm" color="secondary">
+                        {elapsed}
                       </Text>
-                    </span>
-                  ) : (
-                    <Text type="supporting" color="disabled">
-                      -
+                    ) : (
+                      <Text type="supporting" color="disabled">
+                        -
+                      </Text>
+                    )}
+                  </td>
+                  <td>
+                    {record.startedAt ? (
+                      <Text type="code" size="sm" color="secondary">
+                        {dayjs(record.startedAt).format(TIME_FORMAT)}
+                      </Text>
+                    ) : null}
+                  </td>
+                  <td>
+                    {record.errorCode ? (
+                      <span className="bai-substep-code">
+                        <Text type="code" size="sm" color="secondary">
+                          {record.errorCode}
+                        </Text>
+                      </span>
+                    ) : (
+                      <Text type="supporting" color="disabled">
+                        -
+                      </Text>
+                    )}
+                  </td>
+                  <td>
+                    <Text type="supporting">
+                      {isResultMarker
+                        ? t('comp:BAISubStepNodes.ResultMarker')
+                        : toSingleLine(record.message)}
                     </Text>
-                  )}
-                </td>
-                <td>
-                  <Text type="supporting" maxLines={1}>
-                    {isResultMarker
-                      ? t('comp:BAISubStepNodes.ResultMarker')
-                      : toSingleLine(record.message)}
-                  </Text>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -3,16 +3,20 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAISubStepNodes` — the sub-steps of one scheduling-history attempt, drawn as
- a vertical timeline inside the parent row's expanded area.
+ design 3a: a compact inline table, one 32px row per step, with an order
+ connector in a narrow rail column.
 
  The backend flattens `PhaseRecord` groups on write, so what the API returns is
  a plain time-ordered list. Deployment rows carry one extra trailing entry that
- restates the row itself — see `isLifecycleMarkerEntry` — and it renders as an
- open dashed node capping the solid ones.
+ restates the row itself — see `isLifecycleMarkerEntry` — and it renders as a
+ tinted row with an open dashed node.
 
- Every font size, weight and colour comes from the theme through Astryx `Text`
- semantic types (`code` / `supporting`) and the `primary` / `secondary` colour
- ramp — the co-located CSS carries geometry only.
+ It is a hand-rolled `<table>` on purpose: an Astryx `TableCell` sets
+ `overflow: hidden` unconditionally, which would clip the connector at every
+ row boundary, and its densest row is taller than 32px.
+
+ Every font size and colour comes from the theme — the co-located CSS carries
+ geometry and the semantic hue triples only.
 */
 import {
   BAISubStepNodesFragment$data,
@@ -20,7 +24,7 @@ import {
 } from '../../__generated__/BAISubStepNodesFragment.graphql';
 import { filterOutNullAndUndefined, newLineToBrElement } from '../../helper';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
-import BAISchedulingResultBadge, {
+import {
   SchedulingResult,
   resultSemanticColorMap,
 } from '../BAISchedulingResultBadge';
@@ -144,102 +148,128 @@ const BAISubStepNodes = ({
     subStepsFrgmt,
   );
 
-  // Ascending, as the API returns it — the timeline reads top-down and the
+  // Ascending, as the API returns it — the table reads top-down and the
   // trailing result marker must stay last.
   const dataSource = filterOutNullAndUndefined(subSteps);
-  const lastIndex = dataSource.length - 1;
 
   return (
-    <div
-      className={classNames('bai-substep-timeline', className)}
-      {...divProps}
-    >
-      <div className="bai-substep-list">
-        {dataSource.map((record, index) => {
-          const result = toSchedulingResult(record.result);
-          const isLast = index === lastIndex;
-          const isResultMarker = isLifecycleMarkerEntry(
-            record,
-            index,
-            dataSource.length,
-            parentPhase,
-          );
-          const elapsed = formatElapsed(record.startedAt, record.endedAt);
+    <div className={classNames('bai-substep-panel', className)} {...divProps}>
+      <table className="bai-substep-table">
+        <colgroup>
+          <col className="bai-substep-col-rail" />
+          <col className="bai-substep-col-step" />
+          <col className="bai-substep-col-result" />
+          <col className="bai-substep-col-duration" />
+          <col className="bai-substep-col-time" />
+          <col className="bai-substep-col-code" />
+          <col />
+        </colgroup>
+        <thead>
+          <tr>
+            {/* The rail column is decoration, but the header cell has to exist
+                for the column count to line up. */}
+            <th scope="col" />
+            <th scope="col">{t('comp:BAISubStepNodes.Step')}</th>
+            <th scope="col">{t('comp:BAISubStepNodes.Result')}</th>
+            <th scope="col" className="bai-substep-num">
+              {t('comp:BAISubStepNodes.Duration')}
+            </th>
+            <th scope="col">{t('comp:BAISubStepNodes.Time')}</th>
+            <th scope="col">{t('comp:BAISubStepNodes.ErrorCode')}</th>
+            <th scope="col">{t('comp:BAISubStepNodes.Message')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dataSource.map((record, index) => {
+            const result = toSchedulingResult(record.result);
+            const isResultMarker = isLifecycleMarkerEntry(
+              record,
+              index,
+              dataSource.length,
+              parentPhase,
+            );
+            const elapsed = formatElapsed(record.startedAt, record.endedAt);
 
-          return (
-            <div className="bai-substep-item" key={`${record.step}-${index}`}>
-              <div className="bai-substep-rail" aria-hidden>
-                <span
-                  className={classNames(
-                    'bai-substep-dot',
-                    isResultMarker && 'bai-substep-dot--marker',
-                  )}
-                  data-variant={
-                    result ? resultSemanticColorMap[result] : 'default'
-                  }
-                />
-                {!isLast ? <span className="bai-substep-connector" /> : null}
-              </div>
-              <div
+            return (
+              <tr
+                key={`${record.step}-${index}`}
                 className={classNames(
-                  'bai-substep-body',
-                  isResultMarker && 'bai-substep-body--marker',
+                  'bai-substep-row',
+                  isResultMarker && 'bai-substep-row--marker',
                 )}
+                data-variant={
+                  result ? resultSemanticColorMap[result] : 'default'
+                }
               >
-                <div className="bai-substep-header">
+                <td className="bai-substep-rail-cell" aria-hidden />
+                <td>
                   <Text
                     type="code"
-                    weight="medium"
+                    size="sm"
+                    maxLines={1}
                     color={isResultMarker ? 'secondary' : 'primary'}
                   >
                     {record.step}
                   </Text>
-                  <BAISchedulingResultBadge result={result} />
-                  {isResultMarker ? (
-                    <span className="bai-substep-pill">
-                      <Text type="supporting">
-                        {t('comp:BAISubStepNodes.ResultMarker')}
+                </td>
+                <td>
+                  {result ? (
+                    <span className="bai-substep-result">
+                      <Text type="supporting" color="inherit" maxLines={1}>
+                        {result}
                       </Text>
                     </span>
-                  ) : elapsed ? (
+                  ) : null}
+                </td>
+                <td className="bai-substep-num">
+                  {/* The marker is an instant, not work — it has no duration. */}
+                  {!isResultMarker && elapsed ? (
                     <Text type="code" size="sm" color="secondary">
                       {elapsed}
                     </Text>
+                  ) : (
+                    <Text type="supporting" color="disabled">
+                      -
+                    </Text>
+                  )}
+                </td>
+                <td>
+                  {record.startedAt ? (
+                    <Text type="code" size="sm" color="secondary">
+                      {dayjs(record.startedAt).format(TIME_FORMAT)}
+                    </Text>
                   ) : null}
-                </div>
-                {!isResultMarker && record.message ? (
-                  <div className="bai-substep-detail">
-                    <Text type="supporting">
-                      {newLineToBrElement(record.message)}
-                    </Text>
-                  </div>
-                ) : null}
-                {!isResultMarker && result === 'FAILURE' ? (
-                  <div className="bai-substep-error-code">
-                    <Text type="supporting">
-                      {t('comp:BAISubStepNodes.ErrorCode')}
-                    </Text>
-                    <span className="bai-substep-chip">
-                      <Text type="code" size="sm" color="secondary">
-                        {record.errorCode ?? '-'}
+                </td>
+                <td>
+                  {record.errorCode ? (
+                    <span className="bai-substep-code">
+                      <Text
+                        type="code"
+                        size="sm"
+                        color="secondary"
+                        maxLines={1}
+                      >
+                        {record.errorCode}
                       </Text>
                     </span>
-                  </div>
-                ) : null}
-                {!isResultMarker && record.startedAt && record.endedAt ? (
-                  <div className="bai-substep-detail bai-substep-detail--time">
-                    <Text type="code" size="sm" color="secondary">
-                      {`${dayjs(record.startedAt).format(TIME_FORMAT)} → ${dayjs(
-                        record.endedAt,
-                      ).format(TIME_FORMAT)}`}
+                  ) : (
+                    <Text type="supporting" color="disabled">
+                      -
                     </Text>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+                  )}
+                </td>
+                <td>
+                  <Text type="supporting" maxLines={1}>
+                    {isResultMarker
+                      ? t('comp:BAISubStepNodes.ResultMarker')
+                      : newLineToBrElement(record.message ?? '-')}
+                  </Text>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -6,10 +6,9 @@
  a vertical timeline inside the parent row's expanded area.
 
  The backend flattens `PhaseRecord` groups on write, so what the API returns is
- a plain time-ordered list; and `_build_history_sub_steps` appends one trailing
- entry whose result mirrors the parent's and whose `started_at == ended_at` —
- a RESULT MARKER rather than an executed step. Both facts are what the timeline
- renders: solid nodes for the steps, an open dashed node for the marker.
+ a plain time-ordered list. Deployment rows carry one extra trailing entry that
+ restates the row itself — see `isLifecycleMarkerEntry` — and it renders as an
+ open dashed node capping the solid ones.
 
  Every font size, weight and colour comes from the theme through Astryx `Text`
  semantic types (`code` / `supporting`) and the `primary` / `secondary` colour

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -59,20 +59,50 @@ export const formatElapsed = (
   return `${Math.floor(minutes / 60)}h ${String(minutes % 60).padStart(2, '0')}m`;
 };
 
+/** `deploying-rolling-back` and `deploying_rolling_back` are the same name. */
+const normalizeStepName = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '-');
+
 /**
- * The trailing entry appended by `_build_history_sub_steps` — it carries the
- * parent's own result and a zero-length interval, so it is a marker, not a
- * step. Only the LAST entry can be one: an interior zero-length step is a real
- * (very fast) step.
+ * Only the DEPLOYMENT coordinator appends a lifecycle entry to `sub_steps`
+ * (`_build_history_sub_steps`); the session and route coordinators return the
+ * recorder's steps untouched. That entry restates the row it belongs to — its
+ * `step` is the phase's own name and its result is the row's result — so it
+ * caps the timeline as a marker instead of reading as work that was done.
+ *
+ * Identify it by that restatement, not by `started_at == ended_at`: real steps
+ * do finish inside one clock tick (measured — a session's
+ * `All kernels ready for PREPARED` reports 0 ms), which made the timestamp
+ * test label genuine session steps as markers.
  */
-export const isResultMarkerEntry = (
-  record: Pick<SubStepInList, 'startedAt' | 'endedAt'>,
+export const isLifecycleMarkerEntry = (
+  record: Pick<SubStepInList, 'step'>,
   index: number,
   total: number,
+  parentPhase: string | null | undefined,
 ): boolean =>
   index === total - 1 &&
-  !!record.startedAt &&
-  record.startedAt === record.endedAt;
+  !!parentPhase &&
+  normalizeStepName(record.step) === normalizeStepName(parentPhase);
+
+/**
+ * Sub-steps that record actual work — the lifecycle marker excluded. A row
+ * whose `sub_steps` hold nothing else has no detail to expand into: the marker
+ * alone would just repeat the row above it.
+ */
+export const countExecutedSubSteps = (
+  subSteps: ReadonlyArray<Pick<SubStepInList, 'step'> | null | undefined>,
+  parentPhase: string | null | undefined,
+): number => {
+  const entries = filterOutNullAndUndefined(subSteps);
+  return entries.filter(
+    (entry, index) =>
+      !isLifecycleMarkerEntry(entry, index, entries.length, parentPhase),
+  ).length;
+};
 
 const toSchedulingResult = (
   result: SubStepInList['result'],
@@ -84,10 +114,16 @@ export interface BAISubStepNodesProps extends Omit<
   'children'
 > {
   subStepsFrgmt: BAISubStepNodesFragment$key;
+  /**
+   * The owning history row's `phase`. It is what identifies the trailing
+   * lifecycle marker; without it every entry renders as an executed step.
+   */
+  parentPhase?: string | null;
 }
 
 const BAISubStepNodes = ({
   subStepsFrgmt,
+  parentPhase,
   className,
   ...divProps
 }: BAISubStepNodesProps) => {
@@ -123,10 +159,11 @@ const BAISubStepNodes = ({
         {dataSource.map((record, index) => {
           const result = toSchedulingResult(record.result);
           const isLast = index === lastIndex;
-          const isResultMarker = isResultMarkerEntry(
+          const isResultMarker = isLifecycleMarkerEntry(
             record,
             index,
             dataSource.length,
+            parentPhase,
           );
           const elapsed = formatElapsed(record.startedAt, record.endedAt);
 

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -22,7 +22,7 @@ import {
   BAISubStepNodesFragment$data,
   BAISubStepNodesFragment$key,
 } from '../../__generated__/BAISubStepNodesFragment.graphql';
-import { filterOutNullAndUndefined, newLineToBrElement } from '../../helper';
+import { filterOutNullAndUndefined } from '../../helper';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
 import {
   SchedulingResult,
@@ -107,6 +107,22 @@ export const countExecutedSubSteps = (
   ).length;
 };
 
+/**
+ * 3a gives the message one line. A `<br>` is a FORCED break that
+ * `white-space: nowrap` never suppresses, so rendering the newlines as markup
+ * (what `newLineToBrElement` does, and what the stacked 2a layout wanted) would
+ * lay out one line box per fragment — a cell `height` is only a minimum, so the
+ * 32px row would grow with the message. Multi-line messages are the norm on a
+ * failed step: the recorder stores `str(e)`, and a placement failure joins its
+ * per-agent reasons with newlines.
+ *
+ * Collapsing them to spaces keeps the row at 32px AND fixes the hover tooltip,
+ * which Astryx builds from `textContent` — with `<br>`s that came back as
+ * "line onelinetwo".
+ */
+const toSingleLine = (message: string | null | undefined): string =>
+  message?.replace(/\s*\n\s*/g, ' ').trim() || '-';
+
 const toSchedulingResult = (
   result: SubStepInList['result'],
 ): SchedulingResult | null =>
@@ -169,14 +185,25 @@ const BAISubStepNodes = ({
             {/* The rail column is decoration, but the header cell has to exist
                 for the column count to line up. */}
             <th scope="col" />
-            <th scope="col">{t('comp:BAISubStepNodes.Step')}</th>
-            <th scope="col">{t('comp:BAISubStepNodes.Result')}</th>
-            <th scope="col" className="bai-substep-num">
-              {t('comp:BAISubStepNodes.Duration')}
-            </th>
-            <th scope="col">{t('comp:BAISubStepNodes.Time')}</th>
-            <th scope="col">{t('comp:BAISubStepNodes.ErrorCode')}</th>
-            <th scope="col">{t('comp:BAISubStepNodes.Message')}</th>
+            {(
+              [
+                ['Step', undefined],
+                ['Result', undefined],
+                ['Duration', 'bai-substep-num'],
+                ['Time', undefined],
+                ['ErrorCode', undefined],
+                ['Message', undefined],
+              ] as const
+            ).map(([key, cellClassName]) => (
+              <th scope="col" key={key} className={cellClassName}>
+                {/* `maxLines` for the ellipsis and the hover tooltip: the
+                    columns are fixed-width, and a one-word label like ru
+                    `Длительность` needs 103px in the 74px duration column. */}
+                <Text type="supporting" weight="medium" maxLines={1}>
+                  {t(`comp:BAISubStepNodes.${key}`)}
+                </Text>
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
@@ -201,7 +228,10 @@ const BAISubStepNodes = ({
                   result ? resultSemanticColorMap[result] : 'default'
                 }
               >
-                <td className="bai-substep-rail-cell" aria-hidden />
+                {/* No `aria-hidden`: hiding it would leave the row owning
+                    six cells against seven column headers. Empty is right —
+                    the header cell above it is empty too. */}
+                <td className="bai-substep-rail-cell" />
                 <td>
                   <Text
                     type="code"
@@ -262,7 +292,7 @@ const BAISubStepNodes = ({
                   <Text type="supporting" maxLines={1}>
                     {isResultMarker
                       ? t('comp:BAISubStepNodes.ResultMarker')
-                      : newLineToBrElement(record.message ?? '-')}
+                      : toSingleLine(record.message)}
                   </Text>
                 </td>
               </tr>

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -10,6 +10,10 @@
  entry whose result mirrors the parent's and whose `started_at == ended_at` —
  a RESULT MARKER rather than an executed step. Both facts are what the timeline
  renders: solid nodes for the steps, an open dashed node for the marker.
+
+ Every font size, weight and colour comes from the theme through Astryx `Text`
+ semantic types (`code` / `supporting`) and the `primary` / `secondary` colour
+ ramp — the co-located CSS carries geometry only.
 */
 import {
   BAISubStepNodesFragment$data,
@@ -115,84 +119,91 @@ const BAISubStepNodes = ({
       className={classNames('bai-substep-timeline', className)}
       {...divProps}
     >
-      {dataSource.map((record, index) => {
-        const result = toSchedulingResult(record.result);
-        const isLast = index === lastIndex;
-        const isResultMarker = isResultMarkerEntry(
-          record,
-          index,
-          dataSource.length,
-        );
-        const elapsed = formatElapsed(record.startedAt, record.endedAt);
+      <div className="bai-substep-list">
+        {dataSource.map((record, index) => {
+          const result = toSchedulingResult(record.result);
+          const isLast = index === lastIndex;
+          const isResultMarker = isResultMarkerEntry(
+            record,
+            index,
+            dataSource.length,
+          );
+          const elapsed = formatElapsed(record.startedAt, record.endedAt);
 
-        return (
-          <div className="bai-substep-item" key={`${record.step}-${index}`}>
-            <div className="bai-substep-rail" aria-hidden>
-              <span
+          return (
+            <div className="bai-substep-item" key={`${record.step}-${index}`}>
+              <div className="bai-substep-rail" aria-hidden>
+                <span
+                  className={classNames(
+                    'bai-substep-dot',
+                    isResultMarker && 'bai-substep-dot--marker',
+                  )}
+                  data-variant={
+                    result ? resultSemanticColorMap[result] : 'default'
+                  }
+                />
+                {!isLast ? <span className="bai-substep-connector" /> : null}
+              </div>
+              <div
                 className={classNames(
-                  'bai-substep-dot',
-                  isResultMarker && 'bai-substep-dot--marker',
+                  'bai-substep-body',
+                  isResultMarker && 'bai-substep-body--marker',
                 )}
-                data-variant={
-                  result ? resultSemanticColorMap[result] : 'default'
-                }
-              />
-              {!isLast ? <span className="bai-substep-connector" /> : null}
-            </div>
-            <div className="bai-substep-body">
-              <div className="bai-substep-header">
-                <Text
-                  type="code"
-                  weight="medium"
-                  color={isResultMarker ? 'secondary' : 'primary'}
-                >
-                  {record.step}
-                </Text>
-                <BAISchedulingResultBadge result={result} />
-                {isResultMarker ? (
-                  <span className="bai-substep-pill">
-                    <Text type="supporting" color="secondary">
-                      {t('comp:BAISubStepNodes.ResultMarker')}
-                    </Text>
-                  </span>
-                ) : elapsed ? (
-                  <Text type="code" size="sm" color="secondary">
-                    {elapsed}
+              >
+                <div className="bai-substep-header">
+                  <Text
+                    type="code"
+                    weight="medium"
+                    color={isResultMarker ? 'secondary' : 'primary'}
+                  >
+                    {record.step}
                   </Text>
+                  <BAISchedulingResultBadge result={result} />
+                  {isResultMarker ? (
+                    <span className="bai-substep-pill">
+                      <Text type="supporting">
+                        {t('comp:BAISubStepNodes.ResultMarker')}
+                      </Text>
+                    </span>
+                  ) : elapsed ? (
+                    <Text type="code" size="sm" color="secondary">
+                      {elapsed}
+                    </Text>
+                  ) : null}
+                </div>
+                {!isResultMarker && record.message ? (
+                  <div className="bai-substep-detail">
+                    <Text type="supporting">
+                      {newLineToBrElement(record.message)}
+                    </Text>
+                  </div>
+                ) : null}
+                {!isResultMarker && result === 'FAILURE' ? (
+                  <div className="bai-substep-error-code">
+                    <Text type="supporting">
+                      {t('comp:BAISubStepNodes.ErrorCode')}
+                    </Text>
+                    <span className="bai-substep-chip">
+                      <Text type="code" size="sm" color="secondary">
+                        {record.errorCode ?? '-'}
+                      </Text>
+                    </span>
+                  </div>
+                ) : null}
+                {!isResultMarker && record.startedAt && record.endedAt ? (
+                  <div className="bai-substep-detail bai-substep-detail--time">
+                    <Text type="code" size="sm" color="secondary">
+                      {`${dayjs(record.startedAt).format(TIME_FORMAT)} → ${dayjs(
+                        record.endedAt,
+                      ).format(TIME_FORMAT)}`}
+                    </Text>
+                  </div>
                 ) : null}
               </div>
-              {!isResultMarker && record.message ? (
-                <div className="bai-substep-detail">
-                  <Text size="sm" color="secondary">
-                    {newLineToBrElement(record.message)}
-                  </Text>
-                </div>
-              ) : null}
-              {!isResultMarker && result === 'FAILURE' ? (
-                <div className="bai-substep-error-code">
-                  <Text type="supporting">
-                    {t('comp:BAISubStepNodes.ErrorCode')}
-                  </Text>
-                  <span className="bai-substep-chip">
-                    <Text type="code" size="sm" color="secondary">
-                      {record.errorCode ?? '-'}
-                    </Text>
-                  </span>
-                </div>
-              ) : null}
-              {!isResultMarker && record.startedAt && record.endedAt ? (
-                <div className="bai-substep-detail">
-                  <Text type="code" size="sm" color="disabled">
-                    {`${dayjs(record.startedAt).format(TIME_FORMAT)} → ${dayjs(
-                      record.endedAt,
-                    ).format(TIME_FORMAT)}`}
-                  </Text>
-                </div>
-              ) : null}
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -1,67 +1,94 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ `BAISubStepNodes` — the sub-steps of one scheduling-history attempt, drawn as
+ a vertical timeline inside the parent row's expanded area.
+
+ The backend flattens `PhaseRecord` groups on write, so what the API returns is
+ a plain time-ordered list; and `_build_history_sub_steps` appends one trailing
+ entry whose result mirrors the parent's and whose `started_at == ended_at` —
+ a RESULT MARKER rather than an executed step. Both facts are what the timeline
+ renders: solid nodes for the steps, an open dashed node for the marker.
+*/
 import {
   BAISubStepNodesFragment$data,
   BAISubStepNodesFragment$key,
 } from '../../__generated__/BAISubStepNodesFragment.graphql';
-import {
-  filterOutEmpty,
-  filterOutNullAndUndefined,
-  newLineToBrElement,
-} from '../../helper';
+import { filterOutNullAndUndefined, newLineToBrElement } from '../../helper';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
-import { theme } from '../../theme-shim';
 import BAISchedulingResultBadge, {
   SchedulingResult,
+  resultSemanticColorMap,
 } from '../BAISchedulingResultBadge';
-import BAIText from '../BAIText';
-import {
-  BAITableProps,
-  BAIColumnsType,
-  BAIColumnType,
-  BAITable,
-} from '../Table';
+import './BAISubStepNodes.css';
+import { Text } from '@astryxdesign/core/Text';
+import classNames from 'classnames';
 import dayjs from 'dayjs';
-import duration from 'dayjs/plugin/duration';
-import * as _ from 'lodash-es';
+import * as React from 'react';
 import { graphql, useFragment } from 'react-relay';
-
-dayjs.extend(duration);
 
 export type SubStepInList = NonNullable<BAISubStepNodesFragment$data[number]>;
 
-const availableSubStepSorterKeys = [] as const;
+const TIME_FORMAT = 'HH:mm:ss.SSS';
 
-export const availableSubStepSorterValues = [] as const;
-
-const FAILURE_RESULTS: ReadonlyArray<SchedulingResult> = [
-  'FAILURE',
-  'EXPIRED',
-  'GIVE_UP',
-];
-
-const isEnableSorter = (key: string) => {
-  return _.includes(availableSubStepSorterKeys, key);
+/**
+ * Both timestamps are non-null in practice (the recorder always stamps them),
+ * so the elapsed time is a value the timeline can always show. Sub-steps are
+ * short — milliseconds to seconds — hence the two significant sub-second
+ * digits rather than a `HH:mm:ss` clock.
+ */
+export const formatElapsed = (
+  startedAt: string | null | undefined,
+  endedAt: string | null | undefined,
+): string | null => {
+  if (!startedAt || !endedAt) return null;
+  const ms = dayjs(endedAt).diff(dayjs(startedAt));
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(2)} s`;
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${String(totalSeconds % 60).padStart(2, '0')}s`;
+  }
+  return `${Math.floor(minutes / 60)}h ${String(minutes % 60).padStart(2, '0')}m`;
 };
 
+/**
+ * The trailing entry appended by `_build_history_sub_steps` — it carries the
+ * parent's own result and a zero-length interval, so it is a marker, not a
+ * step. Only the LAST entry can be one: an interior zero-length step is a real
+ * (very fast) step.
+ */
+export const isResultMarkerEntry = (
+  record: Pick<SubStepInList, 'startedAt' | 'endedAt'>,
+  index: number,
+  total: number,
+): boolean =>
+  index === total - 1 &&
+  !!record.startedAt &&
+  record.startedAt === record.endedAt;
+
+const toSchedulingResult = (
+  result: SubStepInList['result'],
+): SchedulingResult | null =>
+  result && result !== '%future added value' ? result : null;
+
 export interface BAISubStepNodesProps extends Omit<
-  BAITableProps<SubStepInList>,
-  'dataSource' | 'columns' | 'onChangeOrder'
+  React.HTMLAttributes<HTMLDivElement>,
+  'children'
 > {
   subStepsFrgmt: BAISubStepNodesFragment$key;
-  customizeColumns?: (
-    baseColumns: BAIColumnsType<SubStepInList>,
-  ) => BAIColumnsType<SubStepInList>;
-  disableSorter?: boolean;
 }
 
 const BAISubStepNodes = ({
   subStepsFrgmt,
-  customizeColumns,
-  disableSorter,
-  ...tableProps
+  className,
+  ...divProps
 }: BAISubStepNodesProps) => {
   'use memo';
   const { t } = useBAIi18n();
-  const { token } = theme.useToken();
 
   const subSteps = useFragment<BAISubStepNodesFragment$key>(
     graphql`
@@ -78,115 +105,95 @@ const BAISubStepNodes = ({
     subStepsFrgmt,
   );
 
-  const baseColumns = _.map(
-    filterOutEmpty<BAIColumnType<SubStepInList>>([
-      {
-        key: 'step',
-        title: t('comp:BAISubStepNodes.Step'),
-        dataIndex: 'step',
-        fixed: 'left',
-        sorter: isEnableSorter('step'),
-        render: (_value, record) => {
-          const result =
-            record.result && record.result !== '%future added value'
-              ? (record.result as SchedulingResult)
-              : null;
-          const isFailure = result != null && FAILURE_RESULTS.includes(result);
-          return (
-            <span style={isFailure ? { color: token.colorError } : undefined}>
-              {record.step}
-            </span>
-          );
-        },
-      },
-      {
-        key: 'result',
-        title: t('comp:BAISubStepNodes.Result'),
-        dataIndex: 'result',
-        onCell: () => ({ style: { minWidth: 100 } }),
-        render: (_value, record) => {
-          const result =
-            record.result && record.result !== '%future added value'
-              ? (record.result as SchedulingResult)
-              : null;
-          const isFailure = result != null && FAILURE_RESULTS.includes(result);
-          return (
-            <BAISchedulingResultBadge
-              result={result}
-              style={{
-                color: isFailure ? token.colorError : undefined,
-              }}
-            />
-          );
-        },
-        sorter: isEnableSorter('result'),
-      },
-      {
-        key: 'errorCode',
-        title: t('comp:BAISubStepNodes.ErrorCode'),
-        dataIndex: 'errorCode',
-        render: (__, record) =>
-          record.errorCode ? (
-            <BAIText monospace>{record.errorCode}</BAIText>
-          ) : (
-            '-'
-          ),
-        sorter: isEnableSorter('errorCode'),
-      },
-      {
-        key: 'message',
-        title: t('comp:BAISubStepNodes.Message'),
-        dataIndex: 'message',
-        onCell: () => ({ style: { maxWidth: 500 } }),
-        render: (__, record) =>
-          record.message ? (
-            <BAIText title={record.message} style={{ width: '100%' }}>
-              {newLineToBrElement(record.message)}
-            </BAIText>
-          ) : (
-            '-'
-          ),
-        sorter: isEnableSorter('message'),
-      },
-      {
-        key: 'startedAt',
-        title: t('comp:BAISubStepNodes.StartedAt'),
-        dataIndex: 'startedAt',
-        render: (__, record) =>
-          record.startedAt ? dayjs(record.startedAt).format('ll LTS') : '-',
-        sorter: isEnableSorter('startedAt'),
-      },
-      {
-        key: 'endedAt',
-        title: t('comp:BAISubStepNodes.EndedAt'),
-        dataIndex: 'endedAt',
-        render: (__, record) =>
-          record.endedAt ? dayjs(record.endedAt).format('ll LTS') : '-',
-        sorter: isEnableSorter('endedAt'),
-      },
-    ]),
-    (column) => {
-      return disableSorter ? _.omit(column, 'sorter') : column;
-    },
-  );
-
-  const allColumns = customizeColumns
-    ? customizeColumns(baseColumns)
-    : baseColumns;
-
-  const dataSource = filterOutNullAndUndefined(subSteps).reverse();
+  // Ascending, as the API returns it — the timeline reads top-down and the
+  // trailing result marker must stay last.
+  const dataSource = filterOutNullAndUndefined(subSteps);
+  const lastIndex = dataSource.length - 1;
 
   return (
-    // to-astryx ticket 25: migrated to the Astryx engine. This table renders
-    // INSIDE an expanded row of `BAISchedulingHistoryNodes`, so it also proves
-    // the nested-table case (`onCell` cell styles, `fixed: 'left'`).
-    <BAITable
-      rowKey="step"
-      size="small"
-      dataSource={dataSource}
-      columns={allColumns}
-      {...tableProps}
-    />
+    <div
+      className={classNames('bai-substep-timeline', className)}
+      {...divProps}
+    >
+      {dataSource.map((record, index) => {
+        const result = toSchedulingResult(record.result);
+        const isLast = index === lastIndex;
+        const isResultMarker = isResultMarkerEntry(
+          record,
+          index,
+          dataSource.length,
+        );
+        const elapsed = formatElapsed(record.startedAt, record.endedAt);
+
+        return (
+          <div className="bai-substep-item" key={`${record.step}-${index}`}>
+            <div className="bai-substep-rail" aria-hidden>
+              <span
+                className={classNames(
+                  'bai-substep-dot',
+                  isResultMarker && 'bai-substep-dot--marker',
+                )}
+                data-variant={
+                  result ? resultSemanticColorMap[result] : 'default'
+                }
+              />
+              {!isLast ? <span className="bai-substep-connector" /> : null}
+            </div>
+            <div className="bai-substep-body">
+              <div className="bai-substep-header">
+                <Text
+                  type="code"
+                  weight="medium"
+                  color={isResultMarker ? 'secondary' : 'primary'}
+                >
+                  {record.step}
+                </Text>
+                <BAISchedulingResultBadge result={result} />
+                {isResultMarker ? (
+                  <span className="bai-substep-pill">
+                    <Text type="supporting" color="secondary">
+                      {t('comp:BAISubStepNodes.ResultMarker')}
+                    </Text>
+                  </span>
+                ) : elapsed ? (
+                  <Text type="code" size="sm" color="secondary">
+                    {elapsed}
+                  </Text>
+                ) : null}
+              </div>
+              {!isResultMarker && record.message ? (
+                <div className="bai-substep-detail">
+                  <Text size="sm" color="secondary">
+                    {newLineToBrElement(record.message)}
+                  </Text>
+                </div>
+              ) : null}
+              {!isResultMarker && result === 'FAILURE' ? (
+                <div className="bai-substep-error-code">
+                  <Text type="supporting">
+                    {t('comp:BAISubStepNodes.ErrorCode')}
+                  </Text>
+                  <span className="bai-substep-chip">
+                    <Text type="code" size="sm" color="secondary">
+                      {record.errorCode ?? '-'}
+                    </Text>
+                  </span>
+                </div>
+              ) : null}
+              {!isResultMarker && record.startedAt && record.endedAt ? (
+                <div className="bai-substep-detail">
+                  <Text type="code" size="sm" color="disabled">
+                    {`${dayjs(record.startedAt).format(TIME_FORMAT)} → ${dayjs(
+                      record.endedAt,
+                    ).format(TIME_FORMAT)}`}
+                  </Text>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 };
 

--- a/packages/backend.ai-ui/src/hooks/useSchedulingHistoryExpandable.tsx
+++ b/packages/backend.ai-ui/src/hooks/useSchedulingHistoryExpandable.tsx
@@ -12,8 +12,8 @@ import { useState } from 'react';
 
 /**
  * Minimal shape shared by every scheduling-history row type
- * (session / deployment / route). A row is expandable when it has sub-steps,
- * and it is expanded by default unless its result is a success.
+ * (session / deployment / route). A row is expandable when `isExpandable` says
+ * so, and it is expanded by default unless its result is a success.
  */
 export interface SchedulingHistoryExpandableRow {
   readonly id: string;
@@ -31,23 +31,26 @@ export type SchedulingHistoryExpandMode =
 export const DEFAULT_SCHEDULING_HISTORY_EXPAND_MODE: SchedulingHistoryExpandMode =
   'errors-only';
 
-const isRowExpandable = (record: SchedulingHistoryExpandableRow) =>
+const hasAnySubStep = (record: SchedulingHistoryExpandableRow) =>
   !_.isEmpty(record.subSteps);
-
-// "Collapse success only": every non-success row stays open by default so
-// failures / retries / expirations are visible at a glance.
-const shouldExpandByDefault = (record: SchedulingHistoryExpandableRow) =>
-  isRowExpandable(record) && record.result !== 'SUCCESS';
 
 const computeExpandedRowKeysForMode = (
   dataSource: ReadonlyArray<SchedulingHistoryExpandableRow>,
   mode: SchedulingHistoryExpandMode,
+  isExpandable: (record: SchedulingHistoryExpandableRow) => boolean,
 ): React.Key[] =>
   mode === 'expand-all'
-    ? dataSource.filter(isRowExpandable).map((record) => record.id)
+    ? dataSource.filter(isExpandable).map((record) => record.id)
     : mode === 'collapse-all'
       ? []
-      : dataSource.filter(shouldExpandByDefault).map((record) => record.id);
+      : // "Collapse success only": every non-success row that HAS detail stays
+        // open by default so failures / retries / expirations are visible at a
+        // glance.
+        dataSource
+          .filter(
+            (record) => isExpandable(record) && record.result !== 'SUCCESS',
+          )
+          .map((record) => record.id);
 
 export interface UseSchedulingHistoryExpandableResult {
   /**
@@ -89,15 +92,26 @@ export const useSchedulingHistoryExpandable = <
   options?: {
     mode?: SchedulingHistoryExpandMode;
     onModeChange?: (mode: SchedulingHistoryExpandMode) => void;
+    /**
+     * Which rows have detail worth opening. Defaults to "has any sub-step",
+     * but a caller that can tell a real sub-step from the trailing lifecycle
+     * marker should pass the same predicate it gives `rowExpandable`, so the
+     * master modes never open a row the table renders as non-expandable.
+     */
+    isExpandable?: (record: T) => boolean;
   },
 ): UseSchedulingHistoryExpandableResult => {
   'use memo';
   const { t } = useBAIi18n();
 
   const mode = options?.mode ?? DEFAULT_SCHEDULING_HISTORY_EXPAND_MODE;
+  const isExpandable = (record: SchedulingHistoryExpandableRow) =>
+    options?.isExpandable
+      ? options.isExpandable(record as T)
+      : hasAnySubStep(record);
 
   const [expandedRowKeys, setExpandedRowKeys] = useState<React.Key[]>(() =>
-    computeExpandedRowKeysForMode(dataSource, mode),
+    computeExpandedRowKeysForMode(dataSource, mode, isExpandable),
   );
 
   // The signature changes only on real data changes — not on the new array
@@ -106,7 +120,7 @@ export const useSchedulingHistoryExpandable = <
   const dataSignature = dataSource
     .map(
       (record) =>
-        `${record.id}:${record.result ?? ''}:${isRowExpandable(record) ? 1 : 0}`,
+        `${record.id}:${record.result ?? ''}:${isExpandable(record) ? 1 : 0}`,
     )
     .join('|');
 
@@ -117,11 +131,13 @@ export const useSchedulingHistoryExpandable = <
   if (dataSignature !== prevDataSignature || mode !== prevMode) {
     setPrevDataSignature(dataSignature);
     setPrevMode(mode);
-    setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, mode));
+    setExpandedRowKeys(
+      computeExpandedRowKeysForMode(dataSource, mode, isExpandable),
+    );
   }
 
   const expandableRowKeys = dataSource
-    .filter(isRowExpandable)
+    .filter(isExpandable)
     .map((record) => record.id);
 
   const onExpandedRowsChange = (expandedKeys: readonly React.Key[]) => {
@@ -138,7 +154,9 @@ export const useSchedulingHistoryExpandable = <
     // Apply eagerly so the uncontrolled case (no onModeChange) still reacts. In
     // the controlled case onModeChange updates `mode`, and the `[mode]` effect
     // re-applies the same (idempotent) keys — a harmless redundant set.
-    setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, next));
+    setExpandedRowKeys(
+      computeExpandedRowKeysForMode(dataSource, next, isExpandable),
+    );
     options?.onModeChange?.(next);
   };
 

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Speicher-Proxy auswählen"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Dauer",
     "ErrorCode": "Fehlercode",
-    "ResultMarker": "Ergebnismarkierung"
+    "Message": "Nachricht",
+    "Result": "Ergebnis",
+    "ResultMarker": "Ergebnismarkierung dieses Versuchs",
+    "Step": "Schritt",
+    "Time": "Zeit"
   },
   "comp:BAITable": {
     "Apply": "Anwenden",

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Speicher-Proxy auswählen"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Beendet um",
     "ErrorCode": "Fehlercode",
-    "Message": "Nachricht",
-    "Result": "Ergebnis",
-    "StartedAt": "Gestartet am",
-    "Step": "Schritt"
+    "ResultMarker": "Ergebnismarkierung"
   },
   "comp:BAITable": {
     "Apply": "Anwenden",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Επιλέξτε proxy αποθήκευσης"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Διάρκεια",
     "ErrorCode": "Κωδικός σφάλματος",
-    "ResultMarker": "Δείκτης αποτελέσματος"
+    "Message": "Μήνυμα",
+    "Result": "Αποτέλεσμα",
+    "ResultMarker": "Δείκτης αποτελέσματος αυτής της προσπάθειας",
+    "Step": "Βήμα",
+    "Time": "Ώρα"
   },
   "comp:BAITable": {
     "Apply": "Εφαρμογή",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Επιλέξτε proxy αποθήκευσης"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Έληξε στις",
     "ErrorCode": "Κωδικός σφάλματος",
-    "Message": "Μήνυμα",
-    "Result": "Αποτέλεσμα",
-    "StartedAt": "Ξεκίνησε στις",
-    "Step": "Βήμα"
+    "ResultMarker": "Δείκτης αποτελέσματος"
   },
   "comp:BAITable": {
     "Apply": "Εφαρμογή",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -482,8 +482,13 @@
     "SelectStorageProxy": "Select Storage Proxy"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Duration",
     "ErrorCode": "Error Code",
-    "ResultMarker": "Result Marker"
+    "Message": "Message",
+    "Result": "Result",
+    "ResultMarker": "Result marker for this attempt",
+    "Step": "Step",
+    "Time": "Time"
   },
   "comp:BAITable": {
     "Apply": "Apply",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -482,12 +482,8 @@
     "SelectStorageProxy": "Select Storage Proxy"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Ended At",
     "ErrorCode": "Error Code",
-    "Message": "Message",
-    "Result": "Result",
-    "StartedAt": "Started At",
-    "Step": "Step"
+    "ResultMarker": "Result Marker"
   },
   "comp:BAITable": {
     "Apply": "Apply",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Seleccionar proxy de almacenamiento"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Finalizado en",
     "ErrorCode": "Código de error",
-    "Message": "Mensaje",
-    "Result": "Resultado",
-    "StartedAt": "Fecha de inicio",
-    "Step": "Paso"
+    "ResultMarker": "Marcador de resultado"
   },
   "comp:BAITable": {
     "Apply": "Aplicar",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Seleccionar proxy de almacenamiento"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Duración",
     "ErrorCode": "Código de error",
-    "ResultMarker": "Marcador de resultado"
+    "Message": "Mensaje",
+    "Result": "Resultado",
+    "ResultMarker": "Marcador de resultado de este intento",
+    "Step": "Paso",
+    "Time": "Hora"
   },
   "comp:BAITable": {
     "Apply": "Aplicar",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Valitse tallennusvälityspalvelin"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Kesto",
     "ErrorCode": "Virhekoodi",
-    "ResultMarker": "Tulosmerkintä"
+    "Message": "Viesti",
+    "Result": "Tulos",
+    "ResultMarker": "Tämän yrityksen tulosmerkintä",
+    "Step": "Vaihe",
+    "Time": "Aika"
   },
   "comp:BAITable": {
     "Apply": "Käytä",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Valitse tallennusvälityspalvelin"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Päättymisaika",
     "ErrorCode": "Virhekoodi",
-    "Message": "Viesti",
-    "Result": "Tulos",
-    "StartedAt": "Aloitusaika",
-    "Step": "Vaihe"
+    "ResultMarker": "Tulosmerkintä"
   },
   "comp:BAITable": {
     "Apply": "Käytä",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Sélectionner un proxy de stockage"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Terminé le",
     "ErrorCode": "Code d'erreur",
-    "Message": "Message",
-    "Result": "Résultat",
-    "StartedAt": "Démarré le",
-    "Step": "Étape"
+    "ResultMarker": "Marqueur de résultat"
   },
   "comp:BAITable": {
     "Apply": "Appliquer",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Sélectionner un proxy de stockage"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Durée",
     "ErrorCode": "Code d'erreur",
-    "ResultMarker": "Marqueur de résultat"
+    "Message": "Message",
+    "Result": "Résultat",
+    "ResultMarker": "Marqueur de résultat de cette tentative",
+    "Step": "Étape",
+    "Time": "Heure"
   },
   "comp:BAITable": {
     "Apply": "Appliquer",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Pilih Proksi Penyimpanan"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Berakhir pada",
     "ErrorCode": "Kode Kesalahan",
-    "Message": "Pesan",
-    "Result": "Hasil",
-    "StartedAt": "Dimulai pada",
-    "Step": "Langkah"
+    "ResultMarker": "Penanda Hasil"
   },
   "comp:BAITable": {
     "Apply": "Terapkan",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Pilih Proksi Penyimpanan"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Durasi",
     "ErrorCode": "Kode Kesalahan",
-    "ResultMarker": "Penanda Hasil"
+    "Message": "Pesan",
+    "Result": "Hasil",
+    "ResultMarker": "Penanda hasil untuk percobaan ini",
+    "Step": "Langkah",
+    "Time": "Waktu"
   },
   "comp:BAITable": {
     "Apply": "Terapkan",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Seleziona proxy di archiviazione"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Durata",
     "ErrorCode": "Codice di errore",
-    "ResultMarker": "Indicatore di risultato"
+    "Message": "Messaggio",
+    "Result": "Risultato",
+    "ResultMarker": "Indicatore di risultato di questo tentativo",
+    "Step": "Passo",
+    "Time": "Ora"
   },
   "comp:BAITable": {
     "Apply": "Applica",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Seleziona proxy di archiviazione"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Terminato il",
     "ErrorCode": "Codice di errore",
-    "Message": "Messaggio",
-    "Result": "Risultato",
-    "StartedAt": "Avviato il",
-    "Step": "Passo"
+    "ResultMarker": "Indicatore di risultato"
   },
   "comp:BAITable": {
     "Apply": "Applica",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "ストレージプロキシを選択"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "終了日時",
     "ErrorCode": "エラーコード",
-    "Message": "メッセージ",
-    "Result": "結果",
-    "StartedAt": "開始日時",
-    "Step": "ステップ"
+    "ResultMarker": "結果マーカー"
   },
   "comp:BAITable": {
     "Apply": "適用",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "ストレージプロキシを選択"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "所要時間",
     "ErrorCode": "エラーコード",
-    "ResultMarker": "結果マーカー"
+    "Message": "メッセージ",
+    "Result": "結果",
+    "ResultMarker": "この試行の結果マーカー",
+    "Step": "ステップ",
+    "Time": "時刻"
   },
   "comp:BAITable": {
     "Apply": "適用",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "스토리지 프록시를 선택해주세요"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "소요 시간",
     "ErrorCode": "오류 코드",
-    "ResultMarker": "결과 마커"
+    "Message": "메시지",
+    "Result": "결과",
+    "ResultMarker": "이 시도의 결과 마커",
+    "Step": "세부단계",
+    "Time": "시간"
   },
   "comp:BAITable": {
     "Apply": "적용",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "스토리지 프록시를 선택해주세요"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "종료일",
     "ErrorCode": "오류 코드",
-    "Message": "메시지",
-    "Result": "결과",
-    "StartedAt": "시작일",
-    "Step": "세부단계"
+    "ResultMarker": "결과 마커"
   },
   "comp:BAITable": {
     "Apply": "적용",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Хадгалалтын прокси сонгох"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Дууссан цаг",
     "ErrorCode": "Алдааны код",
-    "Message": "Зурвас",
-    "Result": "Үр дүн",
-    "StartedAt": "Эхэлсэн цаг",
-    "Step": "Алхам"
+    "ResultMarker": "Үр дүнгийн тэмдэглэгээ"
   },
   "comp:BAITable": {
     "Apply": "Хэрэглэх",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Хадгалалтын прокси сонгох"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Үргэлжлэх хугацаа",
     "ErrorCode": "Алдааны код",
-    "ResultMarker": "Үр дүнгийн тэмдэглэгээ"
+    "Message": "Зурвас",
+    "Result": "Үр дүн",
+    "ResultMarker": "Энэ оролдлогын үр дүнгийн тэмдэглэгээ",
+    "Step": "Алхам",
+    "Time": "Цаг"
   },
   "comp:BAITable": {
     "Apply": "Хэрэглэх",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Pilih Proksi Storan"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Berakhir pada",
     "ErrorCode": "Kod Ralat",
-    "Message": "Mesej",
-    "Result": "Hasil",
-    "StartedAt": "Mula pada",
-    "Step": "Langkah"
+    "ResultMarker": "Penanda Keputusan"
   },
   "comp:BAITable": {
     "Apply": "Guna",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Pilih Proksi Storan"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Tempoh",
     "ErrorCode": "Kod Ralat",
-    "ResultMarker": "Penanda Keputusan"
+    "Message": "Mesej",
+    "Result": "Hasil",
+    "ResultMarker": "Penanda keputusan bagi percubaan ini",
+    "Step": "Langkah",
+    "Time": "Masa"
   },
   "comp:BAITable": {
     "Apply": "Guna",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Wybierz serwer proxy pamięci masowej"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Zakończono o",
     "ErrorCode": "Kod błędu",
-    "Message": "Wiadomość",
-    "Result": "Wynik",
-    "StartedAt": "Rozpoczęto",
-    "Step": "Krok"
+    "ResultMarker": "Znacznik wyniku"
   },
   "comp:BAITable": {
     "Apply": "Zastosuj",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Wybierz serwer proxy pamięci masowej"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Czas trwania",
     "ErrorCode": "Kod błędu",
-    "ResultMarker": "Znacznik wyniku"
+    "Message": "Wiadomość",
+    "Result": "Wynik",
+    "ResultMarker": "Znacznik wyniku tej próby",
+    "Step": "Krok",
+    "Time": "Czas"
   },
   "comp:BAITable": {
     "Apply": "Zastosuj",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -464,8 +464,13 @@
     "SelectStorageProxy": "Selecionar proxy de armazenamento"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Duração",
     "ErrorCode": "Código de erro",
-    "ResultMarker": "Marcador de resultado"
+    "Message": "Mensagem",
+    "Result": "Resultado",
+    "ResultMarker": "Marcador de resultado desta tentativa",
+    "Step": "Etapa",
+    "Time": "Hora"
   },
   "comp:BAITable": {
     "Apply": "Aplicar",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -464,12 +464,8 @@
     "SelectStorageProxy": "Selecionar proxy de armazenamento"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Finalizado em",
     "ErrorCode": "Código de erro",
-    "Message": "Mensagem",
-    "Result": "Resultado",
-    "StartedAt": "Iniciado em",
-    "Step": "Etapa"
+    "ResultMarker": "Marcador de resultado"
   },
   "comp:BAITable": {
     "Apply": "Aplicar",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Selecionar proxy de armazenamento"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Finalizado em",
     "ErrorCode": "Código de erro",
-    "Message": "Mensagem",
-    "Result": "Resultado",
-    "StartedAt": "Iniciado em",
-    "Step": "Etapa"
+    "ResultMarker": "Marcador de resultado"
   },
   "comp:BAITable": {
     "Apply": "Aplicar",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Selecionar proxy de armazenamento"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Duração",
     "ErrorCode": "Código de erro",
-    "ResultMarker": "Marcador de resultado"
+    "Message": "Mensagem",
+    "Result": "Resultado",
+    "ResultMarker": "Marcador de resultado desta tentativa",
+    "Step": "Etapa",
+    "Time": "Hora"
   },
   "comp:BAITable": {
     "Apply": "Aplicar",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Выберите прокси хранилища"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Завершено в",
     "ErrorCode": "Код ошибки",
-    "Message": "Сообщение",
-    "Result": "Результат",
-    "StartedAt": "Начато в",
-    "Step": "Шаг"
+    "ResultMarker": "Маркер результата"
   },
   "comp:BAITable": {
     "Apply": "Применить",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Выберите прокси хранилища"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Длительность",
     "ErrorCode": "Код ошибки",
-    "ResultMarker": "Маркер результата"
+    "Message": "Сообщение",
+    "Result": "Результат",
+    "ResultMarker": "Маркер результата этой попытки",
+    "Step": "Шаг",
+    "Time": "Время"
   },
   "comp:BAITable": {
     "Apply": "Применить",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "เลือกพร็อกซีที่เก็บข้อมูล"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "ระยะเวลา",
     "ErrorCode": "รหัสข้อผิดพลาด",
-    "ResultMarker": "เครื่องหมายผลลัพธ์"
+    "Message": "ข้อความ",
+    "Result": "ผลลัพธ์",
+    "ResultMarker": "เครื่องหมายผลลัพธ์ของความพยายามนี้",
+    "Step": "ขั้นตอน",
+    "Time": "เวลา"
   },
   "comp:BAITable": {
     "Apply": "ใช้",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "เลือกพร็อกซีที่เก็บข้อมูล"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "สิ้นสุดเมื่อ",
     "ErrorCode": "รหัสข้อผิดพลาด",
-    "Message": "ข้อความ",
-    "Result": "ผลลัพธ์",
-    "StartedAt": "เริ่มเมื่อ",
-    "Step": "ขั้นตอน"
+    "ResultMarker": "เครื่องหมายผลลัพธ์"
   },
   "comp:BAITable": {
     "Apply": "ใช้",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Depolama Proxy'si Seç"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Süre",
     "ErrorCode": "Hata Kodu",
-    "ResultMarker": "Sonuç İşareti"
+    "Message": "Mesaj",
+    "Result": "Sonuç",
+    "ResultMarker": "Bu denemenin sonuç işareti",
+    "Step": "Adım",
+    "Time": "Zaman"
   },
   "comp:BAITable": {
     "Apply": "Uygula",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Depolama Proxy'si Seç"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Bitiş Zamanı",
     "ErrorCode": "Hata Kodu",
-    "Message": "Mesaj",
-    "Result": "Sonuç",
-    "StartedAt": "Başlama zamanı",
-    "Step": "Adım"
+    "ResultMarker": "Sonuç İşareti"
   },
   "comp:BAITable": {
     "Apply": "Uygula",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "Chọn proxy lưu trữ"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "Kết thúc lúc",
     "ErrorCode": "Mã lỗi",
-    "Message": "Tin nhắn",
-    "Result": "Kết quả",
-    "StartedAt": "Bắt đầu lúc",
-    "Step": "Bước"
+    "ResultMarker": "Dấu kết quả"
   },
   "comp:BAITable": {
     "Apply": "Áp dụng",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "Chọn proxy lưu trữ"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "Thời lượng",
     "ErrorCode": "Mã lỗi",
-    "ResultMarker": "Dấu kết quả"
+    "Message": "Tin nhắn",
+    "Result": "Kết quả",
+    "ResultMarker": "Dấu kết quả của lần thử này",
+    "Step": "Bước",
+    "Time": "Thời gian"
   },
   "comp:BAITable": {
     "Apply": "Áp dụng",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "选择存储代理"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "结束时间",
     "ErrorCode": "错误代码",
-    "Message": "消息",
-    "Result": "结果",
-    "StartedAt": "开始时间",
-    "Step": "步骤"
+    "ResultMarker": "结果标记"
   },
   "comp:BAITable": {
     "Apply": "应用",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "选择存储代理"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "持续时间",
     "ErrorCode": "错误代码",
-    "ResultMarker": "结果标记"
+    "Message": "消息",
+    "Result": "结果",
+    "ResultMarker": "本次尝试的结果标记",
+    "Step": "步骤",
+    "Time": "时间"
   },
   "comp:BAITable": {
     "Apply": "应用",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -458,8 +458,13 @@
     "SelectStorageProxy": "選擇儲存代理"
   },
   "comp:BAISubStepNodes": {
+    "Duration": "持續時間",
     "ErrorCode": "錯誤代碼",
-    "ResultMarker": "結果標記"
+    "Message": "訊息",
+    "Result": "結果",
+    "ResultMarker": "本次嘗試的結果標記",
+    "Step": "步驟",
+    "Time": "時間"
   },
   "comp:BAITable": {
     "Apply": "套用",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -458,12 +458,8 @@
     "SelectStorageProxy": "選擇儲存代理"
   },
   "comp:BAISubStepNodes": {
-    "EndedAt": "結束時間",
     "ErrorCode": "錯誤代碼",
-    "Message": "訊息",
-    "Result": "結果",
-    "StartedAt": "開始時間",
-    "Step": "步驟"
+    "ResultMarker": "結果標記"
   },
   "comp:BAITable": {
     "Apply": "套用",

--- a/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6423974fd699af3b00e2069e111ef76a>>
+ * @generated SignedSource<<2066a80b987a84b3887072c674de0c66>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -278,6 +278,13 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "phase",
+                    "storageKey": null
+                  },
                   (v7/*: any*/),
                   {
                     "alias": null,
@@ -319,13 +326,6 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "category",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "phase",
                     "storageKey": null
                   },
                   {
@@ -377,12 +377,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b24d145b426294eb9cc72c268ccd1df2",
+    "cacheID": "e82c18df8acf543f1ef1d594aebefdec",
     "id": null,
     "metadata": {},
     "name": "DeploymentSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIDeploymentSchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory {\n  id\n  phase\n  result\n  subSteps {\n    step\n    ...BAISubStepNodesFragment\n  }\n  ...BAIDeploymentSchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ded0c3aa6171af69b86f1a792cff28d3>>
+ * @generated SignedSource<<261bf2472907843bfdf5511197fb8426>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -279,6 +279,13 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "phase",
+                    "storageKey": null
+                  },
                   (v7/*: any*/),
                   {
                     "alias": null,
@@ -320,13 +327,6 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "category",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "phase",
                     "storageKey": null
                   },
                   {
@@ -378,12 +378,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e02133438de747b29f05fb0c3109339d",
+    "cacheID": "7d1ce704ec9696f74145fcd31903a9fd",
     "id": null,
     "metadata": {},
     "name": "RouteSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIRouteSchedulingHistoryTableFragment on RouteHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIRouteSchedulingHistoryNodeTableFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIRouteSchedulingHistoryTableFragment on RouteHistory {\n  id\n  phase\n  result\n  subSteps {\n    step\n    ...BAISubStepNodesFragment\n  }\n  ...BAIRouteSchedulingHistoryNodeTableFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<17fabfcf7a1dfe7561f25db712b60f65>>
+ * @generated SignedSource<<6b707264b04d52b5dd1ee4f36ac2b00c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -271,6 +271,13 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "phase",
+                    "storageKey": null
+                  },
                   (v7/*: any*/),
                   {
                     "alias": null,
@@ -348,14 +355,7 @@ return {
                     "name": "toStatus",
                     "storageKey": null
                   },
-                  (v8/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "phase",
-                    "storageKey": null
-                  }
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -368,12 +368,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7c5c34bfae059fe7639c97b11c1a4d9e",
+    "cacheID": "1bfe7bc2611f279e70c35d22c11fb631",
     "id": null,
     "metadata": {},
     "name": "SessionSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  phase\n  result\n  subSteps {\n    step\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/TableAstryxProbeSchedulingQuery.graphql.ts
+++ b/react/src/__generated__/TableAstryxProbeSchedulingQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0351e6e6c2ddac5036381031842afd55>>
+ * @generated SignedSource<<84b78b92f143b141a748281ea8011c3e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -155,6 +155,13 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "phase",
+                    "storageKey": null
+                  },
                   (v2/*: any*/),
                   {
                     "alias": null,
@@ -232,14 +239,7 @@ return {
                     "name": "toStatus",
                     "storageKey": null
                   },
-                  (v3/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "phase",
-                    "storageKey": null
-                  }
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -252,12 +252,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c779ffd855043fd7baff8896baf58374",
+    "cacheID": "b46be6604feb98985cd8d831d5487556",
     "id": null,
     "metadata": {},
     "name": "TableAstryxProbeSchedulingQuery",
     "operationKind": "query",
-    "text": "query TableAstryxProbeSchedulingQuery {\n  sessionScopedSchedulingHistories(scope: {sessionId: \"probe-session\"}, limit: 5, offset: 0) {\n    count\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query TableAstryxProbeSchedulingQuery {\n  sessionScopedSchedulingHistories(scope: {sessionId: \"probe-session\"}, limit: 5, offset: 0) {\n    count\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  phase\n  result\n  subSteps {\n    step\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/components/DeploymentSchedulingHistoryModal.tsx
+++ b/react/src/components/DeploymentSchedulingHistoryModal.tsx
@@ -111,15 +111,7 @@ const DeploymentSchedulingHistoryModal = ({
     <BAIModal
       title={t('deployment.DeploymentSchedulingHistory')}
       open={open}
-      width={'90%'}
-      style={{
-        maxWidth: 1600,
-      }}
-      styles={{
-        body: {
-          minHeight: '80vh',
-        },
-      }}
+      variant="fullscreen"
       footer={null}
       onCancel={onCancel}
       {...modalProps}

--- a/react/src/components/RouteSchedulingHistoryModal.tsx
+++ b/react/src/components/RouteSchedulingHistoryModal.tsx
@@ -111,15 +111,7 @@ const RouteSchedulingHistoryModal = ({
     <BAIModal
       title={t('route.RouteSchedulingHistory')}
       open={open}
-      width={'90%'}
-      style={{
-        maxWidth: 1600,
-      }}
-      styles={{
-        body: {
-          minHeight: '80vh',
-        },
-      }}
+      variant="fullscreen"
       footer={null}
       onCancel={onCancel}
       {...modalProps}

--- a/react/src/components/SessionSchedulingHistoryModal.tsx
+++ b/react/src/components/SessionSchedulingHistoryModal.tsx
@@ -103,15 +103,7 @@ const SessionSchedulingHistoryModal = ({
       title={t('session.SessionSchedulingHistory')}
       loading={loading || deferredOpenValue !== open}
       open={open}
-      width={'90%'}
-      style={{
-        maxWidth: 1600,
-      }}
-      styles={{
-        body: {
-          minHeight: '80vh',
-        },
-      }}
+      variant="fullscreen"
       footer={null}
       onCancel={onCancel}
       {...modalProps}

--- a/react/src/diagnostics/TableAstryxProbe.tsx
+++ b/react/src/diagnostics/TableAstryxProbe.tsx
@@ -12,8 +12,8 @@
 
    users       BAIUserNodes  — sorting, resize, row selection, column settings,
                                CSV export, pagination bar
-   scheduling  BAISchedulingHistoryTable — controlled `expandable` with a
-                               nested `BAISubStepNodes` table in the detail row
+   scheduling  BAISchedulingHistoryTable — controlled `expandable` with the
+                               `BAISubStepNodes` timeline in the detail row
 */
 import type { TableAstryxProbeSchedulingQuery } from '../__generated__/TableAstryxProbeSchedulingQuery.graphql';
 import type { TableAstryxProbeUsersQuery } from '../__generated__/TableAstryxProbeUsersQuery.graphql';


### PR DESCRIPTION

<img width="1504" height="865" alt="image" src="https://github.com/user-attachments/assets/7f528b51-84a3-4de4-84fc-df4b2dea8af9" />

Resolves #9047 (FR-3668)

An expanded row in the three scheduling-history modals rendered its `sub_steps` as a nested `BAITable`. A table inside an expanded row has to invent its own column widths, which never line up with the parent's and fight it for horizontal space. The design study ("Expanded Row Nesting") settled on **3a**: lay the six `SubStepResultInfo` fields out as columns, ~32px per step instead of the ~76px a stacked layout costs, with an order connector in a narrow rail column.

## What changed

### Sub-step panel — design 3a

`BAISubStepNodes` is now a hand-rolled `<table>`: one 32px row per sub-step, columns rail / step / result / duration / time / error code / message, the connector drawn as `::before`/`::after` on the rail cell, and a tinted result chip driven by the same `resultSemanticColorMap` the parent row's badge uses.

It cannot be an Astryx `Table`. `TableCell` sets `overflow: hidden` unconditionally (`core/src/Table/table.stylex.ts`), which clips the connector at every row boundary, and its densest row is taller than 32px. Real `<table>` semantics rather than a `role="table"` grid — the repo has precedent for the former and none for the latter.

Nothing truncates. Step names, error codes and the scheduler's placement-failure text all outrun any column width that still fits six columns, so `table-layout: auto` lets a column take what its content needs, `nowrap` holds the 32px row, and the card scrolls horizontally instead. Its border and radius stay put while the columns slide underneath.

The time column shows the start timestamp alone — a `start → end` range does not fit.

### Modal sizing

`BAIModal` gains `variant?: 'standard' | 'fullscreen'`. The wiring already existed — it forwarded `variant={isFullscreen ? …}` to `BAIDialog` — but `isFullscreen` came only from the window-state machine, which is inert unless `windowActions` is passed, and no caller passes it. The three scheduling-history modals now pass `variant="fullscreen"` in place of `width={'90%'}` + `style={{ maxWidth: 1600 }}` + `styles={{ body: { minHeight: '80vh' } }}`.

A width alone cannot do this: Astryx caps the standard dialog at `maxWidth: 90vw`, so `width="100%"` and `width="90%"` render identically. The inline `maxWidth` had to go regardless — a consumer `style` is merged last and beats the fullscreen class.

### `BAITable`'s detail row — inset and untinted by the table itself

The expanded panel used to cancel `BAITable`'s uniform 12px detail-cell padding with a negative margin and re-apply its own `14/24/14/56` inset, with the 56px start hard-coded to `EXPAND_COLUMN_WIDTH_FIRST`. `BAITable` now pads the detail cell itself: `paddingSM` on three sides and, at the start, the width of the selection + chevron columns it renders — so the expanded content lines up with the first data column whatever the table's configuration (`56` here; `52 + 40` once a `rowSelection` is present), and the sub-step CSS no longer carries a copy of the table's column width.

The cell's `colorFillQuaternary` tint is dropped too. Rows are transparent over whatever surface they sit on, so the tint — `rgba(255,255,255,.04)` over the `#1F1F1F` dialog surface — was the one thing that set the expanded area apart from the rows around it. This is a `BAITable` change, so it reaches every `expandedRowRender` consumer; the only one outside this PR is `ReservoirAuditLogList`, whose expanded block now starts at the first data column instead of the row edge.

### Lifecycle marker — a real defect fixed on the way

Only the **deployment** coordinator appends a trailing lifecycle entry (`_build_history_sub_steps`); the session and route coordinators return the recorder's steps untouched. Identifying it by `started_at == ended_at` was wrong on both sides:

- genuine session steps finish inside one clock tick — `All kernels ready for PREPARED` reports 0 ms — and were being labelled result markers;
- a deployment row whose recorder logged nothing was expandable into a single node that just repeated the row above it.

It is now identified by the fact that it restates its own row: its `step` is the row's `phase` with a different separator (`deploying-rolling-back` vs `deploying_rolling_back`). A row holding only that marker is no longer expandable, and the same predicate backs `rowExpandable` and the expand-all / errors-only modes, so a master mode cannot open a row the table treats as closed.

### i18n

`Step` / `Result` / `Message` restored with the values they were deleted with; `Duration` / `Time` added taking the wording `comp:BAIAuditLogNodes` already ships for the same concepts in every locale; `ResultMarker` reworded to the sentence the design puts in the message cell. All 21 locales.

## Measurements

Everything below was measured in the running app (headless Chromium against a live cluster), light and dark, in both the session and deployment modals.

| | |
|---|---|
| Dialog | `1600×1100` at the origin, `border-radius: 0` |
| Detail-cell padding | `12px 12px 12px 56px`, background `transparent`; the card's leading edge sits at 56px, exactly on the first data column's (3a's 44px is the mock's expand-column width; this table's is `EXPAND_COLUMN_WIDTH_FIRST = 56`) |
| Row height | 32px, header included, every row |
| Columns | `26 / 200 / 116 / 74 / 150 / 96 / 856` |
| Connector | absent on a lone row, trimmed to a half at the first and last |
| Overflowing panel | 2103px of content inside a 1518px card; panels that fit report no overflow |
| Clipped cells | 0 |
| Dark contrast | chip `#9FE59B` on `rgba(132,201,128,.24)` inside a `#69AD67` border |

Defects the measurements caught and this PR fixes:

- `.bai-substep-num` and the rail cell's `overflow` both lost to the `.bai-substep-table th, td` rule — the duration column was rendering start-aligned.
- The message cell clamped to one line but still emitted `<br>` for its newlines. A forced break is not a soft wrap, so `white-space: nowrap` never suppressed it and the row grew with the message (61px measured against 32px). Multi-line messages are the norm on a failed step: the recorder stores `str(e)`, and a placement failure joins its per-agent reasons with newlines.
- The header labels were bare text in cells that clip; ru `Длительность` wants 103px in the 74px duration column. Moot now that nothing truncates, but the header carries its typography on a `Text` either way.
- `aria-hidden` on the rail cell removed an owned cell, leaving six cells against seven column headers.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `node scripts/migration-gates/astryx-token-gate.mjs` → no undeclared token from these files (the 3 remaining are pre-existing)
- `pnpm --filter backend.ai-ui test` → 766 passed, 1 skipped
- Reviewed by a 24-agent adversarial pass: 19 claims, 14 refuted, 5 confirmed (3 distinct defects) — all three fixed above.

## Not in this PR

- Design 3b (compact) and 3c (edge states). Only 3a was requested.
- The nested table's header is not sticky; at full height with enough rows it scrolls with the body, as it did before.

## Open design questions

- The result chip is more saturated than the mock's `#E6F7EF`, because it uses the theme's own `--color-background-green` (20% alpha) rather than a literal.
- The mock's 4px chip radius and 11.5px text have no matching token; they are rounded to `--radius-inner` (6px) and `--font-size-sm` (12px). Making them exact is a theme change, not a per-component override.
- Korean headers use the shipped `소요 시간` / `시간` rather than the mock's `소요` / `시각`, to avoid a second Korean spelling for a concept the app already names.

## Behaviour note — closing the modal

A fullscreen dialog covers the viewport, so there is no backdrop left to click and Escape (or the ✕) is the only way to dismiss these three modals now. `maskClosable` is untouched; it simply has no reachable surface.

The spec that covered that path — `session-scheduling-history-modal.spec.ts`, "close … by clicking outside (backdrop)" — targets `.ant-modal-wrap`, a class this app stopped emitting when antd was removed (`BAIModal.tsx` records the deletion). It matches nothing on `main` either, so it is pre-existing breakage rather than a regression here, and it is left alone as outside this PR's diff.

## Review gate

Copilot reviewed this PR once as a draft, before it went out to humans.

| Bucket | Count | Outcome |
|---|---|---|
| A — fixed | 1 | `d44e3d7e7` — two E2E workflow specs still required the `Started At` / `Ended At` headers 3a replaces; verified by `verify.sh` and the e2e eslint config |
| B — needs a human call | 0 | — |
| C — won't apply | 0 | — |

Unresolved review threads: 0. The bucket-A fix landed **after** the review, so the bot never saw it; `bash scripts/verify.sh` → `=== ALL PASS ===` and `eslint --config e2e/eslint.config.mjs` clean on the spec is what stands in for a second pass.

`3ae5b6ce5` (the `BAITable` detail-row inset/untint above) also landed after the review, from a manual pass over the running app: `verify.sh` → `=== ALL PASS ===`, `pnpm --filter backend.ai-ui test` → 766 passed, 1 skipped, and the cell measured in both the session (dark) and deployment (light) modals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJsAUhmq9EswS3UniYmAzg

