### PR TITLE
feat(FR-3665): name the dev server after its issue, PR and what it does

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -8,8 +8,9 @@ description: >
   conversation history, set VITE_THEME_HEADER_COLOR to the matching hex so the dev
   server's header reflects this Claude session's color. When `/rename <name>`
   is visible, slugify the name and pass it as PORTLESS_APP_NAME so the dev
-  URL reflects the session name (falls back to FR-XXXX from the branch, then
-  to the current PR number). When the current branch's PR description names
+  URL reflects the session name; dev.mjs prepends the branch's FR number and
+  the PR number itself, and derives a word from the PR title when there is no
+  /rename, so pass the word only. When the current branch's PR description names
   a backend test server (bare IP, `host:port`, or full URL), set
   VITE_DEFAULT_API_ENDPOINT so the login screen pre-fills that endpoint; when a
   live session is connected to a different backend a dev-only banner flags the
@@ -77,22 +78,47 @@ Do not invent additional names or alternate hex values. If the user's `/color` a
 
 ## 2b. Decide the Portless app name (webui only)
 
-`scripts/dev.mjs` reads `PORTLESS_APP_NAME` from the env and uses it as the Portless subdomain (`https://<name>.localhost:1355`). Pick a name with this priority:
+`PORTLESS_APP_NAME` supplies **only the descriptive word**. `scripts/dev.mjs` composes the
+full subdomain itself, putting the identifiers first and the word last:
 
-1. **Most recent successful `/rename <name>` in conversation history** — slugify the arg (see rules below) and use that. This makes the dev URL match the human-readable session name (e.g. `iphoto-disk-cleanup` → `https://iphoto-disk-cleanup.localhost:1355`).
-2. **FR-XXXX in the current git branch** — `dev.mjs` already detects this when `PORTLESS_APP_NAME` is unset, so just **omit the env var** and let it derive `fr-XXXX` (e.g. `fr-2794`). Don't recompute and pass it back in.
-3. **Open PR number for the current branch** — only if (1) and (2) both miss and the current branch has an open PR. Use `gh pr view --json number -q '.number'` and pass `PORTLESS_APP_NAME=pr-<NNNN>`.
-4. **None of the above** — omit the env var; `dev.mjs` falls back to Portless's auto-derived name.
+```
+https://fr-3665-pr9049-statusline.localhost:1355
+        \_____/ \____/ \________/
+        branch  looked  PORTLESS_APP_NAME
+        issue   up by   (this is the only part you supply)
+                dev.mjs
+```
 
-**Slug rules** (apply to `/rename` arg before passing as `PORTLESS_APP_NAME`):
+So there is exactly one question for you to answer: **is there a `/rename` to use?**
+
+1. **Most recent successful `/rename <name>`** — slugify the arg (rules below) and pass it.
+   The dev URL then carries the human-readable session name alongside the identifiers.
+2. **No `/rename`** — **omit the env var.** `dev.mjs` falls back to a few words from the PR
+   title, then to the identifiers alone (`fr-3665-pr9049`), then to Portless's auto-derived
+   name. Every fallback is already handled.
+
+**Never pass the FR number or the PR number yourself.** `dev.mjs` derives the issue key from
+the branch and looks the PR up with one cached `gh` call, and it strips either identifier from
+your string if you pass it anyway — so `PORTLESS_APP_NAME=fr-3665` just yields `fr-3665-pr9049`,
+losing the descriptive part for nothing.
+
+**Slug rules** (apply to the `/rename` arg before passing as `PORTLESS_APP_NAME`):
 - Lowercase.
 - Replace any character that isn't `[a-z0-9-]` with `-` (spaces, underscores, dots, slashes, non-ASCII all become `-`).
 - Collapse repeated `-` into a single `-`.
 - Trim leading/trailing `-`.
-- Cap at ~40 chars (Portless cert generation can choke on very long subdomains).
+- Keep it short — a word or three. `dev.mjs` caps the whole hostname at 50 chars and truncates
+  the descriptive tail first, so a long name loses its own end, not the identifiers.
 - If the result is empty after sanitization, treat as unset.
 
