### PR TITLE
fix(FR-3677): default deployment presets to single-node and warn on multi-node

### DIFF
--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -663,7 +663,9 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
       };
     }
     return {
-      clusterMode: 'MULTI_NODE' as const,
+      // Single-node by default: multi-node needs an overlay network that
+      // all-in-one deployments may not have (FR-3677).
+      clusterMode: 'SINGLE_NODE' as const,
       clusterSize: 1,
       // Model definition is off by default (optional). Seed one empty model so
       // it renders once the switch is turned on.
@@ -1095,10 +1097,12 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                 )}
               </Form.List>
             </BAIFormItem>
+            {/* Top-aligned: bottom alignment would push Cluster Size down by
+                the height of Cluster Mode's validation message. */}
             <BAIFlex
               gap="md"
               wrap="wrap"
-              style={{ alignItems: 'flex-end', marginTop: token.marginMD }}
+              style={{ alignItems: 'flex-start', marginTop: token.marginMD }}
             >
               <BAIFormItem
                 name="clusterMode"
@@ -1109,6 +1113,17 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                   {
                     required: true,
                     message: t('adminDeploymentPreset.ClusterModeRequired'),
+                  },
+                  {
+                    warningOnly: true,
+                    validator: async (_rule, value: string) =>
+                      value === 'MULTI_NODE'
+                        ? Promise.reject(
+                            t(
+                              'adminDeploymentPreset.MultiNodeNotConfiguredWarning',
+                            ),
+                          )
+                        : Promise.resolve(),
                   },
                 ]}
               >
@@ -1247,7 +1262,7 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
             }}
             showDivider
           >
-            <BAIFlex gap="md" wrap="wrap" style={{ alignItems: 'flex-end' }}>
+            <BAIFlex gap="md" wrap="wrap" style={{ alignItems: 'flex-start' }}>
               <BAIFormItem
                 name="replicaCount"
                 label={t('adminDeploymentPreset.Replicas')}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Die Modelldefinition muss ein gültiges JSON sein.",
     "ModelDefinitionPlaceholder": "JSON-Modelldefinition eingeben.",
     "MultiNode": "Multi-Node",
+    "MultiNodeNotConfiguredWarning": "Wenn Multi-Node im Cluster nicht konfiguriert ist, können mit dieser Voreinstellung erstellte Sitzungen nicht gestartet werden.",
     "Name": "Name",
     "NamePlaceholder": "z. B. vLLM-GPU-Large",
     "NameRequired": "Name ist erforderlich",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Ο ορισμός μοντέλου πρέπει να είναι έγκυρο JSON.",
     "ModelDefinitionPlaceholder": "Εισάγετε ορισμό μοντέλου σε JSON.",
     "MultiNode": "Πολλαπλοί κόμβοι",
+    "MultiNodeNotConfiguredWarning": "Εάν δεν έχουν ρυθμιστεί πολλαπλοί κόμβοι στο σύμπλεγμα, οι συνεδρίες που δημιουργούνται από αυτήν την προεπιλογή δεν θα ξεκινήσουν.",
     "Name": "Όνομα",
     "NamePlaceholder": "π.χ. vLLM-GPU-Large",
     "NameRequired": "Το όνομα είναι υποχρεωτικό.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Model definition must be valid JSON.",
     "ModelDefinitionPlaceholder": "Enter JSON model definition.",
     "MultiNode": "Multi Node",
+    "MultiNodeNotConfiguredWarning": "If multi-node is not configured on the cluster, sessions created from this preset will fail to start.",
     "Name": "Name",
     "NamePlaceholder": "e.g., vLLM-GPU-Large",
     "NameRequired": "Name is required.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "La definición del modelo debe ser un JSON válido.",
     "ModelDefinitionPlaceholder": "Ingrese la definición del modelo en formato JSON.",
     "MultiNode": "Multi-nodo",
+    "MultiNodeNotConfiguredWarning": "Si el multi-nodo no está configurado en el clúster, las sesiones creadas a partir de este preajuste no se iniciarán.",
     "Name": "Nombre",
     "NamePlaceholder": "ej. vLLM-GPU-Large",
     "NameRequired": "El nombre es obligatorio",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Mallimäärittelyn tulee olla kelvollista JSON:ia.",
     "ModelDefinitionPlaceholder": "Syötä JSON-mallimäärittely.",
     "MultiNode": "Monisolmuinen",
+    "MultiNodeNotConfiguredWarning": "Jos klusterissa ei ole määritetty monisolmutilaa, tästä esiasetuksesta luodut istunnot eivät käynnisty.",
     "Name": "Nimi",
     "NamePlaceholder": "esim. vLLM-GPU-Large",
     "NameRequired": "Nimi on pakollinen",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "La définition du modèle doit être un JSON valide.",
     "ModelDefinitionPlaceholder": "Entrez la définition du modèle en JSON.",
     "MultiNode": "Multi-nœud",
