### PR TITLE
feat(FR-3691): pick filter values by label with a declarative entitySource

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/useBAIUserEntitySourceQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/useBAIUserEntitySourceQuery.graphql.ts
@@ -1,0 +1,147 @@
+/**
+ * @generated SignedSource<<6167fb8819a7456c6b763f82813d7ffa>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type useBAIUserEntitySourceQuery$variables = {
+  filter?: string | null | undefined;
+  first: number;
+};
+export type useBAIUserEntitySourceQuery$data = {
+  readonly user_nodes: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly email: string | null | undefined;
+        readonly full_name: string | null | undefined;
+        readonly id: string;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
+};
+export type useBAIUserEntitySourceQuery = {
+  response: useBAIUserEntitySourceQuery$data;
+  variables: useBAIUserEntitySourceQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "filter"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "filter",
+        "variableName": "filter"
+      },
+      {
+        "kind": "Variable",
+        "name": "first",
+        "variableName": "first"
+      },
+      {
+        "kind": "Literal",
+        "name": "order",
+        "value": "email"
+      }
+    ],
+    "concreteType": "UserConnection",
+    "kind": "LinkedField",
+    "name": "user_nodes",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "UserNode",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "email",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "full_name",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useBAIUserEntitySourceQuery",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useBAIUserEntitySourceQuery",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "1bb4464b8186fc949585eb1c7dc2c5c0",
+    "id": null,
+    "metadata": {},
+    "name": "useBAIUserEntitySourceQuery",
+    "operationKind": "query",
+    "text": "query useBAIUserEntitySourceQuery(\n  $filter: String\n  $first: Int!\n) {\n  user_nodes(filter: $filter, first: $first, order: \"email\") {\n    edges {\n      node {\n        id\n        email\n        full_name\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "b4d68187d7764d9068d5af551942a7b0";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.doc.ts
@@ -31,7 +31,12 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Give an opaque-valued property a `renderInput` and call `onAddCondition(value, label)` with a readable label, so the token shows the label while the raw value still serializes into the filter.',
+          'Give an opaque-valued property an `entitySource` (`{ search, bootstrap?, resolve?, cancel? }`) so the user picks by label while the id still serializes; `resolve` is what makes a shared link or a reload show the label instead of the raw id.',
+      },
+      {
+        guidance: true,
+        description:
+          'Reach for `renderInput` only when `entitySource` cannot express the picker — it takes precedence over `entitySource`, and its `onAddCondition(value, label)` label lives only for the current mount.',
       },
       {
         guidance: true,
@@ -60,7 +65,7 @@ export const docs = {
       name: 'filterProperties',
       type: 'Array<FilterProperty>',
       description:
-        'The filterable columns. Each entry declares `key` (dot paths allowed for nested filters), `propertyLabel`, `type`, and optionally `operators`, `defaultOperator` or `fixedOperator`, `options`, `strictSelection`, `valueMode`, `implicitOperator`, `rule` and `renderInput`.',
+        'The filterable columns. Each entry declares `key` (dot paths allowed for nested filters), `propertyLabel`, `type`, and optionally `operators`, `defaultOperator` or `fixedOperator`, `options`, `strictSelection`, `valueMode`, `implicitOperator`, `rule`, `entitySource` and `renderInput`.',
       required: true,
     },
     {

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
@@ -1,5 +1,9 @@
 import BAIComplexSelect, { BAILabeledValue } from './BAIComplexSelect';
 import BAIGraphQLPropertyFilter from './BAIGraphQLPropertyFilter';
+import type {
+  FilterEntity,
+  FilterEntitySource,
+} from './BAIPowerSearchAdapters';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { action } from 'storybook/actions';
@@ -24,7 +28,8 @@ const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
 New in this version:
 - **DateTime support**: When a property has type 'datetime', a DatePicker with time selection is rendered instead of a text input. Values are serialized as ISO strings and displayed in filter tags as 'YYYY-MM-DD HH:mm'.
 - **UUID support**: UUID type properties use \`equals\`, \`notEquals\`, \`in\`, \`notIn\` operators and support validation rules.
-- **Custom input via \`renderInput\`**: Replace the default AutoComplete input with any controlled control (e.g., a user/domain picker or async select). The control commits a condition via \`onAddCondition(value, label?)\` as soon as a value is selected (so a single-select picker confirms on selection); pass a human-readable \`label\` when the committed value is opaque (e.g. a UUID) so the condition tag shows the label instead. Give the control \`value={null}\` so it stays controlled and clears after each commit. Keep using a built-in \`type\` (e.g. \`uuid\`) that matches what the control emits.
+- **Entity values via \`entitySource\`**: Declarative picker for properties whose value is an opaque id (a user UUID chosen by email). Supply \`{ search, bootstrap?, resolve?, cancel? }\` and the editor renders an Astryx Typeahead (or a Tokenizer when the operator is \`in\`/\`notIn\` — **arity follows the operator, not the property**). \`resolve(ids)\` turns ids restored from a URL back into labels, so a shared link shows the email instead of the UUID. Prefer it over \`renderInput\` for id-valued properties; reach for \`renderInput\` only when you need a control the entity mode cannot express.
+- **Custom input via \`renderInput\`**: Replace the default value editor with any controlled control (e.g., a storage-host picker or async select). The control **stages** a value via \`onAddCondition(value, label?)\` and the edit popover's Apply button commits it; pass a human-readable \`label\` when the staged value is opaque (e.g. a UUID) so the condition tag shows the label instead. The render prop receives \`{ onAddCondition, value, isDisabled }\` — \`value\` is what is currently staged (an existing token's value in edit mode). Keep using a built-in \`type\` (e.g. \`uuid\`) that matches what the control emits.
 - Operatorless fields via valueMode: 'scalar' for properties that should emit direct scalar values (e.g., { isUrgent: true }). Use implicitOperator (defaults to 'equals') to control how tags are displayed in the UI.
 
 The component generates GraphQL-compatible filter objects that can be directly used in GraphQL queries, enabling powerful and flexible data filtering across the platform.
@@ -91,15 +96,24 @@ FilterProperty = {
   valueMode?: 'scalar' | 'operator';
   // Visual operator for UI tags when valueMode='scalar' (default 'equals')
   implicitOperator?: FilterOperator;
-  // Custom input renderer — replaces the default AutoComplete with a controlled
-  // control (e.g. BAIUserSelect). \`onAddCondition(value, label?)\` commits the
-  // value as a condition immediately (single-select pickers confirm on
-  // selection) and serializes it per the property's \`type\`. Pass a
-  // human-readable \`label\` when the value is opaque (e.g. a UUID) so the
-  // condition tag stays readable. Give the control \`value={null}\` so it
-  // stays controlled and clears after each commit.
+  // Declarative picker for opaque-id values (a user UUID chosen by email).
+  // Arity follows the operator: Typeahead for equals/notEquals, Tokenizer for
+  // in/notIn. Ignored when \`renderInput\` is set.
+  entitySource?: {
+    search: (query: string) => Promise<FilterEntity[]> | FilterEntity[];
+    bootstrap?: () => Promise<FilterEntity[]> | FilterEntity[];
+    resolve?: (ids: readonly string[]) => Promise<FilterEntity[]>;
+    cancel?: () => void;
+  };
+  // Custom input renderer — replaces the default value editor with a controlled
+  // control. \`onAddCondition(value, label?)\` STAGES the value; the edit
+  // popover's Apply button commits it, serialized per the property's \`type\`.
+  // Pass a human-readable \`label\` when the value is opaque (e.g. a UUID) so
+  // the token stays readable.
   renderInput?: (props: {
     onAddCondition: (value: string | undefined, label?: string) => void;
+    value: string | null;
+    isDisabled?: boolean;
   }) => ReactNode;
 }
         `,
@@ -873,7 +887,7 @@ export const WithRenderInput: Story = {
     docs: {
       description: {
         story:
-          'When `renderInput` is provided, the default AutoComplete is replaced with a custom control. The control commits a condition via `onAddCondition(value, label?)` as soon as it emits a non-empty value; keep it controlled with `value={null}` so it clears after each commit. Useful for async selects (e.g., fetching options from an API).',
+          "When `renderInput` is provided, the default value editor is replaced with a custom control. The control **stages** a value via `onAddCondition(value, label?)` and the edit popover's Apply button commits it — nothing lands on the filter until Apply. The render prop also receives `value` (what is currently staged) and `isDisabled`. Useful for controls the declarative `entitySource` mode cannot express; for id-valued properties prefer `entitySource`.",
       },
     },
   },
@@ -969,7 +983,7 @@ export const WithCustomType: Story = {
     docs: {
       description: {
         story:
-          "A property whose input is a controlled antd Select supplied via `renderInput`. Selecting an option calls `onAddCondition(value, label)` — the filter commits the value as a condition serialized per `type: 'uuid'` → `{ owner: { id: { equals: <id> } } }`, while the condition tag shows the label (email) instead of the opaque UUID.",
+          "A property whose input is a controlled `BAIComplexSelect` supplied via `renderInput`. Selecting an option calls `onAddCondition(value, label)`, which **stages** it; the popover's Apply button commits it, serialized per `type: 'uuid'` → `{ owner: { id: { equals: <id> } } }`, while the token shows the label (email) instead of the opaque UUID. The same result with less call-site code is what `entitySource` gives you — see *Entity picker via entitySource*.",
       },
     },
   },
@@ -998,5 +1012,100 @@ export const WithCustomType: Story = {
     ],
     combinationMode: 'AND',
     onChange: action('custom input filter changed'),
+  },
+};
+
+// --- Entity picker (entitySource) --------------------------------------------
+
+const sampleUserEntities: Array<FilterEntity> = [
+  {
+    id: 'owner-uuid-0001',
+    label: 'alice@example.com',
+    description: 'Alice Kim',
+  },
+  { id: 'owner-uuid-0002', label: 'bob@example.com', description: 'Bob Lee' },
+  {
+    id: 'owner-uuid-0003',
+    label: 'carol@example.com',
+    description: 'Carol Park',
+  },
+  {
+    id: 'owner-uuid-0004',
+    label: 'dave@example.com',
+    description: 'Dave Choi',
+  },
+  {
+    id: 'owner-uuid-0005',
+    label: 'erin@example.com',
+    description: 'Erin Yoon',
+  },
+];
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Stands in for a Relay-backed source (useBAIUserEntitySource); the latency is
+// what makes the id -> label swap visible in the Canvas.
+const demoUserEntitySource: FilterEntitySource = {
+  search: async (query) => {
+    await sleep(400);
+    const needle = query.trim().toLowerCase();
+    return needle
+      ? sampleUserEntities.filter((entity) =>
+          entity.label.toLowerCase().includes(needle),
+        )
+      : sampleUserEntities;
+  },
+  bootstrap: async () => {
+    await sleep(300);
+    return sampleUserEntities.slice(0, 3);
+  },
+  resolve: async (ids) => {
+    await sleep(1200);
+    return sampleUserEntities.filter((entity) => ids.includes(entity.id));
+  },
+};
+
+export const WithEntitySource: Story = {
+  name: 'Entity picker via entitySource',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`entitySource` is the declarative way to filter on an opaque id: the user searches by email, the filter serializes the UUID (`{ owner: { id: { equals: <uuid> } } }` — the same bytes `renderInput` produced). Arity follows the **operator**: `Owner` is pinned to `equals` and gets a single-select Typeahead, while `Reviewer` offers `in`/`notIn` and gets a multi-select Tokenizer — both from one source, with no call-site branching. Both properties are pre-seeded with raw UUIDs and this demo source resolves them after ~1.2s, so the tokens start as UUIDs and swap to emails — exactly what happens when a shared filter URL is opened in a fresh tab. Without `resolve` the token simply keeps showing the raw id.',
+      },
+    },
+  },
+  args: {
+    filterProperties: [
+      {
+        key: 'owner.id',
+        propertyLabel: 'Owner',
+        type: 'uuid',
+        fixedOperator: 'equals',
+        entitySource: demoUserEntitySource,
+      },
+      {
+        key: 'reviewer.id',
+        propertyLabel: 'Reviewer',
+        type: 'uuid',
+        operators: ['in', 'notIn'],
+        defaultOperator: 'in',
+        entitySource: demoUserEntitySource,
+      },
+      {
+        key: 'name',
+        propertyLabel: 'Name',
+        type: 'string',
+        defaultOperator: 'iContains',
+      },
+    ],
+    combinationMode: 'AND',
+    value: {
+      AND: [
+        { owner: { id: { equals: 'owner-uuid-0003' } } },
+        { reviewer: { id: { in: ['owner-uuid-0001', 'owner-uuid-0002'] } } },
+      ],
+    },
+    onChange: action('entitySource filter changed'),
   },
 };

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -17,6 +17,7 @@ import BAIGraphQLPropertyFilter, {
   graphQLFilterToPowerSearchFilters,
   powerSearchFiltersToGraphQLFilter,
   tokenValueToConditionValue,
+  type FilterEntity,
   type FilterEntitySource,
   type FilterProperty,
   type GraphQLFilter,
@@ -692,6 +693,33 @@ describe('entity label resolution', () => {
       );
       await waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
       // One macrotask: long enough for Node to report an unhandled rejection.
+      await new Promise((done) => setTimeout(done, 0));
+      expect(screen.getByText(TRUNCATED_UUID)).toBeInTheDocument();
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', trackUnhandled);
+    }
+  });
+
+  it('keeps the raw id when the resolver throws synchronously', async () => {
+    const unhandled: Array<unknown> = [];
+    const trackUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', trackUnhandled);
+    try {
+      const resolve = vi.fn((): Promise<Array<FilterEntity>> => {
+        throw new Error('resolve threw');
+      });
+      render(
+        <BAIGraphQLPropertyFilter
+          filterProperties={[
+            entityProperty({ search: async () => [], resolve }),
+          ]}
+          value={filter}
+          onChange={() => {}}
+        />,
+      );
+      await waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
       await new Promise((done) => setTimeout(done, 0));
       expect(screen.getByText(TRUNCATED_UUID)).toBeInTheDocument();
       expect(resolve).toHaveBeenCalledTimes(1);

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -13,12 +13,29 @@
 */
 import BAIGraphQLPropertyFilter, {
   buildNestedFilter,
+  conditionToTokenValue,
   graphQLFilterToPowerSearchFilters,
   powerSearchFiltersToGraphQLFilter,
+  tokenValueToConditionValue,
+  type FilterEntitySource,
   type FilterProperty,
   type GraphQLFilter,
 } from './BAIGraphQLPropertyFilter';
