### PR TITLE
style(FR-3694): converge metadata lists on BAIMetadataList with a card container

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIMetadataList.css
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.css
@@ -2,76 +2,66 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- `BAIMetadataList` bordered variant (to-astryx approved-2).
+ `BAIMetadataList` paint: a lightened item label (always), plus the `bordered`
+ variant — outer frame + a 1px rule between items, on the list's own layout
+ (no forced side labels, no label-column fill).
 
- ## Why this is CSS and not a theme variant
+ ## Why CSS, not a theme variant
 
- Same three routes as `BAITabList.css`, same answer (`astryx docs styling`,
- `astryx docs theme`):
-
-  1. `xstyle` — StyleX. Not available: this repo has no StyleX compiler
-     (CLAUDE.md: "No StyleX/Tailwind compiler here — don't use xstyle").
-     `MetadataList` does expose `xstyle`, but it lands on the ROOT `<div>`
-     only; every declaration below targets the inner `<dl>` / `<dt>` / `<dd>`,
-     which the component owns and exposes no slot for.
-  2. `defineTheme({ components })` — the systematic route, and the right one
-     for a NEW DEFAULT. It cannot express this, for the same two reasons as
-     the card tab strip: (a) a custom variant key (`'variant:bordered'`) only
-     renders if the component REFLECTS that prop, and `MetadataList` reflects
-     `columns` and `orientation` only (`themeProps('metadata-list', {columns,
-     orientation})` — see the theming table in
-     `astryx component MetadataList`); (b) `metadata-list-item.base` is flat
-     per-component, so it would repaint every metadata list in the app, and
-     the brief is explicitly the opposite — bordered is opt-in, the plain list
-     stays the default.
-  3. `className` + design tokens over the stable `.astryx-*` class surface —
-     "the preferred selector surface for new CSS" (`astryx docs styling`).
-     That is what this file uses. Every rule here is unlayered, so it wins
-     over Astryx's own atomic rules (all of `astryx.css` lives in
-     `@layer astryx-base`) without a specificity fight or `!important`.
-
- `astryx swizzle MetadataList` was rejected on the qa2-a precedent: it forks
- the component source (and with it the show-more/collapse machinery and the
- label-position context) into the repo to change nothing but paint.
-
- ## Metrics — measured from antd (`antd/es/descriptions/style`, default tokens)
-
-   frame          1px solid colorSplit              -> `--border-width` / `--color-border`
-   frame radius   borderRadiusLG        = 8px       -> `--radius-element` (8px, exact)
-   row rule       1px solid colorSplit              -> ditto
-   column rule    1px solid colorSplit (the label's
-                  `border-inline-end`)              -> ditto
-   cell padding   padding / paddingLG   = 16px 24px -> `--spacing-4` `--spacing-6`
-     size=middle  paddingSM / paddingLG = 12px 24px -> `--spacing-3` `--spacing-6`
-     size=small   paddingXS / padding   =  8px 16px -> `--spacing-2` `--spacing-4`
-   label bg       labelBg = colorFillAlter          -> `--color-background-muted`
-   label color    colorTextSecondary                -> `--color-text-secondary`
-                  (already Astryx's `dt` colour — nothing to restate)
-
- Every metric is exact; nothing was rounded to reach a token.
+ `defineTheme({ components })` can't express it: a custom variant key only
+ renders if the component reflects that prop, and `MetadataList` reflects
+ `columns`/`orientation` only; `metadata-list-item.base` is flat per-component,
+ so it would repaint every list, but bordered is opt-in. So this uses
+ `className` + tokens over the stable `.astryx-*` surface (the preferred
+ surface for new CSS). The rules are unlayered, so they win over Astryx's
+ `@layer astryx-base` atomics without `!important`.
 
  ## How the rules are drawn
 
- antd painted a real `<table>`, so it could hang the row rule off
- `-row { border-bottom }` and null it on `:last-child`. Astryx's `<dl>` is a
- GRID, and its "last row" is not addressable: with `columns={2}` a row holds
- four cells, so no `:last-of-type` / `:nth-last-of-type()` formula removes the
- final row's rule without hard-coding the column count into the selector.
+ The `<dl>` is a GRID, and its last row is not addressable (with `columns={2}`
+ a row holds several cells, so no `:nth-last-of-type()` formula drops the final
+ row's rule without hard-coding the column count). So the frame and rules are
+ painted as the GRID GAP: the `<dl>` takes `--color-border` as its background
+ plus a 1px gap and 1px padding, and every direct grid child covers it with an
+ opaque fill. What shows through is exactly a 1px lattice plus a 1px frame, for
+ any column count and any number of rows. Two consequences, both accepted:
 
- So the rules are painted as the GRID GAP instead: the `<dl>` takes
- `--color-border` as its background plus a 1px gap and 1px padding, and the
- cells cover it with opaque fills. What shows through is exactly a 1px lattice
- plus a 1px frame — for any column count and any number of rows, with no
- last-row special case. Two consequences, both accepted:
+  - Cells need an OPAQUE fill (`--bai-metadata-list-cell-bg`, default
+    `--color-background-card`); override it when the list sits on a surface
+    that is not card-coloured.
+  - The frame is padding, not a `border`: `--color-border` is an alpha token,
+    so a border over the background would composite the colour twice and read
+    heavier than the interior rules.
 
-  - Cells need an OPAQUE fill where antd's content cells were transparent.
-    It is `--bai-metadata-list-cell-bg`, defaulting to
-    `--color-background-card`; override that variable when the list sits on a
-    surface that is not card-coloured.
-  - The frame is padding rather than a `border`. `--color-border` is an alpha
-    token, so a border stacked over the background would composite the colour
-    twice and read heavier than the interior rules.
+ The direct grid child differs by layout — the item wrapper `<div>` for stacked
+ labels (multi-column default), the `<dt>`/`<dd>` pair for side labels — so the
+ cell rule targets `> dl > *` rather than a specific tag.
+
+ Cell padding: `--spacing-4`/`--spacing-6` (16/24px), stepped down by `size`
+ to 12/24 (`middle`) and 8/16 (`small`).
 */
+
+/* Label tone. Astryx paints `dt` at `--color-text-secondary` (alpha .65), which
+   reads as heavy as the value next to it; the label is the quieter half of the
+   pair. Mixing that token to 70% lands on alpha .45 — antd's measured
+   `colorTextTertiary` (theme-shim `selfTokens`), which has no CSS-variable
+   counterpart in Astryx's text ramp (it goes secondary .65 -> disabled .25, and
+   `disabled` is the wrong meaning here). Override the variable to retune.
+   Applies with or without `bordered`. */
+.bai-metadata-list {
+  --bai-metadata-list-label-color: color-mix(
+    in srgb,
+    var(--color-text-secondary) 70%,
+    transparent
+  );
+}
+
+/* `dt` is a direct grid child for side labels and sits inside the item wrapper
+   for stacked ones, so both depths are matched. */
+.bai-metadata-list > dl > dt,
+.bai-metadata-list > dl > * > dt {
+  color: var(--bai-metadata-list-label-color);
+}
 
 .bai-metadata-list--bordered {
   --bai-metadata-list-cell-bg: var(--color-background-card);
@@ -105,23 +95,13 @@
   overflow: hidden;
 }
 
-.bai-metadata-list--bordered > dl > dt,
-.bai-metadata-list--bordered > dl > dd {
+/* Every direct grid child is a cell — the item wrapper for stacked labels, the
+   dt/dd pair for side labels — so target `> *`, not a specific tag. */
+.bai-metadata-list--bordered > dl > * {
   padding: var(--bai-metadata-list-cell-padding-block)
     var(--bai-metadata-list-cell-padding-inline);
   background-color: var(--bai-metadata-list-cell-bg);
   /* Astryx pins a 24px floor on the bare cells to keep rows even; a padded
      cell sets its own height and the floor only fights it. */
   min-height: 0;
-}
-
-/* The label fill (`--color-background-muted`, an alpha token, as antd's
-   `colorFillAlter` was) has to sit ON TOP of the opaque cell fill so it reads
-   the same over the frame as it would over the page. `background-image` paints
-   above `background-color`, which is exactly that stack. */
-.bai-metadata-list--bordered > dl > dt {
-  background-image: linear-gradient(
-    var(--color-background-muted),
-    var(--color-background-muted)
-  );
 }

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.css
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.css
@@ -43,15 +43,17 @@
 
 /* Label tone. Astryx paints `dt` at `--color-text-secondary` (alpha .65), which
    reads as heavy as the value next to it; the label is the quieter half of the
-   pair. Mixing that token to 70% lands on alpha .45 — antd's measured
-   `colorTextTertiary` (theme-shim `selfTokens`), which has no CSS-variable
-   counterpart in Astryx's text ramp (it goes secondary .65 -> disabled .25, and
-   `disabled` is the wrong meaning here). Override the variable to retune.
-   Applies with or without `bordered`. */
+   pair. 83% is the lightest mix that still clears WCAG AA for normal text:
+   alpha .539 composites to #757575 on the light card (4.61:1) and #939393 on
+   the dark one (6.00:1). Going further fails light mode — antd's measured
+   `colorTextTertiary` (.45) lands at 3.41:1, which is why that token is not
+   used here despite being the obvious parity value. Override the variable to
+   retune, and re-check both themes if you do. Applies with or without
+   `bordered`. */
 .bai-metadata-list {
   --bai-metadata-list-label-color: color-mix(
     in srgb,
-    var(--color-text-secondary) 70%,
+    var(--color-text-secondary) 83%,
     transparent
   );
 }

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
@@ -12,36 +12,27 @@ const meta: Meta<typeof BAIMetadataList> = {
     docs: {
       description: {
         component: `
-**BAIMetadataList** wraps Astryx's \`MetadataList\` and restores antd's
-\`Descriptions bordered\` look as an opt-in \`bordered\` prop.
+**BAIMetadataList** wraps Astryx's \`MetadataList\` and adds an opt-in
+\`bordered\` prop: an outer frame plus a 1px rule between every item.
 
-Astryx's \`MetadataList\` is where antd \`Descriptions\` landed in the
-conversion, and it covers the plain variant exactly — but it has no
-counterpart for \`bordered\`, so every converted call site dropped the prop.
-This wrapper gives that look back without making it the default: the plain
-list stays the default, and \`bordered\` is a per-surface choice.
+\`bordered\` preserves the list's own layout — it does not force side labels,
+shade the label column, or reflow the grid. It adds only the frame and the
+inter-item separators, on whatever \`columns\`/\`label\` layout the list already
+has (a multi-column list keeps its stacked labels). Off, the component is a
+pass-through and no CSS is reached.
 
-\`bordered\` is purely paint — one class, declarations in
-\`BAIMetadataList.css\`, entirely in design tokens. Without it the component
-is a pass-through and no CSS is reached.
+The paint is one class, declarations in \`BAIMetadataList.css\`, entirely in
+design tokens.
 
 ## Props
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| bordered | \`boolean\` | \`false\` | Frame + label/value cell rules, antd \`Descriptions bordered\` |
-| size | \`'default' \\| 'middle' \\| 'small'\` | \`'default'\` | Bordered cell padding (16/24, 12/24, 8/16px). No effect without \`bordered\`, as in antd |
+| bordered | \`boolean\` | \`false\` | Outer frame + a 1px rule between items; keeps the list's own label layout |
+| size | \`'default' \\| 'middle' \\| 'small'\` | \`'default'\` | Bordered cell padding (16/24, 12/24, 8/16px). No effect without \`bordered\` |
 
 Everything else is \`MetadataList\`'s own surface (\`columns\`, \`label\`,
 \`title\`, \`orientation\`, \`maxNumOfItems\`).
-
-### Bordered implies side labels
-
-antd's bordered layout is a table whose label is always the leading cell, so a
-bordered list defaults to \`label={{ position: 'start' }}\` even at
-multi-column widths, where plain Astryx would stack them. An explicit
-\`label\` still wins; \`position: 'top'\` plus \`bordered\` has no antd
-equivalent and is not styled.
         `,
       },
     },
@@ -82,7 +73,7 @@ export const Plain: Story = {
   render: () => <BAIMetadataList>{POLICY_ITEMS}</BAIMetadataList>,
 };
 
-/** The restored antd `Descriptions bordered` look. */
+/** The bordered look — outer frame + a 1px rule between items. */
 export const Bordered: Story = {
   render: () => <BAIMetadataList bordered>{POLICY_ITEMS}</BAIMetadataList>,
 };

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
@@ -18,10 +18,15 @@ const meta: Meta<typeof BAIMetadataList> = {
 \`bordered\` preserves the list's own layout — it does not force side labels,
 shade the label column, or reflow the grid. It adds only the frame and the
 inter-item separators, on whatever \`columns\`/\`label\` layout the list already
-has (a multi-column list keeps its stacked labels). Off, the component is a
-pass-through and no CSS is reached.
+has (a multi-column list keeps its stacked labels).
 
-The paint is one class, declarations in \`BAIMetadataList.css\`, entirely in
+Independently of \`bordered\`, the wrapper lightens the item label so it reads
+quieter than its value — the base class is always applied, so this is the
+default for every list, \`bordered\` or not. The tone is the lightest mix off
+\`--color-text-secondary\` that still clears WCAG AA in both themes; override
+\`--bai-metadata-list-label-color\` to retune it.
+
+The paint is two classes, declarations in \`BAIMetadataList.css\`, entirely in
 design tokens.
 
 ## Props

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
@@ -2,25 +2,21 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- `BAIMetadataList` — Astryx `MetadataList` plus antd's `Descriptions bordered`
- look (to-astryx approved-2).
+ `BAIMetadataList` — Astryx `MetadataList` with an opt-in `bordered` prop that
+ frames the list and rules a 1px separator between its items.
 
- Astryx's `MetadataList` is the destination the conversion picked for antd
- `Descriptions` (MAPPING §4), and it covers the plain variant exactly. It has
- no counterpart for `bordered`, so every converted call site dropped the prop
- — twenty-odd of them, each with a PILOT-DECISION note saying so
- (`git grep -n bordered origin/main -- react/src` for the
- originals). This wrapper gives that look back as an opt-in `bordered` prop,
- so both variants coexist and adopting it is a per-surface choice rather than
- a global restyle.
+ `bordered` preserves the list's own layout: it does not force side labels,
+ shade the label column, or reflow the grid — it adds only the outer frame and
+ the inter-item separators, on whatever `columns`/`label` layout the list
+ already has.
 
- `bordered` is purely paint: one class, and the declarations live in
- `BAIMetadataList.css`, entirely in design tokens. See that file's header for
- WHY it is CSS and not a `defineTheme` variant, for the antd metric each
- declaration reproduces, and for why the rules are drawn as the grid gap.
+ Independently of `bordered`, the wrapper lightens the item label one step off
+ Astryx's `--color-text-secondary` so it reads quieter than its value; nothing
+ about the layout changes.
 
- Not bordered? The component is a pass-through — no class, no CSS reached, and
- the render is byte-for-byte Astryx's.
+ The paint is one class; declarations live in `BAIMetadataList.css`, entirely
+ in design tokens. See that file's header for why it is CSS and how the rules
+ are drawn as the grid gap.
 */
 import './BAIMetadataList.css';
 import {
@@ -33,33 +29,25 @@ import React, { type ReactNode } from 'react';
 
 export interface BAIMetadataListProps extends MetadataListProps {
   /**
-   * antd `Descriptions.bordered`. Frames the list and rules it into
-   * label/value cells, with the label column on a muted fill.
+   * Frames the whole list and draws a 1px separator between every item.
    *
-   * Bordered implies SIDE labels: antd's bordered layout is a table whose
-   * label is always the leading cell, and the rules only make sense against a
-   * `label`/`value` track pair. So a bordered list defaults to
-   * `label={{ position: 'start' }}` even at multi-column widths, where plain
-   * Astryx would default to stacked labels. An explicit `label` prop still
-   * wins — `position: 'top'` plus `bordered` has no antd equivalent and is not
-   * styled.
+   * It does not change the layout: the label position, `columns` and item
+   * order stay whatever the list already uses (a multi-column list keeps its
+   * stacked labels). Unlike antd `Descriptions bordered`, it neither forces
+   * side labels nor shades the label column — only the frame and the
+   * inter-item rules are added.
    */
   bordered?: boolean;
   /**
-   * antd `Descriptions.size`. Sets the bordered cell padding
-   * (`'default'` 16px/24px, `'middle'` 12px/24px, `'small'` 8px/16px) and has
-   * no effect without `bordered` — as in antd, where `size` only feeds the
-   * bordered cell rules.
+   * Sets the bordered cell padding (`'default'` 16px/24px, `'middle'`
+   * 12px/24px, `'small'` 8px/16px) and has no effect without `bordered`.
    */
   size?: 'default' | 'middle' | 'small';
 }
 
-const SIDE_LABELS = { position: 'start' } as const;
-
 const BAIMetadataList: React.FC<BAIMetadataListProps> = ({
   bordered = false,
   size = 'default',
-  label,
   className,
   children,
   ...metadataListProps
@@ -68,8 +56,8 @@ const BAIMetadataList: React.FC<BAIMetadataListProps> = ({
   return (
     <MetadataList
       {...metadataListProps}
-      label={label ?? (bordered ? SIDE_LABELS : undefined)}
       className={[
+        'bai-metadata-list',
         bordered ? 'bai-metadata-list--bordered' : '',
         bordered && size !== 'default'
           ? `bai-metadata-list--bordered-${size}`

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -223,7 +223,6 @@ const BAITableSettingModal: React.FC<BAITableSettingModalProps> = ({
                 placeholder={String(t('comp:BAITable.SearchTableColumn'))}
                 value={search}
                 onChange={(value) => setSearch(value ?? '')}
-                size="sm"
               />
               <div style={{ maxHeight: 360, overflowY: 'auto' }}>
                 {disableReorder || search ? (

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactDescriptions.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactDescriptions.tsx
@@ -17,11 +17,9 @@
 import { BAIArtifactDescriptionsFragment$key } from '../../__generated__/BAIArtifactDescriptionsFragment.graphql';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAILink from '../BAILink';
+import BAIMetadataList from '../BAIMetadataList';
 import BAIArtifactTypeTag from './BAIArtifactTypeTag';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -53,7 +51,7 @@ const BAIArtifactDescriptions = ({
   );
 
   return (
-    <MetadataList columns="multi">
+    <BAIMetadataList columns="multi">
       <MetadataListItem label={t('comp:BAIArtifactDescriptions.Name')}>
         {artifact.name}
       </MetadataListItem>
@@ -74,7 +72,7 @@ const BAIArtifactDescriptions = ({
           'N/A'
         )}
       </MetadataListItem>
-    </MetadataList>
+    </BAIMetadataList>
   );
 };
 

--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -15,15 +15,13 @@ import SourceCodeView from './SourceCodeView';
 import { Badge } from '@astryxdesign/core/Badge';
 import { Button } from '@astryxdesign/core/Button';
 import { Code } from '@astryxdesign/core/Code';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAICard,
   BAIFlex,
+  BAIMetadataList,
   badgeVariantForTagColor,
   BAIText,
   toLocalId,
@@ -282,7 +280,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
             configuration → health check → pre-start actions → image), not
             the order fields were originally added to this summary — see
             AdminDeploymentPresetSettingPageContent.tsx's Basic Info card. */}
-        <MetadataList columns={1}>
+        <BAIMetadataList columns={1}>
           <MetadataListItem label={t('adminDeploymentPreset.Name')}>
             <Text weight="semibold">{values.name || '-'}</Text>
           </MetadataListItem>
@@ -324,7 +322,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
               '-'
             )}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
 
       {/* Resources */}
@@ -334,7 +332,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         title={t('adminDeploymentPreset.step.Resources')}
         extra={extraSlot(0, 'preset-form-card-resources', resourcesHasError)}
       >
-        <MetadataList columns={1}>
+        <BAIMetadataList columns={1}>
           <MetadataListItem label={t('adminDeploymentPreset.ResourceSlots')}>
             <BAIFlex direction="row" align="start" gap="sm" wrap="wrap">
               <ResourceNumbersOfSession
@@ -377,7 +375,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
           <MetadataListItem label={t('adminDeploymentPreset.ClusterSize')}>
             {values.clusterSize != null ? values.clusterSize : '-'}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
 
       {/* Deployment */}
@@ -390,7 +388,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         {/* Multi-column MetadataList defaults its labels to position: top,
             which reads as a different (vertical) layout from every other
             card here — pin the inline label placement. */}
-        <MetadataList columns={2} label={{ position: 'start' }}>
+        <BAIMetadataList columns={2} label={{ position: 'start' }}>
           <MetadataListItem label={t('adminDeploymentPreset.Replicas')}>
             {values.replicaCount ?? '-'}
           </MetadataListItem>
@@ -406,7 +404,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
                 ? t('button.Yes')
                 : t('button.No')}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
 
       {/* Model & Execution */}
@@ -416,7 +414,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         title={t('adminDeploymentPreset.step.ModelAndExecution')}
         extra={extraSlot(1, 'preset-form-card-model', step2HasError)}
       >
-        <MetadataList columns={1}>
+        <BAIMetadataList columns={1}>
           <MetadataListItem label={t('adminDeploymentPreset.StartupCommand')}>
             {values.startupCommand ? (
               <SourceCodeView language="shell">
@@ -568,7 +566,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
                 </>
               );
             })()}
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
     </BAIFlex>
   );

--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -23,6 +23,7 @@ import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Tab, TabList } from '@astryxdesign/core/TabList';
 import { Text } from '@astryxdesign/core/Text';
 import {
+  BAICard,
   BAIDoubleTag,
   BAIFlex,
   BAIIntervalView,
@@ -107,63 +108,66 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
         <AgentActionButtons agentNodeFrgmt={agent} size="lg" />
       </BAIFlex>
 
-      {/* SUPERSEDED (FR-3496): `bordered` now has a destination — BAIMetadataList.
-          Still dropped: per-item `span`. Column count is `md`-driven (R3). */}
-      <BAIMetadataList bordered columns={md ? 2 : 1}>
-        <MetadataListItem label={t('agent.ResourceGroup')}>
-          {agent?.scaling_group}
-        </MetadataListItem>
-        <MetadataListItem label={t('agent.Region')}>
-          <Text>
-            {regionData.length > 1
-              ? _.join([regionData?.[0], regionData?.[1]], ' / ')
-              : regionData?.[0]}
-          </Text>
-        </MetadataListItem>
-        <MetadataListItem label={t('agent.Schedulable')}>
-          {agent?.schedulable ? (
-            <Check style={{ color: token.colorSuccess }} size="1em" />
-          ) : (
-            <X style={{ color: token.colorTextDisabled }} size="1em" />
-          )}
-        </MetadataListItem>
-        <MetadataListItem label={t('agent.Status')}>
-          <AgentStatusTag agentNodeFrgmt={agent} />
-        </MetadataListItem>
-        <MetadataListItem label={t('agent.ComputePlugins')}>
-          <BAIFlex gap="sm" wrap="wrap">
-            <AgentComputePlugins agentNodeFrgmt={agent} />
-          </BAIFlex>
-        </MetadataListItem>
-        <MetadataListItem label={t('agent.StartsAt')}>
-          <BAIFlex gap="sm">
-            <Text>{dayjs(agent?.first_contact).format('lll')}</Text>
-            {agent?.status === 'ALIVE' && (
-              <BAIIntervalView
-                callback={() => {
-                  return baiClient.utils.elapsedTime(
-                    agent?.first_contact || '',
-                    Date.now(),
-                  );
-                }}
-                delay={1000}
-                render={(intervalValue) => (
-                  <BAIDoubleTag
-                    values={[
-                      { label: t('agent.ElapsedTime') },
-                      { label: intervalValue },
-                    ]}
-                  />
-                )}
-              />
+      {/* Dropped from the antd original: per-item `span`. Column count is
+          `md`-driven (R3). */}
+      <BAICard>
+        <BAIMetadataList columns={md ? 2 : 1}>
+          <MetadataListItem label={t('agent.ResourceGroup')}>
+            {agent?.scaling_group}
+          </MetadataListItem>
+          <MetadataListItem label={t('agent.Region')}>
+            <Text>
+              {regionData.length > 1
+                ? _.join([regionData?.[0], regionData?.[1]], ' / ')
+                : regionData?.[0]}
+            </Text>
+          </MetadataListItem>
+          <MetadataListItem label={t('agent.Schedulable')}>
+            {agent?.schedulable ? (
+              <Check style={{ color: token.colorSuccess }} size="1em" />
+            ) : (
+              <X style={{ color: token.colorTextDisabled }} size="1em" />
             )}
-          </BAIFlex>
-        </MetadataListItem>
-      </BAIMetadataList>
+          </MetadataListItem>
+          <MetadataListItem label={t('agent.Status')}>
+            <AgentStatusTag agentNodeFrgmt={agent} />
+          </MetadataListItem>
+          <MetadataListItem label={t('agent.ComputePlugins')}>
+            <BAIFlex gap="sm" wrap="wrap">
+              <AgentComputePlugins agentNodeFrgmt={agent} />
+            </BAIFlex>
+          </MetadataListItem>
+          <MetadataListItem label={t('agent.StartsAt')}>
+            <BAIFlex gap="sm">
+              <Text>{dayjs(agent?.first_contact).format('lll')}</Text>
+              {agent?.status === 'ALIVE' && (
+                <BAIIntervalView
+                  callback={() => {
+                    return baiClient.utils.elapsedTime(
+                      agent?.first_contact || '',
+                      Date.now(),
+                    );
+                  }}
+                  delay={1000}
+                  render={(intervalValue) => (
+                    <BAIDoubleTag
+                      values={[
+                        { label: t('agent.ElapsedTime') },
+                        { label: intervalValue },
+                      ]}
+                    />
+                  )}
+                />
+              )}
+            </BAIFlex>
+          </MetadataListItem>
+        </BAIMetadataList>
+      </BAICard>
 
       {/* antd Tabs → TabList + Tab (MAPPING §4): navigation only, panel is
           self-rendered below. */}
       <TabList
+        hasDivider
         value={activeTabKey}
         onChange={(key) => {
           setActiveTabKey(key as TabKey);

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -10,6 +10,7 @@ import { Grid } from '@astryxdesign/core/Grid';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
+  BAICard,
   BAIFlex,
   BAIMetadataList,
   BAIText,
@@ -62,342 +63,356 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
 
   return (
     <>
-      {/* SUPERSEDED (FR-3497): `bordered` now has a destination — BAIMetadataList,
-          which implies side labels. Still dropped: `labelStyle` word-break. */}
-      <BAIMetadataList bordered columns="single">
-        <MetadataListItem label={t('agent.ResourceAllocation')}>
-          {/* antd Row gutter={[16,16]} + Col xs={24} sm={12} (uniform 2-up
-              from 576px) → Grid columns={{minWidth:280, max:2}} gap={4}
-              (RESPONSIVE-POLICY R1, container-driven). */}
-          <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
-            {_.map(
-              parsedAvailableSlots,
-              (_value: string | number, key: ResourceSlotName) => {
-                if (key === 'cpu') {
-                  const cpuOccupiedSlot = parseFloat(
-                    parsedOccupiedSlots.cpu ?? '0',
-                  );
-                  const cpuAvailableSlot = parseFloat(
-                    parsedAvailableSlots.cpu ?? '0',
-                  );
-                  return (
-                    <BAIFlex
-                      key={key}
-                      direction="column"
-                      align="stretch"
-                      gap={3}
-                    >
-                      <SimpleProgressWithLabel
-                        key="cpu"
-                        size="default"
-                        title={
-                          <BAIFlex gap="xxs">
-                            <ResourceTypeIcon key={key} type={key} />
-                            {mergedResourceSlots?.['cpu']?.human_readable_name}
-                          </BAIFlex>
-                        }
-                        percent={_.toFinite(
-                          (_.toNumber(parsedOccupiedSlots.cpu ?? 0) /
-                            _.toNumber(parsedAvailableSlots.cpu ?? 1)) *
-                            100,
-                        ).toString()}
-                        description={`${cpuOccupiedSlot} / ${cpuAvailableSlot} ${mergedResourceSlots?.['cpu']?.display_unit}`}
-                      />
-                    </BAIFlex>
-                  );
-                } else if (key === 'mem') {
-                  const memOccupiedSlot = convertToBinaryUnit(
-                    parsedOccupiedSlots.mem || '0',
-                    'g',
-                    0,
-                  );
-                  const memAvailableSlot = convertToBinaryUnit(
-                    parsedAvailableSlots.mem || '0',
-                    'g',
-                    0,
-                  );
-
-                  return (
-                    <BAIFlex
-                      key={key}
-                      direction="column"
-                      align="stretch"
-                      gap={3}
-                    >
-                      <SimpleProgressWithLabel
-                        key={'mem'}
-                        size="default"
-                        title={
-                          <BAIFlex gap="xxs">
-                            <ResourceTypeIcon key={key} type={key} />
-                            {mergedResourceSlots?.['mem']?.human_readable_name}
-                          </BAIFlex>
-                        }
-                        percent={_.toFinite(
-                          ((memOccupiedSlot?.number ?? 0) /
-                            (memAvailableSlot?.number ?? 1)) *
-                            100,
-                        ).toString()}
-                        description={`${toFixedFloorWithoutTrailingZeros(
-                          memOccupiedSlot?.numberFixed || 0,
-                          2,
-                        )}${memOccupiedSlot?.displayUnit} / ${toFixedFloorWithoutTrailingZeros(
-                          memAvailableSlot?.numberFixed || 0,
-                          2,
-                        )}${memAvailableSlot?.displayUnit}`}
-                      />
-                    </BAIFlex>
-                  );
-                } else if (parsedAvailableSlots[key]) {
-                  const roundLength =
-                    mergedResourceSlots?.[key]?.number_format?.round_length ||
-                    0;
-                  const formatSlotValue = (v: string | undefined | number) => {
-                    const str = String(v ?? 0);
-                    return roundLength > 0
-                      ? parseFloat(str).toFixed(roundLength)
-                      : str;
-                  };
-                  return (
-                    <SimpleProgressWithLabel
-                      key={key}
-                      size="default"
-                      title={
-                        <BAIFlex gap="xxs">
-                          <ResourceTypeIcon key={key} type={key} />
-                          {mergedResourceSlots?.[key]?.human_readable_name}
-                        </BAIFlex>
-                      }
-                      percent={_.toFinite(
-                        (_.toNumber(parsedOccupiedSlots[key] ?? 0) /
-                          _.toNumber(parsedAvailableSlots[key] ?? 1)) *
-                          100,
-                      ).toString()}
-                      description={`${formatSlotValue(parsedOccupiedSlots[key])} / ${formatSlotValue(parsedAvailableSlots[key])} ${mergedResourceSlots?.[key]?.display_unit}`}
-                    />
-                  );
-                }
-              },
-            )}
-          </Grid>
-        </MetadataListItem>
-        {!_.isEmpty(agent?.gpu_alloc_map) && (
-          <MetadataListItem label={t('agent.AcceleratorAllocations')}>
-            <Grid columns={{ minWidth: 280, max: 2 }} columnGap={4} rowGap={2}>
+      {/* Dropped from the antd original: `labelStyle` word-break. */}
+      <BAICard>
+        <BAIMetadataList columns="single">
+          <MetadataListItem label={t('agent.ResourceAllocation')}>
+            {/* antd Row gutter={[16,16]} + Col xs={24} sm={12} (uniform 2-up
+                from 576px) → Grid columns={{minWidth:280, max:2}} gap={4}
+                (RESPONSIVE-POLICY R1, container-driven). */}
+            <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
               {_.map(
-                agent?.gpu_alloc_map as Record<string, number> | null,
-                (count, deviceId) => (
-                  <BAIFlex key={deviceId} justify="between" gap="xxs">
-                    <BAIText
-                      ellipsis={{ tooltip: true }}
-                      style={{ maxWidth: 140 }}
-                      copyable
-                    >
-                      {deviceId}
-                    </BAIText>
-                    <BAIText>{count}</BAIText>
-                  </BAIFlex>
-                ),
+                parsedAvailableSlots,
+                (_value: string | number, key: ResourceSlotName) => {
+                  if (key === 'cpu') {
+                    const cpuOccupiedSlot = parseFloat(
+                      parsedOccupiedSlots.cpu ?? '0',
+                    );
+                    const cpuAvailableSlot = parseFloat(
+                      parsedAvailableSlots.cpu ?? '0',
+                    );
+                    return (
+                      <BAIFlex
+                        key={key}
+                        direction="column"
+                        align="stretch"
+                        gap={3}
+                      >
+                        <SimpleProgressWithLabel
+                          key="cpu"
+                          size="default"
+                          title={
+                            <BAIFlex gap="xxs">
+                              <ResourceTypeIcon key={key} type={key} />
+                              {
+                                mergedResourceSlots?.['cpu']
+                                  ?.human_readable_name
+                              }
+                            </BAIFlex>
+                          }
+                          percent={_.toFinite(
+                            (_.toNumber(parsedOccupiedSlots.cpu ?? 0) /
+                              _.toNumber(parsedAvailableSlots.cpu ?? 1)) *
+                              100,
+                          ).toString()}
+                          description={`${cpuOccupiedSlot} / ${cpuAvailableSlot} ${mergedResourceSlots?.['cpu']?.display_unit}`}
+                        />
+                      </BAIFlex>
+                    );
+                  } else if (key === 'mem') {
+                    const memOccupiedSlot = convertToBinaryUnit(
+                      parsedOccupiedSlots.mem || '0',
+                      'g',
+                      0,
+                    );
+                    const memAvailableSlot = convertToBinaryUnit(
+                      parsedAvailableSlots.mem || '0',
+                      'g',
+                      0,
+                    );
+
+                    return (
+                      <BAIFlex
+                        key={key}
+                        direction="column"
+                        align="stretch"
+                        gap={3}
+                      >
+                        <SimpleProgressWithLabel
+                          key={'mem'}
+                          size="default"
+                          title={
+                            <BAIFlex gap="xxs">
+                              <ResourceTypeIcon key={key} type={key} />
+                              {
+                                mergedResourceSlots?.['mem']
+                                  ?.human_readable_name
+                              }
+                            </BAIFlex>
+                          }
+                          percent={_.toFinite(
+                            ((memOccupiedSlot?.number ?? 0) /
+                              (memAvailableSlot?.number ?? 1)) *
+                              100,
+                          ).toString()}
+                          description={`${toFixedFloorWithoutTrailingZeros(
+                            memOccupiedSlot?.numberFixed || 0,
+                            2,
+                          )}${memOccupiedSlot?.displayUnit} / ${toFixedFloorWithoutTrailingZeros(
+                            memAvailableSlot?.numberFixed || 0,
+                            2,
+                          )}${memAvailableSlot?.displayUnit}`}
+                        />
+                      </BAIFlex>
+                    );
+                  } else if (parsedAvailableSlots[key]) {
+                    const roundLength =
+                      mergedResourceSlots?.[key]?.number_format?.round_length ||
+                      0;
+                    const formatSlotValue = (
+                      v: string | undefined | number,
+                    ) => {
+                      const str = String(v ?? 0);
+                      return roundLength > 0
+                        ? parseFloat(str).toFixed(roundLength)
+                        : str;
+                    };
+                    return (
+                      <SimpleProgressWithLabel
+                        key={key}
+                        size="default"
+                        title={
+                          <BAIFlex gap="xxs">
+                            <ResourceTypeIcon key={key} type={key} />
+                            {mergedResourceSlots?.[key]?.human_readable_name}
+                          </BAIFlex>
+                        }
+                        percent={_.toFinite(
+                          (_.toNumber(parsedOccupiedSlots[key] ?? 0) /
+                            _.toNumber(parsedAvailableSlots[key] ?? 1)) *
+                            100,
+                        ).toString()}
+                        description={`${formatSlotValue(parsedOccupiedSlots[key])} / ${formatSlotValue(parsedAvailableSlots[key])} ${mergedResourceSlots?.[key]?.display_unit}`}
+                      />
+                    );
+                  }
+                },
               )}
             </Grid>
           </MetadataListItem>
-        )}
-        {/* PILOT-DECISION: the antd Tooltip+icon-Button explaining
-            "Utilization" lived AFTER the label text (composed inside the
-            Descriptions.Item's ReactNode label). MetadataListItem's `label`
-            is a plain string and its only label-adjacent slot (`icon`)
-            renders BEFORE it — flipped position accepted; the control's
-            purpose (open the detail modal) is unchanged. Tooltip on the
-            never-disabled trigger becomes IconButton's own `tooltip`. */}
-        <MetadataListItem
-          label={t('agent.Utilization')}
-          icon={
-            <IconButton
-              icon={<Info size="1em" />}
-              label={t('agent.DetailedInformation')}
-              tooltip={t('agent.DetailedInformation')}
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setOpenInfoModal(true);
-              }}
-            />
-          }
-        >
-          {_.isEmpty(parsedLiveStat?.node) ? (
-            <BAIText type="secondary">-</BAIText>
-          ) : (
-            <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
-              <SimpleProgressWithLabel
-                key={'cpu_util'}
-                size="default"
-                title={mergedResourceSlots?.cpu?.human_readable_name}
-                percent={(
-                  Math.min(
-                    _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
-                      100 /
-                      (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
-                    1,
-                  ) * 100
-                ).toString()}
-                description={`${toFixedFloorWithoutTrailingZeros(
-                  Math.min(
-                    _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
-                      100 /
-                      (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
-                    1,
-                  ) * 100,
-                  2,
-                )}%`}
-              />
-              <SimpleProgressWithLabel
-                key={'mem'}
-                size="default"
-                title={mergedResourceSlots?.mem?.human_readable_name}
-                percent={toFixedFloorWithoutTrailingZeros(
-                  (parsedLiveStat?.node?.mem?.current /
-                    (parsedAvailableSlots?.mem ||
-                      parsedLiveStat?.node?.mem?.capacity)) *
-                    100 || 0,
-                  2,
-                )}
-                description={`${toFixedFloorWithoutTrailingZeros(
-                  convertToBinaryUnit(
-                    parsedLiveStat?.node?.mem?.current || '0',
-                    convertUnitValue(
-                      _.toString(parsedLiveStat?.node?.mem?.capacity),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.number || 0,
-                  2,
-                )} / ${toFixedFloorWithoutTrailingZeros(
-                  convertToBinaryUnit(
-                    parsedAvailableSlots?.mem ||
-                      parsedLiveStat?.node?.mem?.capacity ||
-                      '0',
-                    convertUnitValue(
-                      _.toString(
-                        parsedAvailableSlots?.mem ||
-                          parsedLiveStat?.node?.mem?.capacity,
-                      ),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.number || 0,
-                  2,
-                )}${
-                  convertToBinaryUnit(
-                    parsedLiveStat?.node?.mem?.capacity || '0',
-                    convertUnitValue(
-                      _.toString(parsedLiveStat?.node?.mem?.capacity),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.displayUnit
-                }  (${toFixedFloorWithoutTrailingZeros(
-                  parsedLiveStat?.node?.mem?.pct || 0,
-                  2,
-                )}%)`}
-              />
-              {_.map(_.keys(parsedLiveStat?.node), (statKey) => {
-                if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
-                  return null;
-                }
-                if (_.includes(statKey, '_util')) {
-                  const deviceName =
-                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                  const current = _.toFinite(
-                    parsedLiveStat?.node?.[statKey]?.current,
-                  );
-                  const capacity =
-                    _.toFinite(parsedLiveStat?.node?.[statKey]?.capacity) ||
-                    100;
-                  const percent = (current / capacity) * 100 || 0;
-                  return (
-                    <SimpleProgressWithLabel
-                      key={statKey}
-                      size="default"
-                      title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(util)`}
-                      percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
-                      description={`${toFixedFloorWithoutTrailingZeros(percent, 1)}%`}
-                    />
-                  );
-                }
-                if (_.includes(statKey, '_mem')) {
-                  const deviceName =
-                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                  const current = _.toFinite(
-                    parsedLiveStat?.node?.[statKey]?.current,
-                  );
-                  const capacity = _.toFinite(
-                    parsedLiveStat?.node?.[statKey]?.capacity,
-                  );
-                  const baseUnit =
-                    convertUnitValue(_.toString(capacity), 'auto')?.unit || 'g';
-                  const percent = (current / capacity) * 100 || 0;
-                  return (
-                    <SimpleProgressWithLabel
-                      key={statKey}
-                      size="default"
-                      title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(mem)`}
-                      percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
-                      description={`${
-                        convertToBinaryUnit(_.toString(current), baseUnit)
-                          ?.numberFixed
-                      } / ${
-                        convertToBinaryUnit(_.toString(capacity), baseUnit)
-                          ?.displayValue
-                      }`}
-                    />
-                  );
-                }
-                if (_.includes(statKey, '_power')) {
-                  const deviceName =
-                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                  const humanReadableName =
-                    mergedResourceSlots?.[deviceName]?.human_readable_name;
-                  return (
-                    <BAIFlex key={statKey} justify="between" gap="xxs">
-                      <BAIText>{`${humanReadableName}(power)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} ${parsedLiveStat?.node?.[statKey]?.unit_hint ?? ''}`}</BAIText>
-                    </BAIFlex>
-                  );
-                }
-                if (_.includes(statKey, '_temperature')) {
-                  const deviceName =
-                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                  const humanReadableName =
-                    mergedResourceSlots?.[deviceName]?.human_readable_name;
-                  return (
-                    <BAIFlex key={statKey} justify="between" gap="xxs">
-                      <BAIText>{`${humanReadableName}(temp)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} °C`}</BAIText>
-                    </BAIFlex>
-                  );
-                }
-                if (['net_rx', 'net_tx'].includes(statKey)) {
-                  const convertedValue = convertToDecimalUnit(
-                    parsedLiveStat?.node?.[statKey]?.current,
-                    'auto',
-                  );
-                  return (
-                    <BAIFlex key={statKey} justify="between" gap="xxs">
-                      <BAIText>
-                        {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
+          {!_.isEmpty(agent?.gpu_alloc_map) && (
+            <MetadataListItem label={t('agent.AcceleratorAllocations')}>
+              <Grid
+                columns={{ minWidth: 280, max: 2 }}
+                columnGap={4}
+                rowGap={2}
+              >
+                {_.map(
+                  agent?.gpu_alloc_map as Record<string, number> | null,
+                  (count, deviceId) => (
+                    <BAIFlex key={deviceId} justify="between" gap="xxs">
+                      <BAIText
+                        ellipsis={{ tooltip: true }}
+                        style={{ maxWidth: 140 }}
+                        copyable
+                      >
+                        {deviceId}
                       </BAIText>
-                      <BAIText>{`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}</BAIText>
+                      <BAIText>{count}</BAIText>
+                    </BAIFlex>
+                  ),
+                )}
+              </Grid>
+            </MetadataListItem>
+          )}
+          {/* PILOT-DECISION: the antd Tooltip+icon-Button explaining
+              "Utilization" lived AFTER the label text (composed inside the
+              Descriptions.Item's ReactNode label). MetadataListItem's `label`
+              is a plain string and its only label-adjacent slot (`icon`)
+              renders BEFORE it — flipped position accepted; the control's
+              purpose (open the detail modal) is unchanged. Tooltip on the
+              never-disabled trigger becomes IconButton's own `tooltip`. */}
+          <MetadataListItem
+            label={t('agent.Utilization')}
+            icon={
+              <IconButton
+                icon={<Info size="1em" />}
+                label={t('agent.DetailedInformation')}
+                tooltip={t('agent.DetailedInformation')}
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setOpenInfoModal(true);
+                }}
+              />
+            }
+          >
+            {_.isEmpty(parsedLiveStat?.node) ? (
+              <BAIText type="secondary">-</BAIText>
+            ) : (
+              <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
+                <SimpleProgressWithLabel
+                  key={'cpu_util'}
+                  size="default"
+                  title={mergedResourceSlots?.cpu?.human_readable_name}
+                  percent={(
+                    Math.min(
+                      _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
+                        100 /
+                        (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
+                      1,
+                    ) * 100
+                  ).toString()}
+                  description={`${toFixedFloorWithoutTrailingZeros(
+                    Math.min(
+                      _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
+                        100 /
+                        (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
+                      1,
+                    ) * 100,
+                    2,
+                  )}%`}
+                />
+                <SimpleProgressWithLabel
+                  key={'mem'}
+                  size="default"
+                  title={mergedResourceSlots?.mem?.human_readable_name}
+                  percent={toFixedFloorWithoutTrailingZeros(
+                    (parsedLiveStat?.node?.mem?.current /
+                      (parsedAvailableSlots?.mem ||
+                        parsedLiveStat?.node?.mem?.capacity)) *
+                      100 || 0,
+                    2,
+                  )}
+                  description={`${toFixedFloorWithoutTrailingZeros(
+                    convertToBinaryUnit(
+                      parsedLiveStat?.node?.mem?.current || '0',
+                      convertUnitValue(
+                        _.toString(parsedLiveStat?.node?.mem?.capacity),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.number || 0,
+                    2,
+                  )} / ${toFixedFloorWithoutTrailingZeros(
+                    convertToBinaryUnit(
+                      parsedAvailableSlots?.mem ||
+                        parsedLiveStat?.node?.mem?.capacity ||
+                        '0',
+                      convertUnitValue(
+                        _.toString(
+                          parsedAvailableSlots?.mem ||
+                            parsedLiveStat?.node?.mem?.capacity,
+                        ),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.number || 0,
+                    2,
+                  )}${
+                    convertToBinaryUnit(
+                      parsedLiveStat?.node?.mem?.capacity || '0',
+                      convertUnitValue(
+                        _.toString(parsedLiveStat?.node?.mem?.capacity),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.displayUnit
+                  }  (${toFixedFloorWithoutTrailingZeros(
+                    parsedLiveStat?.node?.mem?.pct || 0,
+                    2,
+                  )}%)`}
+                />
+                {_.map(_.keys(parsedLiveStat?.node), (statKey) => {
+                  if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
+                    return null;
+                  }
+                  if (_.includes(statKey, '_util')) {
+                    const deviceName =
+                      _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                    const current = _.toFinite(
+                      parsedLiveStat?.node?.[statKey]?.current,
+                    );
+                    const capacity =
+                      _.toFinite(parsedLiveStat?.node?.[statKey]?.capacity) ||
+                      100;
+                    const percent = (current / capacity) * 100 || 0;
+                    return (
+                      <SimpleProgressWithLabel
+                        key={statKey}
+                        size="default"
+                        title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(util)`}
+                        percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
+                        description={`${toFixedFloorWithoutTrailingZeros(percent, 1)}%`}
+                      />
+                    );
+                  }
+                  if (_.includes(statKey, '_mem')) {
+                    const deviceName =
+                      _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                    const current = _.toFinite(
+                      parsedLiveStat?.node?.[statKey]?.current,
+                    );
+                    const capacity = _.toFinite(
+                      parsedLiveStat?.node?.[statKey]?.capacity,
+                    );
+                    const baseUnit =
+                      convertUnitValue(_.toString(capacity), 'auto')?.unit ||
+                      'g';
+                    const percent = (current / capacity) * 100 || 0;
+                    return (
+                      <SimpleProgressWithLabel
+                        key={statKey}
+                        size="default"
+                        title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(mem)`}
+                        percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
+                        description={`${
+                          convertToBinaryUnit(_.toString(current), baseUnit)
+                            ?.numberFixed
+                        } / ${
+                          convertToBinaryUnit(_.toString(capacity), baseUnit)
+                            ?.displayValue
+                        }`}
+                      />
+                    );
+                  }
+                  if (_.includes(statKey, '_power')) {
+                    const deviceName =
+                      _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                    const humanReadableName =
+                      mergedResourceSlots?.[deviceName]?.human_readable_name;
+                    return (
+                      <BAIFlex key={statKey} justify="between" gap="xxs">
+                        <BAIText>{`${humanReadableName}(power)`}</BAIText>
+                        <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} ${parsedLiveStat?.node?.[statKey]?.unit_hint ?? ''}`}</BAIText>
+                      </BAIFlex>
+                    );
+                  }
+                  if (_.includes(statKey, '_temperature')) {
+                    const deviceName =
+                      _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                    const humanReadableName =
+                      mergedResourceSlots?.[deviceName]?.human_readable_name;
+                    return (
+                      <BAIFlex key={statKey} justify="between" gap="xxs">
+                        <BAIText>{`${humanReadableName}(temp)`}</BAIText>
+                        <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} °C`}</BAIText>
+                      </BAIFlex>
+                    );
+                  }
+                  if (['net_rx', 'net_tx'].includes(statKey)) {
+                    const convertedValue = convertToDecimalUnit(
+                      parsedLiveStat?.node?.[statKey]?.current,
+                      'auto',
+                    );
+                    return (
+                      <BAIFlex key={statKey} justify="between" gap="xxs">
+                        <BAIText>
+                          {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
+                        </BAIText>
+                        <BAIText>{`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}</BAIText>
+                      </BAIFlex>
+                    );
+                  }
+                  return (
+                    <BAIFlex key={statKey} justify="between" gap="xxs">
+                      <BAIText>{statKey}</BAIText>
+                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current ?? 0, 2)}${parsedLiveStat?.node?.[statKey]?.unit_hint ? ` ${parsedLiveStat?.node?.[statKey]?.unit_hint}` : ''}`}</BAIText>
                     </BAIFlex>
                   );
-                }
-                return (
-                  <BAIFlex key={statKey} justify="between" gap="xxs">
-                    <BAIText>{statKey}</BAIText>
-                    <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current ?? 0, 2)}${parsedLiveStat?.node?.[statKey]?.unit_hint ? ` ${parsedLiveStat?.node?.[statKey]?.unit_hint}` : ''}`}</BAIText>
-                  </BAIFlex>
-                );
-              })}
-            </Grid>
-          )}
-        </MetadataListItem>
-      </BAIMetadataList>
+                })}
+              </Grid>
+            )}
+          </MetadataListItem>
+        </BAIMetadataList>
+      </BAICard>
       <AgentDetailModal
         agentNodeFrgmt={agent}
         open={openInfoModal}

--- a/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
@@ -13,12 +13,14 @@ import { useSetBAINotification } from '../../hooks/useBAINotification';
 // `onChange`).
 import { AstryxFormTextInput } from '../astryxFormControls';
 import { Divider } from '@astryxdesign/core/Divider';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  BAIMetadataList,
+  BAIModal,
+  BAIModalProps,
+} from 'backend.ai-ui';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -120,7 +122,7 @@ const ContainerCommitModal: React.FC<ContainerCommitModalProps> = ({
         style={{ overflow: 'hidden' }}
       >
         <Text>{t('session.DescCommitSession')}</Text>
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('session.SessionName')}>
             {session?.name}
           </MetadataListItem>
@@ -128,7 +130,7 @@ const ContainerCommitModal: React.FC<ContainerCommitModalProps> = ({
             {session?.row_id}
           </MetadataListItem>
           {/* FIXME: need to use legacy_session */}
-        </MetadataList>
+        </BAIMetadataList>
         <Divider />
         <Form ref={formRef}>
           <Form.Item

--- a/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
@@ -8,11 +8,13 @@ import { useTanQuery } from '../../hooks/reactQueryAlias';
 import SourceCodeView from '../SourceCodeView';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Heading } from '@astryxdesign/core/Heading';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+  BAIFlex,
+  BAIMetadataList,
+  BAIModal,
+  BAIModalProps,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation, Trans } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -124,7 +126,7 @@ const SFTPConnectionInfoModal: React.FC<SFTPConnectionInfoModalProps> = ({
           }
         />
 
-        <MetadataList
+        <BAIMetadataList
           title={t('session.ConnectionInformation')}
           columns="single"
           label={{ position: 'start', width: 60 }}
@@ -136,7 +138,7 @@ const SFTPConnectionInfoModal: React.FC<SFTPConnectionInfoModalProps> = ({
           <MetadataListItem label={t('session.Port')}>
             {displayPorts}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
         <BAIFlex
           direction="column"
           align="stretch"

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
@@ -7,13 +7,16 @@ import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';
 import SessionStatusTag from './SessionStatusTag';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import * as stylex from '@stylexjs/stylex';
-import { BAIFlex, BAIModal, type BAIModalProps, BAIText } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  BAIMetadataList,
+  BAIModal,
+  type BAIModalProps,
+  BAIText,
+} from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { CircleCheck, CircleX } from 'lucide-react';
@@ -114,7 +117,7 @@ const SessionStatusDetailModal: React.FC<SessionStatusDetailModalProps> = ({
           PILOT-DECISION: `size="small"` and `Descriptions.Item span` have no
           MetadataList equivalent (MAPPING.md §4) and are dropped; the nested
           "Predicate checks" Descriptions collapses into a labeled item. */}
-      <MetadataList columns="single">
+      <BAIMetadataList columns="single">
         <MetadataListItem label={t('session.SessionName')}>
           <BAIText copyable ellipsis={{ tooltip: true }}>
             {session.name ?? ''}
@@ -215,7 +218,7 @@ const SessionStatusDetailModal: React.FC<SessionStatusDetailModalProps> = ({
               );
             })
           : null}
-      </MetadataList>
+      </BAIMetadataList>
     </BAIModal>
   );
 };

--- a/react/src/components/ComputeSessionNodeItems/TCPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TCPConnectionInfoModal.tsx
@@ -2,11 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
-import { BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
+import { BAIMetadataList, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
 
 interface TCPConnectionInfoModalProps extends BAIModalProps {
@@ -31,13 +28,16 @@ const TCPConnectionInfoModal: React.FC<TCPConnectionInfoModalProps> = ({
       footer={null}
       {...modalProps}
     >
-      <MetadataList columns="single" title={t('session.ConnectionInformation')}>
+      <BAIMetadataList
+        columns="single"
+        title={t('session.ConnectionInformation')}
+      >
         <MetadataListItem label={t('environment.AppName')}>
           {appName}
         </MetadataListItem>
         <MetadataListItem label={t('session.Host')}>{host}</MetadataListItem>
         <MetadataListItem label={t('session.Port')}>{port}</MetadataListItem>
-      </MetadataList>
+      </BAIMetadataList>
     </BAIModal>
   );
 };

--- a/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
@@ -4,11 +4,13 @@
  */
 import { Banner } from '@astryxdesign/core/Banner';
 import { Link } from '@astryxdesign/core/Link';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+  BAIFlex,
+  BAIMetadataList,
+  BAIModal,
+  BAIModalProps,
+} from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
 
 interface VNCConnectionInfoModalProps extends BAIModalProps {
@@ -30,7 +32,7 @@ const VNCConnectionInfoModal: React.FC<VNCConnectionInfoModalProps> = ({
     <BAIModal title={t('session.VNCconnection')} footer={null} {...modalProps}>
       <BAIFlex direction="column" align="stretch" gap="md">
         <Banner status="info" title={t('session.UseYourFavoriteVNCApp')} />
-        <MetadataList
+        <BAIMetadataList
           columns="single"
           title={t('session.ConnectionInformation')}
         >
@@ -39,7 +41,7 @@ const VNCConnectionInfoModal: React.FC<VNCConnectionInfoModalProps> = ({
               {vncDisplayUrl}
             </Link>
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAIFlex>
     </BAIModal>
   );

--- a/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
@@ -7,14 +7,12 @@ import { useTanQuery } from '../../hooks/reactQueryAlias';
 import SourceCodeView from '../SourceCodeView';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAISkeleton,
   BAIFlex,
+  BAIMetadataList,
   BAIModal,
   BAIModalProps,
   BAIText,
@@ -82,7 +80,7 @@ const VSCodeDesktopConnectionModal: React.FC<
         <BAIFlex direction="column" gap="xs" align="stretch">
           <Text weight="semibold">{t('session.ConnectionInformation')}</Text>
           {status === 'success' ? (
-            <MetadataList
+            <BAIMetadataList
               columns="single"
               label={{ position: 'start', width: 210 }}
             >
@@ -91,7 +89,7 @@ const VSCodeDesktopConnectionModal: React.FC<
                   {password ?? ''}
                 </BAIText>
               </MetadataListItem>
-            </MetadataList>
+            </BAIMetadataList>
           ) : status === 'pending' ? (
             <BAISkeleton variant="input" />
           ) : (

--- a/react/src/components/ComputeSessionNodeItems/XRDPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/XRDPConnectionInfoModal.tsx
@@ -4,11 +4,13 @@
  */
 import { Banner } from '@astryxdesign/core/Banner';
 import { Link } from '@astryxdesign/core/Link';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+  BAIFlex,
+  BAIMetadataList,
+  BAIModal,
+  BAIModalProps,
+} from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
 
 interface XRDPConnectionInfoModalProps extends BAIModalProps {
@@ -30,7 +32,7 @@ const XRDPConnectionInfoModal: React.FC<XRDPConnectionInfoModalProps> = ({
     <BAIModal title={t('session.XRDPconnection')} footer={null} {...modalProps}>
       <BAIFlex direction="column" align="stretch" gap="md">
         <Banner status="info" title={t('session.UseYourFavoriteMSTSCApp')} />
-        <MetadataList
+        <BAIMetadataList
           columns="single"
           title={t('session.ConnectionInformation')}
         >
@@ -39,7 +41,7 @@ const XRDPConnectionInfoModal: React.FC<XRDPConnectionInfoModalProps> = ({
               {rdpUrl}
             </Link>
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAIFlex>
     </BAIModal>
   );

--- a/react/src/components/DeploymentBasicInfoCard.tsx
+++ b/react/src/components/DeploymentBasicInfoCard.tsx
@@ -18,10 +18,7 @@ import DeploymentSettingModal from './DeploymentSettingModal';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAIButton,
@@ -32,6 +29,7 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIId,
+  BAIMetadataList,
   BAIText,
   BAIUnmountAfterClose,
   BooleanTag,
@@ -87,7 +85,7 @@ const DeploymentOverviewContent: React.FC<{
   // is the design, and the container-driven layout handles narrow widths.
   // Rendered with the wide-case `columns={2}`.
   return (
-    <MetadataList columns={2}>
+    <BAIMetadataList columns={2}>
       <MetadataListItem label={t('deployment.Lifecycle')}>
         {deployment?.metadata.status ? (
           <BAIFlex align="center" gap="xs">
@@ -174,7 +172,7 @@ const DeploymentOverviewContent: React.FC<{
           fallback={renderFallback()}
         />
       </MetadataListItem>
-    </MetadataList>
+    </BAIMetadataList>
   );
 };
 

--- a/react/src/components/DeploymentPresetDetailModal.tsx
+++ b/react/src/components/DeploymentPresetDetailModal.tsx
@@ -6,14 +6,12 @@ import type { DeploymentPresetDetailModalFragment$key } from '../__generated__/D
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
 import { ResourceAllocationFormValue } from './SessionFormItems/ResourceAllocationFormItems';
 import { Heading } from '@astryxdesign/core/Heading';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAICard,
   BAIFlex,
+  BAIMetadataList,
   BAIModal,
   BAIModalProps,
   BAIText,
@@ -158,7 +156,7 @@ const DeploymentPresetDetailModal: React.FC<
             title={t('adminDeploymentPreset.SectionImage')}
             styles={{ body: { paddingTop: 0 } }}
           >
-            <MetadataList columns={1}>
+            <BAIMetadataList columns={1}>
               <MetadataListItem label={t('adminDeploymentPreset.Image')}>
                 {imageCanonicalName ? (
                   <BAIText copyable>{imageCanonicalName}</BAIText>
@@ -169,21 +167,21 @@ const DeploymentPresetDetailModal: React.FC<
               <MetadataListItem label={t('adminDeploymentPreset.Runtime')}>
                 {preset.runtimeVariant?.name ?? preset.runtimeVariantId}
               </MetadataListItem>
-            </MetadataList>
+            </BAIMetadataList>
           </BAICard>
           <BAICard
             size="small"
             title={t('adminDeploymentPreset.SectionCluster')}
             styles={{ body: { paddingTop: 0 } }}
           >
-            <MetadataList columns={2}>
+            <BAIMetadataList columns={2}>
               <MetadataListItem label={t('adminDeploymentPreset.ClusterMode')}>
                 {preset.cluster?.clusterMode || '-'}
               </MetadataListItem>
               <MetadataListItem label={t('adminDeploymentPreset.ClusterSize')}>
                 {preset.cluster?.clusterSize ?? '-'}
               </MetadataListItem>
-            </MetadataList>
+            </BAIMetadataList>
           </BAICard>
           <BAICard
             size="small"
@@ -207,7 +205,7 @@ const DeploymentPresetDetailModal: React.FC<
               />
               {(preset.resource?.resourceOpts?.filter((o) => o.name !== 'shmem')
                 .length ?? 0) > 0 && (
-                <MetadataList columns={2}>
+                <BAIMetadataList columns={2}>
                   {(preset.resource?.resourceOpts ?? [])
                     .filter((opt) => opt.name !== 'shmem')
                     .map((opt) => (
@@ -215,7 +213,7 @@ const DeploymentPresetDetailModal: React.FC<
                         {opt.value}
                       </MetadataListItem>
                     ))}
-                </MetadataList>
+                </BAIMetadataList>
               )}
             </BAIFlex>
           </BAICard>
@@ -224,7 +222,7 @@ const DeploymentPresetDetailModal: React.FC<
             title={t('adminDeploymentPreset.SectionDeploymentDefaults')}
             styles={{ body: { paddingTop: 0 } }}
           >
-            <MetadataList columns={2}>
+            <BAIMetadataList columns={2}>
               <MetadataListItem label={t('adminDeploymentPreset.Replicas')}>
                 {preset.deploymentDefaults?.replicaCount ?? '-'}
               </MetadataListItem>
@@ -243,7 +241,7 @@ const DeploymentPresetDetailModal: React.FC<
                     : t('button.No')
                   : '-'}
               </MetadataListItem>
-            </MetadataList>
+            </BAIMetadataList>
           </BAICard>
           {hasServiceConfig && (
             <BAICard
@@ -251,7 +249,7 @@ const DeploymentPresetDetailModal: React.FC<
               title={t('adminDeploymentPreset.SectionHealthCheck')}
               styles={{ body: { paddingTop: 0 } }}
             >
-              <MetadataList columns={isHealthCheckEnabled ? 2 : 1}>
+              <BAIMetadataList columns={isHealthCheckEnabled ? 2 : 1}>
                 <MetadataListItem
                   label={t('adminDeploymentPreset.modelDef.EnableHealthCheck')}
                 >
@@ -305,7 +303,7 @@ const DeploymentPresetDetailModal: React.FC<
                     </MetadataListItem>
                   </>
                 )}
-              </MetadataList>
+              </BAIMetadataList>
             </BAICard>
           )}
         </BAIFlex>

--- a/react/src/components/DeploymentRevisionDetail.tsx
+++ b/react/src/components/DeploymentRevisionDetail.tsx
@@ -14,14 +14,13 @@ import './DeploymentRevisionDetail.css';
 import FolderLink from './FolderLink';
 import SourceCodeView from './SourceCodeView';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
+  BAICard,
   BAIFlex,
   BAIId,
+  BAIMetadataList,
   BAIResourceNumberWithIcon,
   BAIText,
   filterOutEmpty,
@@ -602,17 +601,19 @@ const DeploymentRevisionDetail: React.FC<{
   });
 
   return (
-    <MetadataList
-      className="deployment-revision-detail-metadata"
-      columns={screens.md ? 2 : 1}
-      label={{ position: 'start', width: screens.md ? 160 : 120 }}
-    >
-      {[...baseItems, ...modelItems].map((item) => (
-        <MetadataListItem key={item.key} label={item.label}>
-          {item.children}
-        </MetadataListItem>
-      ))}
-    </MetadataList>
+    <BAICard>
+      <BAIMetadataList
+        className="deployment-revision-detail-metadata"
+        columns={screens.md ? 2 : 1}
+        label={{ position: 'start', width: screens.md ? 160 : 120 }}
+      >
+        {[...baseItems, ...modelItems].map((item) => (
+          <MetadataListItem key={item.key} label={item.label}>
+            {item.children}
+          </MetadataListItem>
+        ))}
+      </BAIMetadataList>
+    </BAICard>
   );
 };
 

--- a/react/src/components/DownloadModal.tsx
+++ b/react/src/components/DownloadModal.tsx
@@ -12,15 +12,13 @@ import SourceCodeView from './SourceCodeView';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { Divider } from '@astryxdesign/core/Divider';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Selector } from '@astryxdesign/core/Selector';
 import { Text } from '@astryxdesign/core/Text';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIFlex,
+  BAIMetadataList,
   BAIModal,
   BAIModalProps,
   filterOutEmpty,
@@ -40,7 +38,7 @@ const DesktopAppDownloadTab: React.FC = () => {
     // antd `Descriptions column={1} bordered` -> Astryx `MetadataList
     // columns="single"` (MAPPING §4). `bordered` has NO destination and is
     // dropped: MetadataList lays out label/value rows without a grid frame.
-    <MetadataList columns="single">
+    <BAIMetadataList columns="single">
       <MetadataListItem label={t('summary.OS')}>
         {/* antd `Select` with `Select.Option` children -> `Selector` with an
             `options` array; `label` is required and hidden because the
@@ -81,7 +79,7 @@ const DesktopAppDownloadTab: React.FC = () => {
           ))}
         </BAIFlex>
       </MetadataListItem>
-    </MetadataList>
+    </BAIMetadataList>
   );
 };
 
@@ -154,7 +152,7 @@ const CLIDownloadTab: React.FC = () => {
         <>
           <BAIFlex direction="column" align="stretch" gap="sm">
             <Text weight="semibold">{t('summary.CLIDownloadExecutable')}</Text>
-            <MetadataList columns="single">
+            <BAIMetadataList columns="single">
               <MetadataListItem label={t('summary.OS')}>
                 <Selector
                   label={t('summary.OS')}
@@ -191,7 +189,7 @@ const CLIDownloadTab: React.FC = () => {
                   ))}
                 </BAIFlex>
               </MetadataListItem>
-            </MetadataList>
+            </BAIMetadataList>
             {selectedOS === 'MacOS' ? (
               <Banner
                 status="warning"

--- a/react/src/components/FairShareItems/UsageBucketModal.tsx
+++ b/react/src/components/FairShareItems/UsageBucketModal.tsx
@@ -9,14 +9,12 @@ import UsageBucketChartContent from './UsageBucketChartContent';
 import type { ISODateString } from '@astryxdesign/core/Calendar';
 import { DateRangeInput } from '@astryxdesign/core/DateRangeInput';
 import type { DateRange } from '@astryxdesign/core/DateRangeInput';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
   BAISkeleton,
   BAIFetchKeyButton,
   BAIFlex,
+  BAIMetadataList,
   BAIModal,
   BAIModalProps,
   BAITagList,
@@ -229,7 +227,7 @@ const UsageBucketModal: React.FC<UsageBucketModalProps> = ({
         {/* antd `Descriptions items` → `MetadataList` children (MAPPING §4).
             `size="small"` has no destination and is dropped; `column={1}` is
             `columns="single"`. */}
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           {selectedResourceGroupName ? (
             <MetadataListItem label={t('fairShare.ResourceGroup')}>
               {selectedResourceGroupName}
@@ -275,7 +273,7 @@ const UsageBucketModal: React.FC<UsageBucketModalProps> = ({
               />
             </MetadataListItem>
           ) : null}
-        </MetadataList>
+        </BAIMetadataList>
 
         <Suspense fallback={<BAISkeleton variant="paragraph" rows={8} />}>
           <UsageBucketChartContent

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -19,12 +19,10 @@ import VFolderPermissionCell from './VFolderPermissionCell';
 import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { List, ListItem } from '@astryxdesign/core/List';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack } from '@astryxdesign/core/Stack';
 import {
+  BAIMetadataList,
   BAIModal,
   type BAIModalProps,
   useErrorMessageResolver,
@@ -66,14 +64,14 @@ const FolderInvitationResponseModal: React.FC<
       label={item.vfolder_name ?? ''}
       startContent={<FolderIcon size="1em" />}
       description={
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('data.From')}>
             {item.inviter_user_email || item.inviter || '-'}
           </MetadataListItem>
           <MetadataListItem label={t('data.Permission')}>
             <VFolderPermissionCell permission={item.perm} />
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       }
       endContent={
         <HStack gap={2}>

--- a/react/src/components/InferenceSessionErrorModal.tsx
+++ b/react/src/components/InferenceSessionErrorModal.tsx
@@ -4,11 +4,13 @@
  */
 import { InferenceSessionErrorModalFragment$key } from '../__generated__/InferenceSessionErrorModalFragment.graphql';
 import { Button } from '@astryxdesign/core/Button';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
-import { BAIModal, BAIModalProps, BAIText } from 'backend.ai-ui';
+  BAIMetadataList,
+  BAIModal,
+  BAIModalProps,
+  BAIText,
+} from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -59,7 +61,7 @@ const InferenceSessionErrorModal: React.FC<Props> = ({
           breakpoint-map `column` collapses to `columns="single"` because every
           breakpoint asked for one column anyway; `labelStyle.minWidth` becomes
           the `label.width` budget. */}
-      <MetadataList
+      <BAIMetadataList
         columns="single"
         label={{ position: 'start', width: 100 }}
         style={{ marginTop: 20 }}
@@ -72,7 +74,7 @@ const InferenceSessionErrorModal: React.FC<Props> = ({
         <MetadataListItem label={t('dialog.error.Error')}>
           {iSessionError?.errors[0].repr}
         </MetadataListItem>
-      </MetadataList>
+      </BAIMetadataList>
     </BAIModal>
   );
 };

--- a/react/src/components/Information.tsx
+++ b/react/src/components/Information.tsx
@@ -6,16 +6,12 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import DescriptionLabel from './DescriptionLabel';
 import { Badge } from '@astryxdesign/core/Badge';
-import { Card } from '@astryxdesign/core/Card';
 import { Grid } from '@astryxdesign/core/Grid';
 import { Icon } from '@astryxdesign/core/Icon';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Overlay } from '@astryxdesign/core/Overlay';
 import { Spinner } from '@astryxdesign/core/Spinner';
-import { BAIDoubleTag, BAIFlex } from 'backend.ai-ui';
+import { BAICard, BAIDoubleTag, BAIFlex, BAIMetadataList } from 'backend.ai-ui';
 import { Check, TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -57,8 +53,8 @@ const Information: React.FC<InformationProps> = () => {
           column flow is adopted everywhere in this area instead (same
           decision as tickets 16/18: "drop the column map"). */}
       <Grid columns={{ minWidth: 360, max: 2 }} gap={4}>
-        <Card>
-          <MetadataList title={t('information.Core')}>
+        <BAICard>
+          <BAIMetadataList title={t('information.Core')}>
             <MetadataListItem label={t('information.ManagerVersion')}>
               <BAIFlex direction="column" gap="xxs" align="start">
                 Backend.AI {baiClient.managerVersion}
@@ -73,10 +69,10 @@ const Information: React.FC<InformationProps> = () => {
             <MetadataListItem label={t('information.APIVersion')}>
               {baiClient.apiVersion}
             </MetadataListItem>
-          </MetadataList>
-        </Card>
-        <Card>
-          <MetadataList title={t('information.Security')}>
+          </BAIMetadataList>
+        </BAICard>
+        <BAICard>
+          <BAIMetadataList title={t('information.Security')}>
             <MetadataListItem
               label={t('information.DefaultAdministratorAccountChanged')}
               icon={
@@ -116,12 +112,12 @@ const Information: React.FC<InformationProps> = () => {
                 />
               )}
             </MetadataListItem>
-          </MetadataList>
-        </Card>
+          </BAIMetadataList>
+        </BAICard>
       </Grid>
 
-      <Card>
-        <MetadataList title={t('information.Component')}>
+      <BAICard>
+        <BAIMetadataList title={t('information.Component')}>
           <MetadataListItem
             label={t('information.DockerVersion')}
             icon={
@@ -159,15 +155,15 @@ const Information: React.FC<InformationProps> = () => {
           >
             <Badge label={t('information.Compatible')} variant="neutral" />
           </MetadataListItem>
-        </MetadataList>
-      </Card>
-      <Card>
+        </BAIMetadataList>
+      </BAICard>
+      <BAICard>
         <Overlay
           isOpen={isLoadingLicenseInfo}
           scrim="light"
           content={<Spinner label={t('general.Loading')} />}
         >
-          <MetadataList title={t('information.License')}>
+          <BAIMetadataList title={t('information.License')}>
             <MetadataListItem
               label={t('information.IsLicenseValid')}
               icon={
@@ -230,9 +226,9 @@ const Information: React.FC<InformationProps> = () => {
             >
               <Badge label={licenseInfo.expiration} variant="neutral" />
             </MetadataListItem>
-          </MetadataList>
+          </BAIMetadataList>
         </Overlay>
-      </Card>
+      </BAICard>
     </BAIFlex>
   );
 };

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -5,13 +5,11 @@
 import { KeypairInfoModalFragment$key } from '../__generated__/KeypairInfoModalFragment.graphql';
 import { KeypairInfoModalQuery } from '../__generated__/KeypairInfoModalQuery.graphql';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
 import {
+  BAIMetadataList,
   BAIModal,
   type BAIModalProps,
   PRIMARY_TAG_VARIANT,
@@ -93,7 +91,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
       {/* PILOT-DECISION: `<br />` between the two Descriptions blocks →
           VStack gap (MetadataList has no built-in inter-list spacing). */}
       <VStack align="stretch" gap={4}>
-        <MetadataList
+        <BAIMetadataList
           title={t('credential.Information')}
           label={{ position: 'start', width: '40%' }}
         >
@@ -127,8 +125,8 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
           <MetadataListItem label={t('credential.LastUsed')}>
             {keypair?.last_used ? dayjs(keypair?.last_used).format('lll') : '-'}
           </MetadataListItem>
-        </MetadataList>
-        <MetadataList
+        </BAIMetadataList>
+        <BAIMetadataList
           title={t('credential.Allocation')}
           label={{ position: 'start', width: '40%' }}
         >
@@ -146,7 +144,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
           >
             {keypair?.rate_limit}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </VStack>
     </BAIModal>
   );

--- a/react/src/components/KeypairResourcePolicyInfoModal.tsx
+++ b/react/src/components/KeypairResourcePolicyInfoModal.tsx
@@ -204,18 +204,7 @@ const KeypairResourcePolicyInfoModal: React.FC<InfoModalProps> = ({
       width={BAI_BREAKPOINTS.sm}
       {...modalProps}
     >
-      {/*
-        `bordered` is back (to-astryx approved-2). On main this was
-        `<Descriptions bordered column={1} items={descriptionItems} />`; the
-        conversion had to drop `bordered` because Astryx's `MetadataList` has
-        no counterpart, and this modal is the surface where the loss showed
-        most — nineteen unruled label/value pairs in a scrolling dialog read as
-        one undifferentiated block. `BAIMetadataList` restores exactly that
-        column={1} bordered table. It is opt-in, so this is the only surface
-        adopting it for now; the rest of the converted `Descriptions` sites are
-        a deliberate follow-up choice, not an oversight.
-      */}
-      <BAIMetadataList bordered>
+      <BAIMetadataList>
         {descriptionItems.map((item) => (
           <MetadataListItem key={item.key} label={item.label}>
             {item.children}

--- a/react/src/components/LaunchMultipleSessionsModal.tsx
+++ b/react/src/components/LaunchMultipleSessionsModal.tsx
@@ -10,13 +10,11 @@ import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemain
 import { theme } from '../theme-shim';
 import { ResourceAllocationFormValue } from './SessionFormItems/ResourceAllocationFormItems';
 import { AstryxFormNumberInput } from './astryxFormControls';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAIFlex,
+  BAIMetadataList,
   BAIModal,
   BAIModalProps,
   convertToBinaryUnit,
@@ -237,7 +235,7 @@ const LaunchMultipleSessionsModal: React.FC<
                 // `column={1}` → `columns="single"`, `styles.label.width` →
                 // `label.width`; `size="small"` and `colon={false}` have no
                 // destination (MetadataList renders no colon anyway).
-                <MetadataList
+                <BAIMetadataList
                   columns="single"
                   label={{ position: 'start', width: 160 }}
                 >
@@ -284,7 +282,7 @@ const LaunchMultipleSessionsModal: React.FC<
                       />
                     </BAIFlex>
                   </MetadataListItem>
-                </MetadataList>
+                </BAIMetadataList>
               );
             }}
           </Form.Item>

--- a/react/src/components/ModelCardDrawer.tsx
+++ b/react/src/components/ModelCardDrawer.tsx
@@ -13,17 +13,16 @@ import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import { Badge } from '@astryxdesign/core/Badge';
 import { Button } from '@astryxdesign/core/Button';
 import { Card } from '@astryxdesign/core/Card';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading, Text } from '@astryxdesign/core/Text';
 import {
+  BAICard,
   BAIDrawer,
   BAISkeleton,
   BAIFlex,
   BAILink,
+  BAIMetadataList,
   BAIResourceNumberWithIcon,
   BAIUnmountAfterClose,
   toLocalId,
@@ -205,107 +204,109 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
                 {/* antd `Descriptions bordered column={1} size="small"` ->
                     `MetadataList` (MAPPING.md §4, DIRECT). `bordered`/
                     `size="small"` have no destination — dropped. */}
-                <MetadataList columns="single">
-                  {modelCard.metadata?.author && (
-                    <MetadataListItem label={t('modelStore.Author')}>
-                      {modelCard.metadata.author}
-                    </MetadataListItem>
-                  )}
-                  {modelCard.metadata?.architecture && (
-                    <MetadataListItem label={t('modelStore.Architecture')}>
-                      {modelCard.metadata.architecture}
-                    </MetadataListItem>
-                  )}
-                  <MetadataListItem label={t('modelStore.Framework')}>
-                    <BAIFlex direction="row" gap="xs">
-                      {_.map(
-                        _.filter(
-                          modelCard.metadata?.framework,
-                          (v) => !_.isEmpty(v),
-                        ),
-                        (framework, index) => {
-                          const targetImageKey = framework?.replace(
-                            /\s*\d+\s*$/,
-                            '',
-                          );
-                          const imageInfo = _.find(
-                            imageMetaData?.imageInfo,
-                            (info) => info?.name === targetImageKey,
-                          );
-                          const uniqueKey = `${framework}-${index}`;
-                          return imageInfo?.icon ? (
-                            <BAIFlex gap="xxs" key={uniqueKey}>
-                              <img
-                                style={{ width: '1em', height: '1em' }}
-                                src={'resources/icons/' + imageInfo?.icon}
-                                alt={framework || ''}
-                              />
-                              {framework}
-                            </BAIFlex>
-                          ) : (
-                            <Text key={uniqueKey}>{framework}</Text>
-                          );
-                        },
-                      )}
-                    </BAIFlex>
-                  </MetadataListItem>
-                  {modelCard.metadata?.modelVersion && (
-                    <MetadataListItem label={t('modelStore.Version')}>
-                      {modelCard.metadata.modelVersion}
-                    </MetadataListItem>
-                  )}
-                  {modelCard.createdAt && (
-                    <MetadataListItem label={t('modelStore.Created')}>
-                      {dayjs(modelCard.createdAt).format('lll')}
-                    </MetadataListItem>
-                  )}
-                  <MetadataListItem label={t('modelStore.LastModified')}>
-                    {modelCard.updatedAt
-                      ? dayjs(modelCard.updatedAt).format('lll')
-                      : '-'}
-                  </MetadataListItem>
-                  <MetadataListItem label={t('modelStore.ModelFolder')}>
-                    {modelCard.vfolder?.id ? (
-                      <ErrorBoundaryWithNullFallback>
-                        <Suspense
-                          fallback={
-                            <BAISkeleton variant="input" size="small" />
-                          }
-                        >
-                          <BAILink
-                            type="hover"
-                            to={generateFolderPath(
-                              toLocalId(modelCard.vfolder.id),
-                            )}
-                          >
-                            <BAIFlex gap="xs" align="center">
-                              <VFolderNodeIdenticonV2
-                                vfolderNodeIdenticonFrgmt={modelCard.vfolder}
-                              />
-                              {modelCard.vfolder.metadata?.name}
-                            </BAIFlex>
-                          </BAILink>
-                        </Suspense>
-                      </ErrorBoundaryWithNullFallback>
-                    ) : (
-                      '-'
-                    )}
-                  </MetadataListItem>
-                  {modelCard.minResource &&
-                    modelCard.minResource.length > 0 && (
-                      <MetadataListItem label={t('modelStore.MinResource')}>
-                        <BAIFlex gap="sm" wrap="wrap">
-                          {_.map(modelCard.minResource, (entry) => (
-                            <BAIResourceNumberWithIcon
-                              key={entry.resourceType}
-                              type={entry.resourceType}
-                              value={entry.quantity}
-                            />
-                          ))}
-                        </BAIFlex>
+                <BAICard>
+                  <BAIMetadataList columns="single">
+                    {modelCard.metadata?.author && (
+                      <MetadataListItem label={t('modelStore.Author')}>
+                        {modelCard.metadata.author}
                       </MetadataListItem>
                     )}
-                </MetadataList>
+                    {modelCard.metadata?.architecture && (
+                      <MetadataListItem label={t('modelStore.Architecture')}>
+                        {modelCard.metadata.architecture}
+                      </MetadataListItem>
+                    )}
+                    <MetadataListItem label={t('modelStore.Framework')}>
+                      <BAIFlex direction="row" gap="xs">
+                        {_.map(
+                          _.filter(
+                            modelCard.metadata?.framework,
+                            (v) => !_.isEmpty(v),
+                          ),
+                          (framework, index) => {
+                            const targetImageKey = framework?.replace(
+                              /\s*\d+\s*$/,
+                              '',
+                            );
+                            const imageInfo = _.find(
+                              imageMetaData?.imageInfo,
+                              (info) => info?.name === targetImageKey,
+                            );
+                            const uniqueKey = `${framework}-${index}`;
+                            return imageInfo?.icon ? (
+                              <BAIFlex gap="xxs" key={uniqueKey}>
+                                <img
+                                  style={{ width: '1em', height: '1em' }}
+                                  src={'resources/icons/' + imageInfo?.icon}
+                                  alt={framework || ''}
+                                />
+                                {framework}
+                              </BAIFlex>
+                            ) : (
+                              <Text key={uniqueKey}>{framework}</Text>
+                            );
+                          },
+                        )}
+                      </BAIFlex>
+                    </MetadataListItem>
+                    {modelCard.metadata?.modelVersion && (
+                      <MetadataListItem label={t('modelStore.Version')}>
+                        {modelCard.metadata.modelVersion}
+                      </MetadataListItem>
+                    )}
+                    {modelCard.createdAt && (
+                      <MetadataListItem label={t('modelStore.Created')}>
+                        {dayjs(modelCard.createdAt).format('lll')}
+                      </MetadataListItem>
+                    )}
+                    <MetadataListItem label={t('modelStore.LastModified')}>
+                      {modelCard.updatedAt
+                        ? dayjs(modelCard.updatedAt).format('lll')
+                        : '-'}
+                    </MetadataListItem>
+                    <MetadataListItem label={t('modelStore.ModelFolder')}>
+                      {modelCard.vfolder?.id ? (
+                        <ErrorBoundaryWithNullFallback>
+                          <Suspense
+                            fallback={
+                              <BAISkeleton variant="input" size="small" />
+                            }
+                          >
+                            <BAILink
+                              type="hover"
+                              to={generateFolderPath(
+                                toLocalId(modelCard.vfolder.id),
+                              )}
+                            >
+                              <BAIFlex gap="xs" align="center">
+                                <VFolderNodeIdenticonV2
+                                  vfolderNodeIdenticonFrgmt={modelCard.vfolder}
+                                />
+                                {modelCard.vfolder.metadata?.name}
+                              </BAIFlex>
+                            </BAILink>
+                          </Suspense>
+                        </ErrorBoundaryWithNullFallback>
+                      ) : (
+                        '-'
+                      )}
+                    </MetadataListItem>
+                    {modelCard.minResource &&
+                      modelCard.minResource.length > 0 && (
+                        <MetadataListItem label={t('modelStore.MinResource')}>
+                          <BAIFlex gap="sm" wrap="wrap">
+                            {_.map(modelCard.minResource, (entry) => (
+                              <BAIResourceNumberWithIcon
+                                key={entry.resourceType}
+                                type={entry.resourceType}
+                                value={entry.quantity}
+                              />
+                            ))}
+                          </BAIFlex>
+                        </MetadataListItem>
+                      )}
+                  </BAIMetadataList>
+                </BAICard>
 
                 {modelCard.readme && (
                   <Card padding={4} style={{ width: '100%' }}>

--- a/react/src/components/ResourceGroupInfoModal.tsx
+++ b/react/src/components/ResourceGroupInfoModal.tsx
@@ -6,12 +6,14 @@ import { ResourceGroupInfoModalFragment$key } from '../__generated__/ResourceGro
 import { theme } from '../theme-shim';
 import { ScalingGroupOpts } from './ResourceGroupList';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
-import { BAIModal, BAIModalProps, BAIFlex } from 'backend.ai-ui';
+import {
+  BAIMetadataList,
+  BAIModal,
+  BAIModalProps,
+  BAIFlex,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Check, X } from 'lucide-react';
 import { useMemo } from 'react';
@@ -69,7 +71,7 @@ const ResourceGroupInfoModal: React.FC<ResourceGroupInfoModalProps> = ({
           natively supported. The three blocks are separated by BAIFlex gap
           instead of a bare `<br/>`. */}
       <BAIFlex direction="column" align="stretch" gap="md">
-        <MetadataList
+        <BAIMetadataList
           title={t('resourceGroup.Information')}
           label={{ position: 'start', width: '50%' }}
         >
@@ -102,8 +104,8 @@ const ResourceGroupInfoModal: React.FC<ResourceGroupInfoModalProps> = ({
           <MetadataListItem label={t('resourceGroup.AppProxyAddress')}>
             {resourceGroup?.wsproxy_addr || '-'}
           </MetadataListItem>
-        </MetadataList>
-        <MetadataList
+        </BAIMetadataList>
+        <BAIMetadataList
           title={t('resourceGroup.SchedulerOptions')}
           label={{ position: 'start', width: '50%' }}
         >
@@ -149,11 +151,11 @@ const ResourceGroupInfoModal: React.FC<ResourceGroupInfoModalProps> = ({
               ? `${schedulerOpts.config.num_retries_to_skip} ${t('resourceGroup.RetriesToSkip')}`
               : '-'}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
         {/* FIXME: Currently, the driver options feature is unimplemented. After the feature is implemented,
         it should be changed to show each type instead of the map type. */}
         {!_.isEmpty(driverOpts) ? (
-          <MetadataList
+          <BAIMetadataList
             title={t('resourceGroup.DriverOptions')}
             label={{ position: 'start', width: '50%' }}
           >
@@ -174,7 +176,7 @@ const ResourceGroupInfoModal: React.FC<ResourceGroupInfoModalProps> = ({
                 </MetadataListItem>
               );
             })}
-          </MetadataList>
+          </BAIMetadataList>
         ) : null}
       </BAIFlex>
     </BAIModal>

--- a/react/src/components/RoleDetailDrawerContent.tsx
+++ b/react/src/components/RoleDetailDrawerContent.tsx
@@ -9,12 +9,11 @@ import LegacyRoleScopeTab from './LegacyRoleScopeTab';
 import RoleAssignmentTab from './RoleAssignmentTab';
 import RolePermissionDetailTab from './RolePermissionDetailTab';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Tab, TabList } from '@astryxdesign/core/TabList';
 import {
+  BAICard,
+  BAIMetadataList,
   BAISkeleton,
   badgeVariantForStatus,
   badgeVariantForTagColor,
@@ -73,54 +72,56 @@ const RoleDetailDrawerContent: React.FC<RoleDetailDrawerContentProps> = ({
           dropped — the project-wide decision established in tickets 15/18.
           The two `span={2}` full-width rows keep their content; they simply
           flow in the 2-column grid like every other row. */}
-      <MetadataList columns={2} label={{ position: 'start', width: 160 }}>
-        <MetadataListItem label={t('rbac.Source')}>
-          {/* Tag -> Badge through the repo-global lookup (ticket 13); no
-              per-file colour map. */}
-          <Badge
-            variant={badgeVariantForStatus('role', role.source ?? undefined)}
-            label={
-              role.source === 'SYSTEM' ? t('rbac.System') : t('rbac.Custom')
-            }
-          />
-        </MetadataListItem>
-        <MetadataListItem label={t('rbac.Status')}>
-          <Badge
-            variant={badgeVariantForStatus('role', role.status ?? undefined)}
-            label={
-              role.status === 'ACTIVE' ? t('rbac.Active') : t('rbac.Inactive')
-            }
-          />
-        </MetadataListItem>
-        <MetadataListItem label={t('general.CreatedAt')}>
-          {role.createdAt
-            ? dayjs(role.createdAt).format('YYYY-MM-DD HH:mm:ss')
-            : '-'}
-        </MetadataListItem>
-        <MetadataListItem label={t('general.UpdatedAt')}>
-          {role.updatedAt
-            ? dayjs(role.updatedAt).format('YYYY-MM-DD HH:mm:ss')
-            : '-'}
-        </MetadataListItem>
-        {supportsAutoAssign ? (
-          <MetadataListItem label={t('rbac.AutoAssign')}>
+      <BAICard>
+        <BAIMetadataList columns={2} label={{ position: 'start', width: 160 }}>
+          <MetadataListItem label={t('rbac.Source')}>
+            {/* Tag -> Badge through the repo-global lookup (ticket 13); no
+                per-file colour map. */}
             <Badge
-              variant={badgeVariantForTagColor(
-                role.autoAssign ? 'green' : 'default',
-              )}
+              variant={badgeVariantForStatus('role', role.source ?? undefined)}
               label={
-                role.autoAssign ? t('general.Active') : t('general.Inactive')
+                role.source === 'SYSTEM' ? t('rbac.System') : t('rbac.Custom')
               }
             />
           </MetadataListItem>
-        ) : null}
-        <MetadataListItem label={t('rbac.RoleDescription')}>
-          {role.description || '-'}
-        </MetadataListItem>
-      </MetadataList>
+          <MetadataListItem label={t('rbac.Status')}>
+            <Badge
+              variant={badgeVariantForStatus('role', role.status ?? undefined)}
+              label={
+                role.status === 'ACTIVE' ? t('rbac.Active') : t('rbac.Inactive')
+              }
+            />
+          </MetadataListItem>
+          <MetadataListItem label={t('general.CreatedAt')}>
+            {role.createdAt
+              ? dayjs(role.createdAt).format('YYYY-MM-DD HH:mm:ss')
+              : '-'}
+          </MetadataListItem>
+          <MetadataListItem label={t('general.UpdatedAt')}>
+            {role.updatedAt
+              ? dayjs(role.updatedAt).format('YYYY-MM-DD HH:mm:ss')
+              : '-'}
+          </MetadataListItem>
+          {supportsAutoAssign ? (
+            <MetadataListItem label={t('rbac.AutoAssign')}>
+              <Badge
+                variant={badgeVariantForTagColor(
+                  role.autoAssign ? 'green' : 'default',
+                )}
+                label={
+                  role.autoAssign ? t('general.Active') : t('general.Inactive')
+                }
+              />
+            </MetadataListItem>
+          ) : null}
+          <MetadataListItem label={t('rbac.RoleDescription')}>
+            {role.description || '-'}
+          </MetadataListItem>
+        </BAIMetadataList>
+      </BAICard>
       {/* antd `Tabs` -> `TabList` + `Tab` (MAPPING §4): navigation only, the
           panel is rendered by this component below the bar. */}
-      <TabList value={activeTab} onChange={setActiveTab}>
+      <TabList hasDivider value={activeTab} onChange={setActiveTab}>
         {supportsDetailedPermissions ? (
           <Tab value="detailedPermissions" label={t('rbac.Permissions')} />
         ) : (

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -40,16 +40,15 @@ import { Badge } from '@astryxdesign/core/Badge';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Tab, TabList } from '@astryxdesign/core/TabList';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
+  BAICard,
   BAIFlex,
   BAIIconWithTooltip,
   BAILink,
+  BAIMetadataList,
   BAISessionAgentIds,
   BAISessionClusterMode,
   BAISessionTypeTag,
@@ -379,267 +378,272 @@ const SessionDetailContent: React.FC<{
           <SessionActionButtons size={'large'} compact sessionFrgmt={session} />
         </BAIFlex>
 
-        {/* antd `Descriptions bordered` -> Astryx MetadataList.
-            PILOT-DECISION (ticket 17): `bordered` and per-item `span` have no
-            MetadataList equivalent (MAPPING.md §4) and are dropped; JSX labels
+        {/* Dropped from the antd original: per-item `span`. JSX labels
             (warning triangle / help icon) split so the label stays a plain
             string and the icon affordance moves into the value cell (P2). */}
-        <MetadataList columns={md ? 2 : 1}>
-          <MetadataListItem label={t('session.SessionId')}>
-            <BAIText code copyable ellipsis={{ tooltip: true }}>
-              {session.row_id ?? ''}
-            </BAIText>
-          </MetadataListItem>
-          {(userRole === 'admin' || userRole === 'superadmin') && (
-            <MetadataListItem label={t('credential.UserID')}>
-              {session.owner?.email ? (
-                session.owner.email
-              ) : session.user_id ? (
-                <Suspense
-                  fallback={<BAISkeleton variant="input" size="small" />}
-                >
-                  <UNSAFELazyUserEmailView uuid={session.user_id} />
-                </Suspense>
-              ) : (
-                '-'
-              )}
+        <BAICard>
+          <BAIMetadataList columns={md ? 2 : 1}>
+            <MetadataListItem label={t('session.SessionId')}>
+              <BAIText code copyable ellipsis={{ tooltip: true }}>
+                {session.row_id ?? ''}
+              </BAIText>
             </MetadataListItem>
-          )}
-          <MetadataListItem label={t('general.AccessKey')}>
-            <SessionAccessKey sessionFrgmt={session} copyable />
-          </MetadataListItem>
-          <MetadataListItem label={t('session.Status')}>
-            <BAIFlex>
-              <SessionStatusTag
-                sessionFrgmt={session}
-                showInfo={!supportsSessionSchedulingHistory}
-              />
-              {/* QA-FINDINGS Q-37 — both controls in this row were antd
-                  `type="link"` buttons (`Button` / `BAIButton`), i.e. painted
-                  `colorLink` #FF7A00. The conversion to `IconButton
-                  variant="ghost"` dropped the tint to `--color-text-primary`
-                  (measured rgb(20,20,20) light / rgb(255,255,255) dark),
-                  which is what "버튼 색깔이 default 라서 클릭 가능한지 알기
-                  힘듭니다" is describing. `.bai-action-accent` restores it
-                  through `--color-text-accent`, which resolves to exactly
-                  `colorLink` here and to `colorInfo` under the admin theme —
-                  see `packages/backend.ai-ui/src/styles/actionAccent.css`. */}
-              {!supportsSessionSchedulingHistory &&
-              session?.status_data &&
-              session?.status_data !== '{}' ? (
-                <IconButton
-                  className="bai-action-accent"
-                  variant="ghost"
-                  size="sm"
-                  icon={<Info size="1em" />}
-                  label={t('button.ClickForMoreDetails')}
-                  tooltip={t('button.ClickForMoreDetails')}
-                  onClick={() => {
-                    setOpenStatusDetailModal(true);
-                  }}
+            {(userRole === 'admin' || userRole === 'superadmin') && (
+              <MetadataListItem label={t('credential.UserID')}>
+                {session.owner?.email ? (
+                  session.owner.email
+                ) : session.user_id ? (
+                  <Suspense
+                    fallback={<BAISkeleton variant="input" size="small" />}
+                  >
+                    <UNSAFELazyUserEmailView uuid={session.user_id} />
+                  </Suspense>
+                ) : (
+                  '-'
+                )}
+              </MetadataListItem>
+            )}
+            <MetadataListItem label={t('general.AccessKey')}>
+              <SessionAccessKey sessionFrgmt={session} copyable />
+            </MetadataListItem>
+            <MetadataListItem label={t('session.Status')}>
+              <BAIFlex>
+                <SessionStatusTag
+                  sessionFrgmt={session}
+                  showInfo={!supportsSessionSchedulingHistory}
                 />
-              ) : null}
-              {supportsSessionSchedulingHistory && (
-                <IconButton
-                  className="bai-action-accent"
-                  variant="ghost"
-                  size="sm"
-                  icon={<History size="1em" />}
-                  label={t('session.SessionSchedulingHistory')}
-                  tooltip={t('session.SessionSchedulingHistory')}
-                  onClick={() => toggleOpenSessionSchedulingHistoryModal()}
-                />
-              )}
-            </BAIFlex>
-          </MetadataListItem>
-          <MetadataListItem label={t('session.SessionType')}>
-            {/* QA-FINDINGS Q-36 — the `<dd>` a `MetadataListItem` renders is
-                `display: block`, so a tag and an icon button dropped in as
-                siblings are two inline-flex boxes sitting on the SAME TEXT
-                BASELINE, not on a shared centre line. Their content boxes have
-                different heights, so aligning their baselines puts their
-                centres 4px apart. The Status row above already avoids this by
-                wrapping its identical tag+IconButton pair in a `BAIFlex`
-                (default `align: center`), which replaces baseline alignment
-                with cross-axis centring; this row now does the same. Note this
-                is NOT a migration regression — antd's
-                `.ant-descriptions-item-content` was `display: table-cell` and
-                laid the same pair out on the same baseline, so legacy was 4px
-                off too. */}
-            <BAIFlex>
-              <BAISessionTypeTag sessionFrgmt={session} />
-              {/* QA-FINDINGS Q-37 — legacy `BAIButton type="link"`, so the
-                  accent here is a straight parity restoration. */}
-              {session.type === 'batch' && session.startup_command && (
-                <IconButton
-                  className="bai-action-accent"
-                  variant="ghost"
-                  size="sm"
-                  icon={<Info size="1em" />}
-                  label={t('session.ViewStartupCommand')}
-                  tooltip={t('session.ViewStartupCommand')}
-                  onClick={() => toggleOpenCodeHighlighterModal()}
-                />
-              )}
-            </BAIFlex>
-          </MetadataListItem>
-          <MetadataListItem label={t('session.launcher.Environments')}>
-            {session.kernel_nodes?.edges[0]?.node?.image ? (
-              <ImageNodeSimpleTag
-                imageFrgmt={session.kernel_nodes?.edges[0]?.node?.image || null}
-              />
-            ) : session.row_id ? (
-              <Suspense fallback={<BAISkeleton variant="input" size="small" />}>
-                <UNSAFELazySessionImageTag sessionId={session.row_id} />
-              </Suspense>
-            ) : null}
-          </MetadataListItem>
-          <MetadataListItem label={t('session.launcher.MountedFolders')}>
-            <BAIFlex gap="xs" wrap="wrap">
-              <MountedVFolderLinks sessionFrgmt={session} />
-            </BAIFlex>
-          </MetadataListItem>
-          <MetadataListItem label={t('session.launcher.ResourceAllocation')}>
-            <BAIFlex gap={'sm'} wrap="wrap" align="center">
-              {hasResourceAllocationDifference && (
-                <BAIIconWithTooltip
-                  content={t('session.AllocatedLessThanRequested')}
-                  icon={
-                    <TriangleAlert
-                      size="1em"
-                      style={{ color: 'var(--color-warning)' }}
-                    />
+                {/* QA-FINDINGS Q-37 — both controls in this row were antd
+                    `type="link"` buttons (`Button` / `BAIButton`), i.e. painted
+                    `colorLink` #FF7A00. The conversion to `IconButton
+                    variant="ghost"` dropped the tint to `--color-text-primary`
+                    (measured rgb(20,20,20) light / rgb(255,255,255) dark),
+                    which is what "버튼 색깔이 default 라서 클릭 가능한지 알기
+                    힘듭니다" is describing. `.bai-action-accent` restores it
+                    through `--color-text-accent`, which resolves to exactly
+                    `colorLink` here and to `colorInfo` under the admin theme —
+                    see `packages/backend.ai-ui/src/styles/actionAccent.css`. */}
+                {!supportsSessionSchedulingHistory &&
+                session?.status_data &&
+                session?.status_data !== '{}' ? (
+                  <IconButton
+                    className="bai-action-accent"
+                    variant="ghost"
+                    size="sm"
+                    icon={<Info size="1em" />}
+                    label={t('button.ClickForMoreDetails')}
+                    tooltip={t('button.ClickForMoreDetails')}
+                    onClick={() => {
+                      setOpenStatusDetailModal(true);
+                    }}
+                  />
+                ) : null}
+                {supportsSessionSchedulingHistory && (
+                  <IconButton
+                    className="bai-action-accent"
+                    variant="ghost"
+                    size="sm"
+                    icon={<History size="1em" />}
+                    label={t('session.SessionSchedulingHistory')}
+                    tooltip={t('session.SessionSchedulingHistory')}
+                    onClick={() => toggleOpenSessionSchedulingHistoryModal()}
+                  />
+                )}
+              </BAIFlex>
+            </MetadataListItem>
+            <MetadataListItem label={t('session.SessionType')}>
+              {/* QA-FINDINGS Q-36 — the `<dd>` a `MetadataListItem` renders is
+                  `display: block`, so a tag and an icon button dropped in as
+                  siblings are two inline-flex boxes sitting on the SAME TEXT
+                  BASELINE, not on a shared centre line. Their content boxes have
+                  different heights, so aligning their baselines puts their
+                  centres 4px apart. The Status row above already avoids this by
+                  wrapping its identical tag+IconButton pair in a `BAIFlex`
+                  (default `align: center`), which replaces baseline alignment
+                  with cross-axis centring; this row now does the same. Note this
+                  is NOT a migration regression — antd's
+                  `.ant-descriptions-item-content` was `display: table-cell` and
+                  laid the same pair out on the same baseline, so legacy was 4px
+                  off too. */}
+              <BAIFlex>
+                <BAISessionTypeTag sessionFrgmt={session} />
+                {/* QA-FINDINGS Q-37 — legacy `BAIButton type="link"`, so the
+                    accent here is a straight parity restoration. */}
+                {session.type === 'batch' && session.startup_command && (
+                  <IconButton
+                    className="bai-action-accent"
+                    variant="ghost"
+                    size="sm"
+                    icon={<Info size="1em" />}
+                    label={t('session.ViewStartupCommand')}
+                    tooltip={t('session.ViewStartupCommand')}
+                    onClick={() => toggleOpenCodeHighlighterModal()}
+                  />
+                )}
+              </BAIFlex>
+            </MetadataListItem>
+            <MetadataListItem label={t('session.launcher.Environments')}>
+              {session.kernel_nodes?.edges[0]?.node?.image ? (
+                <ImageNodeSimpleTag
+                  imageFrgmt={
+                    session.kernel_nodes?.edges[0]?.node?.image || null
                   }
                 />
-              )}
-              <Tooltip content={t('session.ResourceGroup')}>
-                <Badge label={session.scaling_group} />
-              </Tooltip>
-              <ResourceNumbersOfSession
-                resource={
-                  hasOccupiedSlots ? occupiedResource : requestedResource
-                }
-                comparedResource={
-                  hasOccupiedSlots ? requestedResource : undefined
-                }
-                showDividers
-              />
-            </BAIFlex>
-          </MetadataListItem>
-          <MetadataListItem label={t('session.Agent')}>
-            <BAISessionAgentIds sessionFrgmt={session} />
-          </MetadataListItem>
-          <MetadataListItem label={t('session.Reservation')}>
-            <BAIFlex gap={'xs'} wrap={'wrap'}>
-              <SessionReservation sessionFrgmt={session} />
-            </BAIFlex>
-          </MetadataListItem>
-          <MetadataListItem label={t('session.ClusterMode')}>
-            <BAISessionClusterMode sessionFrgmt={session} showSize />
-          </MetadataListItem>
-          {baiClient.supports('idle-checks-gql') &&
-          session.status === 'RUNNING' &&
-          imminentExpirationTime ? (
-            <MetadataListItem label={t('session.ReclamationStatus')}>
-              <BAIFlex gap="xxs" align="start">
+              ) : session.row_id ? (
                 <Suspense
                   fallback={<BAISkeleton variant="input" size="small" />}
                 >
-                  <SessionIdleChecks
-                    sessionNodeFrgmt={session}
-                    direction={md ? 'row' : 'column'}
-                  />
+                  <UNSAFELazySessionImageTag sessionId={session.row_id} />
                 </Suspense>
-                {/* QA-FINDINGS Q-37 — recorded honestly: this one is NOT a
-                    parity restoration. Legacy rendered a bare
-                    `<QuestionCircleOutlined style={{cursor:'pointer'}}>` in the
-                    Descriptions LABEL, at the label's inherited neutral colour,
-                    so antd never tinted it either. It gets the accent anyway
-                    because it is a real action affordance (opens
-                    `IdleCheckDescriptionModal`) and it now sits in the drawer's
-                    content column alongside the two ⓘ buttons above — leaving
-                    one of three identical `size="sm"` ghost glyphs black while
-                    the others are accent would read as an inconsistency rather
-                    than a distinction. The report "세션 디테일 드로어에서 i 가
-                    클릭 가능한지 인식하기 어렵네요" names this glyph class. */}
-                <IconButton
-                  className="bai-action-accent"
-                  variant="ghost"
-                  size="sm"
-                  icon={<CircleHelp size="1em" />}
-                  label={t('button.ClickForMoreDetails')}
-                  tooltip={t('button.ClickForMoreDetails')}
-                  onClick={() => setOpenIdleCheckDescriptionModal(true)}
+              ) : null}
+            </MetadataListItem>
+            <MetadataListItem label={t('session.launcher.MountedFolders')}>
+              <BAIFlex gap="xs" wrap="wrap">
+                <MountedVFolderLinks sessionFrgmt={session} />
+              </BAIFlex>
+            </MetadataListItem>
+            <MetadataListItem label={t('session.launcher.ResourceAllocation')}>
+              <BAIFlex gap={'sm'} wrap="wrap" align="center">
+                {hasResourceAllocationDifference && (
+                  <BAIIconWithTooltip
+                    content={t('session.AllocatedLessThanRequested')}
+                    icon={
+                      <TriangleAlert
+                        size="1em"
+                        style={{ color: 'var(--color-warning)' }}
+                      />
+                    }
+                  />
+                )}
+                <Tooltip content={t('session.ResourceGroup')}>
+                  <Badge label={session.scaling_group} />
+                </Tooltip>
+                <ResourceNumbersOfSession
+                  resource={
+                    hasOccupiedSlots ? occupiedResource : requestedResource
+                  }
+                  comparedResource={
+                    hasOccupiedSlots ? requestedResource : undefined
+                  }
+                  showDividers
                 />
               </BAIFlex>
             </MetadataListItem>
-          ) : null}
-          <MetadataListItem label={t('session.ResourceUsage')}>
-            <SessionUsageMonitor
-              sessionFrgmt={session}
-              displayTarget={usageMonitorDisplayTarget}
-            />
-          </MetadataListItem>
-          {(session.dependees?.count ?? 0) > 0 && (
-            <MetadataListItem label={t('session.DependsOn')}>
-              <BAIFlex gap="xs" wrap="wrap">
-                {session.dependees?.edges
-                  ?.map((edge) => edge?.node)
-                  .filter(Boolean)
-                  .map((node) => {
-                    const searchParams = new URLSearchParams(location.search);
-                    if (node?.row_id) {
-                      searchParams.set('sessionDetail', node.row_id);
-                    }
-                    return (
-                      <BAILink
-                        key={node?.row_id}
-                        type="hover"
-                        to={{
-                          pathname: location.pathname,
-                          search: searchParams.toString(),
-                        }}
-                      >
-                        {node?.name}
-                      </BAILink>
-                    );
-                  })}
+            <MetadataListItem label={t('session.Agent')}>
+              <BAISessionAgentIds sessionFrgmt={session} />
+            </MetadataListItem>
+            <MetadataListItem label={t('session.Reservation')}>
+              <BAIFlex gap={'xs'} wrap={'wrap'}>
+                <SessionReservation sessionFrgmt={session} />
               </BAIFlex>
             </MetadataListItem>
-          )}
-          {(session.dependents?.count ?? 0) > 0 && (
-            <MetadataListItem label={t('session.DependedByOthers')}>
-              <BAIFlex gap="xs" wrap="wrap">
-                {session.dependents?.edges
-                  ?.map((edge) => edge?.node)
-                  .filter(Boolean)
-                  .map((node) => {
-                    const searchParams = new URLSearchParams(location.search);
-                    if (node?.row_id) {
-                      searchParams.set('sessionDetail', node.row_id);
-                    }
-                    return (
-                      <BAILink
-                        key={node?.row_id}
-                        type="hover"
-                        to={{
-                          pathname: location.pathname,
-                          search: searchParams.toString(),
-                        }}
-                      >
-                        {node?.name}
-                      </BAILink>
-                    );
-                  })}
-              </BAIFlex>
+            <MetadataListItem label={t('session.ClusterMode')}>
+              <BAISessionClusterMode sessionFrgmt={session} showSize />
             </MetadataListItem>
-          )}
-        </MetadataList>
+            {baiClient.supports('idle-checks-gql') &&
+            session.status === 'RUNNING' &&
+            imminentExpirationTime ? (
+              <MetadataListItem label={t('session.ReclamationStatus')}>
+                <BAIFlex gap="xxs" align="start">
+                  <Suspense
+                    fallback={<BAISkeleton variant="input" size="small" />}
+                  >
+                    <SessionIdleChecks
+                      sessionNodeFrgmt={session}
+                      direction={md ? 'row' : 'column'}
+                    />
+                  </Suspense>
+                  {/* QA-FINDINGS Q-37 — recorded honestly: this one is NOT a
+                      parity restoration. Legacy rendered a bare
+                      `<QuestionCircleOutlined style={{cursor:'pointer'}}>` in the
+                      Descriptions LABEL, at the label's inherited neutral colour,
+                      so antd never tinted it either. It gets the accent anyway
+                      because it is a real action affordance (opens
+                      `IdleCheckDescriptionModal`) and it now sits in the drawer's
+                      content column alongside the two ⓘ buttons above — leaving
+                      one of three identical `size="sm"` ghost glyphs black while
+                      the others are accent would read as an inconsistency rather
+                      than a distinction. The report "세션 디테일 드로어에서 i 가
+                      클릭 가능한지 인식하기 어렵네요" names this glyph class. */}
+                  <IconButton
+                    className="bai-action-accent"
+                    variant="ghost"
+                    size="sm"
+                    icon={<CircleHelp size="1em" />}
+                    label={t('button.ClickForMoreDetails')}
+                    tooltip={t('button.ClickForMoreDetails')}
+                    onClick={() => setOpenIdleCheckDescriptionModal(true)}
+                  />
+                </BAIFlex>
+              </MetadataListItem>
+            ) : null}
+            <MetadataListItem label={t('session.ResourceUsage')}>
+              <SessionUsageMonitor
+                sessionFrgmt={session}
+                displayTarget={usageMonitorDisplayTarget}
+              />
+            </MetadataListItem>
+            {(session.dependees?.count ?? 0) > 0 && (
+              <MetadataListItem label={t('session.DependsOn')}>
+                <BAIFlex gap="xs" wrap="wrap">
+                  {session.dependees?.edges
+                    ?.map((edge) => edge?.node)
+                    .filter(Boolean)
+                    .map((node) => {
+                      const searchParams = new URLSearchParams(location.search);
+                      if (node?.row_id) {
+                        searchParams.set('sessionDetail', node.row_id);
+                      }
+                      return (
+                        <BAILink
+                          key={node?.row_id}
+                          type="hover"
+                          to={{
+                            pathname: location.pathname,
+                            search: searchParams.toString(),
+                          }}
+                        >
+                          {node?.name}
+                        </BAILink>
+                      );
+                    })}
+                </BAIFlex>
+              </MetadataListItem>
+            )}
+            {(session.dependents?.count ?? 0) > 0 && (
+              <MetadataListItem label={t('session.DependedByOthers')}>
+                <BAIFlex gap="xs" wrap="wrap">
+                  {session.dependents?.edges
+                    ?.map((edge) => edge?.node)
+                    .filter(Boolean)
+                    .map((node) => {
+                      const searchParams = new URLSearchParams(location.search);
+                      if (node?.row_id) {
+                        searchParams.set('sessionDetail', node.row_id);
+                      }
+                      return (
+                        <BAILink
+                          key={node?.row_id}
+                          type="hover"
+                          to={{
+                            pathname: location.pathname,
+                            search: searchParams.toString(),
+                          }}
+                        >
+                          {node?.name}
+                        </BAILink>
+                      );
+                    })}
+                </BAIFlex>
+              </MetadataListItem>
+            )}
+          </BAIMetadataList>
+        </BAICard>
       </BAIFlex>
       {/* antd `Tabs` -> Astryx `TabList` + `Tab` (navigation only — the
           panels are rendered below; MAPPING.md §4). */}
       <BAIFlex direction="column" align="stretch" gap="sm">
         <TabList
+          hasDivider
           value={activeTabKey}
           onChange={(key) => {
             if (key === 'auditLog' && session.row_id && !auditLogQueryRef) {

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -33,12 +33,15 @@ import { Button } from '@astryxdesign/core/Button';
 import { Card } from '@astryxdesign/core/Card';
 import { Heading } from '@astryxdesign/core/Heading';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
-import { BAICard, BAIFlex, BAITable, BAIText } from 'backend.ai-ui';
+import {
+  BAICard,
+  BAIFlex,
+  BAIMetadataList,
+  BAITable,
+  BAIText,
+} from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { CheckIcon, CopyIcon } from 'lucide-react';
@@ -134,7 +137,7 @@ const SessionLauncherPreview: React.FC<{
           onClickEditStep('sessionType');
         }}
       >
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('session.SessionType')}>
             {form.getFieldValue('sessionType')}
           </MetadataListItem>
@@ -179,7 +182,7 @@ const SessionLauncherPreview: React.FC<{
               ) : null}
             </>
           )}
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
       <SessionOwnerSetterPreviewCard
         onClickExtraButton={() => {
@@ -210,7 +213,7 @@ const SessionLauncherPreview: React.FC<{
           onClickEditStep('environment');
         }}
       >
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('session.launcher.Project')}>
             {currentProject.name}
           </MetadataListItem>
@@ -353,7 +356,7 @@ const SessionLauncherPreview: React.FC<{
               )}
             </MetadataListItem>
           )}
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
       <BAICard
         title={t('session.launcher.ResourceAllocation')}
@@ -401,7 +404,7 @@ const SessionLauncherPreview: React.FC<{
             />
           )}
 
-          <MetadataList columns={2}>
+          <BAIMetadataList columns={2}>
             <MetadataListItem label={t('general.ResourceGroup')}>
               {form.getFieldValue('resourceGroup') || (
                 <Text color="secondary">{t('general.None')}</Text>
@@ -446,7 +449,7 @@ const SessionLauncherPreview: React.FC<{
                 ? t('session.launcher.SingleNode')
                 : t('session.launcher.MultiNode')}
             </MetadataListItem>
-          </MetadataList>
+          </BAIMetadataList>
           <Card padding={3}>
             <BAIFlex direction="column" align="stretch" gap="xs">
               <Heading level={6}>
@@ -518,7 +521,7 @@ const SessionLauncherPreview: React.FC<{
             />
           )}
           {form.getFieldValue('autoMountedFolderNames')?.length > 0 ? (
-            <MetadataList columns="single">
+            <BAIMetadataList columns="single">
               <MetadataListItem label={t('data.AutomountFolders')}>
                 <BAIFlex gap="xs" wrap="wrap">
                   {_.map(
@@ -529,7 +532,7 @@ const SessionLauncherPreview: React.FC<{
                   )}
                 </BAIFlex>
               </MetadataListItem>
-            </MetadataList>
+            </BAIMetadataList>
           ) : null}
         </BAIFlex>
       </BAICard>
@@ -543,7 +546,7 @@ const SessionLauncherPreview: React.FC<{
           onClickEditStep('network');
         }}
       >
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('session.launcher.PreOpenPortTitle')}>
             <BAIFlex direction="row" gap="xs" style={{ flex: 1 }} wrap="wrap">
               {_.sortBy(form.getFieldValue('ports'), (v) => parseInt(v)).map(
@@ -560,7 +563,7 @@ const SessionLauncherPreview: React.FC<{
               ) : null}
             </BAIFlex>
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
     </>
   );

--- a/react/src/components/SessionOwnerSetterCard.tsx
+++ b/react/src/components/SessionOwnerSetterCard.tsx
@@ -15,10 +15,7 @@ import { Card } from '@astryxdesign/core/Card';
 import { Grid, GridSpan } from '@astryxdesign/core/Grid';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { InputGroup } from '@astryxdesign/core/InputGroup';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Selector } from '@astryxdesign/core/Selector';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading } from '@astryxdesign/core/Text';
@@ -27,6 +24,7 @@ import {
   BAICard,
   BAICardProps,
   BAIFlex,
+  BAIMetadataList,
   BAISelect,
   BAIProjectResourceGroupSelect,
 } from 'backend.ai-ui';
@@ -400,7 +398,7 @@ export const SessionOwnerSetterPreviewCard: React.FC<BAICardProps> = (
       >
         {/* antd `Descriptions size="small" column={1}` -> `MetadataList
             columns="single"` (MAPPING 4; `size` has no destination). */}
-        <MetadataList columns="single">
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('session.launcher.OwnerEmail')}>
             {form.getFieldValue(['owner', 'email'])}
           </MetadataListItem>
@@ -413,7 +411,7 @@ export const SessionOwnerSetterPreviewCard: React.FC<BAICardProps> = (
           <MetadataListItem label={t('session.launcher.OwnerResourceGroup')}>
             {form.getFieldValue(['owner', 'resourceGroup'])}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
     )
   );

--- a/react/src/components/SharedFolderPermissionInfoModal.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModal.tsx
@@ -18,16 +18,14 @@ import { useTanMutation } from '../hooks/reactQueryAlias';
 import VFolderPermissionCell from './VFolderPermissionCell';
 import { Banner } from '@astryxdesign/core/Banner';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading, Text } from '@astryxdesign/core/Text';
 import { BAIPopconfirm } from 'backend.ai-ui';
 import {
   filterOutNullAndUndefined,
   BAITable,
+  BAIMetadataList,
   BAIModal,
   type BAIModalProps,
   BAIText,
@@ -102,7 +100,7 @@ const SharedFolderPermissionInfoModal: React.FC<
               : t('data.folders.ProjectFolderAlertDesc')
           }
         />
-        <MetadataList title={t('data.FolderInfo')} columns={2}>
+        <BAIMetadataList title={t('data.FolderInfo')} columns={2}>
           <MetadataListItem label={t('data.folders.Name')}>
             <BAIText copyable>{vfolder?.name ?? ''}</BAIText>
           </MetadataListItem>
@@ -122,7 +120,7 @@ const SharedFolderPermissionInfoModal: React.FC<
           <MetadataListItem label={t('data.folders.Owner')}>
             {vfolder?.creator || vfolder?.user_email}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
 
         {vfolder?.ownership_type === 'user' ? (
           <VStack align="stretch" gap={4}>

--- a/react/src/components/SharedFolderPermissionInfoModalV2.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModalV2.tsx
@@ -16,16 +16,14 @@ import { useTanMutation } from '../hooks/reactQueryAlias';
 import VFolderPermissionCellV2 from './VFolderPermissionCellV2';
 import { Banner } from '@astryxdesign/core/Banner';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading, Text } from '@astryxdesign/core/Text';
 import { BAIPopconfirm } from 'backend.ai-ui';
 import {
   filterOutNullAndUndefined,
   BAITable,
+  BAIMetadataList,
   BAIModal,
   type BAIModalProps,
   BAIText,
@@ -109,7 +107,7 @@ const SharedFolderPermissionInfoModalV2: React.FC<
               : t('data.folders.ProjectFolderAlertDesc')
           }
         />
-        <MetadataList title={t('data.FolderInfo')} columns={2}>
+        <BAIMetadataList title={t('data.FolderInfo')} columns={2}>
           <MetadataListItem label={t('data.folders.Name')}>
             <BAIText copyable>{vfolder?.metadata?.name ?? ''}</BAIText>
           </MetadataListItem>
@@ -130,7 +128,7 @@ const SharedFolderPermissionInfoModalV2: React.FC<
             {vfolder?.ownership?.creatorEmail ||
               vfolder?.ownership?.user?.basicInfo?.email}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
 
         {isUserOwned ? (
           <VStack align="stretch" gap={4}>

--- a/react/src/components/StorageHostDetailDrawerContent.tsx
+++ b/react/src/components/StorageHostDetailDrawerContent.tsx
@@ -77,6 +77,7 @@ const StorageHostDetailDrawerContent: React.FC<
       {/* antd Tabs → TabList + Tab (MAPPING §4): navigation only, panel is
           self-rendered below. */}
       <TabList
+        hasDivider
         value={activeTabKey}
         onChange={(key) => setActiveTabKey(key as TabKey)}
       >

--- a/react/src/components/StorageHostResourcePanel.tsx
+++ b/react/src/components/StorageHostResourcePanel.tsx
@@ -5,14 +5,11 @@
 import { StorageHostResourcePanelFragment$key } from '../__generated__/StorageHostResourcePanelFragment.graphql';
 import { convertToDecimalUnit } from '../helper/index';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { ProgressBar } from '@astryxdesign/core/ProgressBar';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAICard, BAIFlex, BAIMetadataList } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -63,36 +60,38 @@ const StorageHostResourcePanel: React.FC<{
     // (MAPPING §4). `size`/`bordered` drop; per-item `span={2}` on the Usage
     // item also drops (PILOT-DECISION, project-wide) — it now shares the
     // 2-column flow with Backend Type instead of spanning both columns.
-    <MetadataList columns={2}>
-      <MetadataListItem label={t('storageHost.Usage')}>
-        <HStack width={200}>
-          <ProgressBar
-            label={t('storageHost.Usage')}
-            isLabelHidden
-            value={storageUsage?.percent}
-            variant={usageProgressVariant(storageUsage?.percent)}
-          />
-        </HStack>
-        <Text color="secondary">{t('storageHost.Used')}: </Text>
-        {convertToDecimalUnit(storageUsage?.used_bytes, 'auto')?.displayValue}
-        <Text color="secondary">{' / '}</Text>
-        <Text color="secondary">{t('storageHost.Total')}: </Text>
-        {
-          convertToDecimalUnit(storageUsage?.capacity_bytes, 'auto')
-            ?.displayValue
-        }
-      </MetadataListItem>
-      <MetadataListItem label={t('agent.BackendType')}>
-        {resource?.backend}
-      </MetadataListItem>
-      <MetadataListItem label={t('agent.Capabilities')}>
-        <BAIFlex gap="xs" wrap="wrap">
-          {_.map(resource?.capabilities, (cap) => (
-            <Badge key={cap} variant="neutral" label={cap} />
-          ))}
-        </BAIFlex>
-      </MetadataListItem>
-    </MetadataList>
+    <BAICard>
+      <BAIMetadataList columns={2}>
+        <MetadataListItem label={t('storageHost.Usage')}>
+          <HStack width={200}>
+            <ProgressBar
+              label={t('storageHost.Usage')}
+              isLabelHidden
+              value={storageUsage?.percent}
+              variant={usageProgressVariant(storageUsage?.percent)}
+            />
+          </HStack>
+          <Text color="secondary">{t('storageHost.Used')}: </Text>
+          {convertToDecimalUnit(storageUsage?.used_bytes, 'auto')?.displayValue}
+          <Text color="secondary">{' / '}</Text>
+          <Text color="secondary">{t('storageHost.Total')}: </Text>
+          {
+            convertToDecimalUnit(storageUsage?.capacity_bytes, 'auto')
+              ?.displayValue
+          }
+        </MetadataListItem>
+        <MetadataListItem label={t('agent.BackendType')}>
+          {resource?.backend}
+        </MetadataListItem>
+        <MetadataListItem label={t('agent.Capabilities')}>
+          <BAIFlex gap="xs" wrap="wrap">
+            {_.map(resource?.capabilities, (cap) => (
+              <Badge key={cap} variant="neutral" label={cap} />
+            ))}
+          </BAIFlex>
+        </MetadataListItem>
+      </BAIMetadataList>
+    </BAICard>
   );
 };
 

--- a/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
@@ -16,13 +16,11 @@ import { Badge } from '@astryxdesign/core/Badge';
 import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Heading } from '@astryxdesign/core/Heading';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
   BAICard,
   BAIFlex,
+  BAIMetadataList,
   badgeVariantForStatus,
   useErrorMessageResolver,
 } from 'backend.ai-ui';
@@ -115,14 +113,14 @@ const SummaryItemInvitation: React.FC = () => {
               <Heading level={6}>
                 {`From: ${invitation.inviter_user_email || invitation.inviter || '-'}`}
               </Heading>
-              <MetadataList columns="single">
+              <BAIMetadataList columns="single">
                 <MetadataListItem label={t('summary.FolderName')}>
                   {invitation.vfolder_name}
                 </MetadataListItem>
                 <MetadataListItem label={t('summary.Permission')}>
                   {permissionIndicator(invitation.perm)}
                 </MetadataListItem>
-              </MetadataList>
+              </BAIMetadataList>
               <BAIFlex gap="xs" justify="end">
                 {/* MAPPING §3.3: a `default` button whose only child was a
                     `type="danger"` Text is a `destructive` Button — the

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -6,14 +6,12 @@ import { UserInfoModalFragment$key } from '../__generated__/UserInfoModalFragmen
 import { useTOTPSupported } from '../hooks/backendai';
 import { theme } from '../theme-shim';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Spinner } from '@astryxdesign/core/Spinner';
 import {
   BAIFlex,
   BAIIconWithTooltip,
+  BAIMetadataList,
   BAIModal,
   BAIModalProps,
 } from 'backend.ai-ui';
@@ -93,7 +91,7 @@ const UserInfoModal: React.FC<Props> = ({
       onCancel={onRequestClose}
       {...baiModalProps}
     >
-      <MetadataList
+      <BAIMetadataList
         title={t('credential.Information')}
         label={{ position: 'start', width: '50%' }}
       >
@@ -136,8 +134,8 @@ const UserInfoModal: React.FC<Props> = ({
             )}
           </MetadataListItem>
         )}
-      </MetadataList>
-      <MetadataList
+      </BAIMetadataList>
+      <BAIMetadataList
         title={t('credential.Association')}
         label={{ position: 'start', width: '50%' }}
       >
@@ -150,8 +148,8 @@ const UserInfoModal: React.FC<Props> = ({
         <MetadataListItem label={t('credential.ResourcePolicy')}>
           {user?.organization.resourcePolicy}
         </MetadataListItem>
-      </MetadataList>
-      <MetadataList label={{ position: 'start', width: '50%' }}>
+      </BAIMetadataList>
+      <BAIMetadataList label={{ position: 'start', width: '50%' }}>
         <MetadataListItem label={t('credential.ProjectAndGroup')}>
           {user && !user.projects ? (
             <BAIIconWithTooltip
@@ -174,7 +172,7 @@ const UserInfoModal: React.FC<Props> = ({
             </BAIFlex>
           )}
         </MetadataListItem>
-      </MetadataList>
+      </BAIMetadataList>
     </BAIModal>
   );
 };

--- a/react/src/components/VFolderMountFormItem.tsx
+++ b/react/src/components/VFolderMountFormItem.tsx
@@ -16,14 +16,12 @@ import {
 import { AstryxFormTextInput } from './astryxFormControls';
 import { Badge } from '@astryxdesign/core/Badge';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAISkeleton,
   BAIFlex,
+  BAIMetadataList,
   BAIVFolderSelect,
   BAIVFolderSelectRef,
   toLocalId,
@@ -368,7 +366,7 @@ const AutoMountFolderSection: React.FC<{ currentProjectId: string }> = ({
     // antd `Descriptions size="small"` -> `MetadataList` (MAPPING §4; `size`
     // has no destination). The colourless `<Tag>`s are Astryx's default
     // `neutral` Badge.
-    <MetadataList columns="single">
+    <BAIMetadataList columns="single">
       <MetadataListItem label={t('data.AutomountFolders')}>
         <BAIFlex gap="xxs" wrap="wrap">
           {autoMountNames.map((name) => (
@@ -376,7 +374,7 @@ const AutoMountFolderSection: React.FC<{ currentProjectId: string }> = ({
           ))}
         </BAIFlex>
       </MetadataListItem>
-    </MetadataList>
+    </BAIMetadataList>
   );
 };
 

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -14,10 +14,7 @@ import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useVirtualFolderPath } from '../hooks/useVirtualFolderNodePath';
 import VirtualFolderPath from './VirtualFolderNodeItems/VirtualFolderPath';
 import { Badge } from '@astryxdesign/core/Badge';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Selector } from '@astryxdesign/core/Selector';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
@@ -26,6 +23,7 @@ import {
   BAIUserUnionIcon,
   toLocalId,
   BAIFlex,
+  BAIMetadataList,
   useErrorMessageResolver,
   badgeVariantForStatus,
   BAIText,
@@ -273,13 +271,13 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
   // `styles.content` word-break override goes with them: MetadataList wraps
   // long values itself.
   return (
-    <MetadataList columns="single">
+    <BAIMetadataList columns="single">
       {items.map((item) => (
         <MetadataListItem key={item.key} label={item.label as string}>
           {item.children}
         </MetadataListItem>
       ))}
-    </MetadataList>
+    </BAIMetadataList>
   );
 };
 

--- a/react/src/components/VFolderNodeDescriptionV2.tsx
+++ b/react/src/components/VFolderNodeDescriptionV2.tsx
@@ -23,11 +23,11 @@ import { useCurrentUserProjectRoles } from '../hooks/useCurrentUserProjectRoles'
 import { useVirtualFolderPathV2 } from '../hooks/useVirtualFolderNodePathV2';
 import VirtualFolderPathV2 from './VirtualFolderNodeItems/VirtualFolderPathV2';
 import { Badge } from '@astryxdesign/core/Badge';
-import { MetadataList } from '@astryxdesign/core/MetadataList';
 import { Selector } from '@astryxdesign/core/Selector';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
 import {
+  BAIMetadataList,
   BAIMetadataListItem,
   filterOutEmpty,
   toLocalId,
@@ -334,13 +334,13 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
   ]);
 
   return (
-    <MetadataList columns="single" {...props}>
+    <BAIMetadataList columns="single" {...props}>
       {items.map((item) => (
         <BAIMetadataListItem key={item.key} label={item.label}>
           {item.children}
         </BAIMetadataListItem>
       ))}
-    </MetadataList>
+    </BAIMetadataList>
   );
 };
 

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -20,10 +20,7 @@ import { AstryxFormTextInput } from './astryxFormControls';
 import { Badge } from '@astryxdesign/core/Badge';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import { TextInput } from '@astryxdesign/core/TextInput';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
@@ -31,6 +28,7 @@ import {
   BAIUserUnionIcon,
   BAIFlex,
   BAILink,
+  BAIMetadataList,
   BAITable,
   useEventNotStable,
   useUpdatableState,
@@ -701,7 +699,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
               `size` has no destination and is dropped). Each auto-mounted
               folder name was a colourless `<Tag>`, i.e. Astryx's default
               `neutral` Badge. */}
-          <MetadataList columns="single">
+          <BAIMetadataList columns="single">
             <MetadataListItem label={t('data.AutomountFolders')}>
               <BAIFlex gap="xxs" wrap="wrap">
                 {_.map(autoMountedFolderNames, (name) => {
@@ -709,7 +707,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
                 })}
               </BAIFlex>
             </MetadataListItem>
-          </MetadataList>
+          </BAIMetadataList>
         </>
       ) : null}
       <FolderCreateModalV2

--- a/react/src/pages/InteractiveLoginPage.tsx
+++ b/react/src/pages/InteractiveLoginPage.tsx
@@ -6,11 +6,8 @@ import { CSSTokenVariables } from '../components/MainLayout/MainLayout';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { Button } from '@astryxdesign/core/Button';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
-import { BAI_Z_INDEX, BAICard, BAIFlex } from 'backend.ai-ui';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
+import { BAI_Z_INDEX, BAICard, BAIFlex, BAIMetadataList } from 'backend.ai-ui';
 import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -64,14 +61,14 @@ const Children = () => {
           {/* antd `Descriptions` -> `MetadataList` (MAPPING §4).
               `bordered` has no destination (project-wide PILOT-DECISION since
               ticket 20); `column={1}` becomes `columns="single"`. */}
-          <MetadataList columns="single">
+          <BAIMetadataList columns="single">
             <MetadataListItem label={t('interactiveLogin.ServiceName')}>
               {name}
             </MetadataListItem>
             <MetadataListItem label="URL">
               {callback ? new URL(callback).origin : '-'}
             </MetadataListItem>
-          </MetadataList>
+          </BAIMetadataList>
           <BAIFlex
             direction="row"
             justify="between"

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -20,10 +20,7 @@ import { theme } from '../theme-shim';
 import { Button } from '@astryxdesign/core/Button';
 import { Heading } from '@astryxdesign/core/Heading';
 import { Link } from '@astryxdesign/core/Link';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAIArtifactRevisionDeleteButton,
@@ -38,6 +35,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAIImportArtifactModal,
   BAIImportArtifactModalArtifactRevisionFragmentKey,
+  BAIMetadataList,
   BAIPullingArtifactRevisionAlert,
   BAIText,
   convertToDecimalUnit,
@@ -369,7 +367,7 @@ const ReservoirArtifactDetailPage = () => {
             Last updated and Description — move OUT of the 2-column list into
             their own single-column list below it. That keeps them full width
             without a span mechanism, and keeps the short fields paired. */}
-        <MetadataList columns={2}>
+        <BAIMetadataList columns={2}>
           <MetadataListItem label={t('reservoirPage.Name')}>
             {artifact?.name}
           </MetadataListItem>
@@ -404,8 +402,8 @@ const ReservoirArtifactDetailPage = () => {
                 : 'N/A'}
             </Text>
           </MetadataListItem>
-        </MetadataList>
-        <MetadataList columns="single">
+        </BAIMetadataList>
+        <BAIMetadataList columns="single">
           <MetadataListItem label={t('reservoirPage.LastUpdated')}>
             {artifact?.updatedAt
               ? dayjs(artifact?.updatedAt).format('lll')
@@ -421,7 +419,7 @@ const ReservoirArtifactDetailPage = () => {
               'N/A'
             )}
           </MetadataListItem>
-        </MetadataList>
+        </BAIMetadataList>
       </BAICard>
 
       <BAICard


### PR DESCRIPTION
Resolves #9102 (FR-3694)

## Mechanism

Astryx `MetadataList` was used directly at ~34 call sites while `BAIMetadataList` existed but was barely adopted. The reason was its `bordered` prop: it reproduced antd's `Descriptions bordered` **table**, so it forced `label={{ position: 'start' }}`, shaded the label column and re-flowed the grid. Opting in changed the layout, so most surfaces never did.

`bordered` is now paint only:

- It keeps whatever `columns` / `label` layout the list already has — a multi-column list keeps its stacked labels.
- The frame and rules are still drawn as the **grid gap** (`<dl>` takes `--color-border` as background + 1px gap/padding, cells cover it with an opaque fill), so the lattice closes at any column count with no last-row special case.
- The cell rule targets `> dl > *` instead of `> dl > dt, > dl > dd`, because the direct grid child differs by layout: the item wrapper `<div>` for stacked labels, the `dt`/`dd` pair for side labels.
- The label-column fill is gone.

Label tone: Astryx paints `dt` at `--color-text-secondary` (alpha .65), as heavy as the value beside it. It is now mixed to **83%** — alpha .539 — which is the lightest tone that still clears WCAG AA (4.5:1) for normal text in *both* themes:

| mix | alpha | light (`#FFFFFF`) | dark (`#141414`) |
|---|---|---|---|
| 100% (Astryx default) | .650 | `#595959` — 7.00:1 | `#ADADAD` — 8.21:1 |
| **83% (this PR)** | .539 | `#757575` — **4.61:1** | `#939393` — **6.00:1** |
| 70% (first attempt) | .455 | `#8B8B8B` — 3.41:1 ❌ | `#7F7F7F` — 4.60:1 |

The first attempt targeted antd's measured `colorTextTertiary` (.45) for parity, which Copilot correctly flagged as failing AA in light mode; the CSS comment now records why that value is deliberately not used. Exposed as `--bai-metadata-list-label-color`.

With the layout cost removed, the rest follows: every raw container converts, the three `bordered` call sites drop it, and a list that is not already on a surface is wrapped in `BAICard` (the Session Detail panel pattern).

## Changes

| | |
|---|---|
| **Wrapper** | `bordered` preserves layout; label lightened; base class always applied |
| **Converted** | 34 files: raw `MetadataList` container → `BAIMetadataList` (`MetadataListItem` untouched) |
| **`bordered` dropped** | `AgentDetailDrawerContent`, `AgentResources`, `KeypairResourcePolicyInfoModal` |
| **`BAICard` wrap** | `SessionDetailContent`, `AgentDetailDrawerContent`, `AgentResources`, `RoleDetailDrawerContent`, `ModelCardDrawer`, `StorageHostResourcePanel`, `DeploymentRevisionDetail`, `Information` (×4) |
| **Drawer tabs** | `hasDivider` on the `TabList` in all four detail drawers — Astryx defaults it to `false`, so the rail was missing |
| **Table setting modal** | column search drops `size="sm"` |

Not wrapped, because they are already on a surface: `BAIModal` bodies (the connection-info modals, `UserInfoModal`, `KeypairInfoModal`, …), files that already had `BAICard` (`SessionLauncherPreview`, `AdminDeploymentPresetReviewSummary`, `DeploymentPresetDetailModal`), the folder-explorer info panel (`VFolderNodeDescription(V2)`), and form/table contexts (`VFolderMountFormItem`, `VFolderTable`).

`Information.tsx` was on a raw Astryx `Card`; rather than nest a card in a card it becomes `BAICard`, which is what `use-bai-card.md` asks for anyway.

## Verification

```
bash scripts/verify.sh                 === ALL PASS ===
pnpm --filter backend.ai-ui build      ✓
pnpm --filter backend.ai-ui vitest     790 passed | 1 skipped (67 files)
pnpm --prefix ./react vitest           1627 passed (102 files)
astryx-token-gate --strict             BAIMetadataList.css not flagged
```

Invariants re-checked after rebasing onto latest main: no raw `<MetadataList>` container outside the wrapper, no call site passing `bordered`, all four drawer `TabList`s carrying `hasDivider`, and no nested `BAICard`.

**Pre-existing, not from this PR:** the token gate exits 1 on three untouched files (`BAIDialog.css`, `BAIDrawerPortal.css`, `BAIText.css`); `packages/backend.ai-client` lint reports 224 warnings (0 errors). Both are the same on `main`.

## Residue

- **Not probed in a live browser.** Everything above is static verification. The visual result — the new border weight, the lighter label, and the card insets on the eight wrapped surfaces — has not been checked in light/dark on a running app.
- `Information.tsx`'s fourth block is `BAICard > Overlay > BAIMetadataList`; the card is still the surface, but the two are not adjacent. The `Overlay` (loading scrim) was already there.
- `size` (`default`/`middle`/`small`) still only affects bordered cell padding, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4LvxxY56whvXEQ1sadgqr

