### PR TITLE
fix(FR-3692): let an ellipsized link keep its own colour

### DIFF
--- a/packages/backend.ai-ui/src/components/BAILink.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.test.tsx
@@ -183,6 +183,54 @@ describe('BAILink', () => {
       // The innermost one owns the text, so it is the one that must inherit.
       expect(texts[texts.length - 1]).toHaveAttribute('data-color', 'inherit');
     });
+
+    /*
+     * FR-3692. Astryx `Link` inserts a `Text color="accent"` of its own between
+     * the root and its children, so one inheriting box is not enough — EVERY
+     * `Text` in the chain has to defer, or the root's colour stops at the first
+     * one that names its own. This is the `EditableFileName` case: a caller
+     * tints the link root and expects the text to follow.
+     */
+    it.each([
+      ['ellipsized', true],
+      ['plain', false],
+    ])(
+      'defers the whole Text chain to the link root — %s',
+      (_label, ellipsis) => {
+        render(
+          <BAILink
+            ellipsis={ellipsis}
+            style={{ color: 'rgb(0, 128, 0)' }}
+            data-testid="link"
+          >
+            Renaming…
+          </BAILink>,
+        );
+        const texts = screen
+          .getByTestId('link')
+          .querySelectorAll('.astryx-text');
+        expect(texts.length).toBeGreaterThan(0);
+        texts.forEach((text) =>
+          expect(text).toHaveAttribute('data-color', 'inherit'),
+        );
+      },
+    );
+
+    // Consequence of the same change: a disabled link's text now follows
+    // `.bai-link-disabled` on the root instead of Astryx `Link`'s `accent`
+    // default, which it was rendering (at 50% opacity) before.
+    it('defers to the root for a disabled link too', () => {
+      render(
+        <BAILink type="disabled" data-testid="link">
+          Disabled
+        </BAILink>,
+      );
+      const texts = screen.getByTestId('link').querySelectorAll('.astryx-text');
+      expect(texts.length).toBeGreaterThan(0);
+      texts.forEach((text) =>
+        expect(text).toHaveAttribute('data-color', 'inherit'),
+      );
+    });
   });
 
   describe('onClick Handler', () => {

--- a/packages/backend.ai-ui/src/components/BAILink.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.test.tsx
@@ -162,6 +162,27 @@ describe('BAILink', () => {
       expect(link).toHaveClass('bai-link-ellipsis');
       expect(link.querySelector('.astryx-text')).not.toBeNull();
     });
+
+    /*
+     * FR-3692. Astryx `Text` resolves `color ?? 'primary'` and paints it on its
+     * OWN element, so the truncating box FR-3686 moved inside the link would
+     * repaint the link body text unless it is told to inherit. jsdom computes
+     * no StyleX CSS, so this asserts the reflected `data-color` Astryx emits
+     * from the same resolved value.
+     */
+    it.each([
+      ['onClick (Astryx Link)', undefined],
+      ['to (router link)', '/test'],
+    ])('lets the link keep its own colour — %s', (_label, to) => {
+      renderWithRouter(
+        <BAILink to={to} ellipsis data-testid="link">
+          Some long name
+        </BAILink>,
+      );
+      const texts = screen.getByTestId('link').querySelectorAll('.astryx-text');
+      // The innermost one owns the text, so it is the one that must inherit.
+      expect(texts[texts.length - 1]).toHaveAttribute('data-color', 'inherit');
+    });
   });
 
   describe('onClick Handler', () => {

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -116,6 +116,11 @@ const BAILink: React.FC<BAILinkProps> = ({
   return (
     <AstryxLink
       {...restProps}
+      // Astryx `Link` defaults `color="accent"` and puts it on an internal
+      // `Text`, which sits between this root and its children — so the root's
+      // own colour (`.bai-link-*`, or a caller's inline `style.color`) never
+      // reached the text. `inherit` makes the root the single source (FR-3692).
+      color="inherit"
       className={linkClassName(className)}
       style={style}
       target={target}

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -63,8 +63,15 @@ const BAILink: React.FC<BAILinkProps> = ({
   // `BAIText` goes INSIDE the link rather than around it. That keeps both
   // documented forms working: `ellipsis` shows the text itself, and
   // `ellipsis={{ tooltip: 'custom' }}` measures the box it is anchored to.
+  // `inheritColor` because Astryx `Text` always paints a colour on its own
+  // element (`color ?? 'primary'`), and the link's colour only ever reached the
+  // text by inheritance — so without it this wrapper repaints the link body
+  // text (FR-3692).
   const content = ellipsis ? (
-    <BAIText ellipsis={ellipsis === true ? { tooltip: true } : ellipsis}>
+    <BAIText
+      inheritColor
+      ellipsis={ellipsis === true ? { tooltip: true } : ellipsis}
+    >
       {children}
     </BAIText>
   ) : (

--- a/packages/backend.ai-ui/src/components/BAIText.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.test.tsx
@@ -55,3 +55,36 @@ describe('BAIText copyable', () => {
     expect(writeText).toHaveBeenCalledWith('bare');
   });
 });
+
+// FR-3692 — Astryx `Text` defaults to `primary` and paints it on its OWN
+// element, so a `BAIText` nested in a coloured owner (a link) needs an opt-out.
+describe('BAIText inheritColor', () => {
+  const colorOf = (node: HTMLElement) =>
+    node.closest('.astryx-text')?.getAttribute('data-color');
+
+  it('defaults to Astryx primary', () => {
+    render(<BAIText>plain</BAIText>);
+    expect(colorOf(screen.getByText('plain'))).toBe('primary');
+  });
+
+  it('inherits the surrounding colour when asked', () => {
+    render(<BAIText inheritColor>linked</BAIText>);
+    expect(colorOf(screen.getByText('linked'))).toBe('inherit');
+  });
+
+  it('does not override an explicit type', () => {
+    render(
+      <BAIText inheritColor type="danger">
+        danger
+      </BAIText>,
+    );
+    expect(colorOf(screen.getByText('danger'))).toBe('danger');
+  });
+
+  it('does not leak onto the DOM element as an attribute', () => {
+    render(<BAIText inheritColor>attr</BAIText>);
+    expect(
+      screen.getByText('attr').closest('.astryx-text'),
+    ).not.toHaveAttribute('inheritcolor');
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -98,6 +98,14 @@ export interface BAITextProps extends Omit<
   /** CSS-based ellipsis (multi-line via `rows`), with an optional tooltip. */
   ellipsis?: boolean | BAITextEllipsisConfig;
   copyable?: boolean | BAITextCopyConfig;
+  /**
+   * Take the surrounding colour instead of Astryx `Text`'s `primary` default —
+   * for a `BAIText` nested in an element that owns the colour, e.g. a link
+   * (FR-3692). antd's `Typography.Text` had no colour of its own, so this is
+   * the antd behaviour rather than a new one. Ignored when `type`/`disabled`
+   * name a colour explicitly.
+   */
+  inheritColor?: boolean;
 }
 
 const TYPE_TO_COLOR: Record<BAITextType, NonNullable<TextProps['color']>> = {
@@ -187,6 +195,7 @@ const BAIText: React.FC<BAITextProps> = ({
   monospace,
   ellipsis,
   copyable,
+  inheritColor,
   children,
   strong,
   italic,
@@ -244,7 +253,7 @@ const BAIText: React.FC<BAITextProps> = ({
           ? 'disabled'
           : type
             ? TYPE_TO_COLOR[type]
-            : mark
+            : mark || inheritColor
               ? 'inherit'
               : undefined
       }


### PR DESCRIPTION
Resolves #9100 (FR-3692)

A regression from #9084 (FR-3686): every ellipsized `BAILink` — which is every
`BAINameActionCell` name cell whose title is a link — renders in body text
colour instead of the link accent, so it no longer reads as a link.

## Mechanism

FR-3686 moved the truncating `BAIText` **inside** the link, because an ancestor
can neither shorten an atomic inline box nor see a child that fits it. That part
is correct and stays.

What it did not account for: Astryx `Text` resolves

```ts
const resolvedColor = color ?? defaultColorByType[type] ?? 'primary';
```

and paints the result **on its own element** (`colorStyles.primary` →
`color: var(--color-text-primary)`). The link's colour only ever reached the
text by *inheritance*, and a descendant's own declaration beats inheritance
regardless of specificity — so the injected wrapper repainted the link body.

Both branches are affected, for two different reasons that land in the same
place:

| branch | where the link colour comes from | what overrode it |
|---|---|---|
| `to` — react-router `<a class="bai-link-hover">` | `BAILink.css` → `var(--color-text-accent)` | the injected `BAIText` (1 nested `.astryx-text`) |
| `onClick` — Astryx `Link` `<button>` | Astryx `Link`'s own internal `<Text color="accent">` | the injected `BAIText` (2 nested `.astryx-text`, innermost wins) |

## Fix

Astryx `Text` has a **native `color="inherit"`**, so this is a prop, not a CSS
override. Two commits, because one inheriting box turned out not to be enough:

1. `00a7d1e` — `BAIText` gains `inheritColor`, and `BAILink` passes it on the
   wrapper it injects. An explicit `type` / `disabled` still wins, so nothing
   that names a colour changes.
2. `372c0a1` — **from Copilot's review.** Astryx `Link` inserts a
   `Text color="accent"` of its own between the root and its children, so in the
   no-`to` branch the root's colour still stopped at *that* wrapper. `BAILink`
   now passes Astryx `Link` its supported `color="inherit"` as well, making the
   link root the single source of colour — which is what `BAILink.css` already
   assumed, since `LINK_TYPE_CLASS` puts `.bai-link-hover` /
   `.bai-link-disabled` on that root unconditionally.

Together this restores the antd behaviour the port dropped — antd's
`Typography.Text` had no colour of its own, so a `Text` inside an `<a>`
inherited the link accent.

### One intended pixel change beyond the reported bug

A `type="disabled"` link's text was rendering Astryx's `accent` default at 50%
opacity, because `BAILink` never passed a `color` and `Link`'s default won over
`.bai-link-disabled` on the root. It now renders `--color-text-disabled`, which
is what that class was always for. Pinned by a test.

## Measured — live app, both branches, both modes

Painted colour of the element that actually owns the text
(`getComputedStyle` on the innermost `.astryx-text` inside the link).

| page / branch | mode | before | after | link's own colour |
|---|---|---|---|---|
| `/data` — `to` (router `<a>`) | light | `rgb(20, 20, 20)` | **`rgb(255, 122, 0)`** | `rgb(255, 122, 0)` |
| `/data` — `to` (router `<a>`) | dark | `rgb(255, 255, 255)` | **`rgb(190, 94, 6)`** | `rgb(190, 94, 6)` |
| `/serving` — `onClick` (Astryx `<button>`) | light | `rgb(20, 20, 20)` | **`rgb(255, 122, 0)`** | `rgb(255, 122, 0)` |
| `/serving` — `onClick` (Astryx `<button>`) | dark | `rgb(255, 255, 255)` | **`rgb(190, 94, 6)`** | `rgb(190, 94, 6)` |

`#FF7A00` / `#be5e06` is `--color-text-accent` (`light-dark(#FF7A00, #be5e06)`);
`#141414` / `#FFFFFF` is `--color-text-primary`. Both "before" rows were measured
on a build with the fix backed out, not derived. Dark mode was entered through
`prefers-color-scheme` (the app's `themeMode` default is `system`) with
`document.documentElement.dataset.theme` asserted `dark` in every reading.
Zero `pageerror` in all passes.

**Truncation is unchanged** — the FR-3686 fix stays intact:
`scrollWidth/clientWidth` still `199/37`, `212/37`, `78/63` on the same rows
before and after.

For the second commit, the checkable signal is the DOM contract rather than a
new colour: on `/serving` the link root has two nested `.astryx-text`, and the
outer one's `data-color` goes **`accent` → `inherit`**, with the painted colour
unchanged (`rgb(255, 122, 0)` light, `rgb(190, 94, 6)` dark). Before that
commit the outer box named its own colour and the root's never got past it.

## Screenshots — `/data`, name column

| | before | after |
|---|---|---|
| light | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9105/20260826-fr3692-before-light.png" width="440"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9105/20260826-fr3692-after-light.png" width="440"> |
| dark | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9105/20260826-fr3692-before-dark.png" width="440"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9105/20260826-fr3692-after-dark.png" width="440"> |

## Blast radius

Every `BAILink` with `ellipsis` — 5 call sites, one of which serves every table
name cell in the app:

- `packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx:413` (`to`)
- `packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx:426` (`onClick`)
- `packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx:151`
- `packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx:167`
- `react/src/components/DeploymentReplicasCard.tsx:468`

`inheritColor` is opt-in and defaults off, so `BAIText` used anywhere else is
untouched. The second commit is wider: `color="inherit"` reaches **every**
no-`to` `BAILink`, with or without `ellipsis` — the ~25 pure-`onClick` sites and
every `type="disabled"` one. At rest they resolve to the same accent they
already showed (measured above); the disabled tier is the one that changes, and
it is called out under Fix.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built (required after a
  `packages/backend.ai-ui/src` change)
- `pnpm --filter backend.ai-ui exec vitest run` → **799 passed | 1 skipped**
  (67 files) — includes 9 new tests
- `pnpm --prefix ./react exec vitest run` → **1627 passed** (102 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exit 1 with 3
  undeclared-`var()` findings, **all pre-existing on `main`**: verified by
  running the same gate on a clean `main` checkout, which reports the identical
  3 findings (`BAIDialog.css:17`, `BAIDrawerPortal.css:18`, `BAIText.css:28`) and
  the same exit code. None is in a file this PR touches.

## Tests added

- `BAIText.test.tsx` — `inheritColor` resolves `data-color` to `inherit`,
  defaults to `primary`, does not override an explicit `type`, and does not leak
  onto the DOM element as an attribute.
- `BAILink.test.tsx` — the innermost `.astryx-text` inside the link carries
  `data-color="inherit"`, for both the `to` and `onClick` branches; **every**
  `.astryx-text` in the chain does so under a tinted root
  (`style={{ color }}` — the `EditableFileName` pending-rename shape), ellipsized
  and plain; and the same for `type="disabled"`. The chain-wide assertions are
  the ones that fail on the first commit alone.

jsdom computes no StyleX CSS, so these assert the `data-color` attribute Astryx
reflects from the same resolved value rather than a computed colour; the colour
itself is covered by the live measurements above.

## Residue

- **Hover does not shift the link colour** — and it never did. `BAILink.css`
  declares `:hover { color: var(--color-accent) }` against a rest state of
  `var(--color-text-accent)`, but in this theme both resolve to the same value
  (measured: `light-dark(#FF7A00, #be5e06)` for both, in both modes), so the
  rule is a no-op by theme rather than something this PR broke or should fix.
  The hover affordance is the underline, which FR-3686's QA3 rule already
  carries.
- **One thing I could not measure end to end:** whether a caller's inline
  `style.color` on a no-`to` `BAILink` (the `EditableFileName` pending-rename
  tint) visibly reaches the text now. The DOM contract guarantees it — every
  `Text` in the chain is `color: inherit`, which is what the new tests assert —
  but in the running app, mutating an inline `color` on that `<button>` did not
  move the button's *own* computed colour, while the identical probe worked on a
  control element and on the router `<a>`. That is a property of the root
  element, unchanged by this PR in either direction, so I am recording it rather
  than claiming an outcome I did not observe.
- **Not subsumed:** `react/src/components/VFolderTable.tsx:417` still hand-rolls
  `overflow`/`textOverflow` on a `to` link instead of using `ellipsis`. It
  injects no `BAIText`, so it never had this bug — it has the older
  truncation-without-tooltip one, which is a separate item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCcPwgHmWGYNw79dUMWVMT
