### PR TITLE
fix(FR-3706): paint the tab count badge in the active menu group's primary

### DIFF
--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.css
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.css
@@ -1,0 +1,26 @@
+/*
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ `.bai-tab-count-badge` — the count pill next to a tab label (FR-3706).
+
+ Astryx `Badge.variant` is a closed enum whose only accent-backed member is
+ `info`, so "paint this in the ACTIVE menu group's primary" is inexpressible as
+ a variant. `--color-accent` is: `AutoAdminPrimaryColorProvider`
+ (`react/src/components/MainLayout/MainLayout.tsx`) wraps every non-project
+ scope in `AstryxAdminTheme`, so the token already resolves per menu group —
+ measured on the badge element itself, light mode:
+
+   /session, /data     --color-accent: light-dark(#FF7A00, #be5e06)  (user)
+   /admin/session      --color-accent: light-dark(#028DF2, #0387bf)  (admin)
+
+ UNLAYERED on purpose, matching `actionAccent.css` / `BAITabList.css`: Astryx
+ ships inside `@layer astryx-base` with a `:not(#\#):not(#\#):not(#\#)`
+ specificity boost that no selector can beat within that layer, but any
+ unlayered rule beats every named layer, so a single class is enough and no
+ `!important` is needed.
+*/
+.bai-tab-count-badge--selected {
+  background-color: var(--color-accent);
+  color: var(--color-on-accent);
+}

--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.css
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.css
@@ -4,9 +4,12 @@
 
  `.bai-tab-count-badge` — the count pill next to a tab label (FR-3706).
 
- Astryx `Badge.variant` is a closed enum whose only accent-backed member is
- `info`, so "paint this in the ACTIVE menu group's primary" is inexpressible as
- a variant. `--color-accent` is: `AutoAdminPrimaryColorProvider`
+ Astryx `Badge.variant` is a closed enum with no member that follows the ambient
+ menu accent — `info` looks like one but this theme pins it to a fixed blue
+ (`astryx-theme/built/backendai-default-built.css`, `.astryx-badge.info`:
+ `light-dark(#0074e2, #6d9cfe)`), so "paint this in the ACTIVE menu group's
+ primary" is inexpressible as a variant. `--color-accent` is:
+ `AutoAdminPrimaryColorProvider`
  (`react/src/components/MainLayout/MainLayout.tsx`) wraps every non-project
  scope in `AstryxAdminTheme`, so the token already resolves per menu group —
  measured on the badge element itself, light mode:

--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.test.tsx
@@ -52,8 +52,9 @@ describe('BAITabCountBadge', () => {
     });
 
     it('should not pin a coloured Badge variant for the selected state', () => {
-      // The regression: `variant="green"` / `variant="info"` are fixed hues
-      // that cannot follow AstryxAdminTheme. Neutral + the class is the fix.
+      // The regression: `variant="green"` / `variant="info"` are both fixed
+      // hues in this theme, so neither follows AstryxAdminTheme. Neutral plus
+      // the accent class is the fix.
       const { container } = render(<BAITabCountBadge count={3} selected />);
       expect(badgeOf(container)).toHaveAttribute('data-variant', 'neutral');
     });