+    "MultiNodeNotConfiguredWarning": "Si le multi-nœud n'est pas configuré sur le cluster, les sessions créées à partir de ce préréglage ne démarreront pas.",
     "Name": "Nom",
     "NamePlaceholder": "ex. vLLM-GPU-Large",
     "NameRequired": "Le nom est obligatoire",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Definisi model harus berupa JSON yang valid.",
     "ModelDefinitionPlaceholder": "Masukkan definisi model dalam format JSON.",
     "MultiNode": "Multi-Node",
+    "MultiNodeNotConfiguredWarning": "Jika multi-node tidak dikonfigurasi pada kluster, sesi yang dibuat dari preset ini akan gagal dijalankan.",
     "Name": "Nama",
     "NamePlaceholder": "mis. vLLM-GPU-Large",
     "NameRequired": "Nama wajib diisi",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "La definizione del modello deve essere un JSON valido.",
     "ModelDefinitionPlaceholder": "Inserire la definizione del modello in formato JSON.",
     "MultiNode": "Multi-nodo",
+    "MultiNodeNotConfiguredWarning": "Se il multi-nodo non è configurato sul cluster, le sessioni create da questo preset non si avvieranno.",
     "Name": "Nome",
     "NamePlaceholder": "es. vLLM-GPU-Large",
     "NameRequired": "Il nome è obbligatorio",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "モデル定義は有効なJSONである必要があります。",
     "ModelDefinitionPlaceholder": "JSONモデル定義を入力してください。",
     "MultiNode": "マルチノード",
+    "MultiNodeNotConfiguredWarning": "クラスターにマルチノードが設定されていない場合、このプリセットで作成したセッションの起動に失敗します。",
     "Name": "名前",
     "NamePlaceholder": "例: vLLM-GPU-Large",
     "NameRequired": "名前は必須です。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "모델 정의는 유효한 JSON이어야 합니다.",
     "ModelDefinitionPlaceholder": "JSON 모델 정의를 입력하세요.",
     "MultiNode": "멀티 노드",
+    "MultiNodeNotConfiguredWarning": "멀티 노드 설정이 안 되어 있으면 해당 프리셋으로 만든 추론 세션 생성이 실패합니다.",
     "Name": "이름",
     "NamePlaceholder": "예: vLLM-GPU-Large",
     "NameRequired": "이름은 필수입니다",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Загварын тодорхойлолт нь хүчинтэй JSON байх ёстой.",
     "ModelDefinitionPlaceholder": "JSON загварын тодорхойлолтыг оруулна уу.",
     "MultiNode": "Олон зангилаа",
+    "MultiNodeNotConfiguredWarning": "Хэрэв кластер дээр олон зангилаа тохируулаагүй бол энэ урьдчилсан тохиргоогоор үүсгэсэн сешн эхлэхгүй.",
     "Name": "Нэр",
     "NamePlaceholder": "жн: vLLM-GPU-Large",
     "NameRequired": "Нэр заавал бөглөх ёстой.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Definisi model mesti berupa JSON yang sah.",
     "ModelDefinitionPlaceholder": "Masukkan definisi model dalam format JSON.",
     "MultiNode": "Berbilang Nod",
+    "MultiNodeNotConfiguredWarning": "Jika berbilang nod tidak dikonfigurasikan pada kluster, sesi yang dicipta daripada pratetap ini akan gagal dimulakan.",
     "Name": "Nama",
     "NamePlaceholder": "cth. vLLM-GPU-Large",
     "NameRequired": "Nama diperlukan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Definicja modelu musi być poprawnym formatem JSON.",
     "ModelDefinitionPlaceholder": "Wprowadź definicję modelu w formacie JSON.",
     "MultiNode": "Wielowęzłowy",
+    "MultiNodeNotConfiguredWarning": "Jeśli tryb wielowęzłowy nie jest skonfigurowany w klastrze, sesje utworzone z tego ustawienia wstępnego nie uruchomią się.",
     "Name": "Nazwa",
     "NamePlaceholder": "np. vLLM-GPU-Large",
     "NameRequired": "Nazwa jest wymagana",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "A definição do modelo deve ser um JSON válido.",
     "ModelDefinitionPlaceholder": "Insira a definição do modelo em formato JSON.",
     "MultiNode": "Multi-nó",
+    "MultiNodeNotConfiguredWarning": "Se o multi-nó não estiver configurado no cluster, as sessões criadas a partir desta predefinição não serão iniciadas.",
     "Name": "Nome",
     "NamePlaceholder": "ex. vLLM-GPU-Large",
     "NameRequired": "O nome é obrigatório",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "A definição do modelo deve ser um JSON válido.",
     "ModelDefinitionPlaceholder": "Introduza a definição do modelo em formato JSON.",
     "MultiNode": "Multi-nó",
+    "MultiNodeNotConfiguredWarning": "Se o multi-nó não estiver configurado no cluster, as sessões criadas a partir desta predefinição não serão iniciadas.",
     "Name": "Nome",
     "NamePlaceholder": "ex. vLLM-GPU-Large",
     "NameRequired": "O nome é obrigatório",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Определение модели должно быть валидным JSON.",
     "ModelDefinitionPlaceholder": "Введите определение модели в формате JSON.",
     "MultiNode": "Многоузловой",
