### PR TITLE
test: e2e auto-heal — Astryx locator drift in dashboard, resource-policy, rbac

### DIFF
--- a/e2e/dashboard/dashboard.spec.ts
+++ b/e2e/dashboard/dashboard.spec.ts
@@ -261,8 +261,17 @@ test.describe(
           .first();
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
-        // 2. Verify a resource group selector (dropdown or select) is visible within the widget
-        await expect(widget.locator('.ant-select').first()).toBeVisible();
+        // 2. Verify a resource group selector is visible within the widget.
+        // `SharedResourceGroupSelectForCurrentProject` renders `BAISelect` with
+        // `showSearch`, so Astryx `Selector` renders the trigger as a plain
+        // `<button>` (`role: hasSearch ? undefined : 'combobox'`) whose
+        // accessible name falls back to `t('general.Select')` — the call site
+        // passes no `label`/`placeholder` (`BAISelect.tsx`:
+        // `label: accessibleLabel || t('general.Select')`). `exact` is required:
+        // the widget's info-tooltip button's aria-label contains "selected".
+        await expect(
+          widget.getByRole('button', { name: 'Select', exact: true }),
+        ).toBeVisible();
 
         // 3. Verify the resource content area has finished loading for the current resource group.
         // The widget may show CPU/RAM statistics when the admin user has resource quota allocated
@@ -514,10 +523,12 @@ test.describe(
         const modal = page.getByRole('dialog').filter({ hasText: 'Add panel' });
         await expect(modal).toBeVisible();
 
-        // 3. Pick the "Sessions" resource (project-scoped, available to every
-        //    role). The "Resource" combobox is the AstryxFormSelector; the other
-        //    combobox in the dialog is the condition property filter.
-        await modal.getByRole('combobox', { name: 'Resource' }).click();
+        // 3. Pick the "Sessions" data source (project-scoped, available to every
+        //    role). The AstryxFormSelector for the `resourceType` field is
+        //    labelled `t('dashboard.panelModal.DataSource')` = "Data source"
+        //    (`DashboardPanelModal.tsx`); the other combobox in the dialog is
+        //    the condition property filter ("Search filters").
+        await modal.getByRole('combobox', { name: 'Data source' }).click();
         await page
           .getByRole('option', { name: 'Sessions', exact: true })
           .click();

--- a/e2e/dashboard/dashboard.spec.ts
+++ b/e2e/dashboard/dashboard.spec.ts
@@ -187,7 +187,7 @@ test.describe(
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
         // 2. Click the refresh (BAIFetchKeyButton) in the widget's header area
-        const refreshButton = widget.getByRole('button', { name: 'reload' });
+        const refreshButton = widget.getByRole('button', { name: 'Refresh' });
         await refreshButton.click();
 
         // 3. Verify the widget data remains visible after refresh
@@ -233,7 +233,7 @@ test.describe(
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
         // 2. Click the refresh button in the widget header
-        const refreshButton = widget.getByRole('button', { name: 'reload' });
+        const refreshButton = widget.getByRole('button', { name: 'Refresh' });
         await refreshButton.click();
 
         // 3. Verify the widget still renders CPU/Memory after refresh
@@ -388,7 +388,7 @@ test.describe(
           await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
           // 2. Click the refresh button in the widget header
-          const refreshButton = widget.getByRole('button', { name: 'reload' });
+          const refreshButton = widget.getByRole('button', { name: 'Refresh' });
           await refreshButton.click();
 
           // 3. Verify the widget still renders after refresh (no error state)
@@ -429,11 +429,11 @@ test.describe(
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
         // 2. Click the refresh button in the widget header
-        const refreshButton = widget.getByRole('button', { name: 'reload' });
+        const refreshButton = widget.getByRole('button', { name: 'Refresh' });
         await refreshButton.click();
 
         // 3. Verify the widget still renders after refresh
-        await expect(widget.locator('.ant-table')).toBeVisible();
+        await expect(widget.getByRole('table')).toBeVisible();
       });
     });
 

--- a/e2e/dashboard/dashboard.spec.ts
+++ b/e2e/dashboard/dashboard.spec.ts
@@ -416,7 +416,7 @@ test.describe(
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
         // 2. Verify the sessions table container is displayed
-        await expect(widget.locator('.ant-table')).toBeVisible();
+        await expect(widget.getByRole('table')).toBeVisible();
       });
 
       test('Admin can manually refresh the Recently Created Sessions widget', async ({

--- a/e2e/rbac/rbac-role-crud.spec.ts
+++ b/e2e/rbac/rbac-role-crud.spec.ts
@@ -485,7 +485,15 @@ test.describe(
       // 2. Navigate to RBAC page
       await navigateTo(page, 'rbac');
 
-      // 3. Locate system roles by their "Source" cell value being exactly
+      // 3. Wait for the table's first data row. The header row renders before
+      // the query resolves, so only a data row proves the list loaded — and
+      // the 3s system-row probe below is conditional, so an unloaded table
+      // silently sends the test to a pagination bar that does not exist yet.
+      await expect(page.getByRole('row').nth(1)).toBeVisible({
+        timeout: 30000,
+      });
+
+      // 4. Locate system roles by their "Source" cell value being exactly
       // "System", excluding "monitor" (known bug). Real rows/cells come from
       // `BAITable`'s semantic `<table>`, so role-based locators reach them —
       // the header row has `columnheader`s, not `cell`s, so it never matches.
@@ -514,7 +522,7 @@ test.describe(
       }
       await expect(systemRoleRow).toBeVisible({ timeout: 10000 });
 
-      // 4. Click the role name to open the detail drawer. BAINameActionCell
+      // 5. Click the role name to open the detail drawer. BAINameActionCell
       // renders the title as a button when `onTitleClick` is set, and it is
       // the first control in the row's first cell (actions come after it).
       const titleElement = systemRoleRow
@@ -526,14 +534,14 @@ test.describe(
       const systemRoleName = (await titleElement.textContent())?.trim() ?? null;
       await titleElement.click();
 
-      // 5. Verify the drawer title "RBAC Role Info" appears. `RoleDetailDrawer`
+      // 6. Verify the drawer title "RBAC Role Info" appears. `RoleDetailDrawer`
       // renders `BAIDrawer` (Astryx lab `Drawer`), an Astryx dialog whose
       // accessible name is its fixed `label` — the role name is the visible
       // heading text, not the dialog's name.
       const drawer = page.getByRole('dialog', { name: 'RBAC Role Info' });
       await expect(drawer).toBeVisible();
 
-      // 6. Verify the drawer heading matches the role name we clicked.
+      // 7. Verify the drawer heading matches the role name we clicked.
       // `BAIDrawer`'s title renders through Astryx `Heading level={5}`.
       if (systemRoleName) {
         await expect(
@@ -545,7 +553,7 @@ test.describe(
         });
       }
 
-      // 7. Verify the Edit button is NOT present for system roles.
+      // 8. Verify the Edit button is NOT present for system roles.
       // `RoleDetailDrawer` only renders the Edit Role `IconButton` (aria-label
       // "Edit Role") when `role.source === 'CUSTOM'`.
       await expect(

--- a/e2e/rbac/rbac-role-crud.spec.ts
+++ b/e2e/rbac/rbac-role-crud.spec.ts
@@ -1,7 +1,6 @@
 // spec: e2e/.agent-output/test-plan-rbac-management.md
 // Scenarios: 2.1 – 2.7 (Role CRUD lifecycle)
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import { getNotificationMessageBox } from '../utils/test-util-antd';
 import test, { expect, Page } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
@@ -183,11 +182,14 @@ test.describe.serial(
       // 12. Verify the modal closes
       await expect(modal).toBeHidden({ timeout: 10000 });
 
-      // 13. Verify a success notification "Role created successfully." appears
-      await expect(getNotificationMessageBox(page)).toHaveText(
-        /Role created successfully/i,
-        { timeout: 10000 },
-      );
+      // 13. Verify a success notification "Role created successfully." appears.
+      // RoleFormModal reports through the app-shim's `message.success`, which
+      // is backed by an Astryx toast (role="status"), not BAINotificationStack.
+      await expect(
+        page
+          .getByRole('status')
+          .filter({ hasText: /Role created successfully/i }),
+      ).toBeVisible({ timeout: 10000 });
 
       // 14. Creation is validated via the success notification.
       // Avoid asserting table row visibility here because the RBAC role list is paginated

--- a/e2e/rbac/rbac-role-crud.spec.ts
+++ b/e2e/rbac/rbac-role-crud.spec.ts
@@ -1,6 +1,7 @@
 // spec: e2e/.agent-output/test-plan-rbac-management.md
 // Scenarios: 2.1 – 2.7 (Role CRUD lifecycle)
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import { getNotificationMessageBox } from '../utils/test-util-antd';
 import test, { expect, Page } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
@@ -68,15 +69,16 @@ test.describe.serial(
 
       if (isActiveVisible) {
         // Deactivate button is the first (and only) action button in Active view.
-        // It is wrapped in a Popconfirm that requires a second "Deactivate" click.
+        // It is wrapped in a BAINameActionCell popConfirm (Astryx Popover,
+        // role="dialog" labeled by the action's title) that requires a second
+        // "Deactivate" click.
         await activeRow
           .locator('.bai-name-action-cell-actions button')
           .first()
           .click();
-        // Confirm the Popconfirm
         await page
-          .locator('.ant-popconfirm')
-          .getByRole('button', { name: 'Deactivate' })
+          .getByRole('dialog', { name: 'Deactivate' })
+          .getByRole('button', { name: 'Deactivate', exact: true })
           .click();
         await expect(activeRow).toBeHidden({ timeout: 10000 });
       }
@@ -95,13 +97,12 @@ test.describe.serial(
           .locator('.bai-name-action-cell-actions button')
           .last()
           .click();
-        // BAIDeleteConfirmModal requires typing the role name into its dedicated
-        // #confirmText textbox before the Delete button is enabled.
-        const purgeModal = page
-          .locator('.ant-modal')
-          .filter({ hasText: 'Purge Role' });
+        // BAIDeleteConfirmModal requires typing the role name into its
+        // textbox (carries `name="confirmText"`, not `id`) before Delete
+        // enables.
+        const purgeModal = page.getByRole('dialog', { name: 'Purge Role' });
         await expect(purgeModal).toBeVisible({ timeout: 5000 });
-        await purgeModal.locator('#confirmText').fill(roleName);
+        await purgeModal.getByRole('textbox').fill(roleName);
         await purgeModal.getByRole('button', { name: 'Delete' }).click();
         await expect(inactiveRow).toBeHidden({ timeout: 10000 });
       }
@@ -128,10 +129,9 @@ test.describe.serial(
       // 4. Click the "Create Role" button
       await page.getByRole('button', { name: 'Create Role' }).click();
 
-      // 5. Verify a modal titled "Create Role" appears
-      const modal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Create Role' });
+      // 5. Verify a modal titled "Create Role" appears (RoleFormModal renders
+      // BAIModal, an Astryx dialog whose accessible name is its title).
+      const modal = page.getByRole('dialog', { name: 'Create Role' });
       await expect(modal).toBeVisible();
 
       // 6. Verify the modal has Role Name (required) and Description fields
@@ -159,42 +159,23 @@ test.describe.serial(
       await modal.getByLabel('Description').fill(ROLE_DESCRIPTION);
 
       // 11. Fill in the required "Scope Type / Target" field.
-      // The Create Role modal now requires at least one scope entry.
-      // AntD Form.List generates input IDs: scopes_0_scopeType and scopes_0_scopeId.
-      // Click the parent .ant-select container (not the input directly) to open dropdowns.
-      const scopeTypeContainer = modal
-        .locator('input#scopes_0_scopeType')
-        .locator('xpath=ancestor::div[contains(@class,"ant-select")][1]');
-      await scopeTypeContainer.click();
-      await page
-        .locator(
-          '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-        )
-        .filter({ hasText: 'Domain' })
-        .first()
-        .click();
+      // ScopeRow renders BAISelect (Scope Type) and ScopeIdSelect (Target) as
+      // Astryx Selector triggers (`role="button"`), each opening a floating
+      // `listbox`/`option` panel — not an antd `.ant-select`.
+      await modal.getByRole('button', { name: 'Scope Type' }).click();
+      await page.getByRole('option', { name: 'Domain', exact: true }).click();
 
-      // Wait for Scope Type dropdown to fully close before interacting with Target
-      await expect(
-        page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-      ).toHaveCount(0, { timeout: 5000 });
-
-      // Wait for Target (scopeId) container to become enabled (DomainScopeIdSelect loads asynchronously)
-      const scopeIdContainer = modal
-        .locator('input#scopes_0_scopeId')
-        .locator('xpath=ancestor::div[contains(@class,"ant-select")][1]');
-      await expect(scopeIdContainer).not.toHaveClass(/ant-select-disabled/, {
-        timeout: 5000,
-      });
-      await scopeIdContainer.click();
-      // Wait for domain options to load and select the first available option
-      const domainDropdownOptions = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
-      await expect(domainDropdownOptions.first()).toBeVisible({
-        timeout: 10000,
-      });
-      await domainDropdownOptions.first().click();
+      // Wait for the Target select to become enabled (DomainScopeIdSelect
+      // loads its options asynchronously once a scope type is picked) and
+      // pick the first available domain.
+      const targetTrigger = modal.getByRole('button', { name: 'Target' });
+      await expect(targetTrigger).toBeEnabled({ timeout: 5000 });
+      await targetTrigger.click();
+      const targetOptions = page
+        .getByRole('listbox', { name: 'Target' })
+        .getByRole('option');
+      await expect(targetOptions.first()).toBeVisible({ timeout: 10000 });
+      await targetOptions.first().click();
 
       // 12. Click OK to submit
       await modal.getByRole('button', { name: 'OK' }).click();
@@ -203,11 +184,10 @@ test.describe.serial(
       await expect(modal).toBeHidden({ timeout: 10000 });
 
       // 13. Verify a success notification "Role created successfully." appears
-      await expect(
-        page
-          .locator('.ant-message-notice-wrapper')
-          .filter({ hasText: /Role created successfully/i }),
-      ).toBeVisible({ timeout: 10000 });
+      await expect(getNotificationMessageBox(page)).toHaveText(
+        /Role created successfully/i,
+        { timeout: 10000 },
+      );
 
       // 14. Creation is validated via the success notification.
       // Avoid asserting table row visibility here because the RBAC role list is paginated
@@ -503,16 +483,17 @@ test.describe(
       // 2. Navigate to RBAC page
       await navigateTo(page, 'rbac');
 
-      // 3. Find the Source column index. Columns: Role Name(1) Description(2) Scope Type(3)
-      //    Scope ID(4) Source(5) Created At(6) Updated At(7).
-      // Locate system roles using a column-header-based approach to find
-      // a row where the Source cell value is exactly "System", excluding "monitor" (known bug).
-      // If no system row is visible on page 1, navigate to the last page where they accumulate.
+      // 3. Locate system roles by their "Source" cell value being exactly
+      // "System", excluding "monitor" (known bug). Real rows/cells come from
+      // `BAITable`'s semantic `<table>`, so role-based locators reach them —
+      // the header row has `columnheader`s, not `cell`s, so it never matches.
+      // If no system row is visible on page 1, navigate to the last page
+      // where they accumulate.
       const systemRoleRowLocator = () =>
         page
-          .locator('tr.ant-table-row')
+          .getByRole('row')
           .filter({
-            has: page.locator('td:nth-child(5)', { hasText: /^System$/ }),
+            has: page.getByRole('cell', { name: 'System', exact: true }),
           })
           .filter({ hasNotText: /monitor/i })
           .first();
@@ -522,45 +503,55 @@ test.describe(
         .isVisible({ timeout: 3000 })
         .catch(() => false);
       if (!isSystemVisible) {
-        // Navigate to last page to find system roles
-        const lastPageButton = page.locator('.ant-pagination-item').last();
+        // Navigate to the last page button in the pagination bar.
+        const lastPageButton = page
+          .getByRole('button', { name: /^Go to page \d+$/ })
+          .last();
         await lastPageButton.click();
-        await expect(page.locator('.ant-table-row').first()).toBeVisible({
-          timeout: 10000,
-        });
         systemRoleRow = systemRoleRowLocator();
       }
       await expect(systemRoleRow).toBeVisible({ timeout: 10000 });
 
-      // 4. Click the role name to open the detail drawer.
+      // 4. Click the role name to open the detail drawer. BAINameActionCell
+      // renders the title as a button when `onTitleClick` is set, and it is
+      // the first control in the row's first cell (actions come after it).
       const titleElement = systemRoleRow
         .getByRole('cell')
         .first()
-        .locator('.ant-typography')
+        .getByRole('button')
         .first();
       // Extract name for later verification (must be done before click to avoid stale ref)
       const systemRoleName = (await titleElement.textContent())?.trim() ?? null;
       await titleElement.click();
 
-      // 5. Verify the drawer title "RBAC Role Info" appears
-      const drawer = page.locator('.ant-drawer');
-      await expect(drawer.getByText('RBAC Role Info')).toBeVisible();
+      // 5. Verify the drawer title "RBAC Role Info" appears. `RoleDetailDrawer`
+      // renders `BAIDrawer` (Astryx lab `Drawer`), an Astryx dialog whose
+      // accessible name is its fixed `label` — the role name is the visible
+      // heading text, not the dialog's name.
+      const drawer = page.getByRole('dialog', { name: 'RBAC Role Info' });
+      await expect(drawer).toBeVisible();
 
-      // 6. Verify the drawer heading matches the role name we clicked
+      // 6. Verify the drawer heading matches the role name we clicked.
+      // `BAIDrawer`'s title renders through Astryx `Heading level={5}`.
       if (systemRoleName) {
         await expect(
-          drawer.locator('h3').filter({ hasText: systemRoleName }),
+          drawer
+            .getByRole('heading', { level: 5 })
+            .filter({ hasText: systemRoleName }),
         ).toBeVisible({
           timeout: 5000,
         });
       }
 
-      // 7. Verify the Edit button is NOT present for system roles
-      // The Edit Role button would have size="large" (CSS class .ant-btn-lg) if present
-      await expect(drawer.locator('.ant-btn-lg').first()).toBeHidden();
+      // 7. Verify the Edit button is NOT present for system roles.
+      // `RoleDetailDrawer` only renders the Edit Role `IconButton` (aria-label
+      // "Edit Role") when `role.source === 'CUSTOM'`.
+      await expect(
+        drawer.getByRole('button', { name: 'Edit Role' }),
+      ).toBeHidden();
 
       // Close the drawer
-      await drawer.getByRole('button', { name: 'close' }).click();
+      await drawer.getByRole('button', { name: 'Close' }).click();
     });
   },
 );

--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -8,11 +8,15 @@ async function cleanupPolicy(page: Page, policyName: string) {
   const row = page.getByRole('row').filter({ hasText: policyName });
   const isVisible = await row.isVisible({ timeout: 2000 }).catch(() => false);
   if (isVisible) {
-    // Hover over the name cell to reveal BAINameActionCell actions
-    await row.getByRole('cell').first().hover();
-    await row.getByRole('button', { name: 'delete' }).click();
-    // BAIDeleteConfirmModal with requireConfirmInput: type the policy name to enable Delete
-    const confirmInput = page.locator('#confirmText');
+    // The row's action column is narrow enough that BAINameActionCell
+    // collapses every action into the "More actions" overflow menu instead
+    // of showing a directly-clickable "delete" icon button.
+    await row.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    // BAIDeleteConfirmModal with requireConfirmInput: type the policy name to
+    // enable Delete. The input carries `name="confirmText"` (not `id`), so
+    // scope to the dialog's single textbox instead of an `#confirmText` id.
+    const confirmInput = page.getByRole('dialog').getByRole('textbox');
     await expect(confirmInput).toBeVisible();
     await confirmInput.fill(policyName);
     // Scope to the confirm dialog: FR-3331 exposes each row's delete action
@@ -51,7 +55,11 @@ async function selectPolicyTab(
 async function createKeypairPolicy(page: Page, name: string) {
   // Keypair is the default tab.
   await cleanupPolicy(page, name);
-  await page.getByRole('button', { name: 'Create' }).click();
+  // Anchored regex: a substring match on 'Create' also matches the
+  // "Sort by created_at" column-header button (accessible name contains
+  // "creat" from "created_at"). Anchoring at the start excludes it while
+  // still matching both "Create" and "Create Policy" button labels.
+  await page.getByRole('button', { name: /^Create/i }).click();
   const modal = page.getByRole('dialog', {
     name: 'Create Keypair Resource Policy',
   });
@@ -67,7 +75,8 @@ async function createKeypairPolicy(page: Page, name: string) {
 async function createUserPolicy(page: Page, name: string) {
   await selectPolicyTab(page, 'User');
   await cleanupPolicy(page, name);
-  await page.getByRole('button', { name: 'Create' }).click();
+  // See createKeypairPolicy: anchored to exclude "Sort by created_at".
+  await page.getByRole('button', { name: /^Create/i }).click();
   const modal = page.getByRole('dialog', {
     name: 'Create User Resource Policy',
   });
@@ -90,7 +99,8 @@ async function createUserPolicy(page: Page, name: string) {
 async function createProjectPolicy(page: Page, name: string) {
   await selectPolicyTab(page, 'Project');
   await cleanupPolicy(page, name);
-  await page.getByRole('button', { name: 'Create' }).click();
+  // See createKeypairPolicy: anchored to exclude "Sort by created_at".
+  await page.getByRole('button', { name: /^Create/i }).click();
   const modal = page.getByRole('dialog');
   await expect(modal).toBeVisible();
   await modal.getByRole('textbox', { name: 'Name' }).fill(name);

--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -1,18 +1,37 @@
 // spec: Resource Policy page tests
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import test, { expect, type Page } from '@playwright/test';
+import test, { expect, type Locator, type Page } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
+
+// BAINameActionCell measures the name column and moves whatever does not fit
+// into a "More actions" DropdownMenu, so the SAME action is a directly
+// clickable icon button on one tab and an overflow menu item on another: the
+// Keypair list declares three actions (Info / Edit / Delete) and overflows all
+// of them, while the User and Project lists declare two and render them
+// inline. Resolve both shapes instead of assuming one.
+async function clickRowAction(
+  page: Page,
+  row: Locator,
+  action: 'Edit' | 'Delete',
+) {
+  const iconButton = row.getByRole('button', { name: action, exact: true });
+  const isInline = await iconButton
+    .isVisible({ timeout: 2000 })
+    .catch(() => false);
+  if (isInline) {
+    await iconButton.click();
+    return;
+  }
+  await row.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: action, exact: true }).click();
+}
 
 async function cleanupPolicy(page: Page, policyName: string) {
   const row = page.getByRole('row').filter({ hasText: policyName });
   const isVisible = await row.isVisible({ timeout: 2000 }).catch(() => false);
   if (isVisible) {
-    // The row's action column is narrow enough that BAINameActionCell
-    // collapses every action into the "More actions" overflow menu instead
-    // of showing a directly-clickable "delete" icon button.
-    await row.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await clickRowAction(page, row, 'Delete');
     // BAIDeleteConfirmModal with requireConfirmInput: type the policy name to
     // enable Delete. The input carries `name="confirmText"` (not `id`), so
     // scope to the dialog's single textbox instead of an `#confirmText` id.
@@ -38,14 +57,59 @@ function policyName(kind: string, label: string) {
   return `e2e-${kind}-policy-${TEST_RUN_ID}-${label}`;
 }
 
+// The page's tab strip is `BAICard`'s `tabList`, which renders through
+// `BAITabList` -> Astryx `TabList`. Left without an explicit `role="tablist"`
+// (ResourcePolicyPage does not set one), `TabList` speaks the NAVIGATION
+// pattern: a `<nav aria-label="Tabs">` whose tabs are plain `<button>`s and
+// whose active tab is marked `aria-current="true"` — there is no `role="tab"`
+// and no `aria-selected`. See `Tab.tsx`'s `isTabRole` branch in
+// `@astryxdesign/core`.
+function policyTab(page: Page, tabName: 'Keypair' | 'User' | 'Project') {
+  return page
+    .getByRole('navigation', { name: 'Tabs' })
+    .getByRole('button', { name: `${tabName} Resource Policy`, exact: true });
+}
+
+async function expectPolicyTabActive(
+  page: Page,
+  tabName: 'Keypair' | 'User' | 'Project',
+) {
+  const tab = policyTab(page, tabName);
+  // `navigateTo` resolves on `load`, but the SPA still has to boot, read the
+  // session and render the card — regularly longer than the 5 s expect
+  // timeout. The sibling assertions get this for free from the click's
+  // 30 s actionTimeout; this one has no click in front of it.
+  await expect(tab).toBeVisible({ timeout: 30000 });
+  await expect(tab).toHaveAttribute('aria-current', 'true');
+}
+
 async function selectPolicyTab(
   page: Page,
   tabName: 'Keypair' | 'User' | 'Project',
 ) {
-  await page.getByRole('tab', { name: tabName }).click();
+  await policyTab(page, tabName).click();
+  await expectPolicyTabActive(page, tabName);
+}
+
+// A BAITable column header, matched on its visible label. `getByRole(
+// 'columnheader', { name })` does NOT work for sortable columns: the header's
+// content is a sort button whose `aria-label` ("Sort by max_vfolder_count")
+// overrides the label text in the accessible-name computation, so the
+// user-visible label never appears in the header's accessible name.
+async function expectColumnHeader(page: Page, label: string) {
   await expect(
-    page.getByRole('tab', { name: tabName, selected: true }),
+    page.getByRole('columnheader').filter({ hasText: label }),
   ).toBeVisible();
+}
+
+// The default policy row, located without `.ant-*` classes (antd is gone).
+// A plain `getByRole('row').filter({ hasText: 'default' })` also matches the
+// HEADER row, whose accessible name contains the `default_for_unspecified`
+// column's "Sort by default_for_unspecified" button label. Anchoring the row's
+// accessible name at "default " excludes it: the header row's name starts with
+// "Sort by name".
+function defaultPolicyRow(page: Page) {
+  return page.getByRole('row', { name: /^default\s/ });
 }
 
 // Creation helpers — extracted so each test can provision its own resource.
@@ -117,10 +181,7 @@ async function createProjectPolicy(page: Page, name: string) {
 async function deletePolicyAndVerify(page: Page, name: string) {
   const policyRow = page.getByRole('row').filter({ hasText: name });
   await expect(policyRow).toBeVisible();
-  // Same overflow-menu collapse as cleanupPolicy: BAINameActionCell hides the
-  // delete icon behind "More actions" at this column width.
-  await policyRow.getByRole('button', { name: 'More actions' }).click();
-  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await clickRowAction(page, policyRow, 'Delete');
 
   // BAIDeleteConfirmModal with requireConfirmInput: type the policy name to
   // enable Delete. The input carries `name="confirmText"`, not an `id`.
@@ -165,30 +226,18 @@ test.describe(
       await navigateTo(page, 'resource-policy');
 
       // Verify Keypair tab is selected by default
-      await expect(
-        page.getByRole('tab', { name: 'Keypair', selected: true }),
-      ).toBeVisible();
+      await expectPolicyTabActive(page, 'Keypair');
 
-      // Verify table columns
-      await expect(
-        page.getByRole('columnheader', { name: 'Name' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Concurrent Sessions' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Cluster Size' }),
-      ).toBeVisible();
+      // Verify table columns. A sortable BAITable header's accessible NAME is
+      // the sort button's aria-label ("Sort by max_containers_per_session"),
+      // which replaces the visible label in the name computation — so match the
+      // header's TEXT, which is the label the user actually reads.
+      await expectColumnHeader(page, 'Name');
+      await expectColumnHeader(page, 'Concurrent Sessions');
+      await expectColumnHeader(page, 'Cluster Size');
 
       // Verify default policy row exists
-      // Scope to tbody rows: a column header tooltip also contains the text
-      // "Default" (e.g. "Default For Unspecified"), which a plain
-      // getByRole('row') filter would match too via case-insensitive substring
-      // matching, causing a strict-mode violation.
-      const defaultRow = page
-        .locator('.ant-table-tbody .ant-table-row')
-        .filter({ hasText: 'default' });
-      await expect(defaultRow).toBeVisible();
+      await expect(defaultPolicyRow(page)).toBeVisible();
     });
 
     test('Admin can create a Keypair policy', async ({ page, request }) => {
@@ -210,15 +259,13 @@ test.describe(
       // Provision this test's own policy so it doesn't depend on the create test.
       await createKeypairPolicy(page, name);
 
-      // Find the test policy row, hover to reveal actions, and click the
-      // edit action by its accessible name (the action title is exposed as
-      // the button's `aria-label` by BAINameActionCell — FR-3331).
+      // Find the test policy row and open its edit action. On the Keypair tab
+      // BAINameActionCell collapses all three actions into the "More actions"
+      // menu, so there is no directly-clickable "Edit" icon button —
+      // clickRowAction resolves either shape.
       const policyRow = page.getByRole('row').filter({ hasText: name });
       await expect(policyRow).toBeVisible();
-      await policyRow.getByRole('cell').first().hover();
-      await policyRow
-        .getByRole('button', { name: 'Edit', exact: true })
-        .click();
+      await clickRowAction(page, policyRow, 'Edit');
 
       // Verify Update dialog appears
       const modal = page.getByRole('dialog');
@@ -263,28 +310,14 @@ test.describe(
       await navigateTo(page, 'resource-policy');
 
       // Switch to User tab
-      await page.getByRole('tab', { name: 'User' }).click();
-      await expect(
-        page.getByRole('tab', { name: 'User', selected: true }),
-      ).toBeVisible();
+      await selectPolicyTab(page, 'User');
 
-      // Verify table columns
-      await expect(
-        page.getByRole('columnheader', { name: 'Name' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Max Folder Count' }),
-      ).toBeVisible();
+      // Verify table columns (see the Keypair test for why this matches text).
+      await expectColumnHeader(page, 'Name');
+      await expectColumnHeader(page, 'Max Folder Count');
 
       // Verify default policy row exists
-      // Scope to tbody rows: a column header tooltip also contains the text
-      // "Default" (e.g. "Default For Unspecified"), which a plain
-      // getByRole('row') filter would match too via case-insensitive substring
-      // matching, causing a strict-mode violation.
-      const defaultRow = page
-        .locator('.ant-table-tbody .ant-table-row')
-        .filter({ hasText: 'default' });
-      await expect(defaultRow).toBeVisible();
+      await expect(defaultPolicyRow(page)).toBeVisible();
     });
 
     test('Admin can create a User policy', async ({ page, request }) => {
@@ -316,28 +349,14 @@ test.describe(
       await navigateTo(page, 'resource-policy');
 
       // Switch to Project tab
-      await page.getByRole('tab', { name: 'Project' }).click();
-      await expect(
-        page.getByRole('tab', { name: 'Project', selected: true }),
-      ).toBeVisible();
+      await selectPolicyTab(page, 'Project');
 
-      // Verify table columns
-      await expect(
-        page.getByRole('columnheader', { name: 'Name' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Max Folder Count' }),
-      ).toBeVisible();
+      // Verify table columns (see the Keypair test for why this matches text).
+      await expectColumnHeader(page, 'Name');
+      await expectColumnHeader(page, 'Max Folder Count');
 
       // Verify default policy row
-      // Scope to tbody rows: a column header tooltip also contains the text
-      // "Default" (e.g. "Default For Unspecified"), which a plain
-      // getByRole('row') filter would match too via case-insensitive substring
-      // matching, causing a strict-mode violation.
-      const defaultRow = page
-        .locator('.ant-table-tbody .ant-table-row')
-        .filter({ hasText: 'default' });
-      await expect(defaultRow).toBeVisible();
+      await expect(defaultPolicyRow(page)).toBeVisible();
     });
 
     test('Admin can create a Project policy', async ({ page, request }) => {

--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -117,11 +117,14 @@ async function createProjectPolicy(page: Page, name: string) {
 async function deletePolicyAndVerify(page: Page, name: string) {
   const policyRow = page.getByRole('row').filter({ hasText: name });
   await expect(policyRow).toBeVisible();
-  await policyRow.getByRole('cell').first().hover();
-  await policyRow.getByRole('button', { name: 'delete' }).click();
+  // Same overflow-menu collapse as cleanupPolicy: BAINameActionCell hides the
+  // delete icon behind "More actions" at this column width.
+  await policyRow.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
 
-  // BAIDeleteConfirmModal with requireConfirmInput: type the policy name to enable Delete
-  const confirmInput = page.locator('#confirmText');
+  // BAIDeleteConfirmModal with requireConfirmInput: type the policy name to
+  // enable Delete. The input carries `name="confirmText"`, not an `id`.
+  const confirmInput = page.getByRole('dialog').getByRole('textbox');
   await expect(confirmInput).toBeVisible();
   await confirmInput.fill(name);
 


### PR DESCRIPTION
Produced automatically by the **daily digest auto-heal** stage (2026-08-26 run).
No Jira issue — this is test-side maintenance only. Nothing under `react/` or
`packages/` is touched.

## Why

The repo removed Ant Design entirely in the Astryx migration, so no `.ant-*`
class exists in the rendered DOM any more. Every `.ant-*` selector still sitting
in a spec is dead by definition. These three specs were identified as
locator-drift by triage on 2026-08-25 but were dropped from PR #9043 by that
run's `MAX_HEAL_SPECS=5` cap, so they have been failing for a second day.

Each locator below was verified against the actual component source (not
guessed), and every test marked healed was re-run individually and observed to
pass.

## What changed

**`e2e/dashboard/dashboard.spec.ts`**
- `getByRole('button', { name: 'reload' })` → `{ name: 'Refresh' }` (4 sites).
  `BAIFetchKeyButton`'s `aria-label` is `t('comp:BAIFetchKeyButton.Refresh')`;
  `reload` was the old antd icon name.
- `widget.locator('.ant-table')` → `widget.getByRole('table')` in the Recently
  Created Sessions widget (`RecentlyCreatedSession` → `SessionNodes` →
  `BAITable` renders a real semantic `<table>`).

**`e2e/resource-policy/resource-policy.spec.ts`**
- `getByRole('button', { name: 'Create' })` was a strict-mode violation — the
  accessible-name match is a substring, and the **"Sort by created_at" column
  header** button also contains "creat". Anchored to `/^Create/i` (3 sites), so
  it still matches both "Create" and "Create Policy" without the collision.
- `cleanupPolicy()`: the row's delete action now collapses into the
  "More actions" overflow menu, and the confirm modal's input carries
  `name="confirmText"` rather than `id="confirmText"`.

**`e2e/rbac/rbac-role-crud.spec.ts`**
- `.ant-modal` / `.ant-drawer` → `getByRole('dialog', { name: … })`
- `tr.ant-table-row` → `getByRole('row').filter({ has: getByRole('cell', …) })`
- `.ant-pagination-item` → the `Go to page N` buttons
- `.ant-select` + xpath-ancestor dance → `role="button"` triggers opening
  `listbox` / `option` panels
- `.ant-typography` title click → `getByRole('button')` (`BAINameActionCell`
  renders its title as a button when `onTitleClick` is set)
- `.ant-message-notice-wrapper` → the shared `getNotificationMessageBox()` helper
- `cleanupTestRole()`: `.ant-popconfirm` → `getByRole('dialog', { name: 'Deactivate' })`,
  purge modal → `getByRole('dialog', { name: 'Purge Role' })`, `#confirmText` →
  `purgeModal.getByRole('textbox')`

## Results

**Healed — re-run verified**
- `dashboard.spec.ts` — session count / My Resources / Agent Stats / Recently
  Created Sessions refresh (4 tests pass individually)
- `resource-policy.spec.ts` — "Admin can create a Keypair policy"
- `rbac-role-crud.spec.ts` — "Superadmin cannot edit a system role name or
  description (edit button absent)"

**Not healed — deliberately left alone (retry budget exhausted)**
- `resource-policy.spec.ts` — "create a User policy" / "create a Project
  policy". The Create-button fix moves them past that point; they now fail
  inside `selectPolicyTab` on `getByRole('tab', …)` because those tabs render
  as `role="button"`. That is the suite-wide admin nav-tab cluster triaged as
  **environment**, out of scope for this PR.
- `rbac-role-crud.spec.ts` — "Superadmin can create a new custom role". The
  fixed locators were driven end-to-end in a paused debug session: every field
  fills correctly and OK is clicked, but the **Create Role dialog never
  closes**. That is the standing issue open since 2026-07-29 (suspected
  server-side `adminCreateRole` failure, not test drift). The assertion was
  **not** weakened to make it pass.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all **PASS**.
The `Astryx theme build` step fails, but it fails identically on a clean
`main` with these changes stashed (unbuilt local `backend.ai-ui` dist on the
digest runner) — it is unrelated to this diff.

Report: `/home/ubuntu/e2e-digest-reports/report-2026-08-26.md`

Related: #9043 (yesterday's heal PR, still open — covers the credential /
environment / chat / admin-model-card clusters this PR deliberately does not
touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Verification against a live cluster (2026-08-27)

This PR was re-verified by running the three specs it touches against a dev
server built from this branch, backed by `10.82.130.172:8090`. The first run
was **18 passed / 12 failed**, so a follow-up commit (`0a130783f`) heals the
rest. The three specs now pass except one test, held open deliberately.

### What the original pass got right

`dashboard.spec.ts`'s `reload` → `Refresh` and `.ant-table` →
`getByRole('table')` fixes are correct — all four refresh tests pass.
`resource-policy.spec.ts`'s "Admin can create a Keypair policy" passes.
`rbac-role-crud.spec.ts:478` passes, and its healed locators are correct
(see the correction below).

### What it missed

**`resource-policy.spec.ts` — 2/10 passing, now 10/10.**

- The policy tabs are not ARIA tabs. `BAICard`'s `tabList` renders
  `BAITabList` → Astryx `TabList`, which emits `<nav aria-label="Tabs">` of
  plain buttons with `aria-current="true"`, so `getByRole('tab')` matched
  nothing. Their labels are the full i18n strings ("Keypair Resource
  Policy"), not the bare "Keypair" the spec assumed. This alone accounted for
  7 of the 8 failures.
- The row-action overflow this PR found for *delete* applies to *edit* too —
  but only on Keypair/User. Those lists declare three actions and
  `BAINameActionCell` collapses the surplus into "More actions";
  `ProjectResourcePolicyList` declares two and renders them inline.
  Hard-coding either shape breaks the other, so both now go through one
  `clickRowAction` helper. Without this, fixing the tabs would have broken
  the Project tests as soon as they could reach a row.
- `.ant-table-tbody .ant-table-row` was still present in three tests.
- `getByRole('columnheader', { name: 'Max Folder Count' })` could never
  match: a sortable `BAITable` header's accessible name is its field key
  ("Sort by max_vfolder_count"), which overrides the visible label.
  `name: 'Name'` was matching only by accident, as a substring of "Sort by
  name".

**`dashboard.spec.ts` — two failures this PR does not mention.**

- `:253` — `.ant-select`, the file's last antd residue, is the
  resource-group trigger. `BAISelect` passes `showSearch`, so Astryx
  `Selector` renders a plain button (the combobox is the popup's search
  input) named "Select"; `exact` is required or the panel's info tooltip
  collides.
- `:495` — the panel modal's field is labelled "Data source", not
  "Resource"; the spec guessed the name from the form key `resourceType`.

### Two corrections to this PR's description

**`:478` — the "Healed — re-run verified" claim holds.** It failed in the
first verification run, but passes 6/6 unmodified (alone, `--repeat-each=3`,
in-file under `describe.serial`, and across `e2e/rbac/` in parallel). It
loses a race when the RBAC list takes longer than the test's conditional 3s
probe to resolve: the test then concludes "no system role on page 1" and
clicks a pagination bar that has not rendered yet, burning the 30s
`actionTimeout`. The follow-up waits for the first data row instead.

**`:114` is not a server-side `adminCreateRole` failure.** That diagnosis is
wrong. The mutation returns HTTP 200 with:

```
Invalid scope specified. (scope_id must be a valid UUID for scope_type 'domain', got 'default')
```

The WebUI sends the domain *name*. `client.ts` gates the
`rbac-domain-scope-uuid` feature at manager `26.9.0`, but the test manager
reports `26.8.0rc1` and already enforces the UUID contract — so
`RoleFormModal` picks the legacy `BAIDomainSelect`, which emits the name.
Running the identical flow with **Project** scope succeeds and the modal
closes, which isolates it to the DOMAIN path. This is an app/server interop
defect, not test drift: the only test-side "fix" is to avoid DOMAIN scope,
which would hide it. Left failing on purpose. The real fix is lowering the
gate in `client.ts` or upgrading the manager — neither belongs in an e2e
heal.

### Still out of scope

`rbac-role-crud.spec.ts:199/:287/:333/:384`, the `searchForRole` /
`clearRoleSearch` helpers, and all of `rbac-role-list.spec.ts` /
`rbac-role-detail.spec.ts` remain full of dead antd locators (15 failures in
a parallel `e2e/rbac/` run). The `describe.serial` chain masks them today,
since they are skipped once `:114` fails.

No assertion was weakened, skipped, or deleted anywhere in the follow-up; the
`columnheader` checks are strictly stronger than what they replace.
