### PR TITLE
fix(FR-3688): weld the unit number input's stepper and unit select into one control

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumber.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumber.tsx
@@ -63,10 +63,9 @@ import {
   nextLadderIndex,
   type StepDirection,
 } from './astryxNumberStepper';
-import { InputGroup } from '@astryxdesign/core/InputGroup';
+import { InputGroup, InputGroupText } from '@astryxdesign/core/InputGroup';
 import { NumberInput } from '@astryxdesign/core/NumberInput';
 import { Selector } from '@astryxdesign/core/Selector';
-import { HStack } from '@astryxdesign/core/Stack';
 import * as _ from 'lodash-es';
 import React from 'react';
 import type { CSSProperties, ReactNode } from 'react';
@@ -272,7 +271,7 @@ const BAIDynamicUnitInputNumber: React.FC<BAIDynamicUnitInputNumberProps> = ({
       size={size ? ASTRYX_SIZE[size] : undefined}
       style={style}
     >
-      {addonPrefix ? <HStack align="center">{addonPrefix}</HStack> : null}
+      {addonPrefix ? <InputGroupText>{addonPrefix}</InputGroupText> : null}
       <NumberInput
         label={accessibleLabel}
         isLabelHidden
@@ -323,12 +322,16 @@ const BAIDynamicUnitInputNumber: React.FC<BAIDynamicUnitInputNumberProps> = ({
           }))}
           onChange={(newUnit) => setValue(`${numValue ?? 0}${newUnit}`)}
           isDisabled={disabled}
-          width={96}
+          // Measured: in a group the trigger resolves to `width: 100%`, so it
+          // claims the whole row and the number field shrinks to its flex basis.
+          // Size the unit to its own content and let the number field take the
+          // rest — antd's `Select` in a `Space.Compact` behaved this way.
+          style={{ flex: '0 0 auto', width: 'auto' }}
         />
       ) : (
-        <HStack align="center">{`${unit.toUpperCase()}iB`}</HStack>
+        <InputGroupText>{`${unit.toUpperCase()}iB`}</InputGroupText>
       )}
-      {addonSuffix ? <HStack align="center">{addonSuffix}</HStack> : null}
+      {addonSuffix ? <InputGroupText>{addonSuffix}</InputGroupText> : null}
     </InputGroup>
   );
 };

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.css
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.css
@@ -2,38 +2,88 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- Make the ladder stepper a real `InputGroup` segment (FR-3688).
+ The ladder stepper, drawn as Astryx draws its own (FR-3688).
 
- `InputGroupText` already carries the weld — border, `-1 * --border-width` start
- margin, squared inner corners — so only two things are wrong for a control
- slot: its text padding, and its muted addon fill. Astryx's own in-border
- stepper buttons sit on the input surface, so this one does too; the muted slab
- would read as an addon chip rather than part of the field.
+ `NumberInput hasNumberSteppers` cannot carry a non-linear ladder — the reasons
+ are in `astryxNumberStepper.tsx` — so the affordance stays ours and only the
+ LOOK is borrowed. Every rule below mirrors one in `NumberInput.tsx`, reading
+ the same tokens, so the two steppers stay indistinguishable:
 