-import { render, screen } from '@testing-library/react';
+import {
+  BAIPowerSearchEntityEditor,
+  useEntityLabelCache,
+  useRenderInputEditors,
+  type EntityLabelCache,
+} from './BAIPowerSearchAdapters';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const USER_UUID = '11111111-2222-3333-4444-555555555555';
+/** Matches the token text even after PowerSearch truncates it. */
+const TRUNCATED_UUID = /^11111111-2222-3333-4444-5555/;
+
+/** An `entitySource` with no `resolve`: tokens keep the raw id. */
+const idOnlyUserSource: FilterEntitySource = { search: async () => [] };
 
 describe('buildNestedFilter', () => {
   it('builds a single-level filter', () => {
@@ -167,8 +184,10 @@ const PAGE_FIXTURES: Array<{
         key: 'userId',
         propertyLabel: 'User',
         type: 'uuid',
+        // The page supplies a Relay-backed picker here; serialization is
+        // unaffected by the editor, so the fixture only needs the shape.
+        entitySource: idOnlyUserSource,
         fixedOperator: 'equals',
-        renderInput: () => null,
       },
     ],
     filters: [
@@ -324,6 +343,44 @@ describe('URL filter round-trip (no shared-link regression)', () => {
     expect(roundTrip(filterProperties, filter)).toEqual(filter);
   });
 
+  it('keeps an entitySource id byte-identical (no URL migration)', () => {
+    // The RBAC shape, with the nested key the page actually declares. An
+    // `entitySource` property must serialize exactly what `renderInput` did.
+    const filterProperties: Array<FilterProperty> = [
+      {
+        key: 'assignedUser.userId',
+        propertyLabel: 'User',
+        type: 'uuid',
+        fixedOperator: 'equals',
+        entitySource: idOnlyUserSource,
+      },
+    ];
+    const filter: GraphQLFilter = {
+      assignedUser: { userId: { equals: USER_UUID } },
+    };
+    const result = roundTrip(filterProperties, filter);
+    expect(result).toEqual(filter);
+    expect(JSON.stringify(result)).toBe(JSON.stringify(filter));
+  });
+
+  it('keeps a renderInput value byte-identical too (escape hatch kept)', () => {
+    const filterProperties: Array<FilterProperty> = [
+      {
+        key: 'assignedUser.userId',
+        propertyLabel: 'User',
+        type: 'uuid',
+        fixedOperator: 'equals',
+        renderInput: () => null,
+      },
+    ];
+    const filter: GraphQLFilter = {
+      assignedUser: { userId: { equals: USER_UUID } },
+    };
+    expect(JSON.stringify(roundTrip(filterProperties, filter))).toBe(
+      JSON.stringify(filter),
+    );
+  });
+
   it('re-parses what it emitted (tokens are stable across a second cycle)', () => {
     const { filterProperties } = PAGE_FIXTURES[1];
     const first: GraphQLFilter = {
@@ -409,5 +466,360 @@ describe('BAIGraphQLPropertyFilter render', () => {
       />,
     );
     expect(screen.getByTestId('graphql-property-filter')).toBeInTheDocument();
+  });
+});
+
+/** An entity property; single-valued (`equals`) unless `overrides` says else. */
+const entityProperty = (
+  entitySource: FilterEntitySource,
+  overrides: Partial<FilterProperty> = {},
+): FilterProperty =>
+  ({
+    key: 'assignedUser.userId',
+    propertyLabel: 'User',
+    type: 'uuid',
+    fixedOperator: 'equals',
+    entitySource,
+    ...overrides,
+  }) as FilterProperty;
+
+describe('entitySource token mapping', () => {
+  const property = entityProperty(idOnlyUserSource, {
+    fixedOperator: undefined,
+    operators: ['equals', 'in'],
+  });
+  const condition = (operator: 'equals' | 'in', value: unknown) => ({
+    id: 'c1',
+    property: 'assignedUser.userId',
+    operator,
+    value,
+    propertyLabel: 'User',
+    type: 'uuid' as const,
+  });
+
+  it('maps an `equals` condition to the raw id', () => {
+    expect(
+      conditionToTokenValue(condition('equals', USER_UUID), property),
+    ).toEqual({ type: 'custom', value: USER_UUID });
+  });
+
+  it('maps an `in` condition to a JSON id array', () => {
+    expect(
+      conditionToTokenValue(condition('in', ['a', 'b']), property),
+    ).toEqual({ type: 'custom', value: '["a","b"]' });
+  });
+
+  it('reverses a single-id token back to the raw id', () => {
+    expect(
+      tokenValueToConditionValue(
+        { type: 'custom', value: USER_UUID },
+        property,
+        'equals',
+      ),
+    ).toBe(USER_UUID);
+  });
+
+  it('reverses a JSON-array token back to an id array', () => {
+    expect(
+      tokenValueToConditionValue(
+        { type: 'custom', value: '["a","b"]' },
+        property,
+        'in',
+      ),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('keeps a single id that looks like JSON a string', () => {
+    expect(
+      tokenValueToConditionValue(
+        { type: 'custom', value: '[bracketed-id' },
+        property,
+        'equals',
+      ),
+    ).toBe('[bracketed-id');
+  });
+
+  it.each([
+    { arity: 'single', input: condition('equals', USER_UUID) },
+    { arity: 'multi', input: condition('in', ['a', 'b']) },
+    { arity: 'single', input: condition('equals', '[bracketed-id') },
+  ])('is an exact inverse for the $arity arity', ({ input }) => {
+    expect(
+      tokenValueToConditionValue(
+        conditionToTokenValue(input, property),
+        property,
+        input.operator,
+      ),
+    ).toEqual(input.value);
+  });
+});
+
+describe('renderInput takes precedence over entitySource', () => {
+  const both = {
+    key: 'ownerId',
+    propertyLabel: 'Owner',
+    type: 'string',
+    operators: ['in'],
+    renderInput: () => null,
+    entitySource: idOnlyUserSource,
+  } satisfies FilterProperty;
+  const entityOnly = {
+    ...both,
+    renderInput: undefined,
+  } satisfies FilterProperty;
+  // The reverse parser joins a list value, so this is the shape the pipeline
+  // actually hands `conditionToTokenValue`.
+  const condition = {
+    id: 'c1',
+    property: 'ownerId',
+    operator: 'in' as const,
+    value: 'a, b',
+    propertyLabel: 'Owner',
+    type: 'string' as const,
+  };
+
+  it('emits the renderInput token shape, not the entity JSON array', () => {
+    expect(conditionToTokenValue(condition, both)).toEqual({
+      type: 'custom',
+      value: 'a, b',
+    });
+    expect(conditionToTokenValue(condition, entityOnly)).toEqual({
+      type: 'custom',
+      value: '["a","b"]',
+    });
+  });
+
+  // The two custom editors format their token differently: the entity one maps
+  // each id through the label cache, `renderInput`'s looks the whole staged
+  // value up and misses. So the token text says which editor the config got.
+  const labelledSource: FilterEntitySource = {
+    search: async () => [],
+    resolve: async (ids) =>
+      ids.map((id) => ({ id, label: `${id}@lablup.com` })),
+  };
+  const value: GraphQLFilter = { ownerId: { in: ['a', 'b'] } };
+
+  it('renders resolved labels when only entitySource is declared', async () => {
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={[{ ...entityOnly, entitySource: labelledSource }]}
+        value={value}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      await screen.findByText('a@lablup.com, b@lablup.com'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the raw staged value and asks nothing when both are declared', async () => {
+    const resolve = vi.fn(labelledSource.resolve);
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={[
+          { ...both, entitySource: { ...labelledSource, resolve } },
+        ]}
+        value={value}
+        onChange={() => {}}
+      />,
+    );
+    await act(async () => {
+      await new Promise((done) => setTimeout(done, 0));
+    });
+    expect(resolve).not.toHaveBeenCalled();
+    expect(screen.getByText('a, b')).toBeInTheDocument();
+    expect(screen.queryByText(/@lablup\.com/)).not.toBeInTheDocument();
+  });
+});
+
+describe('content-search field auto-pick', () => {
+  it('skips entitySource properties', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={[
+          {
+            key: 'ownerId',
+            propertyLabel: 'Owner',
+            type: 'string',
+            entitySource: idOnlyUserSource,
+          },
+          { key: 'name', propertyLabel: 'Name', type: 'string' },
+        ]}
+        onChange={onChange}
+      />,
+    );
+    await user.type(screen.getByRole('combobox'), 'hello{Enter}');
+    expect(onChange).toHaveBeenCalledWith({ name: { iContains: 'hello' } });
+  });
+});
+
+describe('entity label resolution', () => {
+  const filter: GraphQLFilter = {
+    assignedUser: { userId: { equals: USER_UUID } },
+  };
+
+  it('swaps the raw id for the label the source resolves', async () => {
+    const resolve = vi.fn(async () => [
+      { id: USER_UUID, label: 'alice@lablup.com' },
+    ]);
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={[entityProperty({ search: async () => [], resolve })]}
+        value={filter}
+        onChange={() => {}}
+      />,
+    );
+    expect(await screen.findByText('alice@lablup.com')).toBeInTheDocument();
+    expect(resolve).toHaveBeenCalledWith([USER_UUID]);
+  });
+
+  it('keeps the raw id, asks once, and swallows a rejecting resolve', async () => {
+    const unhandled: Array<unknown> = [];
+    const trackUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', trackUnhandled);
+    try {
+      const resolve = vi.fn(() => Promise.reject(new Error('resolve failed')));
+      render(
+        <BAIGraphQLPropertyFilter
+          filterProperties={[
+            entityProperty({ search: async () => [], resolve }),
+          ]}
+          value={filter}
+          onChange={() => {}}
+        />,
+      );
+      await waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+      // One macrotask: long enough for Node to report an unhandled rejection.
+      await new Promise((done) => setTimeout(done, 0));
+      expect(screen.getByText(TRUNCATED_UUID)).toBeInTheDocument();
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', trackUnhandled);
+    }
+  });
+
+  it('keeps two properties sharing one id on their own labels', async () => {
+    const sourceFor = (label: string): FilterEntitySource => ({
+      search: async () => [],
+      resolve: async (ids) => ids.map((id) => ({ id, label })),
+    });
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={[
+          entityProperty(sourceFor('assignee@lablup.com')),
+          entityProperty(sourceFor('creator@lablup.com'), {
+            key: 'createdBy.userId',
+            propertyLabel: 'Creator',
+          }),
+        ]}
+        value={{
+          AND: [filter, { createdBy: { userId: { equals: USER_UUID } } }],
+        }}
+        onChange={() => {}}
+      />,
+    );
+    expect(await screen.findByText('assignee@lablup.com')).toBeInTheDocument();
+    expect(screen.getByText('creator@lablup.com')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw id when the source has no resolve', () => {
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={[entityProperty(idOnlyUserSource)]}
+        value={filter}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(TRUNCATED_UUID)).toBeInTheDocument();
+  });
+});
+
+describe('BAIPowerSearchEntityEditor', () => {
+  const labels: EntityLabelCache = {
+    record: () => {},
+    recordMany: () => {},
+    resolveLabel: (_property, id) =>
+      id === USER_UUID ? 'alice@lablup.com' : id,
+    ensureResolved: () => {},
+  };
+
+  const renderEditor = (isDisabled?: boolean) =>
+    render(
+      <BAIPowerSearchEntityEditor
+        propertyKey="assignedUser.userId"
+        source={idOnlyUserSource}
+        labels={labels}
+        isMulti={false}
+        value={USER_UUID}
+        onChange={() => {}}
+        isDisabled={isDisabled}
+      />,
+    );
+
+  it('shows the cached label for the staged id', () => {
+    renderEditor();
+    expect(screen.getByText('alice@lablup.com')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeEnabled();
+  });
+
+  it('disables the control when `isDisabled` is set', () => {
+    renderEditor(true);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+});
+
+describe('useRenderInputEditors', () => {
+  it('hands `value` and `isDisabled` to the render prop', () => {
+    const received: Array<{ value: string | null; isDisabled?: boolean }> = [];
+    const Harness = () => {
+      const editors = useRenderInputEditors({
+        recordLabel: () => {},
+        resolveLabel: (_property, value) => value,
+      });
+      const operatorValue = editors.operatorValueFor('ownerId', (props) => {
+        received.push({ value: props.value, isDisabled: props.isDisabled });
+        return <span data-testid="render-input">{props.value}</span>;
+      });
+      if (!operatorValue) return null;
+      const Editor = operatorValue.Editor;
+      return <Editor value="x" isDisabled onChange={() => {}} placeholder="" />;
+    };
+    render(<Harness />);
+    expect(received.at(-1)).toEqual({ value: 'x', isDisabled: true });
+    expect(screen.getByTestId('render-input')).toHaveTextContent('x');
+  });
+
+  // `getString` is cached on the FIRST call, so it must not freeze the label
+  // cache it was handed on that render.
+  it('reads a label recorded after the operator value was cached', async () => {
+    const Harness = () => {
+      const labels = useEntityLabelCache();
+      const editors = useRenderInputEditors({
+        recordLabel: labels.record,
+        resolveLabel: labels.resolveLabel,
+      });
+      const operatorValue = editors.operatorValueFor('ownerId', () => null);
+      return (
+        <>
+          <button
+            onClick={() =>
+              labels.record('ownerId', USER_UUID, 'alice@lablup.com')
+            }
+          >
+            record
+          </button>
+          <span data-testid="token">
+            {operatorValue?.getString(USER_UUID) ?? ''}
+          </span>
+        </>
+      );
+    };
+    render(<Harness />);
+    expect(screen.getByTestId('token')).toHaveTextContent(USER_UUID);
+    await userEvent.setup().click(screen.getByRole('button'));
+    expect(screen.getByTestId('token')).toHaveTextContent('alice@lablup.com');
   });
 });

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -43,10 +43,16 @@
 import { useControllableValue } from '../hooks';
 import { useBAIi18n } from '../hooks/useBAIi18n';
 import {
+  decodeEntityIds,
+  encodeEntityIds,
   toEnumItems,
   toSearchSource,
+  useEntityEditors,
+  useEntityLabelCache,
   useRenderInputEditors,
   type BAIPowerSearchChromeProps,
+  type FilterEntity,
+  type FilterEntitySource,
   type FilterPropertyOption,
   type FilterRenderInput,
 } from './BAIPowerSearchAdapters';
@@ -62,7 +68,7 @@ import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
 import { SearchIcon } from 'lucide-react';
-import { useRef } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 
 // GraphQL Filter Types (matching schema.graphql)
 export type StringFilter = {
@@ -196,7 +202,14 @@ type BaseFilterProperty = {
    * label while the raw value still serializes into the filter unchanged.
    */
   renderInput?: FilterRenderInput;
+  /**
+   * Declarative entity picker for opaque-id values (e.g. a user UUID picked by
+   * email). Ignored when `renderInput` is set.
+   */
+  entitySource?: FilterEntitySource;
 };
+
+export type { FilterEntity, FilterEntitySource };
 
 // fixedOperator and defaultOperator are mutually exclusive
 export type FilterProperty = BaseFilterProperty &
@@ -528,18 +541,23 @@ const operatorLabel = (operator: FilterOperator, t: TFunction): string =>
 
 /**
  * The PowerSearch value editor for one property/operator pair.
- * `custom` (from `renderInput`) always wins — the call site asked for it.
+ * `custom` (from `renderInput`) always wins — the call site asked for it —
+ * then `entitySource`, whose arity comes from the OPERATOR, not the property.
  */
 function operatorValueFor(
   property: FilterProperty,
   operator: FilterOperator,
   custom: OperatorValue | undefined,
+  entityFor?: (isMulti: boolean) => OperatorValue | undefined,
 ): OperatorValue {
   if (custom) return custom;
+  const isList = _.includes(LIST_OPERATORS, operator);
+  const entity = entityFor?.(isList);
+  if (entity) return entity;
   const options = effectiveOptions(property);
   const strict = effectiveStrictSelection(property);
 
-  if (_.includes(LIST_OPERATORS, operator)) {
+  if (isList) {
     return options && strict
       ? { type: 'enum_list', values: toEnumItems(options) }
       : {
@@ -563,13 +581,33 @@ function operatorValueFor(
     : { type: 'string' };
 }
 
+/** A condition's raw value (array, or the `, `-joined string) -> ids. */
+function rawToEntityIds(raw: any, isList: boolean): Array<string> {
+  if (_.isArray(raw)) return _.compact(_.map(raw, _.toString));
+  return isList
+    ? _.compact(_.map(_.split(_.toString(raw), ','), _.trim))
+    : _.compact([_.toString(raw)]);
+}
+
 /** FilterCondition -> the token value shape the editor above expects. */
 export function conditionToTokenValue(
   condition: FilterCondition,
   property: FilterProperty | undefined,
 ): FilterValue {
   const raw = condition.value;
-  if (_.includes(LIST_OPERATORS, condition.operator)) {
+  const isList = _.includes(LIST_OPERATORS, condition.operator);
+  // Both custom editors come first: they own every operator of their property,
+  // list ones included.
+  if (property?.renderInput) {
+    return { type: 'custom', value: _.toString(raw) };
+  }
+  if (property?.entitySource) {
+    return {
+      type: 'custom',
+      value: encodeEntityIds(rawToEntityIds(raw, isList), isList) ?? '',
+    };
+  }
+  if (isList) {
     const values = _.isArray(raw)
       ? _.map(raw, _.toString)
       : _.compact(_.map(_.split(_.toString(raw), ','), _.trim));
@@ -589,9 +627,6 @@ export function conditionToTokenValue(
   if (property?.type === 'number') {
     return { type: 'float', value: Number(raw) };
   }
-  if (property?.renderInput) {
-    return { type: 'custom', value: _.toString(raw) };
-  }
   if (
     property &&
     effectiveOptions(property) &&
@@ -602,11 +637,29 @@ export function conditionToTokenValue(
   return { type: 'string', value: _.toString(raw) };
 }
 
-/** Exact inverse of `conditionToTokenValue`. */
-export function tokenValueToConditionValue(value: FilterValue): any {
+/**
+ * Exact inverse of `conditionToTokenValue`. Pass `operator` for entity
+ * properties: arity decides whether the custom value is a JSON id array.
+ */
+export function tokenValueToConditionValue(
+  value: FilterValue,
+  property?: FilterProperty,
+  operator?: FilterOperator,
+): any {
   switch (value.type) {
     case 'empty':
       return '';
+    case 'custom': {
+      if (!property?.entitySource) return _.toString(value.value ?? '');
+      // Without an operator, fall back to the encoding's own shape: only the
+      // multi arity emits JSON.
+      const isList = operator
+        ? _.includes(LIST_OPERATORS, operator)
+        : _.startsWith(value.value, '[');
+      return isList
+        ? decodeEntityIds(value.value, true)
+        : _.toString(value.value ?? '');
+    }
     case 'date_absolute':
       return dayjs.unix(value.unixSeconds).toISOString();
     case 'integer':
@@ -670,7 +723,11 @@ export function powerSearchFiltersToGraphQLFilter(
       id: generateId(),
       property: filter.field,
       operator: filter.operator,
-      value: tokenValueToConditionValue(filter.value),
+      value: tokenValueToConditionValue(
+        filter.value,
+        property,
+        filter.operator,
+      ),
       propertyLabel: property?.propertyLabel ?? filter.field,
       type: property?.type ?? 'string',
     };
@@ -714,23 +771,51 @@ const BAIGraphQLPropertyFilter = <
     onChange: propOnChange,
   });
 
-  // Maps a committed value to the human-readable label a `renderInput` control
-  // supplied (e.g. user UUID -> email). Conditions are re-derived from `value`
-  // on every render and only carry the raw value, so the label lives here.
-  // A mutable ref, not state — see the sibling note in `BAIPropertyFilter`.
-  const valueLabelMapRef = useRef<Record<string, string>>({});
-
+  // Conditions are re-derived from `value` on every render and only carry the
+  // raw value, so the label a picker supplied (user UUID -> email) lives here.
+  const labels = useEntityLabelCache();
   const renderInputEditors = useRenderInputEditors({
-    recordLabel: (property, committed, label) => {
-      valueLabelMapRef.current[`${property}::${committed}`] = label;
-    },
-    resolveLabel: (property, committed) =>
-      valueLabelMapRef.current[`${property}::${committed}`] ?? committed,
+    recordLabel: labels.record,
+    resolveLabel: labels.resolveLabel,
   });
+  const entityEditors = useEntityEditors({ labels });
 
   const byKey = _.keyBy(filterProperties, 'key');
   const conditions = convertGraphQLFilterToConditions(value, filterProperties);
   const filters = graphQLFilterToPowerSearchFilters(value, filterProperties);
+
+  // Ids restored from the URL carry no label; ask each source once per id.
+  const pendingEntityIds = _.flatMap(conditions, (condition) => {
+    const property = byKey[condition.property];
+    // `renderInput` wins outright: its editor owns the label, so an entity
+    // source declared alongside it must not fire a request either.
+    if (!property?.entitySource || property.renderInput) return [];
+    return _.map(
+      rawToEntityIds(
+        condition.value,
+        _.includes(LIST_OPERATORS, condition.operator),
+      ),
+      (id) => [property.key, id] as const,
+    );
+  });
+  const resolveEntityLabels = useEffectEvent(() => {
+    _.forEach(
+      _.groupBy(pendingEntityIds, ([key]) => key),
+      (pairs, key) =>
+        labels.ensureResolved(
+          key,
+          byKey[key]?.entitySource,
+          _.map(pairs, ([, id]) => id),
+        ),
+    );
+  });
+  const pendingEntityIdsKey = _.join(
+    _.map(pendingEntityIds, (pair) => _.join(pair, '::')),
+    '\u0000',
+  );
+  useEffect(() => {
+    resolveEntityLabels();
+  }, [pendingEntityIdsKey]);
 
   const config: PowerSearchConfig = {
     name: 'bai-graphql-property-filter',
@@ -741,13 +826,20 @@ const BAIGraphQLPropertyFilter = <
         (property) =>
           property.type === 'string' &&
           !effectiveStrictSelection(property) &&
-          !property.renderInput,
+          !property.renderInput &&
+          !property.entitySource,
       )?.key,
     fields: _.map(filterProperties, (property): PowerSearchField => {
       const custom = renderInputEditors.operatorValueFor(
         property.key,
         property.renderInput,
       );
+      const entityFor = (isMulti: boolean) =>
+        entityEditors.operatorValueFor(
+          property.key,
+          property.entitySource,
+          isMulti,
+        );
       return {
         key: property.key,
         label: property.propertyLabel,
@@ -755,7 +847,7 @@ const BAIGraphQLPropertyFilter = <
         operators: _.map(availableOperatorsOf(property), (operator) => ({
           key: operator,
           label: operatorLabel(operator, t),
-          value: operatorValueFor(property, operator, custom),
+          value: operatorValueFor(property, operator, custom, entityFor),
         })),
       };
     }),

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -650,7 +650,9 @@ export function tokenValueToConditionValue(
     case 'empty':
       return '';
     case 'custom': {
-      if (!property?.entitySource) return _.toString(value.value ?? '');
+      // `renderInput` wins over `entitySource`, as in `conditionToTokenValue`.
+      if (property?.renderInput || !property?.entitySource)
+        return _.toString(value.value ?? '');
       // Without an operator, fall back to the encoding's own shape: only the
       // multi arity emits JSON.
       const isList = operator

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -2,39 +2,33 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- to-astryx TICKET 28 — shared plumbing for the two property filters that are
- now built on Astryx `PowerSearch` (`BAIPropertyFilter`, the Backend.AI
- queryfilter-DSL one, and `BAIGraphQLPropertyFilter`, the GraphQL object one).
+ Shared plumbing for the two property filters built on Astryx `PowerSearch`
+ (`BAIPropertyFilter`, the Backend.AI queryfilter-DSL one, and
+ `BAIGraphQLPropertyFilter`, the GraphQL object one). Both are translating
+ frontiers: their external props keep the antd-era shape (`value` /
+ `onChange` / `filterProperties`) so the ~40 call sites do not move, while the
+ inside is Astryx. Everything the two share in that translation lives here.
 
- Both filters are **translating frontiers**: their external props keep the
- antd-era shape (`value` / `onChange` / `filterProperties`) so that the ~40
- call sites do not move, while the inside is Astryx. Everything in this file
- is the part of that translation the two share:
-
-   - `toEnumItems`        BUI option lists      -> PowerSearch `EnumItem[]`
-   - `toSearchSource`     BUI option lists      -> Typeahead `SearchSource`
-   - `useRenderInputEditors`  BUI `renderInput` -> a `custom` operator value
-
- ## Why `renderInput` needs a component cache
-
- `CustomOperatorValue.Editor` is a **component type**. PowerSearch mounts it
- inside the edit popover, so a new function identity on every render would
- unmount and remount the consumer's control (a Relay-backed select) on every
- keystroke. Call sites declare `renderInput` inline, so its identity DOES
- change every render.
-
- `useRenderInputEditors` therefore keeps one stable component per property key
- for the lifetime of the host, and routes it to the LATEST `renderInput`
- through a ref that is refreshed on each render. The component identity is
- stable; the behaviour is current.
+ `CustomOperatorValue.Editor` is a COMPONENT TYPE that PowerSearch mounts
+ inside its edit popover, so a fresh identity on every render would remount the
+ consumer's control on every keystroke — and call sites declare `renderInput` /
+ `entitySource` inline. Both editor factories below therefore keep one
+ component per property key for the host's lifetime and route it to the LATEST
+ props through a ref refreshed during render.
 */
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import type {
   CustomOperatorValue,
   EnumItem,
 } from '@astryxdesign/core/PowerSearch';
-import type { SearchSource } from '@astryxdesign/core/Typeahead';
+import { Tokenizer } from '@astryxdesign/core/Tokenizer';
+import { Typeahead, TypeaheadItem } from '@astryxdesign/core/Typeahead';
+import type {
+  SearchableItem,
+  SearchSource,
+} from '@astryxdesign/core/Typeahead';
 import * as _ from 'lodash-es';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { ComponentType, ReactNode } from 'react';
 
 /**
@@ -51,7 +45,32 @@ export type FilterPropertyOption = {
 /** The `renderInput` escape hatch shared by both filters (FR-3011 / FR-3258). */
 export type FilterRenderInput = (props: {
   onAddCondition: (value: string | undefined, label?: string) => void;
+  /** The value staged in the popover (an existing token's value in edit mode). */
+  value: string | null;
+  isDisabled?: boolean;
 }) => ReactNode;
+
+/** One selectable entity: the opaque id the filter serializes plus its label. */
+export interface FilterEntity {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+/**
+ * Declarative replacement for `renderInput` on properties whose value is an
+ * opaque id. The host builds it, so Relay stays outside these components.
+ */
+export interface FilterEntitySource {
+  /** Per-keystroke lookup; debounced by the editor (150 ms). */
+  search: (query: string) => Promise<Array<FilterEntity>> | Array<FilterEntity>;
+  /** Shown when the editor opens with an empty query. Enables entries-on-focus. */
+  bootstrap?: () => Promise<Array<FilterEntity>> | Array<FilterEntity>;
+  /** id -> label for ids restored from the URL. Omit and tokens show the raw id. */
+  resolve?: (ids: ReadonlyArray<string>) => Promise<Array<FilterEntity>>;
+  /** Abort in-flight work; forwarded to Typeahead/Tokenizer. */
+  cancel?: () => void;
+}
 
 /** Only string-ish labels survive into a token; anything else falls back. */
 export const optionLabelToString = (
@@ -96,6 +115,315 @@ export function toSearchSource(
   };
 }
 
+export interface EntityLabelCache {
+  record: (propertyKey: string, id: string, label: string) => void;
+  recordMany: (
+    propertyKey: string,
+    entities: ReadonlyArray<FilterEntity>,
+  ) => void;
+  resolveLabel: (propertyKey: string, id: string) => string;
+  /** Fires `source.resolve` once per unseen id; failures fall back to the raw id. */
+  ensureResolved: (
+    propertyKey: string,
+    source: FilterEntitySource | undefined,
+    ids: ReadonlyArray<string>,
+  ) => void;
+}
+
+const labelKey = (propertyKey: string, id: string) => `${propertyKey}::${id}`;
+
+/**
+ * `${propertyKey}::${id}` -> human readable label, e.g. a user UUID -> email.
+ * State, not just a ref: PowerSearch recomputes its token strings only when
+ * the `config` identity changes, which needs a re-render.
+ */
+export function useEntityLabelCache(): EntityLabelCache {
+  'use memo';
+  const [labels, setLabels] = useState<Record<string, string>>({});
+  // Write-through mirror so writes within one tick accumulate and
+  // `ensureResolved` never re-requests an id that just landed.
+  const labelsRef = useRef<Record<string, string>>(labels);
+  const requestedRef = useRef<Set<string>>(new Set());
+
+  const merge = (entries: Record<string, string>) => {
+    const next = { ...labelsRef.current, ...entries };
+    if (_.isEqual(next, labelsRef.current)) return;
+    labelsRef.current = next;
+    setLabels(next);
+  };
+
+  const record = (propertyKey: string, id: string, label: string) => {
+    if (_.isEmpty(id) || _.isEmpty(label)) return;
+    merge({ [labelKey(propertyKey, id)]: label });
+  };
+
+  const recordMany = (
+    propertyKey: string,
+    entities: ReadonlyArray<FilterEntity>,
+  ) => {
+    const entries: Record<string, string> = {};
+    _.forEach(entities, (entity) => {
+      if (_.isEmpty(entity?.id) || _.isEmpty(entity?.label)) return;
+      entries[labelKey(propertyKey, entity.id)] = entity.label;
+    });
+    if (_.isEmpty(entries)) return;
+    merge(entries);
+  };
+
+  // State first so this closure changes identity when a label lands (that is
+  // what repaints tokens); the mirror covers a cached closure holding an older
+  // `labels` and writes not committed yet.
+  const resolveLabel = (propertyKey: string, id: string) => {
+    const key = labelKey(propertyKey, id);
+    return labels[key] ?? labelsRef.current[key] ?? id;
+  };
+
+  const ensureResolved = (
+    propertyKey: string,
+    source: FilterEntitySource | undefined,
+    ids: ReadonlyArray<string>,
+  ) => {
+    const resolve = source?.resolve;
+    if (!resolve) return;
+    const pending = _.filter(_.uniq(_.compact(ids)), (id) => {
+      const key = labelKey(propertyKey, id);
+      return !labelsRef.current[key] && !requestedRef.current.has(key);
+    });
+    if (_.isEmpty(pending)) return;
+    // Marked before awaiting: StrictMode's double-invoke and a rejecting
+    // resolver must not be able to loop.
+    _.forEach(pending, (id) =>
+      requestedRef.current.add(labelKey(propertyKey, id)),
+    );
+    Promise.resolve(resolve(pending))
+      .then((entities) => recordMany(propertyKey, entities))
+      .catch(() => {
+        // Leave the raw-id fallback in place.
+      });
+  };
+
+  return { record, recordMany, resolveLabel, ensureResolved };
+}
+
+type FilterEntityItem = SearchableItem<{ description?: string }>;
+
+const toEntityItems = (
+  entities: ReadonlyArray<FilterEntity> | undefined,
+): Array<FilterEntityItem> =>
+  _.map(entities, (entity) => ({
+    id: entity.id,
+    label: entity.label,
+    auxiliaryData: { description: entity.description },
+  }));
+
+/** Multi values ride as a JSON array — Astryx stores custom values as strings. */
+export const encodeEntityIds = (
+  ids: ReadonlyArray<string>,
+  isMulti: boolean,
+): string | null =>
+  isMulti ? JSON.stringify([...ids]) : (_.first(ids) ?? null);
+
+/** Malformed input yields an empty selection rather than throwing. */
+export const decodeEntityIds = (
+  value: string | null | undefined,
+  isMulti: boolean,
+): Array<string> => {
+  if (_.isNil(value) || value === '') return [];
+  if (!isMulti) return [value];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!_.isArray(parsed)) return [];
+    return _.filter(parsed, _.isString);
+  } catch {
+    return [];
+  }
+};
+
+export interface BAIPowerSearchEntityEditorProps {
+  /** Namespaces the label cache; the filter property this editor edits. */
+  propertyKey: string;
+  source: FilterEntitySource | undefined;
+  labels: EntityLabelCache;
+  /** List operators (`in` / `notIn`) get a Tokenizer, everything else a Typeahead. */
+  isMulti: boolean;
+  value: string | null;
+  onChange: (value: string | null) => void;
+  placeholder?: string;
+  isDisabled?: boolean;
+}
+
+/**
+ * Controlled editor behind a PowerSearch `custom` operator value: it stages the
+ * picked id(s) and the popover's Apply commits them.
+ */
+export const BAIPowerSearchEntityEditor = ({
+  propertyKey,
+  source,
+  labels,
+  isMulti,
+  value,
+  onChange,
+  placeholder,
+  isDisabled,
+}: BAIPowerSearchEntityEditorProps) => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  // BaseTypeahead calls `searchSource.cancel()` from an effect keyed on the
+  // source identity, so an unstable object would abort every in-flight search.
+  const sourceRef = useRef<FilterEntitySource | undefined>(source);
+  useEffect(() => {
+    sourceRef.current = source;
+  }, [source]);
+  const [searchSource] = useState<SearchSource<FilterEntityItem>>(() => ({
+    search: async (query: string) =>
+      toEntityItems(await sourceRef.current?.search(query)),
+    bootstrap: async () =>
+      toEntityItems(await sourceRef.current?.bootstrap?.()),
+    cancel: () => sourceRef.current?.cancel?.(),
+  }));
+
+  const selected: Array<FilterEntityItem> = _.map(
+    decodeEntityIds(value, isMulti),
+    (id) => ({ id, label: labels.resolveLabel(propertyKey, id) }),
+  );
+
+  const commonProps = {
+    label: t('comp:BAIPowerSearchEntityEditor.SelectValue'),
+    isLabelHidden: true,
+    searchSource,
+    placeholder: placeholder ?? t('comp:BAIPowerSearchEntityEditor.Search'),
+    hasEntriesOnFocus: !_.isNil(source?.bootstrap),
+    isDisabled,
+    renderItem: (item: FilterEntityItem) => (
+      <TypeaheadItem
+        item={item}
+        description={item.auxiliaryData?.description}
+      />
+    ),
+  };
+
+  if (isMulti) {
+    return (
+      <Tokenizer<FilterEntityItem>
+        {...commonProps}
+        value={selected}
+        onChange={(items) => {
+          labels.recordMany(propertyKey, items);
+          onChange(encodeEntityIds(_.map(items, 'id'), true));
+        }}
+      />
+    );
+  }
+
+  return (
+    <Typeahead<FilterEntityItem>
+      {...commonProps}
+      value={_.first(selected) ?? null}
+      // `PowerSearchValueEditor`'s CustomEditor drops `onChange(null)`, so a
+      // staged single value cannot be cleared — do not offer a dead control.
+      hasClear={false}
+      onChange={(item) => {
+        if (!item) {
+          onChange(null);
+          return;
+        }
+        labels.recordMany(propertyKey, [item]);
+        onChange(item.id);
+      }}
+    />
+  );
+};
+
+export interface EntityEditorsOptions {
+  labels: EntityLabelCache;
+}
+
+export interface EntityEditors {
+  /**
+   * Returns the `custom` operator value for a property that supplies
+   * `entitySource`, or `undefined` when it does not.
+   */
+  operatorValueFor: (
+    propertyKey: string,
+    source: FilterEntitySource | undefined,
+    isMulti: boolean,
+  ) => CustomOperatorValue | undefined;
+}
+
+type EditorProps = {
+  isDisabled?: boolean;
+  onChange: (value: string | null) => void;
+  placeholder: string;
+  value: string | null;
+};
+
+/** Builds (and caches) one `custom` operator value per `${key}::${arity}`. */
+export function useEntityEditors({
+  labels,
+}: EntityEditorsOptions): EntityEditors {
+  const latestRef = useRef<
+    Record<
+      string,
+      { source: FilterEntitySource | undefined; labels: EntityLabelCache }
+    >
+  >({});
+  const editorCacheRef = useRef<Map<string, CustomOperatorValue>>(new Map());
+
+  const operatorValueFor = (
+    propertyKey: string,
+    source: FilterEntitySource | undefined,
+    isMulti: boolean,
+  ): CustomOperatorValue | undefined => {
+    if (!source) return undefined;
+    const cacheKey = `${propertyKey}::${isMulti ? 'multi' : 'single'}`;
+    latestRef.current[cacheKey] = { source, labels };
+
+    const cached = editorCacheRef.current.get(cacheKey);
+    if (cached) return cached;
+
+    const Editor: ComponentType<EditorProps> = ({
+      onChange,
+      value,
+      isDisabled,
+      placeholder,
+    }) => {
+      const latest = latestRef.current[cacheKey];
+      return (
+        <BAIPowerSearchEntityEditor
+          propertyKey={propertyKey}
+          source={latest?.source}
+          labels={latest?.labels ?? labels}
+          isMulti={isMulti}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          isDisabled={isDisabled}
+        />
+      );
+    };
+    Editor.displayName = `BAIPropertyFilterEntity(${cacheKey})`;
+
+    const operatorValue: CustomOperatorValue = {
+      type: 'custom',
+      Editor,
+      getString: (value: string) => {
+        const cache = latestRef.current[cacheKey]?.labels ?? labels;
+        const ids = decodeEntityIds(value, isMulti);
+        if (_.isEmpty(ids)) return value;
+        return _.join(
+          _.map(ids, (id) => cache.resolveLabel(propertyKey, id)),
+          ', ',
+        );
+      },
+    };
+    editorCacheRef.current.set(cacheKey, operatorValue);
+    return operatorValue;
+  };
+
+  return { operatorValueFor };
+}
+
 export interface RenderInputEditorsOptions {
   /** `${propertyKey}::${value}` -> human readable label, e.g. UUID -> email. */
   recordLabel: (property: string, value: string, label: string) => void;
@@ -113,13 +441,6 @@ export interface RenderInputEditors {
     renderInput: FilterRenderInput | undefined,
   ) => CustomOperatorValue | undefined;
 }
-
-type EditorProps = {
-  isDisabled?: boolean;
-  onChange: (value: string | null) => void;
-  placeholder: string;
-  value: string | null;
-};
 
 /**
  * Builds (and caches) one `custom` operator value per `renderInput` property.
@@ -150,24 +471,29 @@ export function useRenderInputEditors({
     const cached = editorCacheRef.current.get(propertyKey);
     if (cached) return cached;
 
-    const Editor: ComponentType<EditorProps> = ({ onChange }) => {
+    const Editor: ComponentType<EditorProps> = ({
+      onChange,
+      value,
+      isDisabled,
+    }) => {
       const render = latestRenderInputRef.current[propertyKey];
       return (
-        // The consumer's control is very often an antd Select whose dropdown
-        // lives in a body portal. Stop pointer events from bubbling out of the
-        // editor so the popover's dismiss-on-outside-click does not fire while
-        // the user is picking an option.
+        // The consumer's control may open a floating layer of its own; keep
+        // pointer events inside so the popover's light dismiss does not fire
+        // while the user is picking an option.
         <div
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
         >
           {render?.({
-            onAddCondition: (value, label) => {
+            value,
+            isDisabled,
+            onAddCondition: (committed, label) => {
               // Truthy guard: an empty label would blank the token.
-              if (value != null && label) {
-                recordLabel(propertyKey, value, label);
+              if (committed != null && label) {
+                recordLabel(propertyKey, committed, label);
               }
-              onChange(value ?? null);
+              onChange(committed ?? null);
             },
           })}
         </div>

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -362,6 +362,7 @@ type EditorProps = {
 export function useEntityEditors({
   labels,
 }: EntityEditorsOptions): EntityEditors {
+  'use memo';
   const latestRef = useRef<
     Record<
       string,

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -195,7 +195,9 @@ export function useEntityLabelCache(): EntityLabelCache {
     _.forEach(pending, (id) =>
       requestedRef.current.add(labelKey(propertyKey, id)),
     );
-    Promise.resolve(resolve(pending))
+    // Called inside the executor so a resolver that throws SYNCHRONOUSLY
+    // rejects here too, instead of escaping into the effect that ran us.
+    new Promise<Array<FilterEntity>>((settle) => settle(resolve(pending)))
       .then((entities) => recordMany(propertyKey, entities))
       .catch(() => {
         // Leave the raw-id fallback in place.

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.doc.ts
@@ -31,7 +31,12 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use renderInput with an existing select (BAIUserSelect, for example) when the raw value is opaque, and pass the human-readable label to onAddCondition so the token shows the label while the UUID still serializes.',
+          'Give an opaque-valued property an entitySource ({ search, bootstrap?, resolve?, cancel? }) so the user picks by label while the UUID still serializes; resolve is what makes a shared link or a reload show the label instead of the raw id.',
+      },
+      {
+        guidance: true,
+        description:
+          'Reach for renderInput only when entitySource cannot express the picker — it takes precedence over entitySource, and its onAddCondition label lives only for the current mount.',
       },
       {
         guidance: true,
@@ -60,7 +65,7 @@ export const docs = {
       name: 'filterProperties',
       type: 'Array<FilterProperty>',
       description:
-        'The filterable fields. Each entry declares key (the DSL property name), propertyLabel, type, and optionally defaultOperator, options, strictSelection, rule, and renderInput.',
+        'The filterable fields. Each entry declares key (the DSL property name), propertyLabel, type, and optionally defaultOperator, options, strictSelection, rule, entitySource, and renderInput.',
       required: true,
     },
     {

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -1,4 +1,8 @@
 import BAIComplexSelect, { BAILabeledValue } from './BAIComplexSelect';
+import type {
+  FilterEntity,
+  FilterEntitySource,
+} from './BAIPowerSearchAdapters';
 import BAIPropertyFilter from './BAIPropertyFilter';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
@@ -19,7 +23,8 @@ const meta: Meta<typeof BAIPropertyFilter> = {
 - **Autocomplete support**: Predefined options and suggestions for property values
 - **Validation rules**: Custom validation for property values
 - **Query language**: Based on Backend.AI's query filter minilang specification
-- **Custom input via \`renderInput\`**: Replace the built-in value editor with any controlled control (e.g., a user or storage-host picker). The control stages a value via \`onAddCondition(value, label?)\` and the edit popover's Apply button commits it; pass a human-readable \`label\` when the committed value is opaque (e.g. a UUID) so the token shows the label instead. Same contract as \`BAIGraphQLPropertyFilter\`, so controls are interchangeable.
+- **Entity values via \`entitySource\`**: Declarative picker for properties whose value is an opaque id (a user UUID chosen by email). Supply \`{ search, bootstrap?, resolve?, cancel? }\` and the editor renders an Astryx Typeahead (a Tokenizer when the operator is a list one — **arity follows the operator, not the property**). \`resolve(ids)\` turns ids restored from a saved query string back into labels. Prefer it over \`renderInput\` for id-valued properties. Same field as on \`BAIGraphQLPropertyFilter\`.
+- **Custom input via \`renderInput\`**: Replace the built-in value editor with any controlled control (e.g., a user or storage-host picker). The control stages a value via \`onAddCondition(value, label?)\` and the edit popover's Apply button commits it; pass a human-readable \`label\` when the staged value is opaque (e.g. a UUID) so the token shows the label instead. The render prop receives \`{ onAddCondition, value, isDisabled }\`. Same contract as \`BAIGraphQLPropertyFilter\`, so controls are interchangeable.
 
 > **to-astryx ticket 28** — the engine is now Astryx \`PowerSearch\`. The prop contract is unchanged, but the antd chrome it documented (property \`Select\` + \`AutoComplete\` + closable \`Tag\`s + the bespoke reset button) is replaced by PowerSearch's typeahead, tokens and built-in clear. \`rule.validate\` is advisory now: a violating token is reported through the control's error status instead of being refused. **to-astryx ticket 32** refreshed these stories: the \`renderInput\` demo below now uses \`BAIComplexSelect\` (Astryx-native) instead of antd \`Select\`, matching what a migrated call site actually renders.
 
@@ -289,7 +294,7 @@ export const WithRenderInput: Story = {
     docs: {
       description: {
         story:
-          'When `renderInput` is provided, the default AutoComplete is replaced with a custom control. The control commits a condition via `onAddCondition(value, label?)` as soon as it emits a non-empty value; keep it controlled with `value={null}` so it clears after each commit. Pass the option label as the second argument so the condition tag shows a human-readable label (e.g. an email) instead of the opaque committed value (e.g. a UUID). Same contract as the one `BAIGraphQLPropertyFilter` adopts in FR-3011 (#8082), so controls become interchangeable once both land.',
+          "When `renderInput` is provided, the default value editor is replaced with a custom control. The control **stages** a value via `onAddCondition(value, label?)` and the edit popover's Apply button commits it — nothing lands on the filter until Apply. Pass the option label as the second argument so the token shows a human-readable label (e.g. an email) instead of the opaque staged value (e.g. a UUID). The render prop also receives `value` (what is currently staged) and `isDisabled`. Same contract as `BAIGraphQLPropertyFilter`, so controls are interchangeable; for id-valued properties prefer `entitySource`.",
       },
     },
   },
@@ -322,6 +327,80 @@ export const WithRenderInput: Story = {
         ),
       },
     ],
+    onChange: () => console.log('Filter changed'),
+  },
+};
+
+const sampleUserEntities: Array<FilterEntity> = [
+  {
+    id: 'owner-uuid-0001',
+    label: 'alice@example.com',
+    description: 'Alice Kim',
+  },
+  { id: 'owner-uuid-0002', label: 'bob@example.com', description: 'Bob Lee' },
+  {
+    id: 'owner-uuid-0003',
+    label: 'carol@example.com',
+    description: 'Carol Park',
+  },
+  {
+    id: 'owner-uuid-0004',
+    label: 'dave@example.com',
+    description: 'Dave Choi',
+  },
+];
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Stands in for a Relay-backed source (useBAIUserEntitySource); the latency is
+// what makes the id -> label swap visible in the Canvas.
+const demoUserEntitySource: FilterEntitySource = {
+  search: async (query) => {
+    await sleep(400);
+    const needle = query.trim().toLowerCase();
+    return needle
+      ? sampleUserEntities.filter((entity) =>
+          entity.label.toLowerCase().includes(needle),
+        )
+      : sampleUserEntities;
+  },
+  bootstrap: async () => {
+    await sleep(300);
+    return sampleUserEntities.slice(0, 3);
+  },
+  resolve: async (ids) => {
+    await sleep(1200);
+    return sampleUserEntities.filter((entity) => ids.includes(entity.id));
+  },
+};
+
+export const WithEntitySource: Story = {
+  name: 'Entity picker via entitySource',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`entitySource` is the declarative way to filter on an opaque id: the user searches by email while the query string keeps the UUID (`owner == "owner-uuid-0003"` — the same bytes `renderInput` produced). Arity follows the operator, so a single-value operator like `==` gets a single-select Typeahead. The story is pre-seeded with a raw UUID and this demo source resolves it after ~1.2s, so the token starts as the UUID and swaps to the email — what happens when a saved query is reopened. Without `resolve` the token simply keeps showing the raw id.',
+      },
+    },
+  },
+  args: {
+    filterProperties: [
+      {
+        key: 'name',
+        propertyLabel: 'Name',
+        type: 'string',
+        defaultOperator: 'ilike',
+      },
+      {
+        key: 'owner',
+        propertyLabel: 'Owner',
+        type: 'string',
+        defaultOperator: '==',
+        entitySource: demoUserEntitySource,
+      },
+    ],
+    value: 'owner == "owner-uuid-0003"',
     onChange: () => console.log('Filter changed'),
   },
 };

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import BAIPropertyFilter from './BAIPropertyFilter';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
+import { action } from 'storybook/actions';
 
 const meta: Meta<typeof BAIPropertyFilter> = {
   title: 'Filter/BAIPropertyFilter',
@@ -327,7 +328,7 @@ export const WithRenderInput: Story = {
         ),
       },
     ],
-    onChange: () => console.log('Filter changed'),
+    onChange: action('Filter changed'),
   },
 };
 
@@ -401,6 +402,6 @@ export const WithEntitySource: Story = {
       },
     ],
     value: 'owner == "owner-uuid-0003"',
-    onChange: () => console.log('Filter changed'),
+    onChange: action('Filter changed'),
   },
 };

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -12,6 +12,7 @@
  consumer census) and asserts byte-for-byte stability.
 */
 import BAIPopconfirm from './BAIPopconfirm';
+import type { FilterEntitySource } from './BAIPowerSearchAdapters';
 import BAIPropertyFilter, {
   buildFieldSpecs,
   defaultContentSearchFieldKey,
@@ -23,6 +24,13 @@ import BAIPropertyFilter, {
 } from './BAIPropertyFilter';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+const USER_UUID = '3f1c0e7a-0000-4000-8000-000000000001';
+/** Matches the token text even after PowerSearch truncates it. */
+const TRUNCATED_UUID = /^3f1c0e7a-0000-4000-8000-0000/;
+
+/** An `entitySource` with no `resolve`: tokens keep the raw id. */
+const idOnlyUserSource: FilterEntitySource = { search: async () => [] };
 
 describe('parseFilterValue', () => {
   it('should correctly parse filter with binary operators', () => {
@@ -269,12 +277,12 @@ const PAGE_FIXTURES: Array<{
         defaultOperator: '==',
         // The page supplies a Relay-backed picker here; serialization is
         // unaffected by the editor, so the fixture only needs the shape.
-        renderInput: () => null,
+        entitySource: idOnlyUserSource,
       },
     ],
     filters: [
       'name ilike "%training%"',
-      'name ilike "%job%" & project_id == "3f1c0e7a-0000-4000-8000-000000000001"',
+      `name ilike "%job%" & project_id == "${USER_UUID}"`,
     ],
   },
   {
@@ -411,6 +419,13 @@ describe('round-trip edge cases the antd implementation also had to survive', ()
     );
   });
 
+  it('preserves a value holding both a space and an escaped double quote', () => {
+    // The raw-value map is keyed by `field\u0000operator\u0000value`, so a
+    // value carrying the separator's neighbours must still find its own entry.
+    const value = 'name ilike "%say \\"hi\\" now%"';
+    expect(roundTrip(properties, value)).toBe(value);
+  });
+
   it('drops a condition with an empty value (as the antd tag list did)', () => {
     expect(roundTrip(properties, 'name ilike "%%"')).toBe(undefined);
   });
@@ -518,6 +533,134 @@ describe('number / datetime / uuid properties', () => {
 
   it('still routes bare typed text to the first free-text property', () => {
     expect(defaultContentSearchFieldKey(properties)).toBe('name');
+  });
+});
+
+describe('entitySource properties', () => {
+  const properties = (
+    entitySource: FilterEntitySource,
+  ): Array<FilterProperty> => [
+    { key: 'name', propertyLabel: 'Name', type: 'string' },
+    {
+      key: 'user_id',
+      propertyLabel: 'User',
+      type: 'uuid',
+      defaultOperator: '==',
+      entitySource,
+    },
+  ];
+  const specsFor = (value: string) =>
+    buildFieldSpecs(properties(idOnlyUserSource), value);
+
+  it('parses an `==` value into a single-id custom token', () => {
+    const value = `user_id == "${USER_UUID}"`;
+    expect(parseFilterString(value, specsFor(value)).filters).toEqual([
+      {
+        field: 'user_id',
+        operator: '==',
+        value: { type: 'custom', value: USER_UUID },
+      },
+    ]);
+  });
+
+  it('parses an `in` list literal into a JSON id array', () => {
+    // `in` is reachable only by widening from an inbound link — the declared
+    // operators for a uuid field are `==` / `!=`.
+    const value = 'user_id in ["a", "b"]';
+    expect(parseFilterString(value, specsFor(value)).filters).toEqual([
+      {
+        field: 'user_id',
+        operator: 'in',
+        value: { type: 'custom', value: '["a","b"]' },
+      },
+    ]);
+  });
+
+  it('serializes a single-id token back to the DSL byte-identically', () => {
+    const value = `user_id == "${USER_UUID}"`;
+    expect(roundTrip(properties(idOnlyUserSource), value)).toBe(value);
+    expect(
+      roundTrip(properties(idOnlyUserSource), `name ilike "%job%" & ${value}`),
+    ).toBe(`name ilike "%job%" & ${value}`);
+  });
+
+  it('keeps a renderInput value byte-identical too (escape hatch kept)', () => {
+    const value = `user_id == "${USER_UUID}"`;
+    const withRenderInput: Array<FilterProperty> = [
+      {
+        key: 'user_id',
+        propertyLabel: 'User',
+        type: 'uuid',
+        defaultOperator: '==',
+        renderInput: () => null,
+      },
+    ];
+    expect(roundTrip(withRenderInput, value)).toBe(value);
+  });
+
+  it('excludes an entitySource property from the content-search auto-pick', () => {
+    expect(
+      defaultContentSearchFieldKey([
+        {
+          key: 'owner',
+          propertyLabel: 'Owner',
+          type: 'string',
+          entitySource: idOnlyUserSource,
+        },
+        { key: 'name', propertyLabel: 'Name', type: 'string' },
+      ]),
+    ).toBe('name');
+  });
+});
+
+describe('entity label resolution (DSL)', () => {
+  const renderFilter = (entitySource: FilterEntitySource) =>
+    render(
+      <BAIPropertyFilter
+        filterProperties={[
+          {
+            key: 'user_id',
+            propertyLabel: 'User',
+            type: 'uuid',
+            defaultOperator: '==',
+            entitySource,
+          },
+        ]}
+        value={`user_id == "${USER_UUID}"`}
+        onChange={() => {}}
+      />,
+    );
+
+  it('swaps the raw id for the label the source resolves', async () => {
+    const resolve = vi.fn(async () => [
+      { id: USER_UUID, label: 'alice@lablup.com' },
+    ]);
+    renderFilter({ search: async () => [], resolve });
+    expect(await screen.findByText('alice@lablup.com')).toBeInTheDocument();
+    expect(resolve).toHaveBeenCalledWith([USER_UUID]);
+  });
+
+  it('keeps the raw id, asks once, and swallows a rejecting resolve', async () => {
+    const unhandled: Array<unknown> = [];
+    const trackUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', trackUnhandled);
+    try {
+      const resolve = vi.fn(() => Promise.reject(new Error('resolve failed')));
+      renderFilter({ search: async () => [], resolve });
+      await waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+      // One macrotask: long enough for Node to report an unhandled rejection.
+      await new Promise((done) => setTimeout(done, 0));
+      expect(screen.getByText(TRUNCATED_UUID)).toBeInTheDocument();
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', trackUnhandled);
+    }
+  });
+
+  it('falls back to the raw id when the source has no resolve', () => {
+    renderFilter(idOnlyUserSource);
+    expect(screen.getByText(TRUNCATED_UUID)).toBeInTheDocument();
   });
 });
 

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -49,10 +49,15 @@ import { filterOutEmpty } from '../helper';
 import { useControllableValue } from '../hooks';
 import { useBAIi18n } from '../hooks/useBAIi18n';
 import {
+  decodeEntityIds,
+  encodeEntityIds,
   toEnumItems,
   toSearchSource,
+  useEntityEditors,
+  useEntityLabelCache,
   useRenderInputEditors,
   type BAIPowerSearchChromeProps,
+  type FilterEntitySource,
   type FilterPropertyOption,
   type FilterRenderInput,
 } from './BAIPowerSearchAdapters';
@@ -67,7 +72,7 @@ import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
 import { SearchIcon } from 'lucide-react';
-import React, { useRef } from 'react';
+import React, { useEffect, useEffectEvent } from 'react';
 
 export type { FilterPropertyOption } from './BAIPowerSearchAdapters';
 
@@ -100,6 +105,11 @@ export type FilterProperty = {
    * label while the raw value still serializes unchanged.
    */
   renderInput?: FilterRenderInput;
+  /**
+   * Declarative picker for values that are opaque ids (a user UUID chosen by
+   * email). Ignored when `renderInput` is set.
+   */
+  entitySource?: FilterEntitySource;
 };
 
 export interface BAIPropertyFilterProps extends BAIPowerSearchChromeProps {
@@ -140,6 +150,9 @@ const BOOLEAN_OPTIONS: Array<FilterPropertyOption> = [
 
 /** Operators the wildcard convention applies to. */
 const WILDCARD_OPERATORS = ['ilike', 'like'];
+
+/** Operators whose value is a list; an entity picker becomes multi-select. */
+const LIST_OPERATORS = ['in'];
 
 /**
  * DSL operator -> BUI catalog key. Operators outside this table (`>=`, `in`,
@@ -251,6 +264,7 @@ interface FieldSpec {
   options?: Array<FilterPropertyOption>;
   strictSelection?: boolean;
   renderInput?: FilterRenderInput;
+  entitySource?: FilterEntitySource;
   operators: Array<string>;
   defaultOperator: string;
   rule?: FilterProperty['rule'];
@@ -281,6 +295,7 @@ function specForProperty(property: FilterProperty): FieldSpec {
     strictSelection:
       property.type === 'boolean' ? true : property.strictSelection,
     renderInput: property.renderInput,
+    entitySource: property.entitySource,
     operators,
     defaultOperator,
     rule: property.rule,
@@ -338,11 +353,19 @@ const operatorLabel = (operator: string, t: TFunction): string => {
     : operator;
 };
 
+/**
+ * The value editor for one field/operator pair. `renderInput` wins — the call
+ * site asked for it — then `entitySource`, whose arity comes from the OPERATOR.
+ */
 function operatorValueForSpec(
   spec: FieldSpec,
+  operator: string,
   custom: OperatorValue | undefined,
+  entityFor?: (isMulti: boolean) => OperatorValue | undefined,
 ): OperatorValue {
   if (custom) return custom;
+  const entity = entityFor?.(_.includes(LIST_OPERATORS, operator));
+  if (entity) return entity;
   if (spec.isEnum || (spec.options && spec.strictSelection)) {
     return { type: 'enum', values: toEnumItems(spec.options) };
   }
@@ -368,13 +391,14 @@ export function defaultContentSearchFieldKey(
     (property) =>
       property.type === 'string' &&
       !property.strictSelection &&
-      !property.renderInput,
+      !property.renderInput &&
+      !property.entitySource,
   )?.key;
 }
 
 /** Key under which a token's original raw (wildcards included) value is kept. */
 const rawKey = (field: string, operator: string, value: string) =>
-  `${field} ${operator} ${value}`;
+  `${field}\u0000${operator}\u0000${value}`;
 
 export interface ParsedFilterString {
   filters: Array<PowerSearchFilter>;
@@ -412,7 +436,7 @@ export function parseFilterString(
       const token = {
         field: property,
         operator,
-        value: tokenValueForSpec(spec, display),
+        value: tokenValueForSpec(spec, operator, display),
       } satisfies PowerSearchFilter;
       // Keyed by what `serializeFilters` will read back, not by the inbound
       // text: a `date_absolute` token round-trips through a unix stamp, so
@@ -425,12 +449,33 @@ export function parseFilterString(
   return { filters, rawValues };
 }
 
+/** A token's DSL value -> entity ids; a list operator carries `["a", "b"]`. */
+const displayToEntityIds = (
+  display: string,
+  isList: boolean,
+): Array<string> => {
+  if (!isList) return _.compact([display]);
+  const inner = _.trim(display).replace(/^\[/, '').replace(/\]$/, '');
+  return _.compact(
+    _.map(_.split(inner, ','), (part) => _.trim(part).replace(/^"|"$/g, '')),
+  );
+};
+
 /** The token value shape the editor chosen by `operatorValueForSpec` expects. */
 function tokenValueForSpec(
   spec: FieldSpec,
+  operator: string,
   display: string,
 ): PowerSearchFilter['value'] {
+  // Both custom editors own every operator of their field, list ones included.
   if (spec.renderInput) return { type: 'custom', value: display };
+  if (spec.entitySource) {
+    const isList = _.includes(LIST_OPERATORS, operator);
+    return {
+      type: 'custom',
+      value: encodeEntityIds(displayToEntityIds(display, isList), isList) ?? '',
+    };
+  }
   if (spec.isEnum) return { type: 'enum', value: display };
   if (spec.type === 'datetime') {
     const parsed = dayjs(display);
@@ -529,25 +574,51 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
     onChange: propOnChange as ((value: string | undefined) => void) | undefined,
   });
 
-  // Maps a committed value to the human-readable label a `renderInput` control
-  // supplied (e.g. user UUID -> email). Tokens are re-derived from `value` on
-  // every render and only carry the raw value, so the label lives here and is
-  // looked up when the token renders. Deliberately a mutable ref rather than
-  // state: it is written from the editor's commit callback and read from the
-  // token renderer, never during this component's render, and the commit that
-  // records a label is immediately followed by the `onChange` that repaints.
-  const valueLabelMapRef = useRef<Record<string, string>>({});
-
+  // Tokens are re-derived from `value` on every render and only carry the raw
+  // value, so the label a picker supplied (user UUID -> email) lives here.
+  const labels = useEntityLabelCache();
   const renderInputEditors = useRenderInputEditors({
-    recordLabel: (property, committed, label) => {
-      valueLabelMapRef.current[`${property}::${committed}`] = label;
-    },
-    resolveLabel: (property, committed) =>
-      valueLabelMapRef.current[`${property}::${committed}`] ?? committed,
+    recordLabel: labels.record,
+    resolveLabel: labels.resolveLabel,
   });
+  const entityEditors = useEntityEditors({ labels });
 
   const specs = buildFieldSpecs(filterProperties, value);
   const { filters, rawValues } = parseFilterString(value, specs);
+
+  // Ids restored from the URL carry no label; ask each source once per id.
+  const byKey = _.keyBy(specs, 'key');
+  const pendingEntityIds = _.flatMap(filters, (filter) => {
+    const spec = byKey[filter.field];
+    // `renderInput` wins outright: its editor owns the label, so an entity
+    // source declared alongside it must not fire a request either.
+    if (!spec?.entitySource || spec.renderInput) return [];
+    return _.map(
+      decodeEntityIds(
+        tokenValueToString(filter),
+        _.includes(LIST_OPERATORS, filter.operator),
+      ),
+      (id) => [spec.key, id] as const,
+    );
+  });
+  const pendingEntityKey = _.join(
+    _.map(pendingEntityIds, (pair) => _.join(pair, '::')),
+    '\u0000',
+  );
+  const resolveEntityLabels = useEffectEvent(() => {
+    _.forEach(
+      _.groupBy(pendingEntityIds, ([key]) => key),
+      (pairs, key) =>
+        labels.ensureResolved(
+          key,
+          byKey[key]?.entitySource,
+          _.map(pairs, ([, id]) => id),
+        ),
+    );
+  });
+  useEffect(() => {
+    resolveEntityLabels();
+  }, [pendingEntityKey]);
 
   const config: PowerSearchConfig = {
     name: 'bai-property-filter',
@@ -558,7 +629,8 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
         spec.key,
         spec.renderInput,
       );
-      const operatorValue = operatorValueForSpec(spec, custom);
+      const entityFor = (isMulti: boolean) =>
+        entityEditors.operatorValueFor(spec.key, spec.entitySource, isMulti);
       return {
         key: spec.key,
         label: spec.label,
@@ -566,7 +638,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
         operators: _.map(spec.operators, (operator) => ({
           key: operator,
           label: operatorLabel(operator, t),
-          value: operatorValue,
+          value: operatorValueForSpec(spec, operator, custom, entityFor),
         })),
       };
     }),

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -243,3 +243,4 @@ export type {
 } from './BAIAdminImageSelect';
 export { default as BAISubStepNodes } from './BAISubStepNodes';
 export type { BAISubStepNodesProps, SubStepInList } from './BAISubStepNodes';
+export { default as useBAIUserEntitySource } from './useBAIUserEntitySource';

--- a/packages/backend.ai-ui/src/components/fragments/useBAIUserEntitySource.ts
+++ b/packages/backend.ai-ui/src/components/fragments/useBAIUserEntitySource.ts
@@ -1,0 +1,115 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+*/
+import type { useBAIUserEntitySourceQuery } from '../../__generated__/useBAIUserEntitySourceQuery.graphql';
+import { toLocalId } from '../../helper';
+import type {
+  FilterEntity,
+  FilterEntitySource,
+} from '../BAIPowerSearchAdapters';
+import { mergeFilterValues } from '../BAIPropertyFilter';
+import * as _ from 'lodash-es';
+import { useEffect, useRef, useState } from 'react';
+import { fetchQuery, graphql, useRelayEnvironment } from 'react-relay';
+
+const SEARCH_LIMIT = 10;
+/** Same predicate `BAIUserSelect` uses: `user_nodes` filters on the enum. */
+const ACTIVE_USER_FILTER = 'status == "active"';
+
+/** The queryfilter DSL quotes literals with `"`, so a typed quote must not close one. */
+const escapeFilterLiteral = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const UserEntitySourceQuery = graphql`
+  query useBAIUserEntitySourceQuery($filter: String, $first: Int!) {
+    user_nodes(filter: $filter, first: $first, order: "email") {
+      edges {
+        node {
+          id
+          email
+          full_name
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * `FilterEntitySource` over `user_nodes`: searches users by email and resolves
+ * user UUIDs back to emails for `BAIGraphQLPropertyFilter` / `BAIPropertyFilter`.
+ */
+export const useBAIUserEntitySource = (): FilterEntitySource => {
+  'use memo';
+  const environment = useRelayEnvironment();
+  const environmentRef = useRef(environment);
+  useEffect(() => {
+    environmentRef.current = environment;
+  }, [environment]);
+
+  const [source] = useState<FilterEntitySource>(() => {
+    // `cancel()` bumps this so a late search response is discarded. `resolve`
+    // stays outside the guard: its ids are requested once and never retried.
+    let searchGeneration = 0;
+
+    const fetchUsers = async (
+      filter: string | undefined,
+      first: number,
+    ): Promise<Array<FilterEntity>> => {
+      const data = await fetchQuery<useBAIUserEntitySourceQuery>(
+        environmentRef.current,
+        UserEntitySourceQuery,
+        { filter, first },
+      ).toPromise();
+      return _.compact(
+        _.map(data?.user_nodes?.edges, (edge) => {
+          const node = edge?.node;
+          if (!node?.email) return null;
+          return {
+            id: toLocalId(node.id),
+            label: node.email,
+            description: node.full_name ?? undefined,
+          } satisfies FilterEntity;
+        }),
+      );
+    };
+
+    const searchUsers = async (query: string): Promise<Array<FilterEntity>> => {
+      searchGeneration += 1;
+      const generation = searchGeneration;
+      const entities = await fetchUsers(
+        mergeFilterValues([
+          ACTIVE_USER_FILTER,
+          query ? `email ilike "%${escapeFilterLiteral(query)}%"` : null,
+        ]),
+        SEARCH_LIMIT,
+      );
+      return generation === searchGeneration ? entities : [];
+    };
+
+    return {
+      search: searchUsers,
+      bootstrap: () => searchUsers(''),
+      // One batched request; ids the backend does not return stay unresolved
+      // and the filter keeps showing the raw uuid.
+      resolve: (ids) => {
+        const uniqueIds = _.uniq(_.compact([...ids]));
+        if (_.isEmpty(uniqueIds)) return Promise.resolve([]);
+        return fetchUsers(
+          mergeFilterValues(
+            _.map(uniqueIds, (id) => `uuid == "${escapeFilterLiteral(id)}"`),
+            '|',
+          ),
+          uniqueIds.length,
+        );
+      },
+      cancel: () => {
+        searchGeneration += 1;
+      },
+    };
+  });
+
+  return source;
+};
+
+export default useBAIUserEntitySource;

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -41,6 +41,8 @@ export type {
   FilterOperator,
   FilterProperty as BAIGraphQLFilterProperty,
   BAIGraphQLPropertyFilterProps,
+  FilterEntity,
+  FilterEntitySource,
 } from './BAIGraphQLPropertyFilter';
 export { default as BAIRowWrapWithDividers } from './BAIRowWrapWithDividers';
 export { default as BAIStatistic } from './BAIStatistic';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Weitere Aktionen"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Suchen…",
+    "SelectValue": "Wert auswählen"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Die folgenden Projekte werden aktualisiert.",
     "ProjectResourcePolicy": "Projektressourcenrichtlinie",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Περισσότερες ενέργειες"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Αναζήτηση…",
+    "SelectValue": "Επιλέξτε τιμή"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Τα ακόλουθα έργα θα ενημερωθούν.",
     "ProjectResourcePolicy": "Πολιτική πόρων έργου",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "More actions"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Search…",
+    "SelectValue": "Select value"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "The following project(s) will be updated.",
     "ProjectResourcePolicy": "Project Resource Policy",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Más acciones"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Buscar…",
+    "SelectValue": "Seleccionar valor"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Se actualizará(n) el(los) siguiente(s) proyecto(s).",
     "ProjectResourcePolicy": "Política de recursos del proyecto",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Lisää toimintoja"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Hae…",
+    "SelectValue": "Valitse arvo"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Seuraavat projektit päivitetään.",
     "ProjectResourcePolicy": "Projektin resurssipolitiikka",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Plus d'actions"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Rechercher…",
+    "SelectValue": "Sélectionner la valeur"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Le(s) projet(s) suivant(s) sera(ont) mis à jour.",
     "ProjectResourcePolicy": "Politique de ressources du projet",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Tindakan lainnya"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Cari…",
+    "SelectValue": "Pilih nilai"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Proyek berikut akan diperbarui.",
     "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Altre azioni"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Cerca…",
+    "SelectValue": "Seleziona valore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Il/I seguente/i progetto/i verrà/verranno aggiornato/i.",
     "ProjectResourcePolicy": "Politica delle risorse del progetto",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "その他の操作"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "検索…",
+    "SelectValue": "値を選択"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "以下のプロジェクトが更新されます.",
     "ProjectResourcePolicy": "プロジェクトのリソースポリシー",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "추가 작업"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "검색…",
+    "SelectValue": "값 선택"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "다음 프로젝트(들)이 업데이트됩니다.",
     "ProjectResourcePolicy": "프로젝트 리소스 정책",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Бусад үйлдэл"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Хайх…",
+    "SelectValue": "Утга сонгох"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Дараах төсөл(үүд) шинэчлэгдэх болно.",
     "ProjectResourcePolicy": "Төслийн нөөцийн бодлого",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Tindakan lain"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Cari…",
+    "SelectValue": "Pilih nilai"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Projek berikut akan dikemas kini.",
     "ProjectResourcePolicy": "Polisi Sumber Projek",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Więcej akcji"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Szukaj…",
+    "SelectValue": "Wybierz wartość"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Poniższe projekty zostaną zaktualizowane.",
     "ProjectResourcePolicy": "Polityka zasobów projektu",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -306,6 +306,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Mais ações"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Pesquisar…",
+    "SelectValue": "Selecionar valor"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "O(s) projeto(s) a seguir será(ão) atualizado(s).",
     "ProjectResourcePolicy": "Política de Recursos do Projeto",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Mais ações"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Pesquisar…",
+    "SelectValue": "Selecionar valor"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "O(s) projeto(s) a seguir será(ão) atualizado(s).",
     "ProjectResourcePolicy": "Política de Recursos do Projeto",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Больше действий"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Поиск…",
+    "SelectValue": "Выберите значение"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Будут обновлены следующие проекты.",
     "ProjectResourcePolicy": "Политика ресурсов проекта",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "การดำเนินการเพิ่มเติม"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "ค้นหา…",
+    "SelectValue": "เลือกค่า"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "โครงการต่อไปนี้จะถูกอัปเดต.",
     "ProjectResourcePolicy": "นโยบายทรัพยากรโครงการ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Diğer işlemler"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Ara…",
+    "SelectValue": "Değer seçin"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Aşağıdaki proje(ler) güncellenecek.",
     "ProjectResourcePolicy": "Proje Kaynak Politikası",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "Thao tác khác"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "Tìm kiếm…",
+    "SelectValue": "Chọn giá trị"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "Dự án sau sẽ được cập nhật.",
     "ProjectResourcePolicy": "Chính sách tài nguyên dự án",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "更多操作"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "搜索…",
+    "SelectValue": "选择值"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "以下项目将被更新。",
     "ProjectResourcePolicy": "项目资源策略",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -300,6 +300,10 @@
   "comp:BAINameActionCell": {
     "MoreActions": "更多操作"
   },
+  "comp:BAIPowerSearchEntityEditor": {
+    "Search": "搜尋…",
+    "SelectValue": "選擇值"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingProjectsWillBeUpdated": "下列專案將會更新。",
     "ProjectResourcePolicy": "專案資源政策",

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -29,11 +29,11 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
-  BAIUserSelect,
   filterOutEmpty,
   INITIAL_FETCH_KEY,
   toLocalId,
   useBAILogger,
+  useBAIUserEntitySource,
   useFetchKey,
   useMutationWithPromise,
 } from 'backend.ai-ui';
@@ -55,6 +55,7 @@ const RBACManagementPage: React.FC = () => {
 
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
+  const userEntitySource = useBAIUserEntitySource();
   const {
     baiPaginationOption,
     tablePaginationOption,
@@ -273,26 +274,7 @@ const RBACManagementPage: React.FC = () => {
                   propertyLabel: t('rbac.AssignedUser'),
                   type: 'uuid',
                   fixedOperator: 'equals',
-                  renderInput: ({ onAddCondition }) => (
-                    <BAIUserSelect
-                      valuePropName="id"
-                      value={null}
-                      label={t('rbac.AssignedUser')}
-                      isLabelHidden
-                      onChange={(value, option) =>
-                        // The picker emits the user UUID; forward the option
-                        // label (email) so the condition tag stays readable
-                        // (P3C-1 keeps the 2nd argument on this sibling).
-                        onAddCondition(
-                          value as string | undefined,
-                          Array.isArray(option)
-                            ? option[0]?.label
-                            : option?.label,
-                        )
-                      }
-                      width={200}
-                    />
-                  ),
+                  entitySource: userEntitySource,
                 },
                 baiClient?.supports('role-mapped-scope-filter') && {
                   key: 'mappedScope.scopeType',


### PR DESCRIPTION
Resolves #9088 (FR-3691)

## The ask

In the antd era, `BAIGraphQLPropertyFilter` accepted a custom `Select` through `renderInput`, so a property whose value is an opaque id (the RBAC role list's `assignedUser.userId`) could be picked by **searching an email** while the filter still serialized the **UUID**. After the to-astryx rebuild onto Astryx `PowerSearch`, that path still works for the first selection but is degraded, and every call site hand-rolls ~20 lines of JSX to get it.

## What was actually broken

Measured against the source, not assumed:

1. **Editing an existing token opens an empty control.** Astryx passes the staged value to a `custom` operator value's `Editor` (`PowerSearchValueEditor.tsx:606-620`), but the BUI adapter destructured `({ onChange })` only and dropped `value` and `isDisabled`. `FilterRenderInput` had no slot to forward them into, and every call site pins `value={null}`. Since `isSaveDisabled = !partialFilter.value`, Apply stayed enabled and silently re-committed the previous UUID.
2. **A shared link or an F5 shows a raw UUID.** The id -> label map was an in-memory `useRef`, and the URL carries only the filter object. (Not a regression — antd behaved the same — but it is what makes the feature feel broken.)
3. `onChange(null)` is swallowed upstream, so a staged value cannot be cleared.
4. `renderInput` had **zero** test coverage: both fixtures stubbed it to `() => null`.

## What this does

A filter property now takes a declarative `entitySource` instead:

```ts
{
  key: 'assignedUser.userId',
  type: 'uuid',
  fixedOperator: 'equals',
  entitySource: useBAIUserEntitySource(),   // { search, bootstrap?, resolve?, cancel? }
}
```

- **Editor**: Astryx `Typeahead` for a single-valued operator, `Tokenizer` for `in` / `notIn`. Arity follows the **operator**, never the property, so one source serves both with no call-site branching.
- **`resolve(ids)`** is what makes a link readable: ids restored from the URL are batched into one request per page load, once per unseen id. A rejecting or absent resolver leaves the raw-id fallback in place rather than retrying.
- **`renderInput` stays and keeps precedence**, with its two real defects fixed — the render prop now receives `value` and `isDisabled`. The change is additive, so the four remaining call sites compile and behave identically.

### Why not the native `entity_list`

PowerSearch ships `{type: 'entity_list', searchSource}`, which looks like the obvious fit. It was evaluated and rejected:

- It is `Tokenizer`-backed and **multi-only**, with no arity cap reachable from config. It cannot serve `fixedOperator: 'equals'` without silently truncating a multi-selection.
- Its one unique advantage — the label stored inside `FilterValueEntityList` — buys nothing here. What this project serializes is the **GraphQL filter object** (`RoleUserNestedFilter.userId` is a `UUIDFilter`, no label slot) or the queryfilter DSL string, not the PowerSearch `FilterValue`. A resolve step is needed either way.
- `EntityListEditor` forwards neither `hasEntriesOnFocus` nor `isDisabled`, so its picker is blank until the user types.

So the editor mounts the same Astryx primitives `EntityListEditor` itself renders — keeping the combobox/listbox roles, keyboard model, IME guard, debounce, loading state, `cancel()` and race guard — under a `{type:'custom'}` operator value. **The serialized filter is therefore unchanged** (`{assignedUser:{userId:{equals:'<uuid>'}}}`): no URL migration, and no bet on `UUIDFilter.in` behaviour nobody has verified against a manager.

## Also in here

- `conditionToTokenValue` puts the custom editors ahead of the type branches, so a `renderInput` / `entitySource` property with a list operator no longer gets a mismatched `string_list` token.
- `tokenValueToConditionValue` takes the operator, so a single id that happens to start with `[` is not mistaken for a JSON id array.
- `BAIPropertyFilter`'s `rawKey` held two **literal NUL bytes**, which made the whole file (and later its test file) invisible to ripgrep. They are backslash-u escapes now; behaviour identical.

## Tests

- `packages/backend.ai-ui`: **1997 passed / 1 skipped** (full suite). The two filter suites are **136 passed**.
- `react`: **2270 passed** (full suite).

New coverage worth calling out: round-trip **byte-identity** for both the `entitySource` and `renderInput` paths (deep-equal *and* identical `JSON.stringify` on the real nested `assignedUser.userId` key), both arities of the id codec, a single id that looks like JSON, label resolution including a **rejecting** resolver (asserts exactly one call and no unhandled rejection), two properties sharing one id keeping separate labels, a label recorded *after* the operator value was cached, and a regression guard that `renderInput` receives `value` + `isDisabled`.

The PowerSearch edit popover is a native `popover="auto"` layer with a focus trap, so it is not driven in jsdom — the pure functions and the editor component are tested in isolation instead.

## Verification

Rebased onto `origin/main` (the earlier merge commit is gone; the branch is a single commit again). `bash scripts/verify.sh`:

```
--- Relay: PASS ---
--- Lint script coverage: PASS ---
--- Lint: PASS ---
--- Format: PASS ---
--- TypeScript: PASS ---
--- TypeScript (agent-cli): PASS ---
--- Vite warmup paths: PASS ---
--- StyleX cssInjectionTarget: PASS ---
--- Astryx theme build: PASS ---
--- Astryx integration (backend.ai-ui): PASS ---
--- z-index ladder mirrors: PASS ---
--- Agent mappings: PASS ---
--- Terminology: PASS ---
=== ALL PASS ===
```

`pnpm --filter backend.ai-ui run build` also succeeds. No CSS or token changes, so the Astryx token gate is not in play.

## Review notes

- The whole behavioural surface is `packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx` (`useEntityEditors`, `useEntityLabelCache`, `encodeEntityIds` / `decodeEntityIds`, and the `renderInput` `Editor` that now forwards `value` / `isDisabled`). The two filter components only wire it up.
- To check the fix by hand: open RBAC management, filter by assigned user (type an email), then reload the page — the token must read the **email**, not the UUID. Clicking the token must open the picker **pre-populated**.
- `react/src/pages/RBACManagementPage.tsx` is the only call site migrated; the four other `renderInput` users are untouched on purpose and still compile against the widened render prop.

## Needs a live check (not verifiable here)

- Paste an RBAC URL carrying `assignedUser.userId.equals=<uuid>` into a fresh tab -> the token must read the **email**.
- The Typeahead's own floating layer nested inside PowerSearch's popover must not light-dismiss the editor when an option is picked.
- `bootstrap()` on focus, the debounce, `cancel()` and out-of-order responses under real latency; IME composition-Enter; dark mode; a long email against the 40-char token truncation.

## Known limitations

1. **A staged single entity cannot be cleared from inside the popover.** `hasClear={false}` because Astryx's `CustomEditor` swallows `onChange(null)` — the clear button would be visibly dead. The user removes the token instead. Fixing it needs an upstream Astryx change.
2. DSL multi (`in`) entity values do not serialize back to a DSL list. Unreachable from the UI (no operator set offers `in` there), and the plain non-entity `in` path is identically broken today — pre-existing, separate issue.
3. `useBAIAdminProjectEntitySource` is **not** in this PR (follow-up), so `AdminComputeSessionListPage`, `ModelStoreListPageV2`, `AdminModelCard` and `UserFolderPermissionPanelV2` keep using `renderInput` — now with its defects fixed.
4. PowerSearch's search-bar typeahead still offers no *value* suggestions for entity fields (`usePowerSearchSource` returns `[]` for both `custom` and `entity_list`, and its `search` is synchronous). Upstream Astryx.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