--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.test.tsx
@@ -1,0 +1,61 @@
+/*
+ FR-3706: the count pill next to a tab label carries the ACTIVE MENU GROUP's
+ primary, and the three call sites (Sessions / Data / Admin Sessions) must not
+ drift apart again.
+
+ jsdom resolves no custom properties, so the colour itself is not assertable
+ here — it is measured on the running app and recorded in the PR. What IS
+ assertable, and what the regression actually was, is that the selected state
+ routes through the accent CLASS rather than a hardcoded `Badge.variant`.
+*/
+import BAITabCountBadge from './BAITabCountBadge';
+import { render } from '@testing-library/react';
+
+const badgeOf = (container: HTMLElement) =>
+  container.querySelector('.astryx-badge');
+
+describe('BAITabCountBadge', () => {
+  describe('visibility', () => {
+    it('should render nothing when count is undefined', () => {
+      const { container } = render(<BAITabCountBadge />);
+      expect(badgeOf(container)).not.toBeInTheDocument();
+    });
+
+    it('should render nothing when count is 0', () => {
+      const { container } = render(<BAITabCountBadge count={0} />);
+      expect(badgeOf(container)).not.toBeInTheDocument();
+    });
+
+    it('should render a 0 when showZero is set', () => {
+      const { container } = render(<BAITabCountBadge count={0} showZero />);
+      expect(badgeOf(container)).toHaveTextContent('0');
+    });
+
+    it('should render the count when it is positive', () => {
+      const { container } = render(<BAITabCountBadge count={7} />);
+      expect(badgeOf(container)).toHaveTextContent('7');
+    });
+  });
+
+  describe('accent routing', () => {
+    it('should carry the accent class only when selected', () => {
+      const { container: unselected } = render(<BAITabCountBadge count={3} />);
+      expect(badgeOf(unselected)).toHaveClass('bai-tab-count-badge');
+      expect(badgeOf(unselected)).not.toHaveClass(
+        'bai-tab-count-badge--selected',
+      );
+
+      const { container: selected } = render(
+        <BAITabCountBadge count={3} selected />,
+      );
+      expect(badgeOf(selected)).toHaveClass('bai-tab-count-badge--selected');
+    });
+
+    it('should not pin a coloured Badge variant for the selected state', () => {
+      // The regression: `variant="green"` / `variant="info"` are fixed hues
+      // that cannot follow AstryxAdminTheme. Neutral + the class is the fix.
+      const { container } = render(<BAITabCountBadge count={3} selected />);
+      expect(badgeOf(container)).toHaveAttribute('data-variant', 'neutral');
+    });
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.tsx
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.tsx
@@ -1,0 +1,57 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ The count pill next to a tab label. Settles the "accent-vs-fixed-blue" open
+ question left at the top of `BAIBadgeCount` (to-astryx ticket 08): the active
+ tab's count carries the ACTIVE MENU GROUP's primary, via `--color-accent`
+ (see `BAITabCountBadge.css` for why that is a class and not a variant).
+*/
+import './BAITabCountBadge.css';
+import { Badge } from '@astryxdesign/core/Badge';
+import type { BadgeProps } from '@astryxdesign/core/Badge';
+import React from 'react';
+
+export interface BAITabCountBadgeProps extends Omit<
+  BadgeProps,
+  'label' | 'icon' | 'variant'
+> {
+  /** The count to show. Nullish or 0 renders nothing unless `showZero`. */
+  count?: number | null;
+  /** Whether the owning tab is the selected one. */
+  selected?: boolean;
+  /** Keep the pill when `count` is 0. @default false */
+  showZero?: boolean;
+}
+
+const BAITabCountBadge: React.FC<BAITabCountBadgeProps> = ({
+  count,
+  selected = false,
+  showZero = false,
+  className,
+  ...badgeProps
+}) => {
+  'use memo';
+
+  if (count === undefined || count === null || (count === 0 && !showZero)) {
+    return null;
+  }
+
+  return (
+    <Badge
+      className={[
+        'bai-tab-count-badge',
+        selected ? 'bai-tab-count-badge--selected' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      label={count}
+      {...badgeProps}
+    />
+  );
+};
+
+BAITabCountBadge.displayName = 'BAITabCountBadge';
+
+export default BAITabCountBadge;

--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.tsx
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.tsx
@@ -5,7 +5,7 @@
  The count pill next to a tab label. Settles the "accent-vs-fixed-blue" open
  question left at the top of `BAIBadgeCount` (to-astryx ticket 08): the active
  tab's count carries the ACTIVE MENU GROUP's primary, via `--color-accent`
- (see `BAITabCountBadge.css` for why that is a class and not a variant).
+ (see `BAITabCountBadge.css` for why no `Badge.variant` can express that).
 */
 import './BAITabCountBadge.css';
 import { Badge } from '@astryxdesign/core/Badge';

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -12,6 +12,8 @@ export { default as BAICard } from './BAICard';
 export type { BAICardProps, BAICardTabItem } from './BAICard';
 export { default as BAITabList } from './BAITabList';
 export type { BAITabListProps } from './BAITabList';
+export { default as BAITabCountBadge } from './BAITabCountBadge';
+export type { BAITabCountBadgeProps } from './BAITabCountBadge';
 export { default as BAICompactGroup } from './BAICompactGroup';
 export type { BAICompactGroupProps } from './BAICompactGroup';
 export { default as BAIMetadataList } from './BAIMetadataList';

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -24,7 +24,6 @@ import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
-import { Badge } from '@astryxdesign/core/Badge';
 import { Banner } from '@astryxdesign/core/Banner';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import {
@@ -38,11 +37,11 @@ import {
   BAIPropertyFilter,
   BAIResourceUnitGridSkeleton,
   BAISelectionLabel,
+  BAITabCountBadge,
   filterOutEmpty,
   filterOutNullAndUndefined,
   INITIAL_FETCH_KEY,
   mergeFilterValues,
-  PRIMARY_TAG_VARIANT,
   useBAILogger,
   useFetchKey,
 } from 'backend.ai-ui';
@@ -308,27 +307,12 @@ const AdminComputeSessionListPage = () => {
               sessionCounts[key as keyof typeof sessionCounts]?.count ?? 0;
             return {
               key,
-              label: (
-                <BAIFlex justify="center" gap={10}>
-                  {label}
-                  {count > 0 && (
-                    <Badge
-                      // PILOT-DECISION: antd count Badge (brand color when the
-                      // tab is active, gray otherwise) -> Astryx Badge pill.
-                      // Arbitrary token colors are inexpressible (P5); the
-                      // active state maps to PRIMARY_TAG_VARIANT (policy
-                      // class 4) and the inactive state to `neutral`. The
-                      // 10px font-size / paddingXS tweaks are dropped
-                      // (defaults-first).
-                      variant={
-                        queryParams.type === key
-                          ? PRIMARY_TAG_VARIANT
-                          : 'neutral'
-                      }
-                      label={count}
-                    />
-                  )}
-                </BAIFlex>
+              label,
+              endContent: (
+                <BAITabCountBadge
+                  count={count}
+                  selected={queryParams.type === key}
+                />
               ),
             };
           },

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -28,7 +28,6 @@ import { useCSVExport } from '../hooks/useCSVExport';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
 import { useBAIBreakpoint } from '../theme-shim';
-import { Badge } from '@astryxdesign/core/Badge';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { Grid, GridSpan } from '@astryxdesign/core/Grid';
@@ -49,10 +48,10 @@ import {
   BAIResourceUnitGridSkeleton,
   BAISelectionLabel,
   BAISessionsIcon,
+  BAITabCountBadge,
   filterOutNullAndUndefined,
   INITIAL_FETCH_KEY,
   mergeFilterValues,
-  PRIMARY_TAG_VARIANT,
   useBAILogger,
   useFetchKey,
 } from 'backend.ai-ui';
@@ -442,33 +441,13 @@ const ComputeSessionListPage = () => {
             },
             (label, key) => ({
               key,
-              label: (
-                <BAIFlex justify="center" gap={10}>
-                  {label}
-                  {
-                    // display badge only if count is greater than 0
-                    // @ts-ignore
-                    (sessionCounts[key]?.count || 0) > 0 && (
-                      <Badge
-                        // PILOT-DECISION: antd count Badge (brand color when
-                        // active, gray otherwise) -> Astryx Badge pill.
-                        // Arbitrary token colors are inexpressible (P5);
-                        // active maps to PRIMARY_TAG_VARIANT (policy class 4),
-                        // inactive to `neutral`. Font/padding tweaks dropped
-                        // (defaults-first).
-                        variant={
-                          queryParams.type === key
-                            ? PRIMARY_TAG_VARIANT
-                            : 'neutral'
-                        }
-                        label={
-                          // @ts-ignore
-                          sessionCounts[key].count
-                        }
-                      />
-                    )
-                  }
-                </BAIFlex>
+              label,
+              endContent: (
+                <BAITabCountBadge
+                  // @ts-ignore
+                  count={sessionCounts[key]?.count}
+                  selected={queryParams.type === key}
+                />
               ),
             }),
           )}

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -21,7 +21,6 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import { toProjectContext } from '../types/projectContext';
-import { Badge } from '@astryxdesign/core/Badge';
 import { Button } from '@astryxdesign/core/Button';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Link } from '@astryxdesign/core/Link';
@@ -32,6 +31,7 @@ import {
   BAICard,
   BAIPropertyFilter,
   BAISelectionLabel,
+  BAITabCountBadge,
   filterOutEmpty,
   filterOutNullAndUndefined,
   mergeFilterValues,
@@ -329,22 +329,13 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
               // slot, so the original's BAIFlex-wrapped JSX label is split in
               // two. This also restores a correct `aria-label` on the tab.
               label,
-              endContent:
-                // display badge only if count is greater than 0
-                // @ts-ignore
-                (folderCounts[key]?.count || 0) > 0 ? (
-                  // PILOT-DECISION: antd's Badge took an arbitrary `color`
-                  // (brand accent when selected, disabled grey otherwise)
-                  // plus explicit padding/fontSize. Astryx's Badge exposes
-                  // only a closed `variant` set.
-                  <Badge
-                    // @ts-ignore
-                    label={folderCounts[key].count}
-                    variant={
-                      queryParams.statusCategory === key ? 'info' : 'neutral'
-                    }
-                  />
-                ) : undefined,
+              endContent: (
+                <BAITabCountBadge
+                  // @ts-ignore
+                  count={folderCounts[key]?.count}
+                  selected={queryParams.statusCategory === key}
+                />
+              ),
             }),
           )}
         />


### PR DESCRIPTION
Resolves #9124 (FR-3706)

The count pill next to a tab label now carries the **active menu group's**
primary colour, on Sessions, Data and Admin → Sessions alike.

## Mechanism

Astryx `Badge.variant` is a **closed enum with no accent-following member**, so
each of the three tab strips picked a different fixed hue at migration time:

| call site | selected variant | resolves to |
|---|---|---|
| `ComputeSessionListPage` | `PRIMARY_TAG_VARIANT` | the literal `green` |
| `AdminComputeSessionListPage` | `PRIMARY_TAG_VARIANT` | the literal `green` |
| `VFolderNodeListPage` | `info` | a fixed blue |

`info` *looks* like the accent-backed member — Astryx's stock `Badge.tsx` defines
it as `var(--color-accent)` — but this theme's generated component block pins it:
`.astryx-badge.info { background-color: light-dark(#0074e2, #6d9cfe) }`
(`react/src/astryx-theme/built/backendai-default-built.css`). That is why the Data
tab measured `rgb(0,116,226)` while `--color-accent` on the same element was
`#FF7A00`. So the enum genuinely has no menu-accent-following member.

`PRIMARY_TAG_VARIANT` is `'green'` because its comment states "The Backend.AI
brand accent is a green". It is not — the brand accent seed is `#FF7A00`
(`BAI_DEFAULT_SEEDS.accent`); the green is `colorSuccess`. So none of the three
followed the theme, and the same element rendered the *same* colour under the
user and admin scopes while the sidebar and the tab indicator beside it swapped.

`--color-accent` **does** follow the scope, because `AutoAdminPrimaryColorProvider`
(`react/src/components/MainLayout/MainLayout.tsx`) wraps every non-project scope
in `AstryxAdminTheme`. Measured on the badge element itself — not on
`documentElement`, which is the trap here, since the admin theme is a subtree
`<Theme>`:

```
/session, /data     --color-accent: light-dark(#FF7A00, #be5e06)   (user)
/admin/session      --color-accent: light-dark(#028DF2, #0387bf)   (admin)
```

So the selected state routes through that token with an **unlayered
single-class** rule — the `actionAccent.css` idiom, which beats Astryx's
`:not(#\#):not(#\#):not(#\#)` specificity boost without `!important` — and the
three hand-rolled ternaries collapse into one BUI component, `BAITabCountBadge`,
so they cannot drift apart again. This also settles the accent-vs-fixed-blue
question left open in the header of `BAIBadgeCount`.

> A note for reviewers: **Sessions and Admin → Sessions are now deliberately
> different colours.** They render the same component; the point is that the
> colour follows the scope. Same-colour is the bug, not the baseline.

## Measured — badge background vs. the tab indicator beside it

The indicator is the menu group's primary, so "badge == indicator" is the
pass condition. Read on the running app at `1600x950`, dark entered through the
header toggle with `document.documentElement.dataset.theme` asserted `'dark'`.

| page | mode | badge — before | badge — after | indicator (target) |
|---|---|---|---|---|
| Sessions | light | `rgb(197,229,192)` | **`rgb(255,122,0)`** | `rgb(255,122,0)` |
| Sessions | dark | `rgba(132,201,128,.24)` | **`rgb(190,94,6)`** | `rgb(190,94,6)` |
| Data | light | `rgb(0,116,226)` | **`rgb(255,122,0)`** | `rgb(255,122,0)` |
| Data | dark | `rgb(109,156,254)` | **`rgb(190,94,6)`** | `rgb(190,94,6)` |
| Admin → Sessions | light | `rgb(197,229,192)` | **`rgb(2,141,242)`** | `rgb(2,141,242)` |
| Admin → Sessions | dark | `rgba(132,201,128,.24)` | **`rgb(3,135,191)`** | `rgb(3,135,191)` |

Foreground goes to `rgb(255,255,255)` (`--color-on-accent`) in every selected
case. Unselected badges are untouched (`neutral`, `rgb(229,229,229)` light /
`rgb(38,38,38)` dark). Zero `pageerror` in both passes.

### Sessions — light
![Sessions light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/images/fr-3706/cmp-light-Sessions.png)

### Data — light
![Data light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/images/fr-3706/cmp-light-Data.png)

### Admin → Sessions — dark (the scope swap is the point)
![Admin Sessions dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/images/fr-3706/cmp-dark-AdminSessions.png)

<details>
<summary>The other three pairs</summary>

**Sessions — dark**
![Sessions dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/images/fr-3706/cmp-dark-Sessions.png)

**Data — dark**
![Data dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/images/fr-3706/cmp-dark-Data.png)

**Admin → Sessions — light**
![Admin Sessions light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/images/fr-3706/cmp-light-AdminSessions.png)

</details>

## Also in this diff, deliberately

Sessions and Admin → Sessions move their count out of a `BAIFlex`-wrapped JSX
label into Astryx `Tab`'s native `endContent` slot — which is what Data already
did, with a comment saying why. Beyond making the three sites identical, it
fixes the tabs' accessible names: they read **`All2`, `Interactive2`** today
(the count is concatenated into the label text) and read `All`, `Interactive`
after. Visible in the probe output above.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built (required, BUI source changed)
- `pnpm --filter backend.ai-ui exec vitest run` → **790 passed**, 1 skipped (67 files)
- `pnpm --prefix ./react exec vitest run` → **1627 passed** (102 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exit 1, **pre-existing**:
  the same 3 undeclared `var()`s (`BAIDrawerPortal.css:18`, `BAIText.css:28`, +1)
  fail identically on `main` — checked by running the gate in a clean `main`
  checkout (`undeclared: 3` there too). Nothing in this diff is flagged.
- Live probe on `https://fr-3706.localhost:1357` against `10.82.0.130:8090`,
  light **and** dark, all three pages.

Copilot reviewed this PR once, as a draft, and raised both points recorded under
Residue. The comment-accuracy fix (`81368abef`) landed **after** that review and
was therefore not bot-reviewed; it is comments only, and `verify.sh` was re-run
on it (`=== ALL PASS ===`).

## Residue

- **`PRIMARY_TAG_VARIANT` keeps its wrong value and its comment.** Its three
  remaining call sites (`AdminUserCredentialList`, `KeypairInfoModal` ×2) are
  `admin` / main-access-key **tags**, not tab badges — a different surface, and
  under antd they were `<Tag color={token.colorPrimary}>`, i.e. they are green
  today for the same wrong reason. Left out of this PR on purpose so the fix
  stays reviewable — filed as **FR-3715**.
- **The selected badge is white on the accent, 2.61:1, below WCAG AA.** Raised
  by Copilot. It is the same pair as every primary button in the app (measured:
  `Start Session` is the identical `rgb(255,122,0)`/white at 2.61:1), so the fix
  belongs to `--color-on-accent` at the theme level rather than to this badge —
  filed as **FR-3714**. Confirmed with the reporter that this PR keeps the
  current pair.
- The gap between label and count is ~2px tighter after the move, because the
  native `endContent` slot supplies its own spacing instead of the previous
  `BAIFlex gap={10}`. Measured, judged an improvement, not compensated for.
- No Storybook story was added for `BAITabCountBadge`; its colour is not
  reproducible outside a themed app scope, which is exactly what the unit test
  says it cannot assert.