- The button rules beat `Button`'s `sizeStyles.sm` (a fixed `--size-element-sm`
- height) and `styles.iconOnly` (`aspect-ratio: 1 / 1`), which together made each
- button assert 28px in a 32px row — a 56px column overflowing the group. They
- win on layer order, not specificity: `@layer components` is declared after
- `astryx-base` (same mechanism as `BAICompactGroup.css`).
+   .bai-number-stepper          <- styles.numberSteppers
+   .bai-number-stepper__button  <- styles.numberStepperButton
+   …--decrease                  <- styles.decrementButton
+   …--increase > svg            <- styles.incrementIcon
+
+ The one intentional difference is the outer border. Astryx's column lives
+ INSIDE the input's box and needs only a `border-inline-start` hairline; ours is
+ a welded `InputGroup` segment, so `InputGroupText`'s full border supplies the
+ same hairline on the leading edge and collapses with its neighbours on the
+ others. Same painted result, different owner.
 */
 
 @layer components {
+  /* The addon slot becomes the stepper column: no text padding, no muted addon
+     fill, and the field's own surface underneath. */
   .bai-number-stepper {
-    padding-inline: 0;
+    flex-direction: column;
     align-items: stretch;
+    padding-inline: 0;
+    width: var(--spacing-4);
+    overflow: hidden;
     background-color: var(--color-background-surface);
   }
 
-  .bai-number-stepper > * {
-    width: var(--spacing-4);
-    height: 100%;
+  .bai-number-stepper__button {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    outline: none;
+    cursor: pointer;
+    color: var(--color-icon-secondary);
+    background-color: var(--color-background-surface);
   }
 
-  .bai-number-stepper__button {
-    height: auto;
-    min-height: 0;
-    width: 100%;
-    flex: 1;
-    aspect-ratio: auto;
+  /* Astryx paints its hover/pressed wash as a gradient layer rather than a
+     background-color, so the surface underneath keeps showing through. */
+  @media (hover: hover) {
+    .bai-number-stepper__button:not(:disabled):hover {
+      background-image: linear-gradient(
+        var(--color-overlay-hover),
+        var(--color-overlay-hover)
+      );
+    }
+  }
+
+  .bai-number-stepper__button:not(:disabled):active {
+    background-image: linear-gradient(
+      var(--color-overlay-pressed),
+      var(--color-overlay-pressed)
+    );
+  }
+
+  .bai-number-stepper__button:disabled {
+    color: var(--color-icon-disabled);
+    cursor: default;
+    background-image: none;
+  }
+
+  /* The hairline between the two halves. */
+  .bai-number-stepper__button--decrease {
+    border-block-start: var(--border-width) solid var(--color-border-emphasized);
+  }
+
+  /* Astryx renders ONE chevron and rotates the increment half, so both halves
+     are the same glyph at the same optical weight. It rotates the `Icon` ROOT
+     (`styles.incrementIcon` via `xstyle`), and a registry icon resolves to
+     `<span><svg/></span>` — so the target is the button's only child, not the
+     svg, which is a grandchild. */
+  .bai-number-stepper__button--increase > * {
+    transform: rotate(180deg);
   }
 }

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.css
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.css
@@ -1,0 +1,39 @@
+/*
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ Make the ladder stepper a real `InputGroup` segment (FR-3688).
+
+ `InputGroupText` already carries the weld — border, `-1 * --border-width` start
+ margin, squared inner corners — so only two things are wrong for a control
+ slot: its text padding, and its muted addon fill. Astryx's own in-border
+ stepper buttons sit on the input surface, so this one does too; the muted slab
+ would read as an addon chip rather than part of the field.
+
+ The button rules beat `Button`'s `sizeStyles.sm` (a fixed `--size-element-sm`
+ height) and `styles.iconOnly` (`aspect-ratio: 1 / 1`), which together made each
+ button assert 28px in a 32px row — a 56px column overflowing the group. They
+ win on layer order, not specificity: `@layer components` is declared after
+ `astryx-base` (same mechanism as `BAICompactGroup.css`).
+*/
+
+@layer components {
+  .bai-number-stepper {
+    padding-inline: 0;
+    align-items: stretch;
+    background-color: var(--color-background-surface);
+  }
+
+  .bai-number-stepper > * {
+    width: var(--spacing-4);
+    height: 100%;
+  }
+
+  .bai-number-stepper__button {
+    height: auto;
+    min-height: 0;
+    width: 100%;
+    flex: 1;
+    aspect-ratio: auto;
+  }
+}

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.test.tsx
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.test.tsx
@@ -1,0 +1,73 @@
+import { AstryxNumberStepper, nextLadderIndex } from './astryxNumberStepper';
+import { InputGroup } from '@astryxdesign/core/InputGroup';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/*
+ * FR-3688. The weld is CSS (`astryxNumberStepper.css`) and vitest does not
+ * evaluate stylesheets, so these pin the DOM CONTRACT the stylesheet is written
+ * against — what a refactor could break while the component still "renders
+ * fine": the `bai-number-stepper` slot must be the `InputGroupText` (that is
+ * what carries Astryx's border + `-1 * --border-width` weld), the stack must be
+ * its direct child (`.bai-number-stepper > *` sizes it), and both buttons must
+ * carry `bai-number-stepper__button` (that rule is what beats `Button`'s fixed
+ * `sizeStyles.sm` height and `aspect-ratio: 1/1`).
+ *
+ * Same approach as `BAICompactGroup.test.tsx` for the other CSS-only weld.
+ */
+const renderInGroup = (onStep: (d: 'up' | 'down') => void = () => {}) =>
+  render(
+    <InputGroup label="Amount" isLabelHidden>
+      <AstryxNumberStepper
+        onStep={onStep}
+        increaseLabel="Increase"
+        decreaseLabel="Decrease"
+      />
+    </InputGroup>,
+  );
+
+describe('AstryxNumberStepper', () => {
+  it('anchors the stylesheet on an InputGroupText slot', () => {
+    const { container } = renderInGroup();
+    const slot = container.querySelector('.bai-number-stepper');
+    expect(slot).not.toBeNull();
+    // The weld comes from Astryx's own addon primitive, not from a bare Stack.
+    expect(slot).toHaveClass('astryx-input-group-text');
+  });
+
+  it('keeps the stack a DIRECT child of the slot', () => {
+    const { container } = renderInGroup();
+    const slot = container.querySelector('.bai-number-stepper') as HTMLElement;
+    expect(slot.children).toHaveLength(1);
+    expect(slot.children[0]).toHaveClass('astryx-stack');
+    expect(slot.children[0]).toHaveAttribute('data-gap', '0');
+  });
+
+  it('marks both buttons so the size override reaches them', () => {
+    const { container } = renderInGroup();
+    const buttons = container.querySelectorAll('.bai-number-stepper__button');
+    expect(buttons).toHaveLength(2);
+    expect(screen.getByLabelText('Increase')).toHaveClass(
+      'bai-number-stepper__button',
+    );
+    expect(screen.getByLabelText('Decrease')).toHaveClass(
+      'bai-number-stepper__button',
+    );
+  });
+
+  it('still drives the ladder from the buttons', async () => {
+    const steps: Array<string> = [];
+    const user = userEvent.setup();
+    renderInGroup((d) => steps.push(d));
+    await user.click(screen.getByLabelText('Increase'));
+    await user.click(screen.getByLabelText('Decrease'));
+    expect(steps).toEqual(['up', 'down']);
+  });
+
+  it('lands on the next rung, not the current one', () => {
+    const rungs = [1, 2, 4, 8, 16];
+    expect(nextLadderIndex(rungs, 4, 'up')).toBe(3);
+    expect(nextLadderIndex(rungs, 4, 'down')).toBe(1);
+  });
+});

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.test.tsx
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.test.tsx
@@ -36,24 +36,50 @@ describe('AstryxNumberStepper', () => {
     expect(slot).toHaveClass('astryx-input-group-text');
   });
 
-  it('keeps the stack a DIRECT child of the slot', () => {
+  it('keeps both buttons DIRECT children of the slot', () => {
     const { container } = renderInGroup();
     const slot = container.querySelector('.bai-number-stepper') as HTMLElement;
-    expect(slot.children).toHaveLength(1);
-    expect(slot.children[0]).toHaveClass('astryx-stack');
-    expect(slot.children[0]).toHaveAttribute('data-gap', '0');
+    // `.bai-number-stepper` is the flex column itself — no wrapper in between,
+    // or `flex: 1` on the buttons has nothing to divide.
+    expect(slot.children).toHaveLength(2);
+    Array.from(slot.children).forEach((el) =>
+      expect(el).toHaveClass('bai-number-stepper__button'),
+    );
   });
 
-  it('marks both buttons so the size override reaches them', () => {
+  it('keeps the halves off the tab order, as the built-in stepper does', () => {
     const { container } = renderInGroup();
-    const buttons = container.querySelectorAll('.bai-number-stepper__button');
-    expect(buttons).toHaveLength(2);
+    container.querySelectorAll('.bai-number-stepper__button').forEach((el) => {
+      expect(el).toHaveAttribute('tabindex', '-1');
+      expect(el).toHaveAttribute('type', 'button');
+    });
+  });
+
+  it('marks each half so the mirrored Astryx rules reach it', () => {
+    renderInGroup();
+    // The modifier classes carry the hairline between the halves and the
+    // rotation that makes the increment chevron point up.
     expect(screen.getByLabelText('Increase')).toHaveClass(
-      'bai-number-stepper__button',
+      'bai-number-stepper__button--increase',
     );
     expect(screen.getByLabelText('Decrease')).toHaveClass(
-      'bai-number-stepper__button',
+      'bai-number-stepper__button--decrease',
     );
+  });
+
+  it('disables both halves together', () => {
+    render(
+      <InputGroup label="Amount" isLabelHidden>
+        <AstryxNumberStepper
+          onStep={() => {}}
+          isDisabled
+          increaseLabel="Increase"
+          decreaseLabel="Decrease"
+        />
+      </InputGroup>,
+    );
+    expect(screen.getByLabelText('Increase')).toBeDisabled();
+    expect(screen.getByLabelText('Decrease')).toBeDisabled();
   });
 
   it('still drives the ladder from the buttons', async () => {

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.tsx
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.tsx
@@ -23,7 +23,9 @@
  text-backed spinbutton, astryx#4896, renders no native spinner, so the CSS
  is gone.)
 */
+import './astryxNumberStepper.css';
 import { IconButton } from '@astryxdesign/core/IconButton';
+import { InputGroupText } from '@astryxdesign/core/InputGroup';
 import { VStack } from '@astryxdesign/core/Stack';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import React from 'react';
@@ -40,7 +42,8 @@ export interface AstryxNumberStepperProps {
 
 /**
  * The up/down pair that replaces antd `InputNumber`'s built-in spinner.
- * Render it as a sibling of the `NumberInput` inside the same `InputGroup`.
+ * REQUIRES an `InputGroup` ancestor — `InputGroupText` is what welds the column
+ * to the field, and outside a group it is a stray bordered box.
  */
 export const AstryxNumberStepper: React.FC<AstryxNumberStepperProps> = ({
   onStep,
@@ -48,24 +51,28 @@ export const AstryxNumberStepper: React.FC<AstryxNumberStepperProps> = ({
   increaseLabel,
   decreaseLabel,
 }) => (
-  <VStack gap={0} align="center" justify="center">
-    <IconButton
-      variant="ghost"
-      size="sm"
-      icon={<ChevronUp size="1em" />}
-      label={increaseLabel}
-      isDisabled={isDisabled}
-      onClick={() => onStep('up')}
-    />
-    <IconButton
-      variant="ghost"
-      size="sm"
-      icon={<ChevronDown size="1em" />}
-      label={decreaseLabel}
-      isDisabled={isDisabled}
-      onClick={() => onStep('down')}
-    />
-  </VStack>
+  <InputGroupText className="bai-number-stepper">
+    <VStack gap={0} align="stretch" justify="center">
+      <IconButton
+        variant="ghost"
+        size="sm"
+        className="bai-number-stepper__button"
+        icon={<ChevronUp size="1em" />}
+        label={increaseLabel}
+        isDisabled={isDisabled}
+        onClick={() => onStep('up')}
+      />
+      <IconButton
+        variant="ghost"
+        size="sm"
+        className="bai-number-stepper__button"
+        icon={<ChevronDown size="1em" />}
+        label={decreaseLabel}
+        isDisabled={isDisabled}
+        onClick={() => onStep('down')}
+      />
+    </VStack>
+  </InputGroupText>
 );
 
 /**

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.tsx
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.tsx
@@ -9,25 +9,32 @@
 
  `BAIDynamicStepInputNumber` and `BAIDynamicUnitInputNumber` are not "number
  inputs with a step" — their whole substance is a NON-LINEAR step ladder
- (`1, 2, 4, 8, 16, …`, plus a unit carry in the unit variant). Astryx
- `NumberInput` exposes no `onStep` hook (MAPPING §3.17), and every stepping
- affordance it does have — keyboard, wheel, its opt-in trailing buttons — is
- LINEAR by `step`, which would silently replace the ladder. So the ladder gets
- explicit controls: two `IconButton`s drive `onStep('up' | 'down')`, and the
- owning components cancel the built-in ArrowUp/ArrowDown step in `onKeyDown`.
- The ladder arithmetic itself is ported unchanged from each component — this
- module owns only the affordance.
+ (`1, 2, 4, 8, 16, …`, plus a unit carry in the unit variant).
 
- (Until Astryx 0.4.0 the field was a native `<input type="number">` whose
- browser spinner also had to be suppressed in a co-located CSS file; 0.4.0's
- text-backed spinbutton, astryx#4896, renders no native spinner, so the CSS
- is gone.)
+ `NumberInput hasNumberSteppers` cannot express that, and the limit is
+ structural rather than a missing convenience (re-checked against core 0.5.0,
+ FR-3688):
+
+   - `getSteppedValue` snaps to a grid anchored at `min` (`stepBase + n*step`),
+     so no single `step` gives 8 -> 16 going up and 8 -> 4 going down;
+   - the built-in buttons call the internal `stepValue(±1)` directly, so unlike
+     the keyboard path they never reach the consumer's `onKeyDown` and cannot be
+     intercepted;
+   - there is no `onStep` prop, and `onChange` alone cannot be told apart from
+     a typed edit.
+
+ So the ladder keeps explicit controls, and this module matches the built-in
+ stepper's DESIGN instead: the same 16px column, the same chevron glyph rotated
+ for the increment half, the same hairline between the halves, and the same
+ icon/overlay tokens (`NumberInput.tsx` `styles.numberSteppers` /
+ `numberStepperButton` / `decrementButton`). Metrics live in the co-located CSS.
+
+ One deliberate delta: Astryx's buttons re-focus the input after stepping; these
+ only suppress the focus move, because the input they belong to is the caller's.
 */
 import './astryxNumberStepper.css';
-import { IconButton } from '@astryxdesign/core/IconButton';
+import { Icon } from '@astryxdesign/core/Icon';
 import { InputGroupText } from '@astryxdesign/core/InputGroup';
-import { VStack } from '@astryxdesign/core/Stack';
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import React from 'react';
 
 export type StepDirection = 'up' | 'down';
@@ -52,26 +59,30 @@ export const AstryxNumberStepper: React.FC<AstryxNumberStepperProps> = ({
   decreaseLabel,
 }) => (
   <InputGroupText className="bai-number-stepper">
-    <VStack gap={0} align="stretch" justify="center">
-      <IconButton
-        variant="ghost"
-        size="sm"
-        className="bai-number-stepper__button"
-        icon={<ChevronUp size="1em" />}
-        label={increaseLabel}
-        isDisabled={isDisabled}
-        onClick={() => onStep('up')}
-      />
-      <IconButton
-        variant="ghost"
-        size="sm"
-        className="bai-number-stepper__button"
-        icon={<ChevronDown size="1em" />}
-        label={decreaseLabel}
-        isDisabled={isDisabled}
-        onClick={() => onStep('down')}
-      />
-    </VStack>
+    <button
+      type="button"
+      // Not a tab stop, and a click must not pull focus out of the field —
+      // both mirror the built-in stepper.
+      tabIndex={-1}
+      className="bai-number-stepper__button bai-number-stepper__button--increase"
+      aria-label={increaseLabel}
+      disabled={isDisabled}
+      onPointerDown={(event) => event.preventDefault()}
+      onClick={() => onStep('up')}
+    >
+      <Icon icon="chevronDown" size="xsm" color="inherit" />
+    </button>
+    <button
+      type="button"
+      tabIndex={-1}
+      className="bai-number-stepper__button bai-number-stepper__button--decrease"
+      aria-label={decreaseLabel}
+      disabled={isDisabled}
+      onPointerDown={(event) => event.preventDefault()}
+      onClick={() => onStep('down')}
+    >
+      <Icon icon="chevronDown" size="xsm" color="inherit" />
+    </button>
   </InputGroupText>
 );
 


### PR DESCRIPTION
Resolves #9079 (FR-3688)

## Screenshots

Admin → Projects → Create Project, cropped to the **Max allowed CPU + Max
allowed Memory** pair. CPU is the reference shape Memory is supposed to match,
which is why both are in frame.

| | Before | After |
|---|---|---|
| Light | ![memory field, light, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9086/20260825-135150-memfield-light-before.png) | ![memory field, light, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9086/20260825-135150-memfield-light-after.png) |
| Dark | ![memory field, dark, before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9086/20260825-135150-memfield-dark-before.png) | ![memory field, dark, after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9086/20260825-135150-memfield-dark-after.png) |

Before: a text input, a bare ▲▼ pair floating outside any border, and a separate
`GiB` box that takes half the row. After: one continuous control that matches
the CPU field above it.

## Mechanism

Astryx's `InputGroup` **draws nothing**. Its container style is only
`display: inline-flex; align-items: stretch; background: transparent` plus a height token.
The "one control" look is produced **per child**, by `groupStyles.inGroup`, which a child
opts into only by calling `useInputGroup()` — `NumberInput` and `Selector` do. That style
is the whole welding contract: `flex: 1; min-width: 0; height: 100%`, a
`margin-inline-start: calc(-1 * var(--border-width))` that collapses the shared border on
every non-first child, and squaring of the interior corners.

`AstryxNumberStepper` rendered a bare `<VStack>` of two ghost `IconButton`s. `Stack` is a
layout primitive and never calls `useInputGroup()`, so the stepper column got **none** of
it: no border, no −1px weld, no `height: 100%`, no corner squaring, and (ghost) a
transparent background. It also overflowed the row — `IconButton size="sm"` is
`height: var(--size-element-sm)` (28px) with `aspect-ratio: 1/1`, so two stacked buttons
asserted 28×56 inside a 32px group row. Hence "chevrons floating in the gap with a visible
gap on both sides".

Two more pieces of the same field:

- **The unit `Selector` ate the row.** Measured: inside a group the trigger resolves to
  `width: 100%`, so it claimed all 472px and the number field, whose `flex-basis` is `0`,
  shrank to **18px**. The `width={96}` it carried was inert. (The `width="100%"` on the
  `NumberInput` is *not* inert — removing it collapses the field; measured and kept.)
- **`addonPrefix` / `addonSuffix` / the single-unit label were bare `HStack`s** with the
  same defect. Astryx's `InputGroupText` exists exactly for this and hand-implements the
  same weld.

## Fix

`astryxNumberStepper.tsx` — wrap the column in `InputGroupText`, which already carries the
weld, and override only what is wrong for a *control* slot: its text padding and its muted
addon fill. Astryx's own in-border stepper buttons sit on the input surface, so this one
uses `--color-background-surface` rather than `--color-background-muted`; a muted slab
between the field and the select reads as an addon chip, especially in dark mode. The
buttons divide the row (`flex: 1`, `height: auto`, `aspect-ratio: auto`) instead of
asserting a fixed size.

`BAIDynamicUnitInputNumber.tsx` — size the unit `Selector` to its own content
(`flex: 0 0 auto; width: auto`) so the number field takes the rest, which is the shape
antd's `Select` had inside a `Space.Compact`; and swap the three bare `HStack` addon slots
for `InputGroupText`.

Styling goes in a co-located `.css` against the stable `.astryx-*` classes, not `xstyle`:
BUI has no StyleX plugin in its `vite.config.ts` / `vitest.config.ts`, so a
`stylex.create` here would compile in the app and throw on import in Storybook, in
`pnpm --filter backend.ai-ui vitest`, and in any `dist/` consumer. This is the
`BAICompactGroup.css` / `BAITabList.css` precedent. The rules win on **layer order**
(`@layer components` is declared after `astryx-base`), not specificity.

### Why not `NumberInput hasNumberSteppers` — re-checked against core 0.5.0

The obvious move is to delete the hand-rolled affordance and switch the prop on. It does
not work, and the limit is **structural**, not a missing convenience:

- **`getSteppedValue` snaps to a grid anchored at `min`** (`stepBase + n*step`). A
  geometric ladder is not a linear grid, and a *dynamic* `step` does not rescue it: at
  value 8 the up delta is 8 and the down delta is 4, so `step: 8` gives 16 ▲ / **0** ▼
  and `step: 4` gives **12** ▲ / 4 ▼. One `step` cannot serve both directions.
- **The buttons bypass the interception point.** The keyboard path calls the consumer's
  `onKeyDown` first and honours `preventDefault` — which is exactly how the ladder works
  on ArrowUp/Down today. The buttons call the internal `stepValue(±1)` directly and never
  reach it.
- **There is no `onStep` prop.** `StepDirection` is module-local, and `onChange` alone
  cannot be told apart from a typed edit.

So the affordance stays, and the **design** is borrowed instead. Every rule in
`astryxNumberStepper.css` mirrors one in `NumberInput.tsx` and reads the same tokens:

| ours | upstream |
|---|---|
| `.bai-number-stepper` | `styles.numberSteppers` |
| `.bai-number-stepper__button` | `styles.numberStepperButton` |
| `…--decrease` | `styles.decrementButton` |
| `…--increase > *` | `styles.incrementIcon` |

`IconButton` is gone — upstream does not use it either, and its ghost chrome (radius,
focus ring, fixed `sizeStyles.sm` height, `aspect-ratio: 1/1`) was what the first version
of this CSS had to fight. Two bare buttons carrying the mirrored rules need no overrides.
The glyph is Astryx's own `Icon icon="chevronDown"`, rotated for the increment half as
upstream does — so both halves are one glyph at one optical weight, and the same one the
unit `Selector` beside it draws.

One deliberate delta: upstream re-focuses the input after stepping; ours only suppresses
the focus move (`onPointerDown`), because the input belongs to the caller.

#### Stepper closeup (3×), after

| Light | Dark |
|---|---|
| ![stepper closeup, light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9086/20260826-010954-stepper-astryx-parity-light.png) | ![stepper closeup, dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9086/20260826-010954-stepper-astryx-parity-dark.png) |

Measured against upstream's spec, light and dark: 16px column
(`--spacing-4`), 12px glyphs (`xsm`), `--color-icon-secondary`,
`--color-background-surface` fill, `--color-border-emphasized` hairline between the
halves, hover/pressed painted as an overlay **gradient** (so the surface shows through,
as upstream does), `tabIndex=-1`. Ladder unchanged from the buttons: `1 → 2 → 4 → 8`,
then `8 → 4`.

## Measured — Admin → Projects → Create Project, 1440×950

| | before | after |
|---|---|---|
| number input | 220.5px, `radius 8px 0 0 8px` | **384px**, same radius |
| stepper column | 28px wide / **56px tall** in a 32px row, **no border**, transparent | **18px × 32px**, `1px` border, `margin-inline-start: -1px`, `radius 0` |
| stepper buttons | 28×28 each (asserted) | **16×15 each** (divide the row) |
| unit `Selector` | ~half the row (`flex: 1`, basis 0) | **72px**, `radius 0 8px 8px 0`, `margin-inline-start: -1px` |
| reads as | three unrelated widgets | **one continuous control** |

**Dark mode** (entered through the header control, `document.documentElement.dataset.theme`
asserted `dark`): all three segments share `background: rgb(20,20,20)` and
`border: 1px rgb(66,66,66)` — the stepper no longer reads as a muted addon slab.
Light: all three at `rgb(255,255,255)` / `1px rgb(217,217,217)`.

**Interaction exercised** (client-side only, modal never submitted), both modes:
empty → ▲ → `1` → ▲ → `2` → ▼ → `1`, unit stays `GiB`. The ladder is intact.

**Second live call site**, Environments → Resource Presets → Create Preset: both the
`Memory` and `Shared Memory` fields weld identically (384 / 18 / 72, same radii, −1px
overlaps).

**Session launcher**: the `SHM` `addonPrefix` now renders as a leading `InputGroupText`
chip with the muted addon fill and `radius 8px 0 0 8px` — correct for an addon, and
visibly distinct from the stepper slot, which is the intended difference.

Zero `pageerror` across every pass.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → OK (required; a stale BUI `dist` does not carry
  the new CSS)
- `pnpm --filter backend.ai-ui exec vitest run` → **790 passed, 1 skipped**, including
  `BAIDynamicUnitInputNumber.test.tsx` **20/20** (the ladder + unit-carry assertions)
  and the new `astryxNumberStepper.test.tsx` (7)
- `pnpm --prefix ./react exec vitest run` → **1627 passed**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on the **same 3
  pre-existing** undeclared vars as `main` (`BAIDialog.css:17`, `BAIDrawerPortal.css:18`,
  `BAIText.css:28`); confirmed against the stashed baseline. The tokens this PR adds
  (`--color-background-surface`, `--spacing-4`, `--color-icon-secondary`,
  `--color-icon-disabled`, `--color-overlay-hover`, `--color-overlay-pressed`,
  `--color-border-emphasized`, `--border-width`) are declared and pass.

## Blast radius

`AstryxNumberStepper` has two consumers, both of which render it inside an `InputGroup`
(its documented precondition, now load-bearing and noted in the file header):
`BAIDynamicUnitInputNumber` and `BAIDynamicStepInputNumber`. The latter has no live call
sites but has the identical defect and is fixed for free.

`BAIDynamicUnitInputNumber`'s 7 live call sites — `BAIProjectSettingModal` (reported),
`BAIDynamicUnitInputNumberWithSlider` (→ session launcher memory),
`AdminDeploymentPresetResourceFields`, `KeypairResourcePolicySettingModal`,
`ResourcePresetSettingModal` (×2), `ManageImageResourceLimitModal`,
`SharedMemoryFormItems` — all take the `units.length > 1` branch and all showed the same
three-piece field. Two of them were checked live (above); the rest are the same component
with the same structure.

The `Selector` change redistributes the field's width at every call site, several of which
sit in two-column modal grids, so a narrow viewport was part of the probe.

## Residue

- `react/src/components/InputNumberWithSlider.tsx` has the same bare-`HStack` addon slots
  at `:243-245` and `:313-315`. **Not changed here**: it does not use
  `AstryxNumberStepper` (it uses `NumberInput.units`), and no live caller passes
  `addonBefore` / `addonAfter`, so the defect is currently invisible. Worth a follow-up
  when someone does.
- The stepper slot is 18px wide against antd's ~22px spinner. Measured and accepted; it is
  the `--spacing-4` step, and widening it would need a raw value.
- Does **not** touch the `min`/`max` unit-conversion `TODO` already in the file.

## Review

Copilot reviewed this draft once and raised one finding: the visual fix depends
on an exact DOM contract that nothing tested. **Added** —
`astryxNumberStepper.test.tsx` pins which element carries the weld class (the
`InputGroupText`, not a bare Stack), that the stack is its direct child, and that
both buttons are marked — each one a rule that would otherwise fail silently.
Thread replied + resolved.

The test landed **after** the review, so Copilot never saw it; it is verified by
`verify.sh` and the suites above instead of by a second bot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyXpNjdr4aZSrHMGz9aMXi