+    "MultiNodeNotConfiguredWarning": "Если в кластере не настроен многоузловой режим, сессии, созданные по этому пресету, не запустятся.",
     "Name": "Имя",
     "NamePlaceholder": "напр. vLLM-GPU-Large",
     "NameRequired": "Имя обязательно",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "นิยามโมเดลต้องเป็น JSON ที่ถูกต้อง",
     "ModelDefinitionPlaceholder": "ป้อนนิยามโมเดลในรูปแบบ JSON",
     "MultiNode": "หลายโหนด",
+    "MultiNodeNotConfiguredWarning": "หากไม่ได้กำหนดค่าหลายโหนดบนคลัสเตอร์ เซสชันที่สร้างจากพรีเซ็ตนี้จะเริ่มทำงานไม่สำเร็จ",
     "Name": "ชื่อ",
     "NamePlaceholder": "เช่น vLLM-GPU-Large",
     "NameRequired": "ชื่อเป็นสิ่งจำเป็น",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Model tanımı geçerli bir JSON olmalıdır.",
     "ModelDefinitionPlaceholder": "JSON model tanımını girin.",
     "MultiNode": "Çok düğümlü",
+    "MultiNodeNotConfiguredWarning": "Kümede çok düğümlü mod yapılandırılmamışsa bu ön ayarla oluşturulan oturumlar başlatılamaz.",
     "Name": "Ad",
     "NamePlaceholder": "örn. vLLM-GPU-Large",
     "NameRequired": "Ad zorunludur.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "Định nghĩa mô hình phải là JSON hợp lệ.",
     "ModelDefinitionPlaceholder": "Nhập định nghĩa mô hình dạng JSON.",
     "MultiNode": "Đa nút",
+    "MultiNodeNotConfiguredWarning": "Nếu đa nút chưa được cấu hình trên cụm, các phiên được tạo từ cài đặt sẵn này sẽ không khởi động được.",
     "Name": "Tên",
     "NamePlaceholder": "vd: vLLM-GPU-Large",
     "NameRequired": "Tên là bắt buộc",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "模型定义必须是有效的 JSON。",
     "ModelDefinitionPlaceholder": "输入 JSON 格式的模型定义。",
     "MultiNode": "多节点",
+    "MultiNodeNotConfiguredWarning": "如果集群未配置多节点，使用此预设创建的会话将无法启动。",
     "Name": "名称",
     "NamePlaceholder": "例如：vLLM-GPU-Large",
     "NameRequired": "名称为必填项。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -29,6 +29,7 @@
     "ModelDefinitionInvalidJson": "模型定義必須是有效的 JSON。",
     "ModelDefinitionPlaceholder": "輸入 JSON 格式的模型定義。",
     "MultiNode": "多節點",
+    "MultiNodeNotConfiguredWarning": "如果叢集未設定多節點，使用此預設集建立的工作階段將無法啟動。",
     "Name": "名稱",
     "NamePlaceholder": "例如：vLLM-GPU-Large",
     "NameRequired": "名稱為必填項。",


### PR DESCRIPTION
Resolves #9065 (FR-3677)

## Problem

The deployment preset form defaults to cluster mode **Multi-node** with **cluster size 1** (`AdminDeploymentPresetSettingPageContent.tsx`). Multi-node requires an overlay network that all-in-one deployments may not have configured, so a preset saved with that untouched default produces sessions that fail to start — and the admin gets no signal at save time.

## Change

Previous revision of this PR silently rewrote `MULTI_NODE` x1 to `SINGLE_NODE` in `handleSubmit`, mirroring the session launcher (FR-2381). **That normalization is reverted** — `AdminDeploymentPresetSettingPage.tsx` is back to `main`. This is an admin surface: the persisted value must be exactly what the admin selected, not a value the UI quietly corrected.

Two changes instead:

1. **Default is now `SINGLE_NODE`.** The safe mode is what an admin gets without touching the cluster fields.
2. **Selecting `MULTI_NODE` raises a `warningOnly` `Form.Item` rule** on the cluster-mode field:

   > If multi-node is not configured on the cluster, sessions created from this preset will fail to start.

   Same mechanism the session launcher already uses for its cluster-size-1 hint (`ClusterModeFormItems.tsx` → `session.launcher.ClusterSizeOneMultiNodeConvertInfo`). It informs without blocking submit — a multi-node preset on a properly configured cluster stays perfectly valid.

New i18n key `adminDeploymentPreset.MultiNodeNotConfiguredWarning`, added to all 21 locales.

## Scope

`AdminDeploymentPresetSettingPageContent.tsx` (default + one rule) and the 21 locale files. No mutation-input behavior change.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX, Astryx theme build, z-index mirrors, Terminology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Warning message with 'Multi Node'.
<img width="786" height="145" alt="image" src="https://github.com/user-attachments/assets/6bfc3064-a778-4f13-8b32-41b971808147" />
Default value is 'Single Node'.
<img width="799" height="114" alt="image" src="https://github.com/user-attachments/assets/58c6c22b-9d2e-428d-b00f-46d5c77d535c" />


