### PR TITLE
fix(FR-3686): ellipsize the RBAC role name cell instead of hard-clipping it

### DIFF
--- a/packages/backend.ai-ui/src/components/BAILink.css
+++ b/packages/backend.ai-ui/src/components/BAILink.css
@@ -56,6 +56,16 @@
   max-width: 100%;
 }
 
+/*
+ Astryx `Link` wraps its children in a `Text` of its own, which becomes a flex
+ item of the link box. A flex item floors at `min-width: auto` — its min-content
+ — so without this the truncating `BAIText` inside it never shrinks below the
+ full string and the link hard-clips again (measured: 75px inside a 56px link).
+*/
+.bai-link-ellipsis > .astryx-text {
+  min-width: 0;
+}
+
 .bai-link-disabled {
   color: var(--color-text-disabled);
   cursor: not-allowed;

--- a/packages/backend.ai-ui/src/components/BAILink.css
+++ b/packages/backend.ai-ui/src/components/BAILink.css
@@ -45,6 +45,17 @@
   text-decoration: inherit;
 }
 
+/*
+ With no `to`, Astryx `Link` renders a <button>, which is fit-content-sized even
+ at `display: block`. Under a table cell's inherited `white-space: nowrap` its
+ min-content is the whole string, so it never shrinks and `maxLines` has nothing
+ to truncate. `max-width` (not `width`) so a short name keeps a short underline.
+ Measured on /admin/rbac: 75px -> 56px, "preset_u" -> "preset…" (FR-3686).
+*/
+.bai-link-ellipsis {
+  max-width: 100%;
+}
+
 .bai-link-disabled {
   color: var(--color-text-disabled);
   cursor: not-allowed;

--- a/packages/backend.ai-ui/src/components/BAILink.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.test.tsx
@@ -111,6 +111,57 @@ describe('BAILink', () => {
       render(<BAILink ellipsis={false}>No ellipsis</BAILink>);
       expect(screen.getByText('No ellipsis')).toBeInTheDocument();
     });
+
+    /*
+     * FR-3686. jsdom does not lay out, so overflow cannot be measured here;
+     * these pin the DOM CONTRACT the fix depends on — the truncating box lives
+     * INSIDE the link (an ancestor can neither shorten an atomic inline box nor
+     * see a child that fits it), and the link carries the width cap that bounds
+     * it. Both are load-bearing and both are invisible to a render-only assert.
+     */
+    it.each([
+      ['onClick (Astryx Link)', undefined],
+      ['to (router link)', '/test'],
+    ])('puts the truncating text inside the link — %s', (_label, to) => {
+      renderWithRouter(
+        <BAILink to={to} ellipsis data-testid="link">
+          Some long name
+        </BAILink>,
+      );
+      const link = screen.getByTestId('link');
+      expect(link).toHaveClass('bai-link-ellipsis');
+      const text = link.querySelector('.astryx-text');
+      expect(text).not.toBeNull();
+      expect(link).toContainElement(text as HTMLElement);
+      expect(screen.getByText('Some long name')).toBeInTheDocument();
+    });
+
+    it('keeps the caller class alongside the internal ones', () => {
+      renderWithRouter(
+        <BAILink to="/test" ellipsis className="caller" data-testid="link">
+          Name
+        </BAILink>,
+      );
+      const link = screen.getByTestId('link');
+      // The spread must not overwrite the internal classes, or the width cap
+      // disappears and truncation silently stops working.
+      expect(link).toHaveClass('caller');
+      expect(link).toHaveClass('bai-link-ellipsis');
+      expect(link).toHaveClass('bai-link-hover');
+    });
+
+    it('keeps the custom-tooltip form addressable on the truncating box', () => {
+      render(
+        <BAILink ellipsis={{ tooltip: 'Full text here' }} data-testid="link">
+          Truncated text
+        </BAILink>,
+      );
+      const link = screen.getByTestId('link');
+      // The custom tooltip is gated on the truncating box's own overflow, so
+      // that box has to be the one inside the link — not an ancestor of it.
+      expect(link).toHaveClass('bai-link-ellipsis');
+      expect(link.querySelector('.astryx-text')).not.toBeNull();
+    });
   });
 
   describe('onClick Handler', () => {

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -24,6 +24,7 @@
 import './BAILink.css';
 import BAIText from './BAIText';
 import { Link as AstryxLink } from '@astryxdesign/core/Link';
+import { Text } from '@astryxdesign/core/Text';
 import React from 'react';
 import { Link, type LinkProps } from 'react-router-dom';
 
@@ -59,8 +60,16 @@ const BAILink: React.FC<BAILinkProps> = ({
 }) => {
   if (type !== 'disabled' && to) {
     return (
-      <Link className={LINK_TYPE_CLASS[type]} to={to} {...linkProps}>
-        {children}
+      <Link
+        className={`${LINK_TYPE_CLASS[type]}${ellipsis ? ' bai-link-ellipsis' : ''}`}
+        to={to}
+        {...linkProps}
+      >
+        {/* A router <a> has no Astryx Text of its own, so `ellipsis` has to add
+            one: it owns both the clip and the truncate tooltip, which an
+            ancestor cannot (the <a> fits it exactly, so nothing overflows to
+            measure). FR-3686. */}
+        {ellipsis ? <Text maxLines={1}>{children}</Text> : children}
         {icon}
       </Link>
     );

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -24,7 +24,6 @@
 import './BAILink.css';
 import BAIText from './BAIText';
 import { Link as AstryxLink } from '@astryxdesign/core/Link';
-import { Text } from '@astryxdesign/core/Text';
 import React from 'react';
 import { Link, type LinkProps } from 'react-router-dom';
 
@@ -58,18 +57,32 @@ const BAILink: React.FC<BAILinkProps> = ({
   children,
   ...linkProps
 }) => {
+  // FR-3686 — the clip AND the tooltip must sit on the element that owns the
+  // text. An ancestor's `text-overflow` cannot shorten an atomic inline box,
+  // and an ancestor's overflow measurement cannot see a child that fits it, so
+  // `BAIText` goes INSIDE the link rather than around it. That keeps both
+  // documented forms working: `ellipsis` shows the text itself, and
+  // `ellipsis={{ tooltip: 'custom' }}` measures the box it is anchored to.
+  const content = ellipsis ? (
+    <BAIText ellipsis={ellipsis === true ? { tooltip: true } : ellipsis}>
+      {children}
+    </BAIText>
+  ) : (
+    children
+  );
+  // The link is what bounds that Text, so it needs the width cap in both
+  // branches. Internal classes go AFTER the spread — `linkProps.className`
+  // would otherwise replace them.
+  const linkClassName = (callerClassName?: string) =>
+    `${LINK_TYPE_CLASS[type]}${ellipsis ? ' bai-link-ellipsis' : ''}${
+      callerClassName ? ` ${callerClassName}` : ''
+    }`;
+
   if (type !== 'disabled' && to) {
+    const { className: routerClassName, ...routerProps } = linkProps;
     return (
-      <Link
-        className={`${LINK_TYPE_CLASS[type]}${ellipsis ? ' bai-link-ellipsis' : ''}`}
-        to={to}
-        {...linkProps}
-      >
-        {/* A router <a> has no Astryx Text of its own, so `ellipsis` has to add
-            one: it owns both the clip and the truncate tooltip, which an
-            ancestor cannot (the <a> fits it exactly, so nothing overflows to
-            measure). FR-3686. */}
-        {ellipsis ? <Text maxLines={1}>{children}</Text> : children}
+      <Link to={to} {...routerProps} className={linkClassName(routerClassName)}>
+        {content}
         {icon}
       </Link>
     );
@@ -93,32 +106,19 @@ const BAILink: React.FC<BAILinkProps> = ({
     ...restProps
   } = linkProps;
 
-  const link = (
+  return (
     <AstryxLink
       {...restProps}
-      className={`${LINK_TYPE_CLASS[type]}${ellipsis ? ' bai-link-ellipsis' : ''}${className ? ` ${className}` : ''}`}
+      className={linkClassName(className)}
       style={style}
       target={target}
       isDisabled={type === 'disabled'}
       onClick={onClick}
-      // The clip has to sit on the element that owns the text: an ancestor's
-      // `text-overflow` cannot shorten an atomic inline-level box (FR-3686).
-      maxLines={ellipsis ? 1 : 0}
     >
-      {children}
+      {content}
       {icon}
     </AstryxLink>
   );
-
-  if (ellipsis) {
-    return (
-      <BAIText ellipsis={ellipsis === true ? { tooltip: true } : ellipsis}>
-        {link}
-      </BAIText>
-    );
-  }
-
-  return link;
 };
 
 export default BAILink;

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -87,11 +87,14 @@ const BAILink: React.FC<BAILinkProps> = ({
   const link = (
     <AstryxLink
       {...restProps}
-      className={`${LINK_TYPE_CLASS[type]}${className ? ` ${className}` : ''}`}
+      className={`${LINK_TYPE_CLASS[type]}${ellipsis ? ' bai-link-ellipsis' : ''}${className ? ` ${className}` : ''}`}
       style={style}
       target={target}
       isDisabled={type === 'disabled'}
       onClick={onClick}
+      // The clip has to sit on the element that owns the text: an ancestor's
+      // `text-overflow` cannot shorten an atomic inline-level box (FR-3686).
+      maxLines={ellipsis ? 1 : 0}
     >
       {children}
       {icon}

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -410,13 +410,10 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
           <BAILink
             to={to}
             type="hover"
-            style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              display: 'block',
-              minWidth: 0,
-            }}
+            ellipsis
+            // Block + shrinkable so the Text `ellipsis` injects has a width to
+            // truncate against; the clip and the tooltip live on that Text.
+            style={{ display: 'block', minWidth: 0 }}
           >
             {title}
           </BAILink>


### PR DESCRIPTION
Resolves #9076 (FR-3686)

## Screenshots

Admin → RBAC role list, Role Name + Scope Type columns, 1000×800. Cropped to
Project-scoped rows on purpose — the User-scoped rows and the Scope ID column
carry test-account emails and role UUIDs.

| | Before | After |
|---|---|---|
| Light | ![name cell, light, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9084/20260825-135150-name-cell-light-before.png) | ![name cell, light, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9084/20260825-135150-name-cell-light-after.png) |
| Dark | ![name cell, dark, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9084/20260825-135150-name-cell-dark-before.png) | ![name cell, dark, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9084/20260825-135150-name-cell-dark-after.png) |

`project-b` / `preset_p` — cut mid-word with no indication the name continues —
become `projec…` / `preset…`.

The second commit restores the truncation tooltip on **navigating** name cells
(Admin → Data). Hovering a truncated folder name now shows the full name:

![truncation tooltip on a `to` name cell](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9084/20260825-135150-name-cell-tooltip-after.png)

## Mechanism

Both commits are the same defect one element apart: **the truncation and the
thing that reacts to it live on different boxes.**

### 1. The clip landed on an ancestor

`RBACManagementPage` renders the name cell as `<BAINameActionCell onTitleClick=…>`,
whose `onTitleClick` branch is `<BAIText ellipsis><BAILink type="hover" onClick ellipsis>`.
`BAILink ellipsis` only wrapped the link in another `BAIText` — it never touched the
link itself. With no `to`, Astryx `Link` renders an `inline-flex` `<button>` containing
`<Text maxLines={0}>`, i.e. an atomic inline-level box with no truncation of its own.
`text-overflow: ellipsis` cannot shorten an atomic inline, so the ancestor's
`overflow: hidden` simply cut the glyphs — a hard clip with no `…`.

The `description` column on the same table works because it renders
`<Text maxLines={1} hasTruncateTooltip>` around a plain string: the truncation styles
sit on the element whose own inline content is the text.

This is a migration regression. antd's `Typography.Link ellipsis` applied
`overflow/nowrap/ellipsis` to the `<a>` **element**; the migration moved it one level up
and it stopped working.

### 2. …and on the `to` branch, so did the tooltip (reported on this draft)

`BAINameActionCell`'s `to` branch hand-rolled `overflow/text-overflow/white-space`
onto the router `<a>`, so that `<a>` truncates itself — measured on Admin → Data,
`scrollWidth 199` vs `clientWidth 52`. But the tooltip owner is the enclosing
`BAIText`, which decides by `scrollWidth > offsetWidth` on its **own** span, and
the `<a>` fits it exactly (104 == 104). So it never fired, and neither element
carried a `title`. Result: the only name cells with no truncation tooltip were
the navigating ones.

## Fix

`BAILink.tsx` — `ellipsis` now renders `BAIText` **inside** the link instead of
around it, on both branches. That single move is the whole fix: the box that
truncates becomes the box the tooltip is anchored to, so
`ellipsis` shows the text itself and `ellipsis={{ tooltip: 'custom' }}` shows its
own string, and neither depends on an ancestor seeing an overflow it cannot see.
The class list is also built once and applied **after** the spread, so a caller's
`className` merges rather than replacing the internal ones.

`BAILink.css` — two rules on the capped link, both load-bearing and both found by
measurement, not by reading:

- `max-width: 100%` — a `<button>` is fit-content-sized even at `display: block`,
  and under a table cell's inherited `white-space: nowrap` its min-content is the
  whole string, so without the cap nothing ever shrinks. `max-width` rather than
  `width` so a short name keeps a short hover underline.
- `> .astryx-text { min-width: 0 }` — Astryx `Link` wraps children in a `Text` of
  its own, which becomes a flex item and floors at `min-width: auto`. Without
  this the inner truncating box stays at the full string (**measured: 75px of
  text inside a 56px link**) and the link hard-clips again.

`BAINameActionCell.tsx` — the `to` branch drops its hand-rolled truncation style
and just asks for `ellipsis`, keeping only the `display: block; min-width: 0`
that gives the inner box a width to truncate against.

Three lower-level routes were tried and **measured as not working**, recorded so
they are not re-proposed: `maxLines` on the Astryx `Link` alone (button stays at
max-content → still `preset_u`, no ellipsis); an inline
`overflow/textOverflow/whiteSpace` style on the link root, mirroring what the
`to` branch used to do (same result); and moving `BAIText` inside without the
`min-width: 0` release (hard-clips, as above). Astryx `Link`'s own `tooltip` prop
was rejected too — it wraps the link in a second `Tooltip` while the inner
`Text`'s truncate tooltip stays armed, so a custom tooltip would render twice.

`BAIColumnType.ellipsis` (`tableTypes.ts:148`) is **dead API** — declared but never read
by `BAITable`. Adding it to the column would have compiled and done nothing. Not touched
here; worth its own ticket to wire or delete.

## Measured

Admin → RBAC, role `preset_user`, 1000×800:

| | before | after |
|---|---|---|
| link `<button>` width | 75px | **56px** |
| link `max-width` | `none` | **`100%`** |
| link overflowing its own box | **yes** (hard clip) | **no** |
| truncating box `overflow` / `text-overflow` | `visible` / `clip` | **`hidden` / `ellipsis`** |
| truncating box scrollW / clientW | 75 / 75 | **75 / 56 (truncated)** |
| `title` + `aria-describedby` on it | `null` | **present** |
| rendered | `preset_u` (hard clip) | **`preset…`** |

Admin → Data, `to` name cell, 1000×800:

| | before | after |
|---|---|---|
| truncating element | `<a>` (scrollW 199 / clientW 52) | injected `Text` (scrollW 199 / clientW 52) |
| `title` on that element | `null` | **the full name** |
| `aria-describedby` | `null` | **present** |
| enclosing `BAIText` overflowing? | no (104 == 104) — tooltip never fired | no — and it no longer needs to |
| names in the live tooltip layer on hover | none | **all 10 rows** |

Also re-checked on Admin → Sessions and Admin → RBAC after the review fixes:
name tooltips fire on all three pages, zero `pageerror`.

Light and dark both measured; dark entered through the header control with
`document.documentElement.dataset.theme` asserted `dark`. Identical geometry in both —
this is a layout fix with no colour involvement. Zero `pageerror` in every pass.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite
  warmup, StyleX sentinel, Astryx theme build, z-index ladder, Terminology)
- `pnpm --filter backend.ai-ui build` → OK (BUI is consumed as a built package; without
  this the dev server serves the stale component)
- `pnpm --filter backend.ai-ui exec vitest run` → **788 passed, 1 skipped** at the top of
  the stack (`BAILink.test.tsx` 23 → **27**, four new DOM-contract cases)
- `pnpm --prefix ./react exec vitest run` → **1627 passed**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on **3
  pre-existing** undeclared vars (`BAIDialog.css:17`, `BAIDrawerPortal.css:18`,
  `BAIText.css:28`). Confirmed pre-existing by stashing this branch's changes and
  re-running against the baseline: same exit code, same 3 findings. This PR adds no
  `var()` usage.

## Blast radius

**Corrected after review** — an earlier version of this description claimed
`BAILink` + `ellipsis` had one production call site. It has **four**, and all of
them change:

| Call site | Branch | Note |
|---|---|---|
| `Table/BAINameActionCell.tsx:426` | Astryx `Link` | the reported RBAC path |
| `Table/BAINameActionCell.tsx:410` | router `<a>` | gains `ellipsis` in this PR |
| `fragments/BAIRouteNodes.tsx:150` | Astryx `Link` | session-id link |
| `baiClient/FileExplorer/EditableFileName.tsx:159` | Astryx `Link` | also caps at `maxWidth: 180` inline |
| `react/src/components/DeploymentReplicasCard.tsx:467` | Astryx `Link` | also caps at `maxWidth: 160` inline |

The two inline `maxWidth` sites keep their own cap — an inline `max-width`
outranks the class's `100%` — and truncate inside it.

Through `BAINameActionCell` this reaches every name cell that uses
`onTitleClick` or `to`: RBAC (reported), `DeploymentListPage`,
`ProjectAdminDeploymentsPage`, `SessionNodes`, `VFolderNodes`, `VFolderNodesV2`,
`AdminDeployment`, `DeploymentNodesPanel` and the three FairShare tables. All had
the identical latent defect.

`VFolderTable.tsx:417` is a `to` link that hand-rolls the same truncation style
**without** `ellipsis`, so it still has the old tooltip gap. Left alone — it is
outside this report; noted here so it is not mistaken for covered.

The ~71 `BAILink` sites without `ellipsis` are untouched.

Tables that pass `scroll={{x}}` size width-less columns by content, so there the
name is expected to stay full width — that is correct, not a regression.

## Residue

- Does **not** touch `BAITable`'s own cell-level ellipsis span, which has the same
  ancestor-only shape for any cell whose content is a block/flex box. Only the name-cell
  path is closed here.
- Does **not** address FR-3576 (every width-less column getting an equal 1/N share),
  which is what makes the RBAC columns narrow enough to clip in the first place. That
  issue is `Not Planned`; this fix makes its symptom legible rather than silent.
- Sibling report FR-3687 (BAIDoubleTag on the same table) is **not** subsumed — it is a
  separate PR stacked on this one.

## Review

Copilot reviewed this draft once. Findings and what happened:

| Finding | Outcome |
|---|---|
| `{...linkProps}` spread replaced the computed `className`, losing `bai-link-ellipsis` and the width cap | **Fixed** — classes now applied after the spread, caller's class merged. Thread replied + resolved. |
| `ellipsis={{ tooltip: 'custom' }}` silently stopped working | **Fixed** — `BAIText` moved inside the link so the truncating box owns the tooltip. This was a regression this branch introduced. |
| The description's blast radius was wrong (3 more call sites) | **Fixed** — table above, all verified live. |
| No regression coverage for `to + ellipsis` or the custom-tooltip form | **Added** — 4 new tests pinning the DOM contract. |

The fixes landed **after** the review, so Copilot never saw them; they are
verified by `verify.sh`, the test suites and the live measurements above
instead of by a second bot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyXpNjdr4aZSrHMGz9aMXi
