### PR TITLE
fix(FR-3666): drop the Portless placeholder when no dev server belongs here

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -338,7 +338,7 @@ def portless_links(claim_root):
     except Exception:
         pass
     # No default port: a link to the wrong port renders green and live while being
-    # dead, which is worse than the gray placeholder.
+    # dead, which is worse than showing no Portless segment at all.
     port = ""
     try:
         with open(os.path.join(state, "proxy.port")) as f:
@@ -411,8 +411,11 @@ def portless_links(claim_root):
 
 
 def render_portless(matches):
+    # Nothing to click, nothing to show. A dim non-link "Portless" sits among segments
+    # that ARE links and reads as a broken one — the question it prompts is "why can't
+    # I click this", not "ah, no dev server here".
     if not matches:
-        return "\033[90mPortless\033[0m"
+        return ""
     return "  ".join(link(u, "\033[32m%s\033[0m" % lbl) for lbl, u in matches)
 
 


### PR DESCRIPTION
Resolves #9046 (FR-3666)

When no Portless route belongs to the current workspace, the statusline rendered a dim gray `Portless` with no hyperlink:

```
^[[90mPortless^[[0m        <- plain gray text, no OSC 8 wrapper
```

It sits among segments that *are* links (`⧉ VS Code`, `Teams`, the Jira key), so it reads as a broken one. The question it prompts is "why can't I click this", not "ah, no dev server here".

## Why it showed up now

The placeholder is not new — it dates from FR-2900 / FR-2942:

```bash
if [[ -z "$PORTLESS_PART" ]]; then
  PORTLESS_PART=$(printf '\033[90mPortless\033[0m')
fi
```

but it lived *inside* the `command -v portless` gate that #9019 (FR-3658) showed never passes on a dev box, so it had never actually rendered. Removing that gate made it reachable for the first time.

## Fix

Render nothing when the workspace owns no route. The segment appears only when there is something to click.

## Verification

Against the live system, with 10 real Portless routes registered across 9 other worktrees:

**No route owned by this workspace** — the segment is gone, and every remaining item on line 1 is a link:

```
⚠ uncommitted  ⧉ VS Code  FR-3666 (To Do): Statusline: drop the gray Portless placeho…
```

**One route owned by this workspace** — unchanged:

```
$ … | grep -oE 'https://[a-z0-9.-]+\.localhost:[0-9]+'
https://fr-statusline-portless.localhost:1357
```

`bash -n` clean. The call site already skipped empty segments, so this is a one-line behavioural change with no layout special-casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVhEwwuLyb529VUQo2LY67
