### PR TITLE
fix(FR-3698): stop exposing the access token value in a hover tooltip

### DIFF
--- a/react/src/components/DeploymentAccessTokensCard.tsx
+++ b/react/src/components/DeploymentAccessTokensCard.tsx
@@ -240,12 +240,10 @@ const DeploymentAccessTokensCard: React.FC<DeploymentAccessTokensCardProps> = ({
         >
           <BAIFlex direction="column" align="stretch" gap="sm">
             <Text>{t('deployment.accessToken.Created')}</Text>
+            {/* `ellipsis` stays a bare boolean on purpose — a truncate tooltip
+                would put the secret behind a hover. Copy is the way. FR-3698. */}
             {createdToken ? (
-              <BAIText
-                copyable={{ text: createdToken.token }}
-                ellipsis={{ tooltip: true }}
-                code
-              >
+              <BAIText copyable={{ text: createdToken.token }} ellipsis code>
                 {createdToken.token}
               </BAIText>
             ) : null}
@@ -365,12 +363,14 @@ const DeploymentAccessTokensTable: React.FC<
             dataIndex: 'token',
             render: (_text, row) => {
               if (!row) return '-';
+              // `ellipsis` stays a bare boolean on purpose — a truncate tooltip
+              // would put the secret behind a hover. Copy is the way. FR-3698.
               return (
                 <BAINameActionCell
                   title={
                     <BAIText
                       copyable={{ text: row.token }}
-                      ellipsis={{ tooltip: true }}
+                      ellipsis
                       style={{ maxWidth: 200 }}
                     >
                       {row.token}


### PR DESCRIPTION
Resolves #9110 (FR-3698)

## Summary

Both places that render a deployment access token asked for the tooltip form of `ellipsis`, so hovering the truncated value revealed the whole token. This drops the tooltip at both, leaving the copy control as the way to get the value.

## Mechanism

`BAIText` resolves the tooltip from the `ellipsis` prop alone:

```ts
// packages/backend.ai-ui/src/components/BAIText.tsx
const resolveTooltipContent = (ellipsis, children) => {
  if (!ellipsis || typeof ellipsis !== 'object') return undefined;  // ← bare boolean: no tooltip
  ...
};
hasTruncateTooltip={!hasCustomTooltip && tooltipContent !== undefined}
```

and Astryx `Text` gates **both** exposure paths on that one flag — the tooltip layer *and* the native `title` attribute:

```tsx
// @astryxdesign/core/src/Text/Text.tsx
const tooltipEnabled =
  maxLines > 0 && hasTruncateTooltip !== false && truncation.isTruncated;
...
title={tooltipEnabled ? truncation.fullText : undefined}
{tooltipEnabled && (<Suspense><LazyXDSTooltip content={…fullText} /></Suspense>)}
```

So passing `ellipsis` as a bare boolean closes the hover bubble and the `title` tooltip together, while `maxLines: 1` truncation is untouched — the rendered geometry does not move.

## What changed

`react/src/components/DeploymentAccessTokensCard.tsx`, two call sites, `ellipsis={{ tooltip: true }}` → `ellipsis`:

- **L243-249** — the Token modal shown right after *Generate access token*.
- **L366-377** — the Token column of the Access Tokens table, inside `BAINameActionCell`.

## Why

A deployment access token is a **bearer credential**, and a hover is not a gate: screen shares, shoulder-surfing, screenshots and the accessibility tree all pick it up. The report that opened this issue was itself an instance — a full token, legible, sitting on the page background.

It was not useful even when it worked. A ~700-character base64url token wraps to eight lines inside the 300px bubble; nobody transcribes that by eye. The copy control is the real affordance, is already present at both sites, and puts the **full** value on the clipboard.

## The modal: truncate, not a full reveal

The issue left this open. The modal keeps its truncation rather than switching to a full wrapped reveal — twelve lines of unreadable base64 serve nobody, and keeping it matches the table cell and leaves the layout byte-for-byte unchanged. GitHub's full-PAT reveal is the counter-example, but its tokens are ~40 characters, not ~700.

## This deliberately cuts against FR-3608 — don't let it get swept back

**FR-3608** surveyed all 99 `BAIText copyable` call sites, found 12 that truncated with no way to read the value, and **gave 10 of them `ellipsis={{ tooltip: true }}`** (it also flipped `BAIId`'s default to a tooltip). The rule it set is "truncated text should be readable somehow".

This is the deliberate exception for a **secret**: unreadable-but-copyable is the desired end state. Each call site carries a one-line comment saying so, so the next FR-3608-style sweep does not put the tooltip back.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX sentinel, `astryx theme build --check`, z-index mirrors, Terminology).
- `pnpm --prefix ./react exec vitest run` → **102 files, 1627 tests passed**.
- `pnpm --filter backend.ai-ui exec vitest run` → **799 passed, 1 skipped (67 files)**.
- `pnpm --filter backend.ai-ui build` → clean.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 3 undeclared-var findings (`BAIDialog.css:17`, `BAIDrawerPortal.css:18`, `BAIText.css:28`). **All pre-existing** — verified by re-running the gate with this change stashed: output is byte-identical (`diff` clean). No CSS is in this diff.

### Note on `astryx theme build --check`

It fails on a freshly-installed worktree until `pnpm --filter backend.ai-ui build` has run, because the check reads the built `backend.ai-ui`. Unrelated to this change; recorded here because it cost a cycle.

## Residue — no live probe

**The surface is unreachable on the shared test backend: it has zero deployments**, and both sites only render once a deployment exists and a token has been generated. Creating one is a real mutation on a shared cluster, so it was not done. This change is therefore verified statically (the gated flag above, `tsc`, the full suites) rather than by a live hover.

What a reviewer should confirm on a cluster that has a deployment with a token:

- [ ] Hovering the token in the Access Tokens table shows **no** tooltip, and the element has **no** `title` attribute.
- [ ] Same in the Token modal after *Generate access token*.
- [ ] The copy button at both sites still puts the **full** token on the clipboard.
- [ ] The truncation/ellipsis still looks exactly as before.

Separately observed and **left untouched** as out of scope: `DeploymentAccessTokensTable` keeps the token string in `deletingToken` state (`{ id, token }`) but only ever reads `.id` — a dead field holding a secret. Worth a follow-up if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
