### PR TITLE
style(FR-3687): weld BAIDoubleTag back into one joined pair

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDoubleTag.css
+++ b/packages/backend.ai-ui/src/components/BAIDoubleTag.css
@@ -1,0 +1,39 @@
+/*
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ The weld antd's `<Tag style={{ margin: 0, marginRight: -1 }}>` performed
+ (FR-3687). Same three-route analysis as `BAICompactGroup.css`: StyleX `xstyle`
+ is unavailable in BUI, and `defineTheme({ components: { badge } })` is flat and
+ global, so neither can square a corner CONDITIONALLY on having a neighbour.
+
+ antd overlapped two BORDERED tags by 1px so their strokes coincided. Astryx
+ `Badge` carries no border, so the overlap has nothing to merge and `gap: 0`
+ alone FUSES two same-variant halves into one uniform capsule — which seven call
+ sites hit, including the whole `values: Array<string>` API that hardcodes
+ `blue` for every element. So the 1px seam below replaces the stroke antd drew,
+ and is not optional.
+*/
+
+@layer components {
+  /* The seam antd's shared border drew. `gap` only takes a SpacingStep and its
+     smallest nonzero step is 2px, so this cannot be a prop. */
+  .bai-double-tag > .astryx-badge:not(:last-child) {
+    margin-inline-end: var(--border-width);
+  }
+
+  /* Square the corners of every badge that has a neighbour. The OUTER corners
+     are deliberately not declared — restating them as `var(--radius-full)`
+     would pin the run to Badge's current radius. `0` is not a themed quantity,
+     so it is not a raw-value escape (same PILOT-DECISION as
+     `BAICompactGroup.css`). */
+  .bai-double-tag > .astryx-badge:not(:first-child) {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+
+  .bai-double-tag > .astryx-badge:not(:last-child) {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+}

--- a/packages/backend.ai-ui/src/components/BAIDoubleTag.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDoubleTag.test.tsx
@@ -1,0 +1,58 @@
+import BAIDoubleTag from './BAIDoubleTag';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/*
+ * FR-3687. The weld itself is CSS (`BAIDoubleTag.css`) and vitest does not
+ * evaluate stylesheets, so these tests pin the DOM CONTRACT the stylesheet is
+ * written against — what a refactor could silently break while the component
+ * still "renders fine": the `bai-double-tag` anchor, direct-child badges in
+ * source order (the corner rules are `> .astryx-badge:not(:first-child)` /
+ * `:not(:last-child)`), and `gap: 0` (a gap detaches the halves).
+ */
+describe('BAIDoubleTag', () => {
+  const root = (c: HTMLElement) =>
+    c.querySelector('.bai-double-tag') as HTMLElement;
+
+  it('anchors the stylesheet on `bai-double-tag` and pins gap to 0', () => {
+    const { container } = render(<BAIDoubleTag values={['User', 'admin']} />);
+    expect(root(container)).toBeInTheDocument();
+    expect(root(container)).toHaveAttribute('data-gap', '0');
+  });
+
+  it('renders each value as a direct badge child, in source order', () => {
+    const { container } = render(
+      <BAIDoubleTag
+        values={[
+          { label: 'R', color: 'green' },
+          { label: 'W', color: 'blue' },
+          { label: 'D', color: 'red' },
+        ]}
+      />,
+    );
+    const badges = Array.from(root(container).children);
+    expect(badges).toHaveLength(3);
+    badges.forEach((el) => expect(el).toHaveClass('astryx-badge'));
+    expect(badges.map((el) => el.textContent)).toEqual(['R', 'W', 'D']);
+  });
+
+  it('leaves a lone badge with both corners rounded (no neighbour to weld to)', () => {
+    const { container } = render(<BAIDoubleTag values={['only']} />);
+    const badges = Array.from(root(container).children);
+    expect(badges).toHaveLength(1);
+    // `:not(:first-child)` and `:not(:last-child)` both no-op on a single child.
+    expect(badges[0]).toHaveClass('astryx-badge');
+  });
+
+  it('skips empty labels so they cannot open a hole in the run', () => {
+    const { container } = render(
+      <BAIDoubleTag
+        values={[
+          { label: 'User', color: 'blue' },
+          { label: '', color: 'default' },
+        ]}
+      />,
+    );
+    expect(root(container).children).toHaveLength(1);
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIDoubleTag.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDoubleTag.tsx
@@ -1,4 +1,5 @@
 import { badgeVariantForTagColor } from '../helper/astryxTagVariant';
+import './BAIDoubleTag.css';
 import BAITextHighlighter from './BAITextHighlighter';
 import { Badge } from '@astryxdesign/core/Badge';
 import { HStack } from '@astryxdesign/core/Stack';
@@ -11,12 +12,12 @@ import React from 'react';
 // repo-global Tag lookup (ticket 13 policy — unknown runtime strings drop to
 // neutral).
 //
-// PILOT-DECISION: the antd "welded" double-tag look (margin: 0 / -1px between
-// the two Tags) is inexpressible with Badge's closed styling and is dropped —
-// the pair renders as two adjacent badges (HStack gap 0.5). The 150px
-// max-width ellipsis + tooltip on each segment is likewise dropped (Astryx
-// Text cannot be width-capped inside a Badge without xstyle); tag labels
-// render in full (simplicity policy, MIGRATION-SPEC §0).
+// The pair is welded in BAIDoubleTag.css: Badge's radius is theme-owned and
+// adjacency-conditional styling has no prop or defineTheme route (FR-3687).
+//
+// PILOT-DECISION: the 150px max-width ellipsis + tooltip on each segment is
+// dropped (Astryx Text cannot be width-capped inside a Badge without xstyle);
+// tag labels render in full (simplicity policy, MIGRATION-SPEC §0).
 export type DoubleTagObjectValue = {
   label: string;
   color?: string;
@@ -50,7 +51,7 @@ const BAIDoubleTag: React.FC<BAIDoubleTagProps> = ({
   }
 
   return (
-    <HStack gap={0.5} align="center">
+    <HStack gap={0} align="center" className="bai-double-tag">
       {_.map(objectValues, (objValue, idx) =>
         !_.isEmpty(objValue.label) ? (
           <Badge


### PR DESCRIPTION
Resolves #9077 (FR-3687)

## Screenshots

**Closeup — the same-variant pair the 1px seam exists for.** Environments →
Images, an architecture tag (`Amd` + `64`, both `blue`).

| | Before | After |
|---|---|---|
| Light | ![double tag closeup, light, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9085/20260825-135150-doubletag-closeup-light-before.png) | ![double tag closeup, light, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9085/20260825-135150-doubletag-closeup-light-after.png) |
| Dark | ![double tag closeup, dark, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9085/20260825-135150-doubletag-closeup-dark-before.png) | ![double tag closeup, dark, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9085/20260825-135150-doubletag-closeup-dark-after.png) |

**The reported site** — Admin → RBAC, Scope Type column. Cropped to
Project-scoped rows on purpose: the User-scoped rows carry test-account emails.
(The Role Name column also changes here; that is the PR below this one.)

| Before | After |
|---|---|
| ![rbac scope column, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9085/20260825-135150-doubletag-rbac-light-before.png) | ![rbac scope column, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9085/20260825-135150-doubletag-rbac-light-after.png) |

## Mechanism

Two independent causes, both introduced by the antd → Astryx migration, both inside
`BAIDoubleTag.tsx`.

1. **The gap.** `<HStack gap={0.5}>`. Astryx `Stack`'s `gap` is a `SpacingStep`;
   `0.5` resolves through `gapStyles["0.5"]` → `column-gap: var(--spacing-0-5)` →
   **2px**. The antd original had no gap at all and actively welded
   (`margin: 0; marginRight: -1` on every non-last `<Tag>`).
2. **The rounding.** Even at `gap: 0` the pair would not read as one tag: Astryx
   `Badge` is a full-radius pill (`border-radius: var(--radius-full)` = 9999px), so two
   capsules would kiss rather than join. The join requires the **inner** corners of
   adjacent badges to be squared.

The migration recorded this as a deliberate capability drop
("the antd 'welded' double-tag look … is dropped"), but the component's own Storybook
docblock still advertises "Tags are visually connected (no gaps between them)", and the
name is `DoubleTag`. The report asks for the documented behaviour back.

## Why CSS and not a prop or a theme entry

The higher levels are closed, and this is the same three-route analysis already written
up in `BAICompactGroup.css`:

- **Theme token / `defineTheme({ components: { badge } })`** — flat and global per
  component. It cannot square a corner *conditionally on having a neighbour*; it would
  round every badge in the app. Neither `backendAiTheme.ts` nor `theme-shim/antdParity.ts`
  carries a `badge` entry today.
- **An Astryx prop** — `gap={0}` is real and is half the fix, but `Badge`'s radius is not
  exposed (`astryx component Badge` lists only `variant`, `label`, `icon`).
- **Composition** — there is no `BadgeGroup`/`TokenGroup`. `ButtonGroup` is the only
  joining group and welds through `ButtonGroupContext`, which only
  `Button`/`IconButton`/`ToggleButton` read; a `Badge` child would be exactly the
  "non-Astryx child leaves a notch" trap, and `ButtonGroup` also stamps `role="group"` +
  roving tabindex, which is wrong for read-only tags.

So: `gap={0}` in the TSX plus a co-located stylesheet in `@layer components` against the
stable `.astryx-badge` class. The **outer** corners are deliberately not declared —
restating them as `var(--radius-full)` would pin the run to Badge's current radius.

## The 1px seam is not optional

antd overlapped two **bordered** tags by 1px so their strokes coincided. Astryx `Badge`
has **no border** (verified: its base atomic map carries no border-width and no margin),
so the overlap has nothing to merge and `gap: 0` alone would **fuse** two same-variant
halves into one uniform capsule. Seven call sites render a same-variant pair — including
the whole `values: Array<string>` API, which hardcodes `blue` for every element. A 1px
`margin-inline-end: var(--border-width)` on every non-last badge replaces the stroke antd
drew, and degrades correctly for both same- and different-colour pairs. The closeup pair
above is exactly that case.

## Measured — Admin → RBAC Scope Type cell, 1440×900

| | before | after |
|---|---|---|
| `column-gap` on the wrapper | `2px` (`data-gap="0.5"`) | **`0px`** (`data-gap="0"`) |
| left badge `border-radius` | `9999px` | **`9999px 0 0 9999px`** |
| right badge `border-radius` | `9999px` | **`0 9999px 9999px 0`** |
| left badge `margin-inline-end` | `0px` | **`1px`** |
| measured gap between halves | **2px** | **1px** |

Same-variant case, Environments image tags (`blue` + `blue`), 12 tags sampled:
`column-gap: 0px`, inner corners squared, seam **1px** on every pair.

Light and dark both measured; dark entered through the header control with
`document.documentElement.dataset.theme` asserted `dark`. Dark badge fills
(`rgba(158,183,255,0.24)` + `rgb(38,38,38)`) keep the seam and the squared corners
identically. Zero `pageerror` in both passes.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → OK (required — a stale BUI `dist` does not carry
  the new CSS and the fix looks like a no-op)
- `pnpm --filter backend.ai-ui exec vitest run` → **788 passed, 1 skipped**, including
  the new `BAIDoubleTag.test.tsx` (4 tests)
- `pnpm --prefix ./react exec vitest run` → **1627 passed**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on the **same 3
  pre-existing** undeclared vars as `main` (`BAIDialog.css:17`, `BAIDrawerPortal.css:18`,
  `BAIText.css:28`); confirmed against the stashed baseline. The one token this PR adds,
  `var(--border-width)`, is declared and passes.

`BAIDoubleTag.test.tsx` is new: vitest does not evaluate stylesheets, so it pins the DOM
**contract** the stylesheet is written against — the `bai-double-tag` anchor,
`data-gap="0"`, direct-child badges in source order (the corner rules are
`> .astryx-badge:not(:first-child)` / `:not(:last-child)`), the lone-badge no-op, and
that empty labels are skipped so they cannot open a hole in the run.

## Blast radius

19 files render `BAIDoubleTag` and the fix reaches all of them — which is the point; the
joined pair is the component's purpose. Shapes worth calling out:

- Most sites pass two values with **different** colours (`RoleNodes` blue+default,
  `AgentComputePlugins` CUDA+green) → an unambiguous two-tone joined pill.
- `VFolderPermissionTag` passes **three** values (R/W/D). The `:not(:first-child)` /
  `:not(:last-child)` pair handles N children identically, as the antd original did.
- `ImageTags` passes both halves the **same** colour → handled by the seam above.
- `AgentComputePlugins.tsx:57` renders a hand-squared `<BAITag style={{borderRadius: 0}}>`
  next to a `BAIDoubleTag` — independent corroboration that this row is designed as a
  joined run. It sits outside the wrapper, keeps its current look, and is out of scope.

## Residue

- The **other half** of the original PILOT-DECISION — the dropped 150px max-width
  ellipsis + tooltip per segment — is deliberately kept as-is and its note is preserved.
  That is why a long scope name still runs to the cell edge; that is FR-3686/FR-3576
  territory, not this one.
- `DoubleTagObjectValue.style` is dead (declared, never passed to `Badge`). Pre-existing,
  unrelated to the gap, left alone.
- Related but **not** subsumed: FR-3545 (`BAITag`: reserve badge styling for status tags,
  restore a plain rectangular style for generic tags) is still `To Do` and unassigned. If
  that proposal lands, the inner-corner rules here stay correct but the outer radius
  changes with the theme, which is exactly why they are not declared.

## Review

Copilot reviewed this draft once and generated **no comments**; zero review
threads. Nothing was changed in response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyXpNjdr4aZSrHMGz9aMXi
