### PR TITLE
feat(FR-3675): pick the model mount subpath with a directory picker

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -296,7 +296,7 @@ The value is the **sub path inside the vfolder** — \`''\` for the vfolder root
 | \`value\` | \`string\` | - | Selected sub path (\`''\` = vfolder root) |
 | \`defaultValue\` | \`string\` | - | Initial value for uncontrolled usage |
 | \`onChange\` | \`(selectedSubPath?: string) => void\` | - | Fired when a location is confirmed in the modal |
-| \`selectProps\` | \`BAISelectProps\` subset | - | Forwarded to the sub path trigger select |
+| \`label\` | \`string\` | "Select a path" | Accessible name of the trigger (visually hidden; the surrounding Form.Item renders the visible label) |
 
 > The stories run against a mock Relay environment and a mock \`BAIClientContext\` client, so vfolder search, browsing, mkdir, rename and delete all work without a backend. The second folder (\`team-shared-data\`) is read-only — pick it in the Form story to see permission gating disable folder CRUD inside the modal.
         `,

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -6,12 +6,17 @@ import { BAIDirectoryPickerModalQuery } from '../../../__generated__/BAIDirector
 import { toGlobalId } from '../../../helper';
 import { useControllableValue } from '../../../hooks';
 import { useBAIi18n } from '../../../hooks/useBAIi18n';
-import BAISelect, { type BAISelectProps } from '../../BAISelect';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
 import BAIDirectoryPickerModal, {
   BAIDirectoryPickerQuery,
 } from './BAIDirectoryPickerModal';