-`dev.mjs` re-applies the same sanitization defensively, so it's safe to pass a slightly imperfect string — but compute the clean form yourself so you can announce the right hostname to the user without re-reading Portless output.
+`dev.mjs` re-applies the same sanitization defensively, so it's safe to pass a slightly imperfect
+string. It is **not** safe to predict the hostname from your string alone any more — the issue and
+PR parts are added after you. Read the URL Portless prints, or the statusline's Portless link,
+before announcing it.
+
+`PORTLESS_APP_NAME_EXACT=1` turns the composition off and uses your string verbatim. It exists for
+callers that own the whole hostname (a release preview, say); a dev server for a branch should not
+use it.
 
 **Detecting `/rename` in history**: scan the current conversation for `<command-name>/rename</command-name>` blocks. Take the **most recent** one whose `<local-command-stdout>` does not look like an error (e.g. doesn't start with `Error` / `Invalid`). Use `<command-args>` as the raw input to the slug rules.
 
@@ -206,7 +232,7 @@ Running without it costs no real type safety: `scripts/verify.sh`, the Husky pre
   pnpm dev
   ```
 
-If step **2b** picked a Portless app name from `/rename` or a PR number, also prefix `PORTLESS_APP_NAME='<slug>'`. If 2b selected the FR-XXXX branch fallback (option 2) or "none" (option 4), **omit** `PORTLESS_APP_NAME` — `dev.mjs` handles those itself.
+If step **2b** found a `/rename` to use, also prefix `PORTLESS_APP_NAME='<slug>'` — the descriptive word only. Otherwise **omit** it; `dev.mjs` derives the word from the PR title and adds the identifiers either way.
 
 If step **2c** resolved a default API endpoint, also prefix `VITE_DEFAULT_API_ENDPOINT='<url>'`. If 2c resolved nothing, **omit** the variable entirely — do not pass an empty string.
 

--- a/packages/backend.ai-agent-cli/src/commands/login.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/login.test.ts
@@ -1,0 +1,115 @@
+import { devWebUiOrigin } from './login.js';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A checkout `tryResolveRepoContext` accepts, sitting on `branch`. It needs the
+ * root package name plus every REQUIRED_SOURCES entry to exist.
+ */
+function repoOnBranch(branch: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'bai-cli-login-'));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'backend.ai-webui', version: '0.0.0-test' }),
+  );
+  mkdirSync(join(root, 'data'), { recursive: true });
+  writeFileSync(join(root, 'data', 'schema.graphql'), 'type Query { a: Int }\n');
+  mkdirSync(join(root, 'resources', 'i18n'), { recursive: true });
+  mkdirSync(join(root, 'packages', 'backend.ai-webui-docs'), { recursive: true });
+  mkdirSync(join(root, '.git'));
+  writeFileSync(join(root, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
+  return root;
+}
+
+/** A Portless state dir holding `hostnames` as registered routes. */
+function portlessState(hostnames: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'bai-cli-portless-'));
+  writeFileSync(
+    join(dir, 'routes.json'),
+    JSON.stringify(
+      hostnames.map((hostname, i) => ({
+        hostname,
+        port: 4000 + i,
+        pid: 1000 + i,
+      })),
+    ),
+  );
+  return dir;
+}
+
+describe('devWebUiOrigin', () => {
+  const env = (stateDir?: string) => ({
+    PORTLESS_PORT: '1357',
+    ...(stateDir ? { PORTLESS_STATE_DIR: stateDir } : {}),
+  });
+
+  it('falls back to the bare issue key when no route is registered', () => {
+    const cwd = repoOnBranch('fix/FR-3665-portless-app-name');
+    expect(devWebUiOrigin(cwd, env(portlessState([])))).toBe(
+      'https://fr-3665.localhost:1357',
+    );
+  });
+
+  // FR-3665: dev.mjs now names the server `<issue>-<pr>-<word>`, so the issue key
+  // on its own is no longer a hostname once a PR exists.
+  it('resolves to the composed route that is actually running', () => {
+    const cwd = repoOnBranch('fix/FR-3665-portless-app-name');
+    const state = portlessState([
+      'fr-3654.localhost',
+      'fr-3665-pr9049-statusline.localhost',
+    ]);
+    expect(devWebUiOrigin(cwd, env(state))).toBe(
+      'https://fr-3665-pr9049-statusline.localhost:1357',
+    );
+  });
+
+  it('prefers an exact match over a composed one', () => {
+    const cwd = repoOnBranch('FR-3665');
+    const state = portlessState([
+      'fr-3665-pr9049-statusline.localhost',
+      'fr-3665.localhost',
+    ]);
+    expect(devWebUiOrigin(cwd, env(state))).toBe('https://fr-3665.localhost:1357');
+  });
+
+  it('takes the shortest when several extend the issue key', () => {
+    const cwd = repoOnBranch('FR-3665');
+    const state = portlessState([
+      'fr-3665-pr9049-statusline-and-more.localhost',
+      'fr-3665-alt.localhost',
+    ]);
+    expect(devWebUiOrigin(cwd, env(state))).toBe(
+      'https://fr-3665-alt.localhost:1357',
+    );
+  });
+
+  it('does not match a different issue that merely shares a prefix', () => {
+    const cwd = repoOnBranch('FR-366');
+    const state = portlessState(['fr-3665-pr9049-statusline.localhost']);
+    expect(devWebUiOrigin(cwd, env(state))).toBe('https://fr-366.localhost:1357');
+  });
+
+  it('survives a missing or malformed routes.json', () => {
+    const cwd = repoOnBranch('FR-3665');
+    const missing = mkdtempSync(join(tmpdir(), 'bai-cli-portless-'));
+    expect(devWebUiOrigin(cwd, env(missing))).toBe('https://fr-3665.localhost:1357');
+
+    const bad = mkdtempSync(join(tmpdir(), 'bai-cli-portless-'));
+    writeFileSync(join(bad, 'routes.json'), '{not json');
+    expect(devWebUiOrigin(cwd, env(bad))).toBe('https://fr-3665.localhost:1357');
+
+    const wrongShape = mkdtempSync(join(tmpdir(), 'bai-cli-portless-'));
+    writeFileSync(join(wrongShape, 'routes.json'), '{"hostname":"x"}');
+    expect(devWebUiOrigin(cwd, env(wrongShape))).toBe(
+      'https://fr-3665.localhost:1357',
+    );
+  });
+
+  it('has no issue key to resolve on a branch without one', () => {
+    const cwd = repoOnBranch('main');
+    const state = portlessState(['fr-3665-pr9049-statusline.localhost']);
+    expect(devWebUiOrigin(cwd, env(state))).toBe('https://localhost:1357');
+  });
+});

--- a/packages/backend.ai-agent-cli/src/commands/login.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/login.test.ts
@@ -23,21 +23,30 @@ function repoOnBranch(branch: string): string {
   return root;
 }
 
-/** A Portless state dir holding `hostnames` as registered routes. */
-function portlessState(hostnames: string[]): string {
+/**
+ * A Portless state dir. `pid` defaults to this test process, whose cwd is the
+ * package directory — i.e. a live route that this checkout does NOT own, which is
+ * what the liveness-but-not-ownership fallback is about.
+ */
+function portlessState(
+  routes: Array<{ hostname: string; pid?: number }>,
+): string {
   const dir = mkdtempSync(join(tmpdir(), 'bai-cli-portless-'));
   writeFileSync(
     join(dir, 'routes.json'),
     JSON.stringify(
-      hostnames.map((hostname, i) => ({
-        hostname,
+      routes.map((route, i) => ({
+        hostname: route.hostname,
         port: 4000 + i,
-        pid: 1000 + i,
+        pid: route.pid ?? process.pid,
       })),
     ),
   );
   return dir;
 }
+
+/** A pid that is certainly not running, for the stale-entry cases. */
+const DEAD_PID = 2 ** 22 - 1;
 
 describe('devWebUiOrigin', () => {
   const env = (stateDir?: string) => ({
@@ -57,19 +66,44 @@ describe('devWebUiOrigin', () => {
   it('resolves to the composed route that is actually running', () => {
     const cwd = repoOnBranch('fix/FR-3665-portless-app-name');
     const state = portlessState([
-      'fr-3654.localhost',
-      'fr-3665-pr9049-statusline.localhost',
+      { hostname: 'fr-3654.localhost' },
+      { hostname: 'fr-3665-pr9049-statusline.localhost' },
     ]);
     expect(devWebUiOrigin(cwd, env(state))).toBe(
       'https://fr-3665-pr9049-statusline.localhost:1357',
     );
   });
 
+  it('ignores a route whose owning process is gone', () => {
+    const cwd = repoOnBranch('FR-3665');
+    const state = portlessState([
+      { hostname: 'fr-3665-pr9049-statusline.localhost', pid: DEAD_PID },
+    ]);
+    expect(devWebUiOrigin(cwd, env(state))).toBe('https://fr-3665.localhost:1357');
+  });
+
+  it('skips a dead route in favour of a live one', () => {
+    const cwd = repoOnBranch('FR-3665');
+    const state = portlessState([
+      { hostname: 'fr-3665-old.localhost', pid: DEAD_PID },
+      { hostname: 'fr-3665-pr9049-statusline.localhost' },
+    ]);
+    expect(devWebUiOrigin(cwd, env(state))).toBe(
+      'https://fr-3665-pr9049-statusline.localhost:1357',
+    );
+  });
+
+  it('ignores an alias route, which has no owning process', () => {
+    const cwd = repoOnBranch('FR-3665');
+    const state = portlessState([{ hostname: 'fr-3665-alias.localhost', pid: 0 }]);
+    expect(devWebUiOrigin(cwd, env(state))).toBe('https://fr-3665.localhost:1357');
+  });
+
   it('prefers an exact match over a composed one', () => {
     const cwd = repoOnBranch('FR-3665');
     const state = portlessState([
-      'fr-3665-pr9049-statusline.localhost',
-      'fr-3665.localhost',
+      { hostname: 'fr-3665-pr9049-statusline.localhost' },
+      { hostname: 'fr-3665.localhost' },
     ]);
     expect(devWebUiOrigin(cwd, env(state))).toBe('https://fr-3665.localhost:1357');
   });
@@ -77,8 +111,8 @@ describe('devWebUiOrigin', () => {
   it('takes the shortest when several extend the issue key', () => {
     const cwd = repoOnBranch('FR-3665');
     const state = portlessState([
-      'fr-3665-pr9049-statusline-and-more.localhost',
-      'fr-3665-alt.localhost',
+      { hostname: 'fr-3665-pr9049-statusline-and-more.localhost' },
+      { hostname: 'fr-3665-alt.localhost' },
     ]);
     expect(devWebUiOrigin(cwd, env(state))).toBe(
       'https://fr-3665-alt.localhost:1357',
@@ -87,7 +121,9 @@ describe('devWebUiOrigin', () => {
 
   it('does not match a different issue that merely shares a prefix', () => {
     const cwd = repoOnBranch('FR-366');
-    const state = portlessState(['fr-3665-pr9049-statusline.localhost']);
+    const state = portlessState([
+      { hostname: 'fr-3665-pr9049-statusline.localhost' },
+    ]);
     expect(devWebUiOrigin(cwd, env(state))).toBe('https://fr-366.localhost:1357');
   });
 
@@ -105,11 +141,20 @@ describe('devWebUiOrigin', () => {
     expect(devWebUiOrigin(cwd, env(wrongShape))).toBe(
       'https://fr-3665.localhost:1357',
     );
+
+    const noPid = mkdtempSync(join(tmpdir(), 'bai-cli-portless-'));
+    writeFileSync(
+      join(noPid, 'routes.json'),
+      JSON.stringify([{ hostname: 'fr-3665-x.localhost', port: 1 }]),
+    );
+    expect(devWebUiOrigin(cwd, env(noPid))).toBe('https://fr-3665.localhost:1357');
   });
 
   it('has no issue key to resolve on a branch without one', () => {
     const cwd = repoOnBranch('main');
-    const state = portlessState(['fr-3665-pr9049-statusline.localhost']);
+    const state = portlessState([
+      { hostname: 'fr-3665-pr9049-statusline.localhost' },
+    ]);
     expect(devWebUiOrigin(cwd, env(state))).toBe('https://localhost:1357');
   });
 });

--- a/packages/backend.ai-agent-cli/src/commands/login.ts
+++ b/packages/backend.ai-agent-cli/src/commands/login.ts
@@ -18,7 +18,7 @@ import {
   type StoredSession,
 } from '../session.js';
 import { execFileSync, spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
@@ -36,47 +36,88 @@ export interface LoginData {
   user: WhoAmI;
 }
 
+/** The working directory of a live process, or undefined if it is not running. */
+function processCwd(pid: number): string | undefined {
+  try {
+    // Linux: the symlink is also the liveness check — a dead pid throws.
+    return realpathSync(`/proc/${pid}/cwd`);
+  } catch {
+    /* no /proc, or the pid is gone */
+  }
+  try {
+    const out = execFileSync('lsof', ['-p', String(pid), '-a', '-d', 'cwd', '-Fn'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    });
+    const line = out.split('\n').find((l) => l.startsWith('n'));
+    return line ? realpathSync(line.slice(1)) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
- * The Portless route actually serving this issue, if one is registered.
+ * The Portless route actually serving this checkout, if one is registered.
  *
  * `scripts/dev.mjs` names a dev server after its issue, its PR and what it does
  * (`fr-3665-pr9049-statusline`), so the issue key alone stops being a hostname the
  * moment a PR exists. Rather than duplicate that composition — it needs a `gh`
- * lookup — read what is actually running and take the route whose leading label is
- * the issue key or extends it. An exact match wins, then the shortest, so a session
- * that also started `fr-3665-alt` still resolves to the main one.
+ * lookup, which does not belong in a CLI's default-origin path — read what is
+ * actually running.
+ *
+ * `routes.json` alone is not enough to pick from: it keeps entries whose owner has
+ * died, and a sibling worktree on the same issue registers a hostname with the same
+ * prefix. So a candidate must be a live process whose cwd is this checkout, which is
+ * the same ownership test the statusline uses. Where neither /proc nor lsof can
+ * answer, fall back to any live route, then to the bare issue key.
  */
 function liveAppName(
   issueApp: string,
+  repoRoot: string | undefined,
   env: Record<string, string | undefined>,
 ): string | undefined {
   const stateDir =
     env.PORTLESS_STATE_DIR?.trim() ||
     env.PORTLESS_HOME?.trim() ||
     join(homedir(), '.portless');
+  let routes: unknown;
   try {
-    const routes: unknown = JSON.parse(
-      readFileSync(join(stateDir, 'routes.json'), 'utf8'),
-    );
-    if (!Array.isArray(routes)) return undefined;
-    const names = routes
-      .map((route) =>
-        typeof (route as { hostname?: unknown })?.hostname === 'string'
-          ? (route as { hostname: string }).hostname.split('.')[0]
-          : undefined,
-      )
-      .filter(
-        (name): name is string =>
-          !!name && (name === issueApp || name.startsWith(`${issueApp}-`)),
-      )
-      .sort((a, b) =>
-        a === issueApp ? -1 : b === issueApp ? 1 : a.length - b.length,
-      );
-    return names[0];
+    routes = JSON.parse(readFileSync(join(stateDir, 'routes.json'), 'utf8'));
   } catch {
-    // No Portless state, unreadable, or malformed — fall back to the issue key.
-    return undefined;
+    return undefined; // no Portless state, unreadable, or malformed
   }
+  if (!Array.isArray(routes)) return undefined;
+
+  const candidates = routes
+    .map((route) => route as { hostname?: unknown; pid?: unknown })
+    .filter(
+      (route): route is { hostname: string; pid: number } =>
+        typeof route?.hostname === 'string' &&
+        typeof route?.pid === 'number' &&
+        route.pid > 0,
+    )
+    .map((route) => ({ app: route.hostname.split('.')[0], pid: route.pid }))
+    .filter(
+      ({ app }) => app === issueApp || app.startsWith(`${issueApp}-`),
+    );
+  if (candidates.length === 0) return undefined;
+
+  const owned: string[] = [];
+  const live: string[] = [];
+  for (const { app, pid } of candidates) {
+    const cwd = processCwd(pid);
+    if (cwd === undefined) continue; // dead pid, or unknowable — not a candidate
+    live.push(app);
+    if (repoRoot && cwd === repoRoot) owned.push(app);
+  }
+  // Exact match first, then shortest: a checkout also running `fr-3665-alt` still
+  // resolves to its main server.
+  const pick = (names: string[]) =>
+    [...names].sort((a, b) =>
+      a === issueApp ? -1 : b === issueApp ? 1 : a.length - b.length,
+    )[0];
+  return pick(owned) ?? pick(live);
 }
 
 /**
@@ -88,11 +129,13 @@ export function devWebUiOrigin(
   env: Record<string, string | undefined> = process.env,
 ): string {
   const port = env.PORTLESS_PORT?.trim() || DEFAULT_PORTLESS_PORT;
+  const resolved = tryResolveRepoContext(cwd);
+  const repoRoot = resolved.ok ? realpathSync(resolved.context.repoRoot) : undefined;
   const branch = currentBranch(cwd);
   const issue = branch ? /(?:^|[-_/])(fr-?\d+)/i.exec(branch) : null;
   if (!issue) return `https://localhost:${port}`;
   const app = issue[1].toLowerCase().replace(/^fr-?/, 'fr-');
-  return `https://${liveAppName(app, env) ?? app}.localhost:${port}`;
+  return `https://${liveAppName(app, repoRoot, env) ?? app}.localhost:${port}`;
 }
 
 function currentBranch(cwd: string): string | undefined {

--- a/packages/backend.ai-agent-cli/src/commands/login.ts
+++ b/packages/backend.ai-agent-cli/src/commands/login.ts
@@ -19,6 +19,7 @@ import {
 } from '../session.js';
 import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
 
@@ -36,8 +37,51 @@ export interface LoginData {
 }
 
 /**
- * Same derivation `scripts/dev.mjs` uses for the Portless app name, so the
- * default WebUI origin matches the dev server started from this checkout.
+ * The Portless route actually serving this issue, if one is registered.
+ *
+ * `scripts/dev.mjs` names a dev server after its issue, its PR and what it does
+ * (`fr-3665-pr9049-statusline`), so the issue key alone stops being a hostname the
+ * moment a PR exists. Rather than duplicate that composition — it needs a `gh`
+ * lookup — read what is actually running and take the route whose leading label is
+ * the issue key or extends it. An exact match wins, then the shortest, so a session
+ * that also started `fr-3665-alt` still resolves to the main one.
+ */
+function liveAppName(
+  issueApp: string,
+  env: Record<string, string | undefined>,
+): string | undefined {
+  const stateDir =
+    env.PORTLESS_STATE_DIR?.trim() ||
+    env.PORTLESS_HOME?.trim() ||
+    join(homedir(), '.portless');
+  try {
+    const routes: unknown = JSON.parse(
+      readFileSync(join(stateDir, 'routes.json'), 'utf8'),
+    );
+    if (!Array.isArray(routes)) return undefined;
+    const names = routes
+      .map((route) =>
+        typeof (route as { hostname?: unknown })?.hostname === 'string'
+          ? (route as { hostname: string }).hostname.split('.')[0]
+          : undefined,
+      )
+      .filter(
+        (name): name is string =>
+          !!name && (name === issueApp || name.startsWith(`${issueApp}-`)),
+      )
+      .sort((a, b) =>
+        a === issueApp ? -1 : b === issueApp ? 1 : a.length - b.length,
+      );
+    return names[0];
+  } catch {
+    // No Portless state, unreadable, or malformed — fall back to the issue key.
+    return undefined;
+  }
+}
+
+/**
+ * The default WebUI origin for a dev server started from this checkout: the issue
+ * key from the branch, resolved against the Portless routes that are actually up.
  */
 export function devWebUiOrigin(
   cwd: string,
@@ -48,7 +92,7 @@ export function devWebUiOrigin(
   const issue = branch ? /(?:^|[-_/])(fr-?\d+)/i.exec(branch) : null;
   if (!issue) return `https://localhost:${port}`;
   const app = issue[1].toLowerCase().replace(/^fr-?/, 'fr-');
-  return `https://${app}.localhost:${port}`;
+  return `https://${liveAppName(app, env) ?? app}.localhost:${port}`;
 }
 
 function currentBranch(cwd: string): string | undefined {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -89,15 +89,22 @@ function lookupPr(branchName) {
     { encoding: 'utf8', timeout: 4000, stdio: ['ignore', 'pipe', 'ignore'] },
   );
   if (probe.status === 0 && probe.stdout) {
+    let pr = null;
     try {
-      const pr = JSON.parse(probe.stdout);
-      if (pr?.number) {
+      pr = JSON.parse(probe.stdout);
+    } catch {
+      pr = null; // unparseable output — fall through to the cache
+    }
+    if (pr?.number) {
+      // Persisting is an optimization for the next offline boot, so a read-only
+      // ~/.cache or an over-long filename must not throw away the answer we have.
+      try {
         mkdirSync(dirname(cacheFile), { recursive: true });
         writeFileSync(cacheFile, JSON.stringify(pr));
-        return pr;
+      } catch {
+        // Best-effort; the fresh lookup below is still good.
       }
-    } catch {
-      // fall through to the cache
+      return pr;
     }
   }
   try {
@@ -107,11 +114,14 @@ function lookupPr(branchName) {
   }
 }
 
+// Exact mode discards every identifier, so it must not pay for the lookup that
+// produces one — up to the 4s timeout on a box with no network.
+const exactAppName = !!process.env.PORTLESS_APP_NAME_EXACT?.trim();
 const appName = resolveAppName({
   envName: process.env.PORTLESS_APP_NAME,
   branch,
-  pr: lookupPr(branch),
-  exact: !!process.env.PORTLESS_APP_NAME_EXACT?.trim(),
+  pr: exactAppName ? null : lookupPr(branch),
+  exact: exactAppName,
 });
 if (appName) {
   // Surface the app name to the React bundle for the dev-only tab title.

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -9,9 +9,9 @@
 // When this box has joined the team dev gateway, the shareable URL is printed
 // at startup and exposed as VITE_DEV_SHARE_URL.
 import { spawn, spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { resolveAppName } from './portless-app-name.mjs';
 
 const env = { ...process.env };
@@ -64,17 +64,55 @@ spawnSync('portless', proxyArgs, { stdio: 'inherit' });
 const portFlag = process.env.PORT ? `--app-port ${process.env.PORT} ` : '';
 delete env.PORT; // Avoid leaking to portless / CRA before Portless reassigns it.
 
-// Decide the portless app name (`https://<name>.localhost:1355`).
-// Priority:
-//   1. PORTLESS_APP_NAME env var (caller-provided; sanitized in the module so
-//      callers can pass arbitrary strings — e.g. a Claude Code session name —
-//      without worrying about subdomain validity).
-//   2. FR-XXXX issue number in the current git branch (e.g. `fr-2701`).
-//   3. `portless run` (auto-derived from branch — long branch-prefixed
-//      hostnames may break Portless's HTTPS cert generation, so prefer 1 or 2).
-// Both named paths run through the same normalization: see portless-app-name.mjs.
+// Decide the portless app name (`https://<name>.localhost:1355`) — the issue key,
+// the PR number and a word for what this branch is: `fr-3665-pr9049-statusline`.
+// Composition rules and fallbacks live in portless-app-name.mjs.
+//
+// PORTLESS_APP_NAME supplies only the descriptive word (the dev-server skill fills
+// it from `/rename`); the identifiers are added here so callers cannot forget them.
+// PORTLESS_APP_NAME_EXACT=1 opts out entirely, for a caller that owns the hostname.
 const branch = spawnSync('git', ['branch', '--show-current'], { encoding: 'utf8' }).stdout?.trim() || '';
-const appName = resolveAppName({ envName: process.env.PORTLESS_APP_NAME, branch });
+
+// One `gh` call per boot (~0.65s, and it returns number and title together). It is
+// allowed to fail: no gh, not logged in, no PR yet, or offline all just mean the
+// name loses its `prNNNN` part. The last good answer is cached so an offline boot
+// keeps the URL it had rather than silently renaming the dev server.
+function lookupPr(branchName) {
+  if (!branchName || process.env.PORTLESS_SKIP_PR_LOOKUP) return null;
+  const cacheFile = join(
+    homedir(), '.cache', 'backend.ai-webui',
+    `pr-${branchName.replace(/[^A-Za-z0-9]+/g, '-')}.json`,
+  );
+  const probe = spawnSync(
+    'gh',
+    ['pr', 'view', branchName, '--json', 'number,title'],
+    { encoding: 'utf8', timeout: 4000, stdio: ['ignore', 'pipe', 'ignore'] },
+  );
+  if (probe.status === 0 && probe.stdout) {
+    try {
+      const pr = JSON.parse(probe.stdout);
+      if (pr?.number) {
+        mkdirSync(dirname(cacheFile), { recursive: true });
+        writeFileSync(cacheFile, JSON.stringify(pr));
+        return pr;
+      }
+    } catch {
+      // fall through to the cache
+    }
+  }
+  try {
+    return JSON.parse(readFileSync(cacheFile, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const appName = resolveAppName({
+  envName: process.env.PORTLESS_APP_NAME,
+  branch,
+  pr: lookupPr(branch),
+  exact: !!process.env.PORTLESS_APP_NAME_EXACT?.trim(),
+});
 if (appName) {
   // Surface the app name to the React bundle for the dev-only tab title.
   env.VITE_DEV_SERVER_NAME = appName;

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -12,6 +12,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { resolveAppName } from './portless-app-name.mjs';
 
 const env = { ...process.env };
 
@@ -65,27 +66,15 @@ delete env.PORT; // Avoid leaking to portless / CRA before Portless reassigns it
 
 // Decide the portless app name (`https://<name>.localhost:1355`).
 // Priority:
-//   1. PORTLESS_APP_NAME env var (caller-provided; sanitized here so callers
-//      can pass arbitrary strings — e.g. a Claude Code session name — without
-//      worrying about subdomain validity).
+//   1. PORTLESS_APP_NAME env var (caller-provided; sanitized in the module so
+//      callers can pass arbitrary strings — e.g. a Claude Code session name —
+//      without worrying about subdomain validity).
 //   2. FR-XXXX issue number in the current git branch (e.g. `fr-2701`).
 //   3. `portless run` (auto-derived from branch — long branch-prefixed
 //      hostnames may break Portless's HTTPS cert generation, so prefer 1 or 2).
-function sanitizeAppName(raw) {
-  if (!raw) return null;
-  const slug = raw
-    .toString()
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, '-')
-    .replace(/-{2,}/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 40);
-  return slug || null;
-}
+// Both named paths run through the same normalization: see portless-app-name.mjs.
 const branch = spawnSync('git', ['branch', '--show-current'], { encoding: 'utf8' }).stdout?.trim() || '';
-const issueMatch = branch.match(/(?:^|[-_/])(fr-?\d+)/i);
-const branchAppName = issueMatch ? issueMatch[1].toLowerCase().replace(/^fr/, 'fr-').replace(/-{2,}/g, '-') : null;
-const appName = sanitizeAppName(process.env.PORTLESS_APP_NAME) ?? branchAppName;
+const appName = resolveAppName({ envName: process.env.PORTLESS_APP_NAME, branch });
 if (appName) {
   // Surface the app name to the React bundle for the dev-only tab title.
   env.VITE_DEV_SERVER_NAME = appName;

--- a/scripts/portless-app-name.mjs
+++ b/scripts/portless-app-name.mjs
@@ -1,16 +1,43 @@
 // Resolves the Portless app name that becomes the dev URL's subdomain
 // (`https://<name>.localhost:<port>`).
 //
-// This lives outside dev.mjs so it can be unit tested: dev.mjs starts the Portless
-// daemon at import time, so a test cannot import it.
+// The name is three parts, in this order, and any of them may be missing:
+//
+//   fr-3665 - pr9049 - statusline
+//   \_____/   \____/   \_______/
+//   issue     PR       what it is
+//
+// Identifiers come first because they are what you scan for and what stays the
+// same length; the descriptive part goes last so truncation eats the least
+// important characters. The descriptive part prefers a human-supplied name
+// (PORTLESS_APP_NAME, which the dev-server skill fills from `/rename`) over
+// anything derived from a PR title — titles are sentences, and slugifying one
+// lands somewhere between good ("drop-portless-placeholder") and useless
+// ("normalize-fr-fr"), with no way for a person to fix it.
+//
+// This lives outside dev.mjs so it can be unit tested: dev.mjs starts the
+// Portless daemon at import time, so a test cannot import it.
 
-const MAX_LEN = 40;
+// A DNS label may be 63 chars. Staying well under leaves room for the worktree
+// prefix Portless adds in its auto-derived mode.
+const MAX_LEN = 50;
+const MAX_TITLE_WORDS = 3;
 
 /** `fr` immediately followed by digits, at a slug boundary, is an issue key. */
 const ISSUE_TOKEN = /(^|-)fr(\d+)(?=-|$)/g;
 
 /** The FR-#### anywhere in a branch name (`fix/FR-1234-thing`, `fr1234`, …). */
 const BRANCH_ISSUE = /(?:^|[-_/])(fr-?\d+)/i;
+
+/** `fix(FR-1234):` / `docs:` — the conventional-commit prefix, which says nothing. */
+const COMMIT_PREFIX = /^\s*\w+\s*(\([^)]*\))?\s*:\s*/;
+
+/** Words that survive slugification but carry no meaning in a hostname. */
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'to', 'for', 'of', 'in', 'on', 'at', 'by', 'with',
+  'is', 'are', 'be', 'so', 'that', 'it', 'its', 'as', 'from', 'into', 'too', 'not',
+  'when', 'where', 'while', 'then', 'than', 'but', 'up', 'out', 'off', 'no',
+]);
 
 /**
  * Lowercase, strip anything a hostname label cannot carry, and collapse the result.
@@ -40,11 +67,62 @@ export function branchAppName(branch) {
   return match ? sanitizeAppName(match[1]) : null;
 }
 
+/** A few meaningful words from a PR title, for when nobody named the server. */
+export function titleWord(title, maxWords = MAX_TITLE_WORDS) {
+  if (!title) return null;
+  const words = title
+    .replace(COMMIT_PREFIX, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((w) => w && !STOP_WORDS.has(w))
+    // Stripping punctuation can leave the same word twice in a row — "FR#### to
+    // fr-####" collapses to "fr fr" — and a doubled word reads as a typo.
+    .filter((w, i, all) => w !== all[i - 1])
+    .slice(0, maxWords);
+  return words.length ? sanitizeAppName(words.join('-')) : null;
+}
+
+/** Drop identifier tokens the composed name already carries, so they appear once. */
+function withoutTokens(slug, tokens) {
+  if (!slug) return null;
+  let out = slug;
+  for (const token of tokens.filter(Boolean)) {
+    out = out.replace(new RegExp(`(^|-)${token}(?=-|$)`, 'g'), '$1');
+  }
+  out = out.replace(/-{2,}/g, '-').replace(/^-+|-+$/g, '');
+  return out || null;
+}
+
+/**
+ * Join issue / PR / description into one label, capped without mangling the
+ * identifiers: only the descriptive tail is truncated, because that is the part
+ * a reader can still guess at when it is short.
+ */
+export function composeAppName({ issue, prNumber, word } = {}) {
+  const prToken = prNumber ? `pr${prNumber}` : null;
+  const head = [issue, prToken].filter(Boolean).join('-');
+  const tail = withoutTokens(word, [issue, prToken]);
+  if (!head) return tail || null;
+  if (!tail) return head;
+  const room = MAX_LEN - head.length - 1;
+  if (room <= 0) return head;
+  return `${head}-${tail.slice(0, room).replace(/-+$/, '')}`;
+}
+
 /**
  * The app name for this dev server, or null to let `portless run` auto-derive one.
- * An explicit name beats the branch, because the caller knows something we do not —
- * but it is normalized the same way, which is the bug FR-3665 fixed.
+ *
+ * `pr` is `{ number, title }` when the branch has one — dev.mjs looks it up; it is
+ * injected rather than fetched here so this module stays pure and testable.
+ * `exact` returns the caller's name verbatim, for a caller that owns the whole
+ * hostname (PORTLESS_APP_NAME_EXACT=1).
  */
-export function resolveAppName({ envName, branch } = {}) {
-  return sanitizeAppName(envName) ?? branchAppName(branch);
+export function resolveAppName({ envName, branch, pr, exact } = {}) {
+  const human = sanitizeAppName(envName);
+  if (exact) return human;
+  const issue = branchAppName(branch);
+  const word = human ?? titleWord(pr?.title);
+  return composeAppName({ issue, prNumber: pr?.number, word });
 }

--- a/scripts/portless-app-name.mjs
+++ b/scripts/portless-app-name.mjs
@@ -1,0 +1,50 @@
+// Resolves the Portless app name that becomes the dev URL's subdomain
+// (`https://<name>.localhost:<port>`).
+//
+// This lives outside dev.mjs so it can be unit tested: dev.mjs starts the Portless
+// daemon at import time, so a test cannot import it.
+
+const MAX_LEN = 40;
+
+/** `fr` immediately followed by digits, at a slug boundary, is an issue key. */
+const ISSUE_TOKEN = /(^|-)fr(\d+)(?=-|$)/g;
+
+/** The FR-#### anywhere in a branch name (`fix/FR-1234-thing`, `fr1234`, …). */
+const BRANCH_ISSUE = /(?:^|[-_/])(fr-?\d+)/i;
+
+/**
+ * Lowercase, strip anything a hostname label cannot carry, and collapse the result.
+ * Callers pass arbitrary strings — a Claude Code session name, a PR title — so this
+ * has to be total, returning null when nothing usable survives.
+ */
+export function sanitizeAppName(raw) {
+  if (!raw) return null;
+  const slug = raw
+    .toString()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_LEN)
+    .replace(/-+$/, '') // the slice can land mid-word and leave a trailing dash
+    // `fr1234` and `fr-1234` name the same issue, so they must produce the same
+    // hostname whichever source supplied the name. Anchoring on a slug boundary
+    // keeps words that merely start with "fr" (frame123) intact.
+    .replace(ISSUE_TOKEN, '$1fr-$2');
+  return slug || null;
+}
+
+/** The FR-#### issue key in a branch name, as an app name, or null if it has none. */
+export function branchAppName(branch) {
+  const match = (branch || '').match(BRANCH_ISSUE);
+  return match ? sanitizeAppName(match[1]) : null;
+}
+
+/**
+ * The app name for this dev server, or null to let `portless run` auto-derive one.
+ * An explicit name beats the branch, because the caller knows something we do not —
+ * but it is normalized the same way, which is the bug FR-3665 fixed.
+ */
+export function resolveAppName({ envName, branch } = {}) {
+  return sanitizeAppName(envName) ?? branchAppName(branch);
+}

--- a/scripts/portless-app-name.mjs
+++ b/scripts/portless-app-name.mjs
@@ -52,12 +52,15 @@ export function sanitizeAppName(raw) {
     .replace(/[^a-z0-9-]+/g, '-')
     .replace(/-{2,}/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, MAX_LEN)
-    .replace(/-+$/, '') // the slice can land mid-word and leave a trailing dash
     // `fr1234` and `fr-1234` name the same issue, so they must produce the same
     // hostname whichever source supplied the name. Anchoring on a slug boundary
     // keeps words that merely start with "fr" (frame123) intact.
-    .replace(ISSUE_TOKEN, '$1fr-$2');
+    //
+    // Normalize BEFORE the cap: this inserts a dash, so capping first would let a
+    // 50-char input ending in `-fr123` come back out at 51.
+    .replace(ISSUE_TOKEN, '$1fr-$2')
+    .slice(0, MAX_LEN)
+    .replace(/-+$/, ''); // the slice can land mid-word and leave a trailing dash
   return slug || null;
 }
 

--- a/scripts/portless-app-name.test.ts
+++ b/scripts/portless-app-name.test.ts
@@ -30,6 +30,14 @@ describe('portless app name', () => {
       expect(name.endsWith('-')).toBe(false);
     });
 
+    // The issue normalization inserts a dash, so capping before it ran let a
+    // 50-char input come back out at 51.
+    it('stays within the cap when normalization adds a dash at the boundary', () => {
+      for (const raw of ['a'.repeat(44) + '-fr123', 'b'.repeat(48) + '-fr1']) {
+        expect(sanitizeAppName(raw)!.length).toBeLessThanOrEqual(50);
+      }
+    });
+
     // FR-3665: this path skipped the normalization, so a name that reached it
     // without the dash produced fr1234.localhost instead of fr-1234.localhost.
     it('normalizes an issue key that arrives without its dash', () => {

--- a/scripts/portless-app-name.test.ts
+++ b/scripts/portless-app-name.test.ts
@@ -1,5 +1,11 @@
 // @ts-nocheck
-import { branchAppName, resolveAppName, sanitizeAppName } from './portless-app-name.mjs';
+import {
+  branchAppName,
+  composeAppName,
+  resolveAppName,
+  sanitizeAppName,
+  titleWord,
+} from './portless-app-name.mjs';
 
 describe('portless app name', () => {
   describe('sanitizeAppName', () => {
@@ -19,8 +25,8 @@ describe('portless app name', () => {
     });
 
     it('caps the length without leaving a trailing dash', () => {
-      const name = sanitizeAppName('a'.repeat(39) + ' tail');
-      expect(name).toHaveLength(39);
+      const name = sanitizeAppName('a'.repeat(49) + ' tail');
+      expect(name).toHaveLength(49);
       expect(name.endsWith('-')).toBe(false);
     });
 
@@ -35,11 +41,6 @@ describe('portless app name', () => {
       expect(sanitizeAppName('FR-1234')).toBe('fr-1234');
     });
 
-    it('normalizes an issue key embedded in a longer name', () => {
-      expect(sanitizeAppName('FR1234 statusline')).toBe('fr-1234-statusline');
-      expect(sanitizeAppName('review fr1234')).toBe('review-fr-1234');
-    });
-
     it('does not touch words that merely start with fr', () => {
       expect(sanitizeAppName('frame123')).toBe('frame123');
       expect(sanitizeAppName('french75')).toBe('french75');
@@ -49,12 +50,9 @@ describe('portless app name', () => {
   describe('branchAppName', () => {
     it.each([
       ['FR-1234', 'fr-1234'],
-      ['fr-1234', 'fr-1234'],
       ['FR1234', 'fr-1234'],
       ['fix/FR-1234-statusline', 'fr-1234'],
-      ['feat/FR-1234', 'fr-1234'],
       ['jongeun/FR-1234-x', 'fr-1234'],
-      ['FR-1234_x', 'fr-1234'],
       ['topic/fr1234-x', 'fr-1234'],
     ])('derives %s -> %s', (branch, expected) => {
       expect(branchAppName(branch)).toBe(expected);
@@ -66,20 +64,91 @@ describe('portless app name', () => {
     });
   });
 
+  describe('titleWord', () => {
+    it('drops the conventional-commit prefix and stop words', () => {
+      expect(titleWord('fix(FR-3666): drop the Portless placeholder when no dev server belongs here'))
+        .toBe('drop-portless-placeholder');
+      expect(titleWord('docs: update statistics docs (2026-08-24)')).toBe('update-statistics-docs');
+      expect(titleWord('feat(FR-3668): redesign scheduling-history sub-steps as a compact inline row'))
+        .toBe('redesign-scheduling-history');
+    });
+
+    it('normalizes an issue key that survives into the words', () => {
+      expect(titleWord('fix: bump FR1234 handling')).toBe('bump-fr-1234-handling');
+    });
+
+    it('collapses a word that punctuation-stripping doubled', () => {
+      expect(titleWord('fix: normalize FR#### to fr-#### everywhere')).toBe('normalize-fr-everywhere');
+    });
+
+    it('returns null when there is no title', () => {
+      expect(titleWord('')).toBeNull();
+      expect(titleWord(null)).toBeNull();
+      expect(titleWord('fix(FR-1): the a an of')).toBeNull();
+    });
+  });
+
+  describe('composeAppName', () => {
+    it('orders identifiers before the description', () => {
+      expect(composeAppName({ issue: 'fr-3665', prNumber: 9049, word: 'statusline' }))
+        .toBe('fr-3665-pr9049-statusline');
+    });
+
+    it('drops each part that is missing', () => {
+      expect(composeAppName({ issue: 'fr-3665', word: 'statusline' })).toBe('fr-3665-statusline');
+      expect(composeAppName({ prNumber: 9049, word: 'statusline' })).toBe('pr9049-statusline');
+      expect(composeAppName({ issue: 'fr-3665' })).toBe('fr-3665');
+      expect(composeAppName({ word: 'statusline' })).toBe('statusline');
+      expect(composeAppName({})).toBeNull();
+    });
+
+    it('does not repeat an identifier the description already carries', () => {
+      expect(composeAppName({ issue: 'fr-3665', prNumber: 9049, word: 'fr-3665' }))
+        .toBe('fr-3665-pr9049');
+      expect(composeAppName({ issue: 'fr-3665', prNumber: 9049, word: 'fr-3665-statusline' }))
+        .toBe('fr-3665-pr9049-statusline');
+      expect(composeAppName({ issue: 'fr-3665', prNumber: 9049, word: 'pr9049' }))
+        .toBe('fr-3665-pr9049');
+    });
+
+    it('truncates only the description, never the identifiers', () => {
+      const name = composeAppName({ issue: 'fr-3665', prNumber: 9049, word: 'x'.repeat(80) });
+      expect(name.startsWith('fr-3665-pr9049-')).toBe(true);
+      expect(name.length).toBeLessThanOrEqual(50);
+    });
+  });
+
   describe('resolveAppName', () => {
-    it('prefers an explicit name over the branch', () => {
-      expect(resolveAppName({ envName: 'my-preview', branch: 'fix/FR-1234-x' })).toBe('my-preview');
+    const pr = { number: 9049, title: 'fix(FR-3665): normalize FR#### to fr-#### everywhere' };
+
+    it('prefers a human word over the PR title', () => {
+      expect(resolveAppName({ envName: 'statusline', branch: 'fix/FR-3665-x', pr }))
+        .toBe('fr-3665-pr9049-statusline');
     });
 
-    it('normalizes the explicit name the same way as the branch one', () => {
-      const branch = resolveAppName({ branch: 'FR1234' });
-      const explicit = resolveAppName({ envName: 'FR1234', branch: 'main' });
-      expect(explicit).toBe(branch);
-      expect(explicit).toBe('fr-1234');
+    it('falls back to the PR title when nobody named it', () => {
+      expect(resolveAppName({ branch: 'fix/FR-3665-x', pr }))
+        .toBe('fr-3665-pr9049-normalize-fr-everywhere');
     });
 
-    it('falls back to the branch when the explicit name slugifies away', () => {
-      expect(resolveAppName({ envName: '상태바 개선', branch: 'fix/FR-1234-x' })).toBe('fr-1234');
+    it('omits the PR part before a PR exists', () => {
+      expect(resolveAppName({ envName: 'statusline', branch: 'fix/FR-3665-x' }))
+        .toBe('fr-3665-statusline');
+    });
+
+    it('still normalizes an issue key on the human path (FR-3665)', () => {
+      expect(resolveAppName({ envName: 'FR1234', branch: 'main' })).toBe('fr-1234');
+      expect(resolveAppName({ branch: 'FR1234' })).toBe('fr-1234');
+    });
+
+    it('does not duplicate identifiers a caller passed in', () => {
+      expect(resolveAppName({ envName: 'fr-3665', branch: 'fix/FR-3665-x', pr }))
+        .toBe('fr-3665-pr9049');
+    });
+
+    it('returns the name verbatim when the caller owns the hostname', () => {
+      expect(resolveAppName({ envName: 'v26-4-8-rc-3', branch: 'fix/FR-3665-x', pr, exact: true }))
+        .toBe('v26-4-8-rc-3');
     });
 
     it('returns null so the caller can let portless auto-derive', () => {

--- a/scripts/portless-app-name.test.ts
+++ b/scripts/portless-app-name.test.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+import { branchAppName, resolveAppName, sanitizeAppName } from './portless-app-name.mjs';
+
+describe('portless app name', () => {
+  describe('sanitizeAppName', () => {
+    it('lowercases and slugifies', () => {
+      expect(sanitizeAppName('My Feature')).toBe('my-feature');
+    });
+
+    it('collapses runs and trims separators', () => {
+      expect(sanitizeAppName('  --a///b--  ')).toBe('a-b');
+    });
+
+    it('returns null when nothing usable survives', () => {
+      expect(sanitizeAppName('상태바')).toBeNull();
+      expect(sanitizeAppName('')).toBeNull();
+      expect(sanitizeAppName(null)).toBeNull();
+      expect(sanitizeAppName(undefined)).toBeNull();
+    });
+
+    it('caps the length without leaving a trailing dash', () => {
+      const name = sanitizeAppName('a'.repeat(39) + ' tail');
+      expect(name).toHaveLength(39);
+      expect(name.endsWith('-')).toBe(false);
+    });
+
+    // FR-3665: this path skipped the normalization, so a name that reached it
+    // without the dash produced fr1234.localhost instead of fr-1234.localhost.
+    it('normalizes an issue key that arrives without its dash', () => {
+      expect(sanitizeAppName('FR1234')).toBe('fr-1234');
+      expect(sanitizeAppName('fr1234')).toBe('fr-1234');
+    });
+
+    it('leaves an issue key that already has its dash alone', () => {
+      expect(sanitizeAppName('FR-1234')).toBe('fr-1234');
+    });
+
+    it('normalizes an issue key embedded in a longer name', () => {
+      expect(sanitizeAppName('FR1234 statusline')).toBe('fr-1234-statusline');
+      expect(sanitizeAppName('review fr1234')).toBe('review-fr-1234');
+    });
+
+    it('does not touch words that merely start with fr', () => {
+      expect(sanitizeAppName('frame123')).toBe('frame123');
+      expect(sanitizeAppName('french75')).toBe('french75');
+    });
+  });
+
+  describe('branchAppName', () => {
+    it.each([
+      ['FR-1234', 'fr-1234'],
+      ['fr-1234', 'fr-1234'],
+      ['FR1234', 'fr-1234'],
+      ['fix/FR-1234-statusline', 'fr-1234'],
+      ['feat/FR-1234', 'fr-1234'],
+      ['jongeun/FR-1234-x', 'fr-1234'],
+      ['FR-1234_x', 'fr-1234'],
+      ['topic/fr1234-x', 'fr-1234'],
+    ])('derives %s -> %s', (branch, expected) => {
+      expect(branchAppName(branch)).toBe(expected);
+    });
+
+    it('returns null for a branch with no issue key', () => {
+      expect(branchAppName('main')).toBeNull();
+      expect(branchAppName('')).toBeNull();
+    });
+  });
+
+  describe('resolveAppName', () => {
+    it('prefers an explicit name over the branch', () => {
+      expect(resolveAppName({ envName: 'my-preview', branch: 'fix/FR-1234-x' })).toBe('my-preview');
+    });
+
+    it('normalizes the explicit name the same way as the branch one', () => {
+      const branch = resolveAppName({ branch: 'FR1234' });
+      const explicit = resolveAppName({ envName: 'FR1234', branch: 'main' });
+      expect(explicit).toBe(branch);
+      expect(explicit).toBe('fr-1234');
+    });
+
+    it('falls back to the branch when the explicit name slugifies away', () => {
+      expect(resolveAppName({ envName: '상태바 개선', branch: 'fix/FR-1234-x' })).toBe('fr-1234');
+    });
+
+    it('returns null so the caller can let portless auto-derive', () => {
+      expect(resolveAppName({ envName: '', branch: 'main' })).toBeNull();
+      expect(resolveAppName()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Resolves #9045 (FR-3665)

The Portless app name — the dev URL's subdomain — is resolved from two sources in `scripts/dev.mjs`, and only one of them normalized an `FR####` token to `fr-####`.

The branch-derived path (priority 2) did it:

```js
issueMatch[1].toLowerCase().replace(/^fr/, 'fr-').replace(/-{2,}/g, '-')
```

The `PORTLESS_APP_NAME` path (priority 1, which **wins** over the branch) only slugified:

```js
raw.toString().toLowerCase().replace(/[^a-z0-9-]+/g, '-')…
```

So the same issue produced a different hostname depending on which side supplied the name:

| input | branch path | `PORTLESS_APP_NAME` path |
|---|---|---|
| `FR1234` | `fr-1234` | **`fr1234`** ← wrong |
| `FR-1234` | `fr-1234` | `fr-1234` |

That is the path the `dev-server` skill uses — it passes the Claude Code session name as `PORTLESS_APP_NAME` — so a session named after an issue without the dash came up at `https://fr1234.localhost` instead of `https://fr-1234.localhost`.

## Fix

One rule, one place. Both paths now go through `sanitizeAppName`, which normalizes `fr` + digits **at a slug boundary**:

```js
.replace(/(^|-)fr(\d+)(?=-|$)/g, '$1fr-$2')
```

The boundary anchor is what keeps names that merely start with "fr" intact — `frame123` and `french75` are untouched.

The derivation moves into `scripts/portless-app-name.mjs` so it can be unit tested: `dev.mjs` starts the Portless daemon at import time, so a test cannot import it as-is. `dev.mjs` keeps the same priority order and produces the same name for every input it produced correctly before.

## Naming the dev server after what it is

Second commit on this branch, and the reason the PR title now says `feat`. The dev URL was the issue key and nothing else, so a wall of tabs read `fr-3654`, `fr-3652`, `fr-3475` with no way to tell them apart without opening them. It now composes three parts:

```
https://fr-3665-pr9049-statusline.localhost:1357
        \_____/ \____/ \________/
        branch  looked  PORTLESS_APP_NAME
        issue   up      (the only part a caller supplies)
```

Identifiers first — they are what you scan for and they are a fixed width — and the descriptive part last, so the 50-char cap truncates the characters a reader can most easily guess at.

**The descriptive part prefers a human-supplied name over the PR title.** Slugifying a title lands anywhere between good and useless, and nobody can fix a bad one:

| PR | derived from title | |
|---|---|---|
| #9050 | `drop-portless-placeholder` | good |
| #9048 | `redesign-scheduling-history` | good |
| #9049 | `normalize-fr-everywhere` | thin |
| #9038 | `update-astryx-0` | useless ("update Astryx to 0.5.0") |

`/rename` already exists and the dev-server skill already plumbs it through, so `PORTLESS_APP_NAME` now supplies **only that word** and `dev.mjs` adds the identifiers — a caller cannot forget them, and either identifier is stripped back out if one is passed anyway rather than repeated.

Branch names in this repo are mostly bare (`FR-3314`, `FR-3494`), so the title lookup is what makes the automatic path useful at all. One `gh pr view` per boot (~0.65 s) returns number and title together. It is allowed to fail — no `gh`, not logged in, no PR yet, offline — and the name just loses its `prNNNN` part; the last good answer is cached so an offline boot keeps the URL it had instead of silently renaming the server out from under an open tab.

Fallbacks, all covered by tests:

| situation | name |
|---|---|
| `/rename` + PR | `fr-3665-pr9049-statusline` |
| no `/rename` | `fr-3665-pr9049-normalize-fr-everywhere` |
| no PR yet | `fr-3665-statusline` |
| no issue in branch | `pr9049-statusline` |
| caller passed `fr-3665` as the word | `fr-3665-pr9049` (not repeated) |
| `PORTLESS_APP_NAME_EXACT=1` | `v26-4-8-rc-3` (verbatim) |
| nothing at all | `null` → `portless run` auto-derives |

**Trade-off worth a reviewer's attention:** opening a PR changes the URL on the next dev restart, which costs one re-login on that origin. That was the accepted cost of having the PR number in the URL; `PORTLESS_APP_NAME_EXACT=1` opts out of composition entirely.

`.claude/skills/dev-server/SKILL.md` is updated in the same commit — its old guidance told the agent to pass the FR number or PR number itself, which would now be stripped.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

`pnpm vitest run scripts/portless-app-name.test.ts` → **28 passed**, covering the normalization, the boundary cases, both paths agreeing, title-word extraction, identifier de-duplication, truncation that never eats an identifier, and every fallback in the table above.

Every input converges on one issue key (shown with no PR present, so the `prNNNN` part is absent):

| `PORTLESS_APP_NAME` | branch | resolved URL |
|---|---|---|
| `FR1234` | `main` | `https://fr-1234.localhost:1357` |
| `FR-1234` | `main` | `https://fr-1234.localhost:1357` |
| — | `fix/FR-1234-thing` | `https://fr-1234.localhost:1357` |
| — | `FR1234` | `https://fr-1234.localhost:1357` |
| `frame123` | `main` | `https://frame123.localhost:1357` (unchanged) |

**End to end with the real dev server**, not just the helper.

The normalization fix — `PORTLESS_APP_NAME='FR1234' pnpm dev`:

```
$ grep hostname ~/.portless/routes.json | grep 1234
    "hostname": "fr-1234.localhost",       # was fr1234.localhost

$ curl -sk -o /dev/null -w '%{http_code}' https://fr-1234.localhost:1357/
200
```

The composition — `PORTLESS_APP_NAME='statusline' pnpm dev` on this branch (FR-3665, PR #9049):

```
$ grep hostname ~/.portless/routes.json | grep statusline
    "hostname": "fr-3665-pr9049-statusline.localhost",

$ curl -sk -o /dev/null -w '%{http_code}' https://fr-3665-pr9049-statusline.localhost:1357/
200
```

and the statusline picks each of them up as its Portless link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVhEwwuLyb529VUQo2LY67
