### PR TITLE
fix(FR-3684): right-align the auto-scaling refresh and Add Rules buttons

### DIFF
--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -266,9 +266,9 @@ const DeploymentAutoScalingCardContent: React.FC<
   return (
     <>
       <BAIFlex direction="column" align="stretch" gap="sm">
-        <BAIFlex align="center" gap="xs">
+        <BAIFlex align="center" justify="between" wrap="wrap" gap="xs">
           <BAIGraphQLPropertyFilter<AutoScalingRuleFilter>
-            style={{ flex: 1 }}
+            style={{ flexShrink: 1 }}
             filterProperties={[
               {
                 key: 'createdAt',
@@ -293,24 +293,26 @@ const DeploymentAutoScalingCardContent: React.FC<
               });
             }}
           />
-          <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            value=""
-            onChange={() => {
-              startRefetchTransition(() => updateFetchKey());
-            }}
-          />
-          <BAIButton
-            type="primary"
-            icon={<PlusIcon />}
-            disabled={isEndpointDestroying || !isOwnedByCurrentUser}
-            onClick={() => {
-              setEditingRuleId(null);
-              setIsOpenEditorModal(true);
-            }}
-          >
-            {t('modelService.AddRules')}
-          </BAIButton>
+          <BAIFlex align="center" gap="xs">
+            <BAIFetchKeyButton
+              loading={isPendingRefetch}
+              value=""
+              onChange={() => {
+                startRefetchTransition(() => updateFetchKey());
+              }}
+            />
+            <BAIButton
+              type="primary"
+              icon={<PlusIcon />}
+              disabled={isEndpointDestroying || !isOwnedByCurrentUser}
+              onClick={() => {
+                setEditingRuleId(null);
+                setIsOpenEditorModal(true);
+              }}
+            >
+              {t('modelService.AddRules')}
+            </BAIButton>
+          </BAIFlex>
         </BAIFlex>
         <AutoScalingRuleListNodes
           autoScalingRulesFrgmt={autoScalingRuleNodes}


### PR DESCRIPTION
Resolves #9074 (FR-3684)

The Auto-scaling card's refresh and primary **Add Rules** buttons were bunched against the card's left edge, right next to the search filter. They now sit at the **right end of the same toolbar row**; the title and the search filter keep their existing positions.

## Mechanism

The toolbar row was a plain `BAIFlex align="center"` with **no `justify`**, so its children packed at flex-start. The filter carried `style={{ flex: 1 }}` — clearly intended to stretch and push the buttons right — but it never took effect: the search box measures a fixed 212px in the live DOM, so the intended layout silently collapsed to the left.

Fix: give the row `justify="between"`, group the two buttons in their own `BAIFlex` so they travel together, and replace the dead `flex: 1` with `flexShrink: 1`. This is the toolbar idiom already used by `AdminDeploymentPreset` and `AdminModelCard`. No CSS, no new tokens, no restructuring — 3 lines of real change.

## Measured — 1600px viewport, light and dark identical

Card spans x 264–1576; its inner content edges are 288 and 1552.

| | title row | search filter | refresh | Add Rules | card height |
|---|---|---|---|---|---|
| before | y 513, 288–1552 | y 558, 297–509 | y 553, **526–558** | y 553, **566–678** | 276px |
| after | y 513, 288–1552 | y 558, 297–509 | y 553, **1400–1432** | y 553, **1440–1552** | 276px |

Add Rules now ends flush with the card's inner right edge (1552) instead of 874px short of it. The title row, the search filter and the card height are **byte-identical** before and after — only the two buttons moved.

## Screenshots

**Light**

| before | after |
|---|---|
| ![before light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9078/20260825-090858-before-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9078/20260825-100655-after-v2-light.png) |

**Dark**

| before | after |
|---|---|
| ![before dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9078/20260825-090909-before-dark.png) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9078/20260825-100701-after-v2-dark.png) |

## Verification

Run in a clean worktree based on `main` (`pnpm install --frozen-lockfile` + `pnpm --filter backend.ai-ui build` first — a fresh worktree has no BUI dist, which otherwise fails `astryx theme build --check`):

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → **102 files, 1627 tests passed**
- `pnpm --filter backend.ai-ui exec vitest run` → **64 files passed, 1 skipped; 775 tests passed, 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on **3 pre-existing** findings (`BAIDialog.css:17`, `BAIDrawerPortal.css:18`, `BAIText.css:28`), all in `packages/backend.ai-ui/src/**` CSS this PR does not touch. This diff adds zero `var()`, so the gate result is identical with and without it.

Live probe on a dev server against the shared backend, light **and** dark (dark entered via the header toggle with `document.documentElement.dataset.theme` asserted `'dark'`): **zero `pageerror` in both passes**. Interactions exercised non-destructively — refresh fires the refetch, **Add Rules** opens the editor modal (`[data-bai-modal-open]` count 1) and `Escape` closes it (count 0), the filter combobox opens.

## Residue

- `BAIGraphQLPropertyFilter` not honouring `flex: 1` is worked around here, not fixed. Whether it should forward `style` / grow as a flex child is a separate BUI question.
- Only the Auto-scaling card changes. Sibling cards on the Deployment detail page keep their current toolbar placement.