-import { useState, useTransition } from 'react';
+import { ComplexSelector } from '@astryxdesign/core/ComplexSelector';
+import {
+  useEffectEvent,
+  useLayoutEffect,
+  useState,
+  useTransition,
+} from 'react';
 import { useQueryLoader } from 'react-relay';
 
 export interface BAIVFolderPathPickerProps {
@@ -31,12 +36,36 @@ export interface BAIVFolderPathPickerProps {
   onChange?: (selectedSubPath?: string) => void;
   disabled?: boolean;
   style?: React.CSSProperties;
-  /** Forwarded to the sub path trigger select. */
-  selectProps?: Omit<
-    BAISelectProps,
-    'value' | 'onChange' | 'open' | 'onOpenChange' | 'loading' | 'disabled'
-  >;
+  /**
+   * Accessible name of the trigger; visually hidden (the surrounding
+   * Form.Item renders the visible label). Defaults to the picker's own
+   * "Select a path" copy.
+   */
+  label?: string;
 }
+
+/**
+ * Any popover open (ArrowDown bypasses the trigger's click path) is redirected
+ * to the directory picker modal before paint.
+ */
+const PopoverToModalRedirect: React.FC<{
+  isOpen: boolean;
+  close: () => void;
+  openPicker: () => void;
+}> = ({ isOpen, close, openPicker }) => {
+  'use memo';
+
+  const redirect = useEffectEvent(() => {
+    close();
+    openPicker();
+  });
+  useLayoutEffect(() => {
+    if (isOpen) {
+      redirect();
+    }
+  }, [isOpen]);
+  return null;
+};
 
 /**
  * A sub path picker for a given vfolder: a select-like trigger that opens a
@@ -51,7 +80,7 @@ export interface BAIVFolderPathPickerProps {
 const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
   'use memo';
 
-  const { vfolderUuid, disabled, style, selectProps } = props;
+  const { vfolderUuid, disabled, style, label } = props;
   const { t } = useBAIi18n();
   const [selectedSubPath, setSelectedSubPath] = useControllableValue<
     string | undefined
@@ -81,20 +110,22 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
 
   return (
     <>
-      <BAISelect
-        // Display-only trigger: the dropdown never opens (`open={false}`);
-        // every open gesture (click, Enter, arrow keys) arrives through
-        // onOpenChange and is redirected to the directory picker modal.
-        open={false}
-        onOpenChange={(nextOpen) => {
-          if (nextOpen) {
-            openPicker();
-          }
+      <ComplexSelector<string | undefined>
+        // Display-only trigger. Astryx `Selector` owns its popup with no open
+        // hook (BAISelect keeps `open`/`onOpenChange` inert), so the trigger
+        // is a ComplexSelector: preventDefault() makes composeEventHandlers
+        // skip its own popover-open handler, and the modal opens instead.
+        onClick={(e) => {
+          e.preventDefault();
+          openPicker();
         }}
-        loading={isPickerPending}
+        label={label ?? t('comp:VFolderPathPicker.SelectAPath')}
+        isLabelHidden
+        value={selectedSubPath}
+        isLoading={isPickerPending}
         // Leading '/' distinguishes "vfolder root picked" ('' → '/') from
         // "nothing picked yet" (undefined → placeholder).
-        value={
+        triggerLabel={
           selectedSubPath === undefined ? undefined : `/${selectedSubPath}`
         }
         placeholder={
@@ -102,10 +133,18 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
             ? t('comp:VFolderPathPicker.ClickToSelectPath')
             : t('comp:VFolderPathPicker.SelectFolderFirst')
         }
-        disabled={disabled}
+        isDisabled={disabled}
+        width={style?.width}
         style={style}
-        {...selectProps}
-      />
+      >
+        {(_value, _onChange, close, { isOpen }) => (
+          <PopoverToModalRedirect
+            isOpen={isOpen}
+            close={close}
+            openPicker={openPicker}
+          />
+        )}
+      </ComplexSelector>
       {/* Mounted only while open (BAIUnmountAfterClose) and only after the
           first loadQuery. The modal suspends until its preloaded query
           resolves; because it mounts inside the transition above, React

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -2397,6 +2397,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                 style={{ flex: 1 }}
               >
                 <BAIVFolderPathPicker
+                  label={t('modelService.Subpath')}
                   vfolderUuid={
                     watchedModelFolderId
                       ? toLocalId(watchedModelFolderId)

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -98,6 +98,7 @@ import {
   BAIModalProps,
   BAIRuntimeVariantSelect,
   BAIComplexSelect,
+  BAIVFolderPathPicker,
   BAIVFolderSelect,
   BAIVFolderSelectRef,
   convertToUUID,
@@ -2323,6 +2324,10 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                     isDisabled={!deploymentProject}
                     excludeDeleted
                     filter='usage_mode == "model"'
+                    onChange={() => {
+                      // A subpath belongs to the folder it was picked from.
+                      customForm.setFieldValue('modelSubpath', undefined);
+                    }}
                   />
                 </BAIFormItem>
               </Suspense>
@@ -2391,9 +2396,13 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                 tooltip={t('modelService.SubpathTooltip')}
                 style={{ flex: 1 }}
               >
-                <AstryxFormTextInput
-                  label={t('modelService.Subpath')}
-                  hasClear
+                <BAIVFolderPathPicker
+                  vfolderUuid={
+                    watchedModelFolderId
+                      ? toLocalId(watchedModelFolderId)
+                      : undefined
+                  }
+                  disabled={!watchedModelFolderId}
                 />
               </BAIFormItem>
             )}
@@ -2678,6 +2687,9 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                 ? presetVFolderSelectRef
                 : customVFolderSelectRef;
             activeForm.setFieldValue('modelFolderId', newFolderGlobalId);
+            // Programmatic setFieldValue skips the select's onChange, so drop
+            // any subpath picked from the previously selected folder here.
+            customForm.setFieldValue('modelSubpath', undefined);
             startTransition(() => {
               activeRef.current?.refetch();
             });


### PR DESCRIPTION
Resolves #9063 (FR-3675)

## What & why

When a model's files live in a subfolder of the model-type vfolder, the deployment revision form requires a mount **subpath** — but it was a free-typed text input, so a typo or a nonexistent path only surfaced at serve time. This replaces the input with **`BAIVFolderPathPicker`** (its first application), which opens a directory-only picker modal on the selected model folder, so only a real directory can be picked (`''` = folder root).

## Changes (`DeploymentAddRevisionModal.tsx`)

- The Custom form's `modelSubpath` field now renders `BAIVFolderPathPicker`, keyed to the watched `modelFolderId` (`toLocalId`) and disabled until a model folder is chosen.
- A subpath only makes sense inside the folder it was picked from, so:
  - changing the model folder via the select resets the subpath field;
  - the create-new-folder callback (programmatic `setFieldValue`, which skips `onChange`) resets it too.
- Prefills from an existing revision (edit/duplicate) keep their stored subpath, as before; submit semantics are unchanged (`'' | undefined` → `null`).

The field still renders only when the manager supports `model-mount-subpath`, and the Preset form is untouched (it has no subpath field).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, i18n terminology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BhoynodeDDhwqQzUDV6rY