### PR TITLE
feat(FR-3690): show a search icon at the start of every Power search

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -61,6 +61,7 @@ import type {
 import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
+import { SearchIcon } from 'lucide-react';
 import { useRef } from 'react';
 
 // GraphQL Filter Types (matching schema.graphql)
@@ -788,6 +789,7 @@ const BAIGraphQLPropertyFilter = <
     <PowerSearch
       config={config}
       filters={filters}
+      startIcon={SearchIcon}
       label={label ?? t('comp:BAIPropertyFilter.SearchLabel')}
       placeholder={placeholder ?? t('comp:BAIPropertyFilter.PlaceHolder')}
       popoverSaveButtonLabel={applyLabel ?? t('comp:BAIPropertyFilter.Apply')}

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -66,6 +66,7 @@ import type {
 import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
+import { SearchIcon } from 'lucide-react';
 import React, { useRef } from 'react';
 
 export type { FilterPropertyOption } from './BAIPowerSearchAdapters';
@@ -586,6 +587,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
     <PowerSearch
       config={config}
       filters={filters}
+      startIcon={SearchIcon}
       label={label ?? t('comp:BAIPropertyFilter.SearchLabel')}
       placeholder={placeholder ?? t('comp:BAIPropertyFilter.PlaceHolder')}
       popoverSaveButtonLabel={applyLabel ?? t('comp:BAIPropertyFilter.Apply')}


### PR DESCRIPTION
Resolves #9081 (FR-3690)

## What

Every Power search control now renders a magnifier as its start icon.

Astryx `PowerSearch` is rendered from exactly two places, both in BUI, and every host call site (Data, Admin → Data, session/image/agent lists, …) goes through one of them:

- `packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx` (DSL filter)
- `packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx` (GraphQL object filter)

Both now pass `startIcon={SearchIcon}` (lucide-react), so no call site changes.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `vitest run BAIPropertyFilter.test.tsx BAIGraphQLPropertyFilter.test.tsx` → 87 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FznsYMaJyU9SqTgFZJp1zR