### PR TITLE
feat(FR-3708): register backend.ai-ui as an Astryx CLI integration

### DIFF
--- a/.claude/rules/use-bai-card.md
+++ b/.claude/rules/use-bai-card.md
@@ -105,7 +105,7 @@ When a card's content is data-driven and uses Suspense, place the Suspense bound
 
 ```tsx
 <BAICard title={t('section.Title')}>
-  <Suspense fallback={<BAISkeleton active />}>
+  <Suspense fallback={<BAISkeleton />}>
     <DataDrivenContent />
   </Suspense>
 </BAICard>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,12 +152,13 @@ RULES:
 - Tokens for every value (`astryx docs tokens`). Brand/accent belongs in the theme (`astryx theme list` / `theme add <slug>`, or `astryx theme template` for a custom one) — never override --color-* in :root.
 - SELF-CHECK before you finish: re-read the file and replace any className=, style={{…}}, raw <div>/<span> layout, imported .css/@apply, or hardcoded #hex/px with the component or the xstyle prop + a token. If unsure a component/prop exists, run `astryx component <Name>` / `astryx search "<thing>"`; don't hand-roll CSS.
 - MIGRATION RELAXATION (antd → Astryx): the className=/style={{…}} part of the SELF-CHECK is relaxed for files carried over from the antd era, which are still full of `className` / inline `style` and `theme.useToken()` reads. Do not rewrite those wholesale — convert a file's idioms when you are already changing it for another reason. A style that props/xstyle cannot express goes in a co-located `.css` file the component imports (P17), with `var(--…)` Astryx tokens; never a runtime style engine.
+- BUI INTEGRATION (this repo): `backend.ai-ui` is registered as an Astryx integration, so `astryx component`, `astryx search` and `astryx component --list` cover the `BAI*` wrappers next to core's primitives, and `astryx docs backend-ai-ui` explains the layer. When a `BAI*` component and a core primitive both fit, use the `BAI*` one — it carries the project defaults, and it imports from `backend.ai-ui` (the Import line `astryx component` prints for it names core — an upstream CLI 0.5.0 bug). A new `BAI*` component ships a same-stem `{Name}.doc.ts` beside its source.
 
 MORE CLI:
   search "<query>"   find any component / hook / doc / template / block
   component --list   163 components by category
   template --list    page + block recipes
-  docs <topic>       browser-support, cli-integrations, color, elevation, getting-started, icons, illustrations, internationalization, layout, migration, motion, principles, shape, spacing, styling-libraries, styling, theme, tokens, typography, working-with-ai
+  docs <topic>       browser-support, cli-integrations, color, elevation, getting-started, icons, illustrations, internationalization, layout, migration, motion, principles, shape, spacing, styling-libraries, styling, theme, tokens, typography, working-with-ai, backend-ai-ui
   swizzle <Name>     eject component source for deep customization
   upgrade --apply    run after any @astryxdesign/core bump
 <!-- ASTRYX:END -->

--- a/packages/backend.ai-ui/astryx.integration.ts
+++ b/packages/backend.ai-ui/astryx.integration.ts
@@ -1,0 +1,12 @@
+import type { AstryxIntegration } from '@astryxdesign/cli/authoring';
+
+/**
+ * What BUI contributes to the Astryx CLI. Identity (name, version) comes from
+ * package.json; every root below is optional and only the ones we ship are
+ * declared. No `templates` / `codemods`: BUI ships neither.
+ */
+export default {
+  components: './src/components',
+  docs: './src/astryx-docs',
+  issuesUrl: 'https://github.com/lablup/backend.ai-webui/issues',
+} satisfies AstryxIntegration;

--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -77,6 +77,7 @@
     "react-i18next": "catalog:"
   },
   "devDependencies": {
+    "@astryxdesign/cli": "catalog:",
     "@astryxdesign/core": "catalog:",
     "@astryxdesign/theme-neutral": "catalog:",
     "@astryxdesign/lab": "catalog:",

--- a/packages/backend.ai-ui/src/astryx-docs/astryxIntegration.test.ts
+++ b/packages/backend.ai-ui/src/astryx-docs/astryxIntegration.test.ts
@@ -1,0 +1,149 @@
+import integration from '../../astryx.integration';
+import { parseDoc, parseReference } from '@astryxdesign/cli/authoring';
+import fg from 'fast-glob';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the Astryx CLI integration BUI ships (`astryx.integration.ts`).
+ *
+ * The CLI's discovery is deliberately fault-tolerant — a doc file that fails
+ * the authoring schema is skipped with a warning instead of crashing the
+ * command — so a broken doc drops its component out of `astryx component` /
+ * `astryx search` silently. These assertions are what make that loud.
+ */
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const componentsRoot = resolve(packageDir, integration.components);
+const docsRoot = resolve(packageDir, integration.docs);
+
+const componentDocs = fg.sync('**/*.doc.ts', {
+  cwd: componentsRoot,
+  absolute: true,
+});
+const referenceDocs = fg.sync('*.doc.ts', { cwd: docsRoot, absolute: true });
+
+const stemOf = (file: string) => basename(file, '.doc.ts');
+
+interface DocProp {
+  name: string;
+  description: string;
+}
+
+/** Every prop list in a doc — the top-level one, or each `components` entry's. */
+const propLists = (docs: {
+  props?: DocProp[];
+  components?: Array<{ props?: DocProp[] }>;
+}): DocProp[][] =>
+  docs.props
+    ? [docs.props]
+    : (docs.components ?? [])
+        .map((entry) => entry.props)
+        .filter((props): props is DocProp[] => !!props);
+
+describe('astryx integration manifest', () => {
+  it('points at roots that exist', () => {
+    expect(existsSync(componentsRoot)).toBe(true);
+    expect(existsSync(docsRoot)).toBe(true);
+  });
+
+  it('ships at least one component doc and one reference doc', () => {
+    expect(componentDocs.length).toBeGreaterThan(0);
+    expect(referenceDocs.length).toBeGreaterThan(0);
+  });
+});
+
+describe.each(componentDocs.map((file) => [stemOf(file), file]))(
+  'component doc %s',
+  (stem, file) => {
+    it('documents a component that exists next to it', () => {
+      expect(existsSync(resolve(dirname(file), `${stem}.tsx`))).toBe(true);
+    });
+
+    it('exports `docs` as both the named and the default export', async () => {
+      // The CLI's component loader reads the NAMED export only, while the
+      // authoring docs describe a default export. Shipping one without the
+      // other loads as `undefined` on one of the two paths.
+      const mod = await import(/* @vite-ignore */ file);
+      expect(mod.docs).toBeDefined();
+      expect(mod.default).toBe(mod.docs);
+    });
+
+    it('satisfies the authoring schema', async () => {
+      const { docs } = await import(/* @vite-ignore */ file);
+      expect(() => parseDoc(docs)).not.toThrow();
+    });
+
+    it('stamps a single-component doc and leaves a multi-component one unstamped', async () => {
+      const { docs } = await import(/* @vite-ignore */ file);
+      // The stamped `type: 'component'` schema requires a top-level `props`
+      // array and has no multi-component variant (CLI 0.5.0). A file that
+      // exports several components documents them under `components` and
+      // therefore has to go through the unstamped, shape-sniffed path.
+      if (docs.components) {
+        expect(docs.type).toBeUndefined();
+      } else {
+        expect(docs.type).toBe('component');
+      }
+    });
+
+    it('is named after its file, with a BAI-prefixed display name', async () => {
+      const { docs } = await import(/* @vite-ignore */ file);
+      // Discovery keys a component on the doc file's stem; a `name` that
+      // disagrees makes `astryx component <name>` miss it.
+      expect(docs.name).toBe(stem);
+      expect(docs.displayName).toBeTruthy();
+      if (stem.startsWith('BAI')) {
+        expect(docs.displayName).toMatch(/^BAI /);
+      }
+    });
+
+    it('documents only props the component source mentions', async () => {
+      // The cheapest defence against a doc that drifts away from its
+      // component: a prop the source never names cannot be a prop. It does
+      // not prove the type or the default is still right — review and
+      // `tsc` cover the shape — but it catches renamed and deleted props,
+      // which is how these files go stale.
+      const { docs } = await import(/* @vite-ignore */ file);
+      const source = readFileSync(
+        resolve(dirname(file), `${stem}.tsx`),
+        'utf-8',
+      );
+      for (const props of propLists(docs)) {
+        for (const prop of props) {
+          expect(
+            new RegExp(`\\b${prop.name}\\b`).test(source),
+            `${stem}.doc.ts documents a prop \`${prop.name}\` that ${stem}.tsx never names`,
+          ).toBe(true);
+        }
+      }
+    });
+
+    it('documents each prop once, with a description', async () => {
+      const { docs } = await import(/* @vite-ignore */ file);
+      for (const props of propLists(docs)) {
+        const names = props.map((prop) => prop.name);
+        expect(names).toEqual([...new Set(names)]);
+        for (const prop of props) {
+          expect(prop.description.trim().length).toBeGreaterThan(0);
+        }
+      }
+    });
+  },
+);
+
+describe.each(referenceDocs.map((file) => [stemOf(file), file]))(
+  'reference doc %s',
+  (stem, file) => {
+    it('satisfies the ReferenceDoc schema and is named after its file', async () => {
+      const mod = await import(/* @vite-ignore */ file);
+      expect(mod.docs).toBeDefined();
+      expect(mod.default).toBe(mod.docs);
+      expect(() => parseReference(mod.docs)).not.toThrow();
+      // A topic name is a CLI argument and a docsite path.
+      expect(mod.docs.name).toBe(stem);
+      expect(mod.docs.name).toMatch(/^[\w-]+$/);
+    });
+  },
+);

--- a/packages/backend.ai-ui/src/astryx-docs/backend-ai-ui.doc.ts
+++ b/packages/backend.ai-ui/src/astryx-docs/backend-ai-ui.doc.ts
@@ -1,0 +1,173 @@
+import type { ReferenceDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'generic',
+  name: 'backend-ai-ui',
+  title: 'Backend.AI UI (BUI)',
+  description:
+    'The BAI* component layer this repository builds on top of Astryx, and when to reach past it.',
+  category: 'guide',
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'backend.ai-ui (BUI) is the workspace package that owns every reusable BAI* component. It wraps Astryx primitives with the Backend.AI design-system defaults, its own i18next instance, and the app-shim that replaced antd. Components import from the package root: `import { BAICard, BAIFlex } from "backend.ai-ui";`.',
+        },
+        {
+          type: 'prose',
+          text: 'BUI is registered as an Astryx CLI integration, so `astryx component <Name>`, `astryx search`, and `astryx component --list` answer with BAI* components alongside Astryx core. When both could serve, the BAI* one wins — it carries the project defaults that a bare Astryx primitive does not.',
+        },
+        {
+          type: 'prose',
+          text: 'One caveat while reading those answers: the **Import** line `astryx component <Name>` prints for a BUI component says `@astryxdesign/core`. That is an upstream CLI 0.5.0 bug — the human renderer recomputes the specifier against core instead of using the resolved one — and it is cosmetic. Every BAI* component imports from `backend.ai-ui`, which is what `astryx search` and `--json` correctly report.',
+        },
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Search before writing UI: `astryx search "<thing>"` lists core and BUI together.',
+            'Read the BAI* doc first — it names the Astryx component it wraps and what it adds.',
+            'Add reusable components to BUI, not to react/src (see "Where a component lives").',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Choosing between a BAI wrapper and an Astryx primitive',
+      content: [
+        {
+          type: 'prose',
+          text: 'A BAI wrapper exists when the project needs a behavior or default the Astryx primitive does not provide. Reaching past the wrapper to the primitive loses that default silently — the UI still renders, it just stops matching every other screen.',
+        },
+        {
+          type: 'table',
+          headers: ['Instead of', 'Use', 'Because'],
+          rows: [
+            [
+              'Card',
+              'BAICard',
+              'No header divider, status border colors, standardized title/extra layout.',
+            ],
+            [
+              'Button (async onClick)',
+              'BAIButton with `action`',
+              'Drives the pending state from the returned promise.',
+            ],
+            [
+              'a raw layout element',
+              'BAIFlex',
+              'The project has no raw <div> layout; BAIFlex carries the gap/align vocabulary.',
+            ],
+            [
+              'Popover + buttons',
+              'BAIPopconfirm',
+              'The anchored confirm tier, with the danger styling and promise-aware confirm.',
+            ],
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Destructive confirmation tiers',
+      content: [
+        {
+          type: 'prose',
+          text: 'Ask: if the user clicks OK by accident, can they recover the state in under 30 seconds without contacting support? No means the action is irreversible and needs a typed confirmation.',
+        },
+        {
+          type: 'table',
+          headers: ['Tier', 'Component'],
+          rows: [
+            [
+              'Irreversible (delete, purge, force-terminate)',
+              'BAIDeleteConfirmModal with `requireConfirmInput`',
+            ],
+            ['Reversible, anchored', 'BAIPopconfirm'],
+            [
+              'Reversible, inside a table row',
+              "BAINameActionCell action's `popConfirm`",
+            ],
+            [
+              'Reversible, imperative',
+              'App.useApp().modal.confirm() from the app-shim',
+            ],
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Confirm a permanent deletion with an anchored popover, even when the server also guards it.',
+            'Hand-roll a modal with a text input — BAIDeleteConfirmModal is the shared one.',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Translations',
+      content: [
+        {
+          type: 'prose',
+          text: "BUI components bind to BUI's own i18next instance. Use `useBAIi18n()` / `<BAITrans>` inside packages/backend.ai-ui/src, with keys in packages/backend.ai-ui/src/locale/. Importing `useTranslation` / `Trans` from react-i18next inside BUI is blocked by ESLint — those belong to host components under react/src.",
+        },
+      ],
+    },
+    {
+      title: 'Where a component lives',
+      content: [
+        {
+          type: 'prose',
+          text: 'BUI is the single home for reusable BAI* components. A component stays under react/src only when it genuinely depends on host-app context — the host router, host jotai state, or host resources/i18n keys that would make no sense in a library. Relay is not a reason to stay host-side: BUI has its own Relay project and host queries can spread BUI fragments.',
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Fork a BUI component host-side to add a capability — add the capability to the BUI component.',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Documenting a component',
+      content: [
+        {
+          type: 'prose',
+          text: "A BAI* component becomes visible to this CLI when it ships a same-stem doc file next to its source: `BAICard.tsx` and `BAICard.doc.ts`. The doc must export a `docs` constant — the CLI's component loader reads the named export, so a default-only file loads as undefined — and re-export it as default to match the documented authoring shape.",
+        },
+        {
+          type: 'code',
+          lang: 'ts',
+          label: 'BAICard.doc.ts',
+          code: [
+            "import type { ComponentDoc } from '@astryxdesign/cli/authoring';",
+            '',
+            'export const docs = {',
+            "  type: 'component',",
+            "  name: 'BAICard',",
+            "  displayName: 'BAI Card',",
+            "  category: 'Container',",
+            "  keywords: ['card', 'panel', 'surface'],",
+            "  usage: { description: 'What it is, and when to use it instead of the primitive.' },",
+            "  props: [{ name: 'title', type: 'ReactNode', description: 'Header title.' }],",
+            '} satisfies ComponentDoc;',
+            '',
+            'export default docs;',
+          ].join('\n'),
+        },
+        {
+          type: 'prose',
+          text: 'Doc files sit inside src/ on purpose: `tsc --noEmit` type-checks them against ComponentDoc, so a prop list that drifts from the component fails the same harness as the rest of the code. They are excluded from the published dist.',
+        },
+        {
+          type: 'prose',
+          text: 'One doc per component FILE — discovery keys a component on the doc file\'s stem, so a file that exports several components (BAISelect and its option markers, BAIMetadataList and its item) documents them under `components: [...]` instead of `props`. Such a doc must OMIT the `type: "component"` stamp: the stamped schema requires a top-level `props` array and has no multi-component variant, so a stamped multi doc fails validation while an unstamped one is shape-sniffed and accepted.',
+        },
+      ],
+    },
+  ],
+} satisfies ReferenceDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/astryx-docs/backend-ai-ui.doc.ts
+++ b/packages/backend.ai-ui/src/astryx-docs/backend-ai-ui.doc.ts
@@ -159,7 +159,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Doc files sit inside src/ on purpose: `tsc --noEmit` type-checks them against ComponentDoc, so a prop list that drifts from the component fails the same harness as the rest of the code. They are excluded from the published dist.',
+          text: 'Doc files sit inside src/ on purpose, so `tsc --noEmit` type-checks them. Be clear about what that buys: `satisfies ComponentDoc` validates the SHAPE of the doc — an unknown field, a category outside the union, a missing usage.description — and nothing more. Prop names and types are strings to the compiler, so it cannot see a doc that has drifted from its component. The name-level drift guard is a separate one, in astryxIntegration.test.ts: it fails when a doc names a prop the component source never mentions. A prop whose TYPE or DEFAULT went stale is caught by neither, and stays a review concern. They are excluded from the published dist.',
         },
         {
           type: 'prose',

--- a/packages/backend.ai-ui/src/components/BAIButton.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIButton.doc.ts
@@ -1,0 +1,120 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIButton',
+  displayName: 'BAI Button',
+  category: 'Action',
+  keywords: ['button', 'action', 'cta', 'submit', 'icon button', 'loading'],
+  usage: {
+    description:
+      'The project button. It renders Astryx Button, or Astryx IconButton when an icon is passed with no children, behind an antd-shaped prop vocabulary (type, size, danger, block, loading) so the call sites carried over from the antd era keep compiling. On top of that mapping it adds an accessible-name fallback: an icon-only button resolves its label from aria-label, then title, then a generic placeholder, because Astryx requires a label and antd did not. Remaining props pass through to the underlying Astryx component, and title becomes its tooltip rather than the native browser one.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Pass an async handler to action for mutations and refetches — Astryx clickAction shows the pending spinner, sets aria-busy, and swallows re-clicks until the promise settles, so no local isPending state is needed.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give every icon-only button an aria-label or title; without one it falls back to a generic placeholder and a screen reader announces nothing useful.',
+      },
+      {
+        guidance: false,
+        description:
+          'Hand-roll a loading flag around an async onClick when action already derives it from the returned promise.',
+      },
+      {
+        guidance: false,
+        description:
+          'Expect ghost, shape, htmlType or iconPosition to work — they are not part of the surface, and color is accepted but only danger carries meaning.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'type',
+      type: "'primary' | 'default' | 'text' | 'link' | 'dashed'",
+      description:
+        'Emphasis axis. primary maps to the Astryx primary variant, text and link to ghost, default and dashed to secondary. danger overrides whatever this selects.',
+    },
+    {
+      name: 'danger',
+      type: 'boolean',
+      description:
+        'Renders the destructive variant, winning over type and variant. Use it for delete, terminate and purge triggers.',
+    },
+    {
+      name: 'size',
+      type: "'small' | 'middle' | 'large'",
+      description:
+        'antd size names, mapped to the Astryx sm / md / lg element sizes. Left unset, the Astryx default applies.',
+    },
+    {
+      name: 'icon',
+      type: 'ReactNode',
+      description:
+        'Glyph rendered before the label. With no children the component switches to Astryx IconButton, which needs an accessible name from aria-label or title.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description:
+        'Button content. It is also flattened into the Astryx label prop, so text children double as the accessible name.',
+    },
+    {
+      name: 'action',
+      type: '() => Promise<void>',
+      description:
+        'Async click handler wired to Astryx clickAction. The button shows a spinner and reports aria-busy while the promise is pending, and ignores further clicks until it settles.',
+    },
+    {
+      name: 'loading',
+      type: 'boolean',
+      description:
+        'Forces the spinner and blocks interaction. Only needed when the pending state comes from outside; action drives it on its own.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description:
+        'Blocks interaction and applies the Astryx disabled styling.',
+    },
+    {
+      name: 'block',
+      type: 'boolean',
+      description: 'Stretches the button to the full width of its container.',
+    },
+    {
+      name: 'title',
+      type: 'string',
+      description:
+        'Becomes the Astryx tooltip instead of the native browser title, and serves as the accessible name when there are no text children.',
+    },
+    {
+      name: 'variant',
+      type: "'filled' | 'outlined' | 'solid' | 'dashed' | 'text' | 'link'",
+      description:
+        'antd v6 emphasis axis, resolved together with type. solid behaves like primary, text and link like ghost, everything else like secondary.',
+    },
+    {
+      name: 'color',
+      type: 'string',
+      description:
+        'antd v6 colour axis. Only danger is honoured — it selects the destructive variant; any other value is accepted and ignored, because Astryx Button has no colour slot.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Async action',
+      code: '<BAIButton type="primary" action={handleAssign}>\n  {t(\'general.Add\')}\n</BAIButton>',
+    },
+    {
+      label: 'Destructive icon-only row action',
+      code: '<BAIButton\n  danger\n  size="small"\n  icon={<Trash2 />}\n  title={t(\'button.Delete\')}\n  onClick={() => setDeletingTarget(record)}\n/>',
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAICard.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAICard.doc.ts
@@ -205,7 +205,7 @@ export const docs = {
     { key: 'logs', label: t('session.Logs') },
   ]}
 >
-  <Suspense fallback={<BAISkeleton active />}>
+  <Suspense fallback={<BAISkeleton />}>
     <TabContent tab={activeTab} />
   </Suspense>
 </BAICard>`,

--- a/packages/backend.ai-ui/src/components/BAICard.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAICard.doc.ts
@@ -1,0 +1,216 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAICard',
+  displayName: 'BAI Card',
+  category: 'Container',
+  keywords: ['card', 'panel', 'surface', 'section', 'container', 'tabs'],
+  usage: {
+    description:
+      'The card container for every card surface in Backend.AI. It composes Astryx Card with a title row, an extra action slot, an optional full-bleed tab strip, status border tints, a loading skeleton, and a footer action row — none of which Astryx Card, a bare padded surface, provides on its own. Reaching for Astryx Card directly loses those defaults and produces a header that does not match the rest of the app. Remaining DOM props (id, data-*, style, event handlers) pass through to the underlying Astryx Card element.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Put card-scoped actions — refresh, the primary create button, edit configuration, export — in extra, grouped in a BAIFlex with the primary button rightmost.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep content-scoped controls (filters, search, sort) inside the body, and place a Suspense boundary inside the card so the title stays visible while data loads.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use status to signal content state; it colors the border and switches the extraButtonTitle button to a matching icon.',
+      },
+      {
+        guidance: false,
+        description:
+          'Pass styles={{ body: { paddingTop: 0 } }} — Astryx Card has one padding step for the whole surface, so the prop is accepted and ignored. Use padding or size="small" for a per-card inset.',
+      },
+      {
+        guidance: false,
+        description:
+          'Add marginTop to the first child for breathing room; the flush-to-header look is intentional, and spacing belongs in the parent layout.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'title',
+      type: 'ReactNode',
+      description:
+        'Header title. A string renders as an Astryx Heading level 5, so it joins the document outline; a node renders verbatim.',
+    },
+    {
+      name: 'extra',
+      type: 'ReactNode',
+      description:
+        'Content for the right side of the title row. Takes precedence over extraButtonTitle.',
+    },
+    {
+      name: 'extraButtonTitle',
+      type: 'string | ReactNode',
+      description:
+        'Renders a link-style BAIButton in the header when extra is not given. With status="error" or "warning" it gains the matching icon.',
+    },
+    {
+      name: 'onClickExtraButton',
+      type: '() => void',
+      description: 'Click handler for the button produced by extraButtonTitle.',
+    },
+    {
+      name: 'status',
+      type: "'success' | 'error' | 'warning' | 'default'",
+      description:
+        'Content state. Tints the card border and, for error, adds the bai-card-error class that product tours anchor to.',
+      default: "'default'",
+    },
+    {
+      name: 'showDivider',
+      type: 'boolean',
+      description:
+        'Draws a Divider under the header. Nothing is drawn by default; tabList supplies its own rule.',
+    },
+    {
+      name: 'size',
+      type: "'default' | 'small'",
+      description:
+        'Compact step. "small" drops the Astryx padding from 6 (24px) to 3 (12px).',
+    },
+    {
+      name: 'padding',
+      type: "React.ComponentProps<typeof Card>['padding']",
+      description:
+        'Astryx Card padding step, overriding the size-derived value. The full-bleed tab strip follows it.',
+      default: '6 (3 when size="small")',
+    },
+    {
+      name: 'width',
+      type: "React.ComponentProps<typeof Card>['width']",
+      description: 'Astryx Card width passthrough.',
+    },
+    {
+      name: 'type',
+      type: "'inner'",
+      description:
+        'Nested-card treatment; maps to the Astryx Card muted variant for a tinted surface.',
+    },
+    {
+      name: 'bordered',
+      type: 'boolean',
+      description:
+        'Accepted for source compatibility with the antd-shaped call sites. The card always renders the default Astryx variant.',
+    },
+    {
+      name: 'variant',
+      type: "'outlined' | 'borderless'",
+      description:
+        'The antd v6 spelling of bordered, accepted for the same reason and with the same effect.',
+    },
+    {
+      name: 'hoverable',
+      type: 'boolean',
+      description: 'Adds a hover shadow from BAICard.css.',
+    },
+    {
+      name: 'loading',
+      type: 'boolean',
+      description:
+        'Replaces the body with three Skeleton bars while keeping the header and tabs visible.',
+    },
+    {
+      name: 'cover',
+      type: 'ReactNode',
+      description:
+        'Content rendered above the title row, inside the card padding.',
+    },
+    {
+      name: 'actions',
+      type: 'Array<ReactNode>',
+      description:
+        'Footer actions, rendered under a Divider and distributed evenly across the card.',
+    },
+    {
+      name: 'tabList',
+      type: 'Array<BAICardTabItem>',
+      description:
+        'Tab descriptors ({ key, label | tab, endContent }) rendered as a BAITabList that full-bleeds to the card borders. A rich tab label must be split: keep label a string and pass the trailing node as endContent.',
+    },
+    {
+      name: 'activeTabKey',
+      type: 'string',
+      description: 'Controlled active tab key.',
+    },
+    {
+      name: 'defaultActiveTabKey',
+      type: 'string',
+      description:
+        'Active tab used when activeTabKey is absent. Falls back to the first tab.',
+    },
+    {
+      name: 'onTabChange',
+      type: '(key: string) => void',
+      description: 'Fired with the key of the tab the user selected.',
+    },
+    {
+      name: 'tabBarExtraContent',
+      type: 'ReactNode',
+      description:
+        'Trailing slot rendered inside the tab bar, to the right of the tabs.',
+    },
+    {
+      name: 'styles',
+      type: 'BAICardSlotStyles',
+      description:
+        'The antd slot-style map (header, body, cover, actions, extra, title). Accepted and ignored — use padding or size instead.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Card body content.',
+    },
+    {
+      name: 'ref',
+      type: 'Ref<HTMLDivElement>',
+      description: 'Ref to the card container element.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Card with header actions',
+      code: `<BAICard
+  title={t('modelService.AutoScalingRules')}
+  extra={
+    <BAIFlex gap="xs" align="center">
+      <BAIFetchKeyButton loading={isPending} value="" onChange={refetch} />
+      <BAIButton type="primary" icon={<PlusIcon />} onClick={openCreate}>
+        {t('button.Add')}
+      </BAIButton>
+    </BAIFlex>
+  }
+>
+  <AutoScalingRuleTable />
+</BAICard>`,
+    },
+    {
+      label: 'Tabbed card',
+      code: `<BAICard
+  activeTabKey={activeTab}
+  onTabChange={setActiveTab}
+  tabList={[
+    { key: 'general', label: t('session.General') },
+    { key: 'logs', label: t('session.Logs') },
+  ]}
+>
+  <Suspense fallback={<BAISkeleton active />}>
+    <TabContent tab={activeTab} />
+  </Suspense>
+</BAICard>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.doc.ts
@@ -1,0 +1,153 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIFetchKeyButton',
+  displayName: 'BAI Fetch Key Button',
+  category: 'Action',
+  keywords: [
+    'refresh',
+    'reload',
+    'refetch',
+    'fetch key',
+    'auto refresh',
+    'polling',
+    'interval',
+  ],
+  usage: {
+    description:
+      'The refresh control for any data surface. It renders a BAIButton with a rotate icon and, on each click, calls `onChange` with a fresh ISO timestamp — the fetch key a Relay query or refetch reads to reload. It can also refresh on a timer: wiring `onChangeAutoUpdateDelay` turns the control into an Astryx ButtonGroup whose second half is a DropdownMenu of interval presets (plus "Off"), and while an interval is active a BAICountdownBorder fills around the control once per cycle. Manual clicks, interval changes and finished loads all re-anchor that countdown, so the animation never runs ahead of the real reload. Remaining props pass through to BAIButton.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Place it in the `extra` slot of the BAICard whose content it reloads, so a card has exactly one refresh affordance.',
+      },
+      {
+        guidance: true,
+        description:
+          'Feed `loading` from the refetch transition — the icon spins for at least 700ms so a fast reload still reads as a refresh, and auto-refresh pauses while a load is in flight.',
+      },
+      {
+        guidance: true,
+        description:
+          'Persist the chosen interval by pairing `autoUpdateDelay` with `onChangeAutoUpdateDelay` (the host-side AutoUpdateFetchKeyButton stores it in user settings) instead of hardcoding a delay.',
+      },
+      {
+        guidance: true,
+        description:
+          'Leave `pauseWhenHidden` on so auto-refresh stops issuing requests once the browser tab moves to the background.',
+      },
+      {
+        guidance: false,
+        description:
+          'Include `null` in `autoUpdateDelayOptions` — "Off" is prepended by the component and a null entry would duplicate it.',
+      },
+      {
+        guidance: false,
+        description:
+          'Thread a fetch key through `value` when nothing reads it; the button generates its own key and `onChange` alone is enough.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'onChange',
+      type: '(fetchKey: string) => void',
+      description:
+        'Called with a new ISO timestamp on every refresh, manual or automatic. Trigger the refetch here.',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'string',
+      description:
+        'Current fetch key. Optional and unread by the component — it generates its own key — so consumers that refetch directly inside `onChange` can omit it.',
+    },
+    {
+      name: 'loading',
+      type: 'boolean',
+      description:
+        'Whether a load is in flight. Drives the spinner (held for at least 700ms), pauses auto-refresh, and freezes the countdown border until the load finishes.',
+    },
+    {
+      name: 'lastLoadTime',
+      type: 'Date',
+      description:
+        'Timestamp of the last successful load. Left unset, the component records it itself on each load-to-idle transition.',
+    },
+    {
+      name: 'showLastLoadTime',
+      type: 'boolean',
+      description:
+        'Replaces the "Refresh" tooltip with a relative "Last updated: …" message that re-renders every 5 seconds.',
+    },
+    {
+      name: 'autoUpdateDelay',
+      type: 'number | null',
+      description:
+        'Auto-refresh interval in milliseconds; `null` means off. Controllable — pass it together with `onChangeAutoUpdateDelay` to let the host own and persist the value.',
+    },
+    {
+      name: 'onChangeAutoUpdateDelay',
+      type: '(delayMs: number | null) => void',
+      description:
+        'Called when the user picks an interval or "Off". Providing it is what opts the button into the interval dropdown; without it the control is a single refresh button.',
+    },
+    {
+      name: 'autoUpdateDelayOptions',
+      type: 'readonly number[]',
+      description:
+        'Interval presets shown in the dropdown, in milliseconds. An active value outside this list stays selectable for the lifetime of the component instead of disappearing.',
+      default: '[5000, 10000, 15000, 30000, 60000]',
+    },
+    {
+      name: 'showCountdownBorder',
+      type: 'boolean',
+      description:
+        'Whether the animated border fills around the control while auto-refresh is on. Set it to `false` where the animation would compete with nearby motion.',
+      default: 'true',
+    },
+    {
+      name: 'pauseWhenHidden',
+      type: 'boolean',
+      description:
+        'Suspends auto-refresh and the "last updated" ticker while the document is hidden.',
+      default: 'true',
+    },
+    {
+      name: 'hidden',
+      type: 'boolean',
+      description:
+        'Renders nothing. Auto-refresh stops with it, since the whole component unmounts its timers.',
+    },
+    {
+      name: 'size',
+      type: "'small' | 'middle' | 'large'",
+      description:
+        'Button size, mapped onto the Astryx sm/md/lg scale and applied to the dropdown trigger too.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Manual refresh',
+      code: `<BAIFetchKeyButton
+  loading={isPendingRefetch}
+  value={fetchKey}
+  onChange={updateFetchKey}
+/>`,
+    },
+    {
+      label: 'With the auto-refresh interval dropdown',
+      code: `<BAIFetchKeyButton
+  loading={isPendingRefetch}
+  showLastLoadTime
+  onChange={updateFetchKey}
+  autoUpdateDelay={autoUpdateDelay}
+  onChangeAutoUpdateDelay={setAutoUpdateDelay}
+/>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.doc.ts
@@ -119,7 +119,7 @@ export const docs = {
       name: 'hidden',
       type: 'boolean',
       description:
-        'Renders nothing. Auto-refresh stops with it, since the whole component unmounts its timers.',
+        'Renders nothing. It does not stop refreshing: the early return sits below the interval hooks, so auto-refresh keeps calling onChange while hidden. Unmount the component, or clear autoUpdateDelay, to actually stop the requests.',
     },
     {
       name: 'size',

--- a/packages/backend.ai-ui/src/components/BAIFlex.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIFlex.doc.ts
@@ -1,0 +1,114 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIFlex',
+  displayName: 'BAI Flex',
+  category: 'Layout',
+  keywords: [
+    'flex',
+    'flexbox',
+    'stack',
+    'hstack',
+    'vstack',
+    'row',
+    'column',
+    'space',
+  ],
+  usage: {
+    description:
+      'The layout primitive of the Backend.AI UI: a flex container that renders one element with a normalized reset (zero margin and padding, min-width and min-height 0, border-box sizing) and resolves named gap rungs against the theme size tokens. It carries the layout vocabulary of this repository — rows, columns, alignment and spacing are expressed through BAIFlex rather than through raw layout elements with hand-written flex CSS. Remaining props pass through to the underlying element (it accepts React.HTMLAttributes<HTMLDivElement> except dir), and the ref is forwarded there.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use the named gap rungs (xxs through xxl) so spacing resolves against the theme size tokens instead of a hardcoded pixel value.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass a two-element gap tuple when row and column spacing differ on a wrapping container, for example gap={[16, "xs"]}.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set align="stretch" on a vertical stack whose children should fill the width; the default is center, which shrink-wraps them.',
+      },
+      {
+        guidance: false,
+        description:
+          'Reach for a raw layout element with hand-written display flex when a BAIFlex expresses the same thing.',
+      },
+      {
+        guidance: false,
+        description:
+          'Put margins on children to separate them; set gap on the container so the spacing stays consistent when children are added or removed.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'direction',
+      type: "'row' | 'row-reverse' | 'column' | 'column-reverse'",
+      description: 'Main axis of the container, applied as flex-direction.',
+      default: "'row'",
+    },
+    {
+      name: 'wrap',
+      type: "'nowrap' | 'wrap' | 'wrap-reverse'",
+      description:
+        'Whether children may flow onto additional lines, applied as flex-wrap.',
+      default: "'nowrap'",
+    },
+    {
+      name: 'justify',
+      type: "'start' | 'end' | 'center' | 'between' | 'around'",
+      description:
+        'Distribution along the main axis. The short names expand to their CSS values, so between becomes space-between and around becomes space-around.',
+      default: "'start'",
+    },
+    {
+      name: 'align',
+      type: "'start' | 'end' | 'center' | 'baseline' | 'stretch'",
+      description:
+        'Alignment along the cross axis, applied as align-items. The default centers children, so a column of full-width children needs stretch.',
+      default: "'center'",
+    },
+    {
+      name: 'gap',
+      type: "number | 'xxs' | 'xs' | 'sm' | 'ms' | 'md' | 'lg' | 'xl' | 'xxl' | [GapSize, GapSize]",
+      description:
+        'Spacing between children. A named rung resolves to the matching theme size token, a number is used as pixels, and a two-element tuple sets row gap and column gap separately.',
+      default: '0',
+    },
+    {
+      name: 'style',
+      type: 'React.CSSProperties',
+      description:
+        'Merged over the computed flex styles, so it can override display, flex-direction, alignment or sizing for a one-off case.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'The flex items.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Vertical stack with token spacing',
+      code: `<BAIFlex direction="column" align="stretch" gap="sm">
+  <BAIGraphQLPropertyFilter {...filterProps} />
+  <BAITable {...tableProps} />
+</BAIFlex>`,
+    },
+    {
+      label: 'Inline icon and label row',
+      code: `<BAIFlex gap="xs">
+  <BAIJupyterIcon />
+  {t('import.ImportNotebook')}
+</BAIFlex>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIModal.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIModal.doc.ts
@@ -1,0 +1,305 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIModal',
+  displayName: 'BAI Modal',
+  category: 'Overlay',
+  keywords: [
+    'modal',
+    'dialog',
+    'popup',
+    'overlay',
+    'drawer',
+    'confirm',
+    'alertdialog',
+  ],
+  usage: {
+    description:
+      'The application modal, built on BAIDialog (a portalled Astryx Dialog) with the controller behaviour a bare Dialog does not provide: a header with title, subtitle and close button, a generated OK and Cancel footer with loading and danger states, backdrop and Escape dismissal policy, a skeleton loading state, an afterClose lifecycle, optional window controls (minimize, maximize, fullscreen) and a close guard that can veto a dismissal. Use it for any modal surface in the app; reaching for Astryx Dialog directly means rebuilding the header, footer and dismissal wiring by hand. Nothing is rendered while closed, so children mount fresh on every open, and the built-in labels are translated through useBAIi18n.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Drive the OK button from confirmLoading while an async submit is in flight so the modal cannot be double-submitted.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass footer={null} for read-only detail modals; the header close button remains the dismissal path.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set confirmBeforeClose with onConfirmClose on modals holding unsaved form input — returning false or rejecting keeps the modal open.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use variant="fullscreen" for edge-to-edge surfaces; a standard dialog is capped at 90vw, so width="90%" and width="100%" render alike.',
+      },
+      {
+        guidance: false,
+        description:
+          'Build an irreversible-deletion flow on a bare BAIModal — BAIDeleteConfirmModal with requireConfirmInput is the required surface for permanent deletes.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on centered, draggable, getContainer, modalRender or the other compatibility props kept for the migrated call sites; they are accepted and have no effect.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'open',
+      type: 'boolean',
+      description:
+        'Whether the modal is visible. While false the component renders nothing, so children unmount.',
+    },
+    {
+      name: 'isOpen',
+      type: 'boolean',
+      description: 'Alias for open, read when open is not supplied.',
+    },
+    {
+      name: 'onCancel',
+      type: '(e: BAIModalCancelEvent) => void',
+      description:
+        'Fired when the user dismisses the modal through the cancel button, the header close button, Escape or a backdrop click. Escape and backdrop carry no React event, so the argument is undefined there.',
+    },
+    {
+      name: 'onOpenChange',
+      type: '(isOpen: boolean) => void',
+      description: 'Alias for onCancel, called with false on dismissal.',
+    },
+    {
+      name: 'afterClose',
+      type: '() => void',
+      description:
+        'Called once the modal has closed. Fires from the open-to-closed transition, which is what BAIUnmountAfterClose subscribes to.',
+    },
+    {
+      name: 'afterOpenChange',
+      type: '(open: boolean) => void',
+      description: 'Called with the new visibility right after it changes.',
+    },
+    {
+      name: 'title',
+      type: 'ReactNode',
+      description:
+        'Header title. A node is accepted, so an icon and text row can be passed, and the dialog labels itself from it.',
+    },
+    {
+      name: 'subtitle',
+      type: 'string',
+      description: 'Secondary line rendered under the title.',
+    },
+    {
+      name: 'headerContent',
+      type: 'ReactNode',
+      description:
+        'Replaces the entire header row. A close button is appended so dismissal stays reachable.',
+    },
+    {
+      name: 'closeLabel',
+      type: 'string',
+      description:
+        'Accessible name for the close button rendered next to headerContent.',
+    },
+    {
+      name: 'closable',
+      type: 'boolean | { closeIcon?: ReactNode }',
+      description: 'false removes the header close button.',
+    },
+    {
+      name: 'closeIcon',
+      type: 'ReactNode | false',
+      description: 'false removes the header close button, like closable.',
+    },
+    {
+      name: 'type',
+      type: "'normal' | 'warning' | 'error'",
+      description: 'Colors the header title to signal the severity.',
+      default: "'normal'",
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Body content, rendered inside the scrolling content slot.',
+    },
+    {
+      name: 'bodyRef',
+      type: 'React.Ref<HTMLDivElement>',
+      description:
+        'Ref to the body wrapper, used where the body doubles as a file drag-and-drop target.',
+    },
+    {
+      name: 'bodyProps',
+      type: 'React.HTMLAttributes<HTMLDivElement>',
+      description: 'Extra props spread onto the body wrapper element.',
+    },
+    {
+      name: 'loading',
+      type: 'boolean',
+      description: 'Renders a BAISkeleton in place of the body content.',
+    },
+    {
+      name: 'footer',
+      type: 'ReactNode | BAIModalFooterRender',
+      description:
+        'Replaces the generated footer. null removes the footer entirely; a render function receives the generated footer plus OkBtn and CancelBtn.',
+    },
+    {
+      name: 'onOk',
+      type: '(e: React.MouseEvent<HTMLButtonElement>) => void',
+      description: 'Click handler for the generated OK button.',
+    },
+    {
+      name: 'okText',
+      type: 'ReactNode',
+      description: 'Label of the OK button. Falls back to OK.',
+    },
+    {
+      name: 'cancelText',
+      type: 'ReactNode',
+      description:
+        'Label of the Cancel button. Falls back to the translated Cancel label.',
+    },
+    {
+      name: 'okType',
+      type: "'primary' | 'danger' | 'default' | 'dashed' | 'link' | 'text' | 'ghost'",
+      description:
+        'Maps onto the OK button variant. danger renders the destructive variant.',
+    },
+    {
+      name: 'okButtonProps',
+      type: 'BAIModalActionButtonProps',
+      description:
+        'Applied to the OK button: danger, disabled, loading, icon, htmlType, form, style and className are honoured.',
+    },
+    {
+      name: 'cancelButtonProps',
+      type: 'BAIModalActionButtonProps',
+      description: 'The same options applied to the Cancel button.',
+    },
+    {
+      name: 'confirmLoading',
+      type: 'boolean',
+      description: 'Puts the OK button into its loading state.',
+    },
+    {
+      name: 'maskClosable',
+      type: 'boolean',
+      description: 'Whether a backdrop click closes the modal.',
+      default: 'true',
+    },
+    {
+      name: 'keyboard',
+      type: 'boolean',
+      description:
+        'Whether Escape closes the modal. Only takes effect once maskClosable is false, since a live backdrop enables both.',
+      default: 'true',
+    },
+    {
+      name: 'mask',
+      type: 'boolean | { closable?: boolean; blur?: boolean }',
+      description:
+        'Only closable is read, as an alias for maskClosable. The backdrop itself is owned by BAIDialog and cannot be removed.',
+    },
+    {
+      name: 'width',
+      type: 'number | string | BAIModalResponsiveWidth',
+      description:
+        'Dialog width. A per-breakpoint record collapses to its largest entry, and "auto" is translated to fit-content.',
+      default: '520',
+    },
+    {
+      name: 'maxHeight',
+      type: 'number | string',
+      description:
+        'Caps the dialog height; the body scrolls past it while the header and footer stay fixed.',
+    },
+    {
+      name: 'variant',
+      type: "'standard' | 'fullscreen'",
+      description:
+        'fullscreen fills the viewport and makes width and maxHeight inert. It is the only way to render edge to edge.',
+    },
+    {
+      name: 'windowActions',
+      type: "Array<'minimize' | 'maximize' | 'fullscreen'>",
+      description:
+        'Renders the named window controls in the header. A minimized modal collapses to a title bar but still keeps the page behind it blocked.',
+    },
+    {
+      name: 'onWindowStateChange',
+      type: "(state: 'default' | 'minimized' | 'maximized' | 'fullscreen') => void",
+      description:
+        'Called whenever a window control changes the state, including the reset back to default on close.',
+    },
+    {
+      name: 'minimizedPlacement',
+      type: "'bottomRight' | 'bottomLeft' | 'topRight' | 'topLeft'",
+      description: 'Corner the minimized title bar parks in.',
+      default: "'bottomRight'",
+    },
+    {
+      name: 'confirmBeforeClose',
+      type: 'boolean',
+      description: 'Runs onConfirmClose before every dismissal.',
+    },
+    {
+      name: 'onConfirmClose',
+      type: '() => void | boolean | Promise<boolean>',
+      description:
+        'Close guard. Returning false or rejecting prevents the modal from closing.',
+    },
+    {
+      name: 'styles',
+      type: 'BAIModalSemanticStyles',
+      description:
+        'Per-slot inline styles for root, header, title, body, footer and container. The function form is accepted and ignored.',
+    },
+    {
+      name: 'classNames',
+      type: 'BAIModalSemanticClassNames',
+      description:
+        'Per-slot class names for the same slots. The function form is accepted and ignored.',
+    },
+    {
+      name: 'zIndex',
+      type: 'number',
+      description:
+        'Forwarded to BAIDialog. The modal is a portalled element with a real z-index, so a passed value takes effect.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Read-only detail modal',
+      code: `<BAIModal
+  open={open}
+  title={t('credential.UserDetail')}
+  footer={null}
+  onCancel={onRequestClose}
+>
+  <UserDetail userId={userId} />
+</BAIModal>`,
+    },
+    {
+      label: 'Form modal with a pending OK button',
+      code: `<BAIModal
+  open={open}
+  title={t('settings.ConfigPerJobScheduler')}
+  confirmLoading={isSaving}
+  okText={t('button.Save')}
+  onOk={handleSave}
+  onCancel={onRequestClose}
+>
+  <SchedulerSettingForm ref={formRef} />
+</BAIModal>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIQuestionIconWithTooltip.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIQuestionIconWithTooltip.doc.ts
@@ -1,0 +1,121 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIQuestionIconWithTooltip',
+  displayName: 'BAI Question Icon With Tooltip',
+  category: 'Overlay',
+  keywords: [
+    'tooltip',
+    'help',
+    'hint',
+    'question mark',
+    'info icon',
+    'popover',
+    'infotip',
+  ],
+  usage: {
+    description:
+      'A lucide `CircleHelp` glyph that reveals explanatory text on hover or focus. It renders BAIIconWithTooltip, which supplies the focusable trigger, so the hint is reachable by keyboard and not only by pointer; the glyph inherits the theme placeholder text colour rather than a resolved hex. The prop surface is the antd Tooltip vocabulary the call sites were written against (`title`, `placement`, `open`, `mouseEnterDelay`) and is translated to Astryx placement/alignment and milliseconds at the boundary. Use it next to a form label, a card title, or a table column header when the explanation is too long to sit inline.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Keep `title` to one or two sentences the user can act on; anything longer belongs in the page body or the manual.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass `focusable={false}` when the icon sits inside another interactive element, so the trigger does not create a nested control.',
+      },
+      {
+        guidance: true,
+        description:
+          'Translate the `title` through the caller’s i18n hook — the component renders whatever node it is given and adds no copy of its own.',
+      },
+      {
+        guidance: false,
+        description:
+          'Put information the user must read into the tooltip; it is hidden until hover or focus and never appears in print or search.',
+      },
+      {
+        guidance: false,
+        description:
+          'Reach for it as a general-purpose tooltip — it always renders the question glyph. Wrap the element in Astryx Tooltip when the trigger is something else.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'title',
+      type: 'ReactNode',
+      description: 'Tooltip body. Nothing is shown on hover when it is empty.',
+    },
+    {
+      name: 'placement',
+      type: "AntdPlacement ('top' | 'bottom' | 'topLeft' | 'bottomRight' | …)",
+      description:
+        'antd-shaped placement, split into Astryx `placement` + `alignment` before it reaches the tooltip.',
+    },
+    {
+      name: 'open',
+      type: 'boolean',
+      description:
+        'Controls visibility instead of letting hover and focus drive it.',
+    },
+    {
+      name: 'onOpenChange',
+      type: '(open: boolean) => void',
+      description:
+        'Fires when the tooltip wants to open or close; pair it with `open` for a controlled tooltip.',
+    },
+    {
+      name: 'mouseEnterDelay',
+      type: 'number',
+      description:
+        'Delay before the tooltip appears, in seconds (antd unit). Converted to milliseconds internally.',
+    },
+    {
+      name: 'iconProps',
+      type: 'React.ComponentProps<typeof CircleHelp>',
+      description:
+        'Props forwarded to the lucide `CircleHelp` glyph, such as `strokeWidth` or `color`. `size` is fixed to `1em` so the icon tracks the surrounding text.',
+    },
+    {
+      name: 'focusable',
+      type: 'boolean',
+      description:
+        'Whether the trigger takes keyboard focus. Set it to `false` for an icon nested inside another interactive element.',
+    },
+    {
+      name: 'style',
+      type: 'CSSProperties',
+      description: 'Inline style applied to the trigger element.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Class names applied to the trigger element.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Hint next to a label',
+      code: `<BAIFlex gap="xxs" align="center">
+  {t('storageProxy.SFTPStorageProxies')}
+  <BAIQuestionIconWithTooltip
+    title={t('storageProxy.SFTPStorageProxiesDescription')}
+  />
+</BAIFlex>`,
+    },
+    {
+      label: 'Placement override',
+      code: `<BAIQuestionIconWithTooltip
+  title={t('data.HostDetails')}
+  placement="bottomLeft"
+/>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAISelect.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAISelect.doc.ts
@@ -76,12 +76,13 @@ export const docs = {
           name: 'onChange',
           type: '(value: any, option?: any) => void',
           description:
-            'Fired with the new selection and the matching option data. Also fired once on mount when autoSelectOption resolves a value.',
+            'Fired with the new selection. The second argument carries the matching option only in single mode — multiple and tags mode pass an array of original values and undefined. autoSelectOption also emits through it, from a layout effect keyed on the resolved value, so it fires again whenever that value changes rather than once on mount.',
         },
         {
           name: 'onSelect',
           type: '(value: any, option?: any) => void',
-          description: 'Fired when an option is picked, alongside onChange.',
+          description:
+            'Fired alongside onChange when an option is picked, in single mode only. Multiple and tags mode never call it, so a multi-select consumer must use onChange.',
         },
         {
           name: 'placeholder',
@@ -180,7 +181,7 @@ export const docs = {
           name: 'autoSelectOption',
           type: 'boolean | ((options: Array<OptionType> | undefined) => ValueType)',
           description:
-            'Selects an option when nothing is chosen — the first one, or the value the function returns — and reports it through onChange.',
+            'Selects an option when nothing is chosen — the first one, or the value the function returns — and reports it through onChange so the enclosing form actually receives it. The emission is a layout effect keyed on the resolved value, so it repeats whenever that value changes, not only on mount.',
         },
         {
           name: 'header',

--- a/packages/backend.ai-ui/src/components/BAISelect.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAISelect.doc.ts
@@ -1,0 +1,409 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+// No `type: 'component'` stamp: CLI 0.5.0's stamped component schema requires
+// a top-level `props` array and has no multi-component variant, so a stamped
+// `components` doc fails validation. Unstamped docs are shape-sniffed and the
+// multi form is accepted.
+export const docs = {
+  name: 'BAISelect',
+  displayName: 'BAI Select',
+  category: 'Data Input',
+  keywords: [
+    'select',
+    'dropdown',
+    'combobox',
+    'picker',
+    'selector',
+    'multiselect',
+    'listbox',
+  ],
+  usage: {
+    description:
+      'The single-choice and multi-choice select used across Backend.AI forms. It renders Astryx Selector, or MultiSelector when mode is "multiple" or "tags", and adds what those primitives do not carry on their own: ReactNode option labels (the flattened text becomes the accessible name and search key while the original node is restored through renderOption), an accessible name derived from placeholder when no label is given, section headers and footers built on the native option model, a below placement so the popup never covers the trigger, and a labels-first multi-select trigger instead of the "N selected" count. It also accepts the Select.Option / Select.OptGroup children form through BAISelectOptionItem and BAISelectOptionGroup. The prop surface is antd-Select-shaped so the twelve components that extend BAISelectProps keep compiling; several of those props are accepted and inert because Astryx owns the mechanism internally — they are marked below.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Pass a placeholder on every instance — it is what the accessible name falls back to when label is absent.',
+      },
+      {
+        guidance: true,
+        description:
+          'Supply options as data and use optionRender for rich rows, so the trigger and the search index keep a plain-text label.',
+      },
+      {
+        guidance: true,
+        description:
+          'Reach for BAIComplexSelect instead when the list is server-paginated or needs server-side search; Selector filters only the options it already holds.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on filterOption, optionFilterProp, searchAction, endReached, or maxTagCount — they are accepted for source compatibility and have no effect.',
+      },
+      {
+        guidance: false,
+        description:
+          'Pass a ReactNode as header or footer; only the string form survives, since it becomes a real section title or a trailing disabled option.',
+      },
+    ],
+  },
+  components: [
+    {
+      name: 'BAISelect',
+      displayName: 'BAI Select',
+      description:
+        'The select control itself. Renders Astryx Selector, or MultiSelector in multiple/tags mode.',
+      props: [
+        {
+          name: 'options',
+          type: 'Array<OptionType>',
+          description:
+            'Option data. Each entry carries value, label (string or node), disabled, and any extra keys the call site reads back in optionRender.',
+        },
+        {
+          name: 'value',
+          type: 'ValueType',
+          description:
+            'Controlled selection. An array in multiple/tags mode, a single value otherwise.',
+        },
+        {
+          name: 'defaultValue',
+          type: 'ValueType',
+          description: 'Initial selection for the uncontrolled case.',
+        },
+        {
+          name: 'onChange',
+          type: '(value: any, option?: any) => void',
+          description:
+            'Fired with the new selection and the matching option data. Also fired once on mount when autoSelectOption resolves a value.',
+        },
+        {
+          name: 'onSelect',
+          type: '(value: any, option?: any) => void',
+          description: 'Fired when an option is picked, alongside onChange.',
+        },
+        {
+          name: 'placeholder',
+          type: 'ReactNode',
+          description:
+            'Empty-state text on the trigger. Doubles as the accessible name when label is not given.',
+        },
+        {
+          name: 'mode',
+          type: "'multiple' | 'tags'",
+          description:
+            'Switches to MultiSelector. "tags" routes there too, so free entry of values outside the option list is not available — use a Tokenizer for that.',
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          description: 'Blocks interaction; maps to Astryx isDisabled.',
+        },
+        {
+          name: 'loading',
+          type: 'boolean',
+          description:
+            'Shows the pending state on the trigger; maps to Astryx isLoading.',
+        },
+        {
+          name: 'allowClear',
+          type: 'boolean',
+          description: 'Adds the clear affordance; maps to Astryx hasClear.',
+        },
+        {
+          name: 'showSearch',
+          type: 'boolean | { searchValue?: string; onSearch?: (value: string) => void; filterOption?: boolean | ((input: string, option?: any) => boolean); optionFilterProp?: string }',
+          description:
+            'Enables the in-popup search box. The object form is accepted, but filterOption and optionFilterProp are inert — Selector filters on the option label it renders.',
+        },
+        {
+          name: 'status',
+          type: "'error' | 'warning' | ''",
+          description:
+            'Validation state on the trigger. "error" maps to the Astryx error status.',
+        },
+        {
+          name: 'size',
+          type: "'small' | 'middle' | 'large'",
+          description: 'Control height, in the antd sizing vocabulary.',
+        },
+        {
+          name: 'open',
+          type: 'boolean',
+          description:
+            'Accepted and inert — Astryx Selector owns its popup visibility.',
+        },
+        {
+          name: 'onOpenChange',
+          type: '(open: boolean) => void',
+          description: 'Accepted and inert, for the same reason as open.',
+        },
+        {
+          name: 'optionRender',
+          type: '(option: { data: BAISelectOption; label?: ReactNode; value?: string | number | null }) => ReactNode',
+          description:
+            'Custom option row. Receives the original option data, so a node label can be rebuilt in full inside the popup.',
+        },
+        {
+          name: 'label',
+          type: 'string',
+          description:
+            'Accessible name. Falls back to the flattened placeholder, then to a translated generic.',
+        },
+        {
+          name: 'isLabelHidden',
+          type: 'boolean',
+          description:
+            'Whether the label is visually hidden. Hidden by default, since no call site renders a visible one.',
+        },
+        {
+          name: 'triggerDisplay',
+          type: "'count' | 'labels' | 'badges'",
+          description:
+            'How the closed multi-select trigger summarizes the selection: the first three labels comma-joined plus "+N", a plain count, or Badge chips.',
+          default: "'labels'",
+        },
+        {
+          name: 'maxBadges',
+          type: 'number',
+          description:
+            'Badges shown before "+N". Only meaningful with triggerDisplay="badges".',
+        },
+        {
+          name: 'optionLabelProp',
+          type: 'string',
+          description:
+            'Set to "children" to render the selected option’s rich node on the closed trigger. Any other value falls back to the flattened text.',
+        },
+        {
+          name: 'autoSelectOption',
+          type: 'boolean | ((options: Array<OptionType> | undefined) => ValueType)',
+          description:
+            'Selects an option when nothing is chosen — the first one, or the value the function returns — and reports it through onChange.',
+        },
+        {
+          name: 'header',
+          type: 'ReactNode',
+          description:
+            'Leading popup slot. A string becomes a native section title; a node is dropped.',
+        },
+        {
+          name: 'footer',
+          type: 'ReactNode',
+          description:
+            'Trailing popup slot. A string becomes a divider plus a disabled option; a node is dropped.',
+        },
+        {
+          name: 'ghost',
+          type: 'boolean',
+          description:
+            'On-dark treatment for the select that sits on the header’s brand-accent band.',
+        },
+        {
+          name: 'tooltip',
+          type: 'string',
+          description: 'Hover description for the control.',
+        },
+        {
+          name: 'children',
+          type: 'ReactNode',
+          description:
+            'The element form of the option list — BAISelectOptionItem and BAISelectOptionGroup. Read only when options is undefined.',
+        },
+        {
+          name: 'className',
+          type: 'string',
+          description: 'Class applied to the control wrapper.',
+        },
+        {
+          name: 'style',
+          type: 'CSSProperties',
+          description:
+            'Inline style on the wrapper; a width here is forwarded to the Astryx width prop.',
+        },
+        {
+          name: 'autoFocus',
+          type: 'boolean',
+          description: 'Focuses the trigger on mount.',
+        },
+        {
+          name: 'tabIndex',
+          type: 'number',
+          description: 'Tab order of the trigger.',
+        },
+        {
+          name: 'notFoundContent',
+          type: 'ReactNode',
+          description:
+            'Accepted and inert — Astryx Selector renders its own empty state.',
+        },
+        {
+          name: 'suffixIcon',
+          type: 'ReactNode',
+          description:
+            'Accepted and inert — the trigger affordance is owned by Astryx.',
+        },
+        {
+          name: 'popupRender',
+          type: '(menu: ReactNode) => ReactNode',
+          description:
+            'Accepted and inert — there is no arbitrary popup-body escape hatch; use header and footer.',
+        },
+        {
+          name: 'popupMatchSelectWidth',
+          type: 'boolean | number',
+          description: 'Accepted and inert — popup sizing is owned by Astryx.',
+        },
+        {
+          name: 'maxTagCount',
+          type: "number | 'responsive'",
+          description:
+            'Accepted and inert — the multi-select overflow policy is fixed at three labels then "+N".',
+        },
+        {
+          name: 'maxTagPlaceholder',
+          type: 'ReactNode | ((omitted: Array<any>) => ReactNode)',
+          description: 'Accepted and inert, alongside maxTagCount.',
+        },
+        {
+          name: 'labelRender',
+          type: '(props: any) => ReactNode',
+          description:
+            'Accepted and inert — use optionLabelProp="children" for a rich trigger label.',
+        },
+        {
+          name: 'searchAction',
+          type: '(value: string) => Promise<void>',
+          description:
+            'Accepted and inert — server-driven search belongs to BAIComplexSelect, not Selector.',
+        },
+        {
+          name: 'endReached',
+          type: '() => void',
+          description:
+            'Accepted and inert — Astryx owns the popup and emits no scroll event. Paginated lists use BAIComplexSelect.',
+        },
+        {
+          name: 'atBottomStateChange',
+          type: '(atBottom: boolean) => void',
+          description: 'Accepted and inert, alongside endReached.',
+        },
+        {
+          name: 'atBottomThreshold',
+          type: 'number',
+          description: 'Accepted and inert, alongside endReached.',
+        },
+        {
+          name: 'bottomLoading',
+          type: 'boolean',
+          description: 'Accepted and inert, alongside endReached.',
+        },
+        {
+          name: 'filterOption',
+          type: 'boolean | ((input: string, option?: any) => boolean)',
+          description:
+            'Accepted and inert — Selector filters on the visible option label.',
+        },
+        {
+          name: 'defaultActiveFirstOption',
+          type: 'boolean',
+          description: 'Accepted and inert.',
+        },
+        {
+          name: 'title',
+          type: 'string',
+          description: 'Accepted and inert.',
+        },
+        {
+          name: 'ref',
+          type: 'React.Ref<any>',
+          description:
+            'Accepted and inert — Astryx Selector exposes no imperative focus/blur handle.',
+        },
+      ],
+    },
+    {
+      name: 'BAISelectOptionItem',
+      displayName: 'BAI Select Option Item',
+      description:
+        'A carrier element for the children form of the option list. It renders nothing; BAISelect walks the element tree and flattens it into the Astryx option model.',
+      props: [
+        {
+          name: 'value',
+          type: 'string | number | null',
+          description: 'Value emitted when this option is selected.',
+        },
+        {
+          name: 'label',
+          type: 'string',
+          description:
+            'Text shown on the closed trigger and matched by search when children is rich JSX whose key facts the text flattener cannot reach.',
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          description: 'Makes the option unselectable.',
+        },
+        {
+          name: 'filterValue',
+          type: 'string',
+          description:
+            'Accepted and ignored — a synthetic search key would leak onto the trigger, since Astryx renders the option label there too.',
+        },
+        {
+          name: 'children',
+          type: 'ReactNode',
+          description:
+            'The option row. Rich JSX survives, restored through renderOption.',
+        },
+      ],
+    },
+    {
+      name: 'BAISelectOptionGroup',
+      displayName: 'BAI Select Option Group',
+      description:
+        'A carrier element that groups BAISelectOptionItem children under a heading. It renders nothing; BAISelect turns it into a native Astryx option section.',
+      props: [
+        {
+          name: 'label',
+          type: 'ReactNode',
+          description:
+            'Section heading, flattened to a string for the accessible name.',
+        },
+        {
+          name: 'children',
+          type: 'ReactNode',
+          description: 'The BAISelectOptionItem elements in this group.',
+        },
+      ],
+    },
+  ],
+  examples: [
+    {
+      label: 'Single select in a form',
+      code: `<BAIFormItem name="status" label={t('credential.Status')}>
+  <BAISelect
+    placeholder={t('credential.SelectStatus')}
+    options={[
+      { value: 'active', label: t('general.Active') },
+      { value: 'inactive', label: t('general.Inactive') },
+    ]}
+  />
+</BAIFormItem>`,
+    },
+    {
+      label: 'Multiple select',
+      code: `<BAISelect
+  mode="multiple"
+  allowClear
+  style={{ width: '100%' }}
+  placeholder={t('rbac.SelectUsers')}
+  options={userOptions}
+  onChange={(value: string[]) => setUserIds(value)}
+/>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAISkeleton.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAISkeleton.doc.ts
@@ -1,0 +1,117 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAISkeleton',
+  displayName: 'BAI Skeleton',
+  category: 'Feedback & Status',
+  keywords: [
+    'skeleton',
+    'placeholder',
+    'loading',
+    'shimmer',
+    'suspense',
+    'fallback',
+  ],
+  usage: {
+    description:
+      'Loading placeholder composed from Astryx Skeleton, which draws a single shimmering box. It adds the multi-part shapes antd offered: a paragraph of title bar plus lines, an avatar row, and control-height input and button boxes. Boxes in one instance take successive shimmer indices so the animation reads as a single wave rather than several synchronised pulses; startIndex extends that wave across adjacent instances. Remaining props pass through to Astryx Skeleton.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Place it as the Suspense fallback inside a BAICard body so the card header stays visible while the data loads.',
+      },
+      {
+        guidance: true,
+        description:
+          'Match the shape to what is loading — variant="input" or "button" for a single control, and rows tuned to the real line count for a text block.',
+      },
+      {
+        guidance: false,
+        description:
+          'Pass an active prop; Astryx skeletons animate unconditionally and there is no way to freeze them.',
+      },
+      {
+        guidance: false,
+        description:
+          'Wrap a whole card or page in one paragraph skeleton when only one region is pending — the layout shifts when the real content replaces it.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'variant',
+      type: "'block' | 'paragraph' | 'input' | 'button'",
+      description:
+        'Which shape to draw. paragraph builds a title bar plus rows lines, block is a bare box you size yourself, input fills the container at control height, and button uses a control height with a per-size minimum width.',
+      default: "'paragraph'",
+    },
+    {
+      name: 'rows',
+      type: 'number',
+      description:
+        'Number of paragraph lines. The last line is shortened whenever a title is present or more than one line is drawn.',
+      default: '3',
+    },
+    {
+      name: 'hasTitle',
+      type: 'boolean',
+      description:
+        'Draws a title bar above the paragraph lines. Ignored by the block, input and button variants.',
+      default: 'true',
+    },
+    {
+      name: 'hasAvatar',
+      type: 'boolean',
+      description:
+        'Puts a round avatar box to the left of the lines and narrows the title bar so it fits beside it.',
+      default: 'false',
+    },
+    {
+      name: 'size',
+      type: "'small' | 'default' | 'large'",
+      description:
+        'Height of the input and button variants, taken from the Astryx element-size tokens so the placeholder matches the control it stands in for. Also sets the button variant minimum width.',
+      default: "'default'",
+    },
+    {
+      name: 'height',
+      type: "SkeletonProps['height']",
+      description:
+        'Explicit box height for the block, input and button variants, overriding the size-derived height. Paragraph lines keep their fixed line height.',
+    },
+    {
+      name: 'width',
+      type: "SkeletonProps['width']",
+      description:
+        'Box width. It reaches the block variant directly and, for a paragraph without an avatar, sets the title bar width.',
+    },
+    {
+      name: 'radius',
+      type: "SkeletonProps['radius']",
+      description:
+        'Corner radius step applied to every box except the avatar, which is always fully rounded.',
+      default: '1',
+    },
+    {
+      name: 'startIndex',
+      type: 'number',
+      description:
+        'Shimmer offset of the first box; later boxes count up from it. Give a following skeleton the index after the previous one ended so the two share one continuous wave.',
+      default: '0',
+    },
+  ],
+  examples: [
+    {
+      label: 'Suspense fallback in a card body',
+      code: "<BAICard title={t('section.Title')}>\n  <Suspense fallback={<BAISkeleton rows={4} />}>\n    <DataDrivenContent />\n  </Suspense>\n</BAICard>",
+    },
+    {
+      label: 'Standing in for a control',
+      code: '<Suspense fallback={<BAISkeleton variant="input" size="small" />}>\n  <ImageEnvironmentSelect />\n</Suspense>',
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIText.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIText.doc.ts
@@ -1,0 +1,143 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIText',
+  displayName: 'BAI Text',
+  category: 'Content',
+  keywords: [
+    'text',
+    'typography',
+    'label',
+    'ellipsis',
+    'truncate',
+    'copyable',
+    'code',
+  ],
+  usage: {
+    description:
+      'Inline text built on the Astryx Text primitive, adding the treatments Text does not carry on its own: truncation with an optional tooltip and an expand link, a copy-to-clipboard control, and the semantic color, mark and code boxes. The type, strong, delete, ellipsis and copyable props are mapped onto Astryx equivalents internally (type onto Text color, strong onto weight semibold, delete onto hasStrikethrough, ellipsis onto maxLines), so callers keep one vocabulary across the app. Its strings (the copy label, the expand and collapse links) are translated through useBAIi18n. Remaining props pass through to Astryx Text, which also forwards standard HTML attributes.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Pair ellipsis with a width constraint on the element — truncation only happens once the text box is actually bounded.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass ellipsis={{ tooltip: true }} in table cells so the full value stays reachable on hover after it is clipped.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set copyable on identifiers users need to paste elsewhere, such as access keys, image names and endpoint URLs.',
+      },
+      {
+        guidance: false,
+        description:
+          'Combine copyable with non-string children and expect the clipboard to receive the rendered output — the copy target falls back to an empty string unless children are a string or a number, or copyable.text is supplied.',
+      },
+      {
+        guidance: false,
+        description:
+          'Express a status color with an inline style; use type="danger", "warning", "success" or "secondary" so the color comes from the theme.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description:
+        'The text content. A string or number is also what copyable writes to the clipboard.',
+    },
+    {
+      name: 'type',
+      type: "'secondary' | 'success' | 'warning' | 'danger'",
+      description:
+        'Semantic color, mapped onto the matching Astryx Text color. The status colors are defined once in the theme rather than per call site.',
+    },
+    {
+      name: 'strong',
+      type: 'boolean',
+      description: 'Renders the text at semibold weight.',
+    },
+    {
+      name: 'italic',
+      type: 'boolean',
+      description: 'Applies an italic font style.',
+    },
+    {
+      name: 'underline',
+      type: 'boolean',
+      description:
+        'Underlines the text. Combined with delete it renders underline plus line-through.',
+    },
+    {
+      name: 'delete',
+      type: 'boolean',
+      description:
+        'Strikes the text through, for values that have been removed or superseded.',
+    },
+    {
+      name: 'mark',
+      type: 'boolean',
+      description: 'Wraps the text in a highlighted mark box.',
+    },
+    {
+      name: 'code',
+      type: 'boolean',
+      description: 'Wraps the text in an Astryx Code box.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description:
+        'Renders the text in the disabled color. Takes precedence over type.',
+    },
+    {
+      name: 'monospace',
+      type: 'boolean',
+      description:
+        'Switches to the code font family without the Code box, for identifiers and hashes shown inline in a table.',
+    },
+    {
+      name: 'size',
+      type: "TextProps['size']",
+      description: 'Astryx Text size step, forwarded as-is.',
+    },
+    {
+      name: 'ellipsis',
+      type: 'boolean | BAITextEllipsisConfig',
+      description:
+        'Clamps the text. true clamps to one line; the object form takes rows for a multi-line clamp, tooltip to reveal the full value on hover, expandable to append an expand and collapse link, and onExpand to observe it.',
+    },
+    {
+      name: 'copyable',
+      type: 'boolean | BAITextCopyConfig',
+      description:
+        'Appends a copy button beside the text. The object form takes text to copy something other than the children, icon to replace the glyph, and onCopy to observe the click; the button shows a check for 1.5 seconds after copying.',
+    },
+    {
+      name: 'style',
+      type: 'React.CSSProperties',
+      description:
+        'Merged over the decoration styles this component computes, so it can carry the width constraint that ellipsis needs.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Monospace identifier in a table cell',
+      code: `<BAIText monospace>{record.access_key}</BAIText>`,
+    },
+    {
+      label: 'Truncated name with a tooltip',
+      code: `<BAIText ellipsis={{ tooltip: row.name }} style={{ maxWidth: 160 }}>
+  {row.name}
+</BAIText>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.doc.ts
@@ -1,0 +1,65 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIUnmountAfterClose',
+  displayName: 'BAI Unmount After Close',
+  category: 'Utility',
+  keywords: [
+    'modal',
+    'drawer',
+    'unmount',
+    'destroyonclose',
+    'destroyonhidden',
+    'lifecycle',
+    'reset',
+  ],
+  usage: {
+    description:
+      'Renders no markup of its own: it clones its single modal or drawer child, keeps it mounted until the close animation has finished, then returns null so the child unmounts completely. It reads the child structurally (open, afterClose, afterOpenChange), so any modal-shaped component flows through unchanged, and the callbacks the call site already passed still fire. Use it when a dialog must start from a clean state on every open — a fresh form instance re-applying initialValues, selectors back at their defaults — without losing the exit transition that a bare {open && <Modal />} conditional throws away.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Wrap a modal whose internal state must not survive between opens, such as a form that reads initialValues only on mount.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep the child controlled by the parent — the wrapper only observes open, it never opens or closes the dialog itself.',
+      },
+      {
+        guidance: false,
+        description:
+          'Pass more than one child; React.Children.only throws on a fragment or a list.',
+      },
+      {
+        guidance: false,
+        description:
+          'Reach for it when the dialog already resets itself — the extra mount cycle refetches every query the child owns.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'children',
+      type: 'React.ReactElement<BAIUnmountAfterCloseChildProps>',
+      description:
+        'The single modal or drawer element to manage. It must accept open; its afterClose and afterOpenChange callbacks are intercepted (the originals are still invoked) to detect when the exit animation has completed.',
+      required: true,
+    },
+  ],
+  examples: [
+    {
+      label: 'Reset a modal between opens',
+      code: `<BAIUnmountAfterClose>
+  <ImageInstallModal
+    open={isOpenInstallModal}
+    onRequestClose={() => setIsOpenInstallModal(false)}
+  />
+</BAIUnmountAfterClose>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.doc.ts
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.doc.ts
@@ -1,0 +1,150 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAINameActionCell',
+  displayName: 'BAI Name Action Cell',
+  category: 'Table & List',
+  keywords: [
+    'table',
+    'cell',
+    'row actions',
+    'name column',
+    'overflow menu',
+    'kebab menu',
+    'popconfirm',
+  ],
+  usage: {
+    description:
+      'The name column of a table row: an optional leading icon, the row title (plain text, a react-router link via `to`, or a click handler via `onTitleClick`), and a set of row actions on the right. The actions render as small icon buttons and collapse into an Astryx DropdownMenu (…) as the column narrows — a ResizeObserver measures the cell and moves the ones that no longer fit into the menu, so a narrow table never clips its actions. An action carrying `popConfirm` is gated by an anchored Astryx Popover confirm while it is a visible button, and falls back to `modal.confirm` with the same copy once it overflows into the menu.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Place it in the first (name) column of a BAITable so every row exposes its actions in one predictable spot instead of a separate actions column.',
+      },
+      {
+        guidance: true,
+        description:
+          'Reserve `popConfirm` for reversible actions such as deactivating or unassigning; permanent deletion should open BAIDeleteConfirmModal with requireConfirmInput from an `onClick` instead.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pair `disabled` with `disabledReason` — the reason becomes the button tooltip and is appended to the label once the action overflows into the more menu.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set `minVisibleActions` when an action must never hide, and `showInMenu: "always"` for secondary actions that should only ever live in the more menu.',
+      },
+      {
+        guidance: false,
+        description:
+          'Add a parallel actions column beside this cell — the overflow measurement assumes the actions share the cell with the title.',
+      },
+      {
+        guidance: false,
+        description:
+          'Give one action both `onClick`/`action` and `popConfirm`; in the overflow menu the handler wins and the confirmation is skipped.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'title',
+      type: 'ReactNode',
+      description:
+        'Row title. A string title is what `copyable` copies and what the ellipsis tooltip shows.',
+    },
+    {
+      name: 'icon',
+      type: 'ReactNode',
+      description:
+        'Icon rendered before the title. Its measured width is reserved before the action buttons are laid out.',
+    },
+    {
+      name: 'to',
+      type: "LinkProps['to']",
+      description:
+        'Renders the title as a react-router link to this path. Takes precedence over `onTitleClick`.',
+    },
+    {
+      name: 'onTitleClick',
+      type: '(e: React.MouseEvent) => void',
+      description:
+        'Makes the title clickable without navigating. Used only when `to` is absent.',
+    },
+    {
+      name: 'actions',
+      type: 'BAINameActionCellAction[]',
+      description:
+        'Row actions. Each entry takes `key`, `title`, `icon`, `onClick` or async `action`, `type: "default" | "danger"`, `disabled` with `disabledReason`, `showInMenu`, and `popConfirm`.',
+    },
+    {
+      name: 'showActions',
+      type: "'hover' | 'always'",
+      description:
+        'Whether the action area appears on row hover or stays visible. `always` reserves title width for the buttons, so fewer of them fit before overflowing.',
+      default: "'hover'",
+    },
+    {
+      name: 'minVisibleActions',
+      type: 'number',
+      description:
+        'Lower bound on how many action buttons stay outside the more menu, even when the cell is too narrow for them.',
+      default: '0',
+    },
+    {
+      name: 'moreMenuDisabled',
+      type: 'boolean',
+      description:
+        'Disables the overflow (…) trigger. Actions that live in the menu stay listed but become unreachable.',
+    },
+    {
+      name: 'copyable',
+      type: 'boolean',
+      description:
+        'Shows a copy-to-clipboard control next to the title. Copies the title only when it is a string.',
+    },
+    {
+      name: 'style',
+      type: 'React.CSSProperties',
+      description: 'Inline style applied to the cell wrapper.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Extra class names merged onto the cell wrapper.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Name cell with row actions',
+      code: `<BAINameActionCell
+  title={record.user_id}
+  showActions="always"
+  actions={actions}
+/>`,
+    },
+    {
+      label: 'Reversible action behind a confirm',
+      code: `const actions = [
+  {
+    key: 'deactivate',
+    title: t('credential.Deactivate'),
+    icon: <BanIcon />,
+    type: 'danger' as const,
+    popConfirm: {
+      title: t('credential.DeactivateCredential'),
+      description: record.user_id,
+      okButtonProps: { danger: true },
+      onConfirm: () => deactivate(record.access_key),
+    },
+  },
+];`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/Table/BAITable.doc.ts
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.doc.ts
@@ -1,0 +1,220 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAITable',
+  displayName: 'BAI Table',
+  category: 'Table & List',
+  keywords: [
+    'table',
+    'data grid',
+    'datagrid',
+    'grid',
+    'list',
+    'pagination',
+    'sorting',
+    'columns',
+  ],
+  usage: {
+    description:
+      'The project table: Astryx Table plus an assembled plugin pipeline (column settings, sorting, selection, resizing, sticky columns, scroll modes, expansion) behind an antd-v6-shaped prop contract. It is the only table implementation, so every list surface uses it rather than composing Astryx Table and its plugins by hand — the plugin order it fixes is load-bearing and easy to get wrong. It also owns what Astryx leaves to the caller: its own bottom pagination bar next to the settings gear, a column settings modal, a CSV export modal, and the empty state. Props Astryx exposes and this wrapper does not rename are inherited and forwarded to Astryx Table.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Drive server-side sorting through order and onChangeOrder, which speak the Backend.AI order string (for example -created_at), and give each sortable column a stable key or dataIndex so the string names the right field.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass total on the pagination config when the rows are already sliced server-side; leave it out and the table slices dataSource itself.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give tableSettings a persisted columnOverrides record so column visibility, order and width survive a reload.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on expandedRowRender, column-level fixed, multi-level header groups, or row virtualization — group headers are flattened into captions, pinning is table-wide through sticky, and virtualization is a deferred product decision.',
+      },
+      {
+        guidance: false,
+        description:
+          'Set showHeader={false} on a table with sortable or selectable columns; the header carries both controls, so hiding it makes them unreachable.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'columns',
+      type: 'BAIColumnsType<RecordType>',
+      description:
+        'antd-shaped column model — title, dataIndex, key, render, sorter, width, align, fixed. Nested children groups are flattened, with the group title rendered as a muted caption above each child header.',
+    },
+    {
+      name: 'dataSource',
+      type: 'ReadonlyArray<RecordType>',
+      description:
+        'Rows to render. Sliced by the pagination config unless its total says the slicing already happened server-side.',
+    },
+    {
+      name: 'rowKey',
+      type: 'string | ((record: RecordType) => React.Key)',
+      description:
+        'Stable row identity used for selection, expansion and React keys. A string names a field on the record.',
+      default: "'id'",
+    },
+    {
+      name: 'size',
+      type: "'small' | 'middle' | 'large'",
+      description:
+        'antd density names, mapped to the Astryx compact / balanced / spacious densities.',
+      default: "'small'",
+    },
+    {
+      name: 'loading',
+      type: 'boolean',
+      description:
+        'Dims the rows while a refetch is in flight. There is no spinner — the existing rows stay readable and in place.',
+    },
+    {
+      name: 'spinnerLoading',
+      type: 'boolean',
+      description:
+        'Parity alias kept for call sites written against the retired antd engine; it behaves exactly like loading.',
+    },
+    {
+      name: 'resizable',
+      type: 'boolean',
+      description:
+        'Drag-to-resize column borders. Resized widths ride the same override record as visibility and order, so tableSettings persists them.',
+      default: 'true',
+    },
+    {
+      name: 'order',
+      type: 'string | null',
+      description:
+        'Current sort as a Backend.AI order string, e.g. -created_at for descending. Drives which header shows the active sort arrow.',
+    },
+    {
+      name: 'onChangeOrder',
+      type: '(order?: string) => void',
+      description:
+        'Fired when a sortable header is clicked, with the next order string or undefined when sorting is cleared. Feed it back into the query variables.',
+    },
+    {
+      name: 'rowSelection',
+      type: 'BAITableRowSelection<RecordType>',
+      description:
+        'Enables the checkbox column and reports selection through onChange. Only checkbox selection exists; getCheckboxProps honours disabled, and preserveSelectedRowKeys keeps rows selected across pages.',
+    },
+    {
+      name: 'pagination',
+      type: 'false | BAITablePaginationConfig',
+      description:
+        'Configures the bottom bar — current, defaultPageSize, total, onChange, showSizeChanger, hideOnSinglePage, extraContent. Pass false to drop the bar entirely.',
+    },
+    {
+      name: 'tableSettings',
+      type: 'BAITableSettings',
+      description:
+        'Turns on the settings gear. Column visibility, order and width live in a controllable columnOverrides record reported through onColumnOverridesChange; drag-to-reorder is on unless disableColumnReorder is set.',
+    },
+    {
+      name: 'exportSettings',
+      type: 'BAIExportSettings',
+      description:
+        'Turns on the CSV export button. supportedFields limits what the modal offers and onExport receives the field keys the user picked.',
+    },
+    {
+      name: 'expandable',
+      type: 'BAITableExpandable<RecordType>',
+      description:
+        'Injects a chevron column and renders expandedRowRender output as a synthetic detail row. Expansion can be controlled through expandedRowKeys and onExpandedRowsChange.',
+    },
+    {
+      name: 'emptyState',
+      type: 'ReactNode | false',
+      description:
+        'Shown in place of the body when dataSource is empty. A string is wrapped in the default icon-and-padding EmptyState, any other node renders as-is, and false renders nothing.',
+    },
+    {
+      name: 'locale',
+      type: '{ emptyText?: ReactNode }',
+      description:
+        'antd parity shim. Only emptyText is read, and it follows the same wrapping rules as emptyState.',
+    },
+    {
+      name: 'onRow',
+      type: '(record: RecordType, index?: number) => React.HTMLAttributes<HTMLTableRowElement>',
+      description:
+        'Per-row html props. Only the returned handlers, style and className are applied to the row element.',
+    },
+    {
+      name: 'sticky',
+      type: 'boolean',
+      description:
+        'Pins the leading run of columns marked fixed to the start edge and the trailing run of fixed: "right" columns to the end edge while the table scrolls horizontally.',
+      default: 'true',
+    },
+    {
+      name: 'bordered',
+      type: 'boolean',
+      description:
+        'Draws the full cell grid instead of row rules only, by switching Astryx dividers to grid.',
+    },
+    {
+      name: 'scroll',
+      type: '{ x?: number | string | true; y?: number | string }',
+      description:
+        'Enables the scroll modes. x lets width-less columns size to their content and the table scroll sideways; y caps the wrapper height and sticks every header cell.',
+    },
+    {
+      name: 'showHeader',
+      type: 'boolean',
+      description:
+        'Collapses the header row via CSS. Intended only for list-shaped tables with a single unlabelled column; sorting and selection become unreachable while it is off.',
+      default: 'true',
+    },
+    {
+      name: 'hasHover',
+      type: 'boolean',
+      description:
+        'Highlights the row under the pointer. Inherited from Astryx Table but defaulted on here, unlike Astryx itself.',
+      default: 'true',
+    },
+    {
+      name: 'textOverflow',
+      type: "'wrap' | 'truncate'",
+      description:
+        'How cell content that exceeds its column behaves. Inherited from Astryx Table but defaulted to truncate here so rows keep a uniform height.',
+      default: "'truncate'",
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description:
+        'Applied to the dim/scroll wrapper around the table rather than to the table element itself.',
+    },
+    {
+      name: 'style',
+      type: 'React.CSSProperties',
+      description:
+        'Applied to the dim/scroll wrapper around the table rather than to the table element itself.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Selectable table with server-side sorting',
+      code: '<BAITable<Keypair>\n  rowKey="id"\n  loading={isPending}\n  dataSource={items}\n  columns={columns}\n  order={order}\n  onChangeOrder={setOrder}\n  rowSelection={{\n    type: \'checkbox\',\n    selectedRowKeys: selectedKeys,\n    onChange: (keys, rows) => setSelected(rows),\n  }}\n/>',
+    },
+    {
+      label: 'Server-paginated table with column settings',
+      code: '<BAITable\n  dataSource={rows}\n  columns={columns}\n  pagination={{\n    current: page,\n    pageSize,\n    total: totalCount,\n    onChange: (nextPage, nextSize) => setPagination(nextPage, nextSize),\n  }}\n  tableSettings={{\n    columnOverrides,\n    onColumnOverridesChange: setColumnOverrides,\n  }}\n/>',
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/vite.config.ts
+++ b/packages/backend.ai-ui/vite.config.ts
@@ -75,7 +75,15 @@ export default defineConfig(({ mode }) => {
       }),
       dts({
         include: ['src/**/*', 'vite-env.d.ts'],
-        exclude: ['**/*.{stories,test}.{ts,tsx}', 'src/locale/*.json'],
+        // `**/*.doc.ts` and `src/astryx-docs/**` are the Astryx CLI integration's
+        // contributions — read by the CLI from source, never imported by the
+        // library, so they have no business in the published types.
+        exclude: [
+          '**/*.{stories,test}.{ts,tsx}',
+          'src/locale/*.json',
+          '**/*.doc.ts',
+          'src/astryx-docs/**',
+        ],
         rollupTypes: false,
         insertTypesEntry: true,
         compilerOptions: {

--- a/packages/backend.ai-ui/vitest.config.ts
+++ b/packages/backend.ai-ui/vitest.config.ts
@@ -70,6 +70,10 @@ export default defineConfig({
         'src/**/__generated__/**',
         'src/index.ts',
         'src/locale/**',
+        // Astryx CLI contributions: data files the CLI reads from source, not
+        // library code, so they would only dilute the coverage figure.
+        'src/**/*.doc.ts',
+        'src/astryx-docs/**',
       ],
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,9 @@ importers:
         specifier: 'catalog:'
         version: 20.1.1(patch_hash=cc791a2ea160bc7c87571401d2f1430d50527847c44039d45579a5bfa60effa6)
     devDependencies:
+      '@astryxdesign/cli':
+        specifier: 'catalog:'
+        version: 0.5.0(4fb3ec2f0e525e320c5de82c8ac7f3fb)
       '@astryxdesign/core':
         specifier: 'catalog:'
         version: 0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)

--- a/react/AGENTS.md
+++ b/react/AGENTS.md
@@ -23,12 +23,13 @@ RULES:
 - Tokens for every value (`astryx docs tokens`). Brand/accent belongs in the theme (`astryx theme list` / `theme add <slug>`, or `astryx theme template` for a custom one) — never override --color-* in :root.
 - SELF-CHECK before you finish: re-read the file and replace any className=, style={{…}}, raw <div>/<span> layout, imported .css/@apply, or hardcoded #hex/px with the component or the xstyle prop + a token. If unsure a component/prop exists, run `astryx component <Name>` / `astryx search "<thing>"`; don't hand-roll CSS.
 - MIGRATION RELAXATION (antd → Astryx): the className=/style={{…}} part of the SELF-CHECK is relaxed for files carried over from the antd era, which are still full of `className` / inline `style` and `theme.useToken()` reads. Do not rewrite those wholesale — convert a file's idioms when you are already changing it for another reason. A style that props/xstyle cannot express goes in a co-located `.css` file the component imports (P17), with `var(--…)` Astryx tokens; never a runtime style engine.
+- BUI INTEGRATION (this repo): `backend.ai-ui` is registered as an Astryx integration, so `astryx component`, `astryx search` and `astryx component --list` cover the `BAI*` wrappers next to core's primitives, and `astryx docs backend-ai-ui` explains the layer. When a `BAI*` component and a core primitive both fit, use the `BAI*` one — it carries the project defaults, and it imports from `backend.ai-ui` (the Import line `astryx component` prints for it names core — an upstream CLI 0.5.0 bug). A new `BAI*` component ships a same-stem `{Name}.doc.ts` beside its source.
 
 MORE CLI:
   search "<query>"   find any component / hook / doc / template / block
   component --list   163 components by category
   template --list    page + block recipes
-  docs <topic>       browser-support, cli-integrations, color, elevation, getting-started, icons, illustrations, internationalization, layout, migration, motion, principles, shape, spacing, styling-libraries, styling, theme, tokens, typography, working-with-ai
+  docs <topic>       browser-support, cli-integrations, color, elevation, getting-started, icons, illustrations, internationalization, layout, migration, motion, principles, shape, spacing, styling-libraries, styling, theme, tokens, typography, working-with-ai, backend-ai-ui
   swizzle <Name>     eject component source for deep customization
   upgrade --apply    run after any @astryxdesign/core bump
 <!-- ASTRYX:END -->

--- a/react/astryx.config.ts
+++ b/react/astryx.config.ts
@@ -1,0 +1,15 @@
+import type { AstryxConfig } from '@astryxdesign/cli/authoring';
+
+/**
+ * Registers `backend.ai-ui` (BUI) as an Astryx CLI integration, so `astryx
+ * component` / `search` / `docs` answer with the BAI* wrappers this project
+ * actually uses instead of only Astryx core's primitives.
+ *
+ * The CLI reads this file from the nearest package.json root, and resolves
+ * each integration from that root's `node_modules` — so it lives here (the
+ * workspace whose devDependency the CLI is), not at the repository root.
+ */
+export default {
+  integrations: ['backend.ai-ui'],
+  issuesUrl: 'https://github.com/lablup/backend.ai-webui/issues',
+} satisfies AstryxConfig;

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -29,6 +29,7 @@
   },
   "include": [
     "src",
+    "astryx.config.ts",
     "../packages/backend.ai-ui/src",
     "../packages/backend.ai-client/src"
   ],

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -176,6 +176,18 @@ check_astryx_theme_built() {
     -o src/astryx-theme/built/backendai-default-built.css
 }
 
+check_astryx_integration() {
+  # `backend.ai-ui` is registered as an Astryx CLI integration
+  # (react/astryx.config.ts → packages/backend.ai-ui/astryx.integration.ts), so
+  # `astryx component` / `search` / `docs` answer with the BAI* wrappers too.
+  # Discovery is deliberately fault-tolerant: a doc file that fails the
+  # authoring schema is skipped with a warning on stderr instead of crashing
+  # the CLI, which means a broken `{Name}.doc.ts` silently drops that component
+  # out of the catalog. This command re-validates every contribution and exits
+  # non-zero on an error-severity issue (warnings are allowed).
+  pnpm --prefix ./react exec astryx validate-integration backend.ai-ui
+}
+
 check_z_index_ladder() {
   # Drift between the ladder and its hand-mirrors is silent, and vitest.yml's
   # path filter never fires for an index.html-only PR — so it runs here, always.
@@ -190,6 +202,7 @@ run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
 run_check "Vite warmup paths" check_warmup_paths
 run_check "StyleX cssInjectionTarget" check_stylex_injection
 run_check "Astryx theme build" check_astryx_theme_built
+run_check "Astryx integration (backend.ai-ui)" check_astryx_integration
 run_check "z-index ladder mirrors" check_z_index_ladder
 run_check "Terminology" check_terminology_drift
 


### PR DESCRIPTION
Resolves #9128 (FR-3708)

`astryx search "card"` answers `Card`. `.claude/rules/use-bai-card.md` says the answer is `BAICard`. The agent block tells everyone to discover components through the CLI instead of guessing them — but the catalog it searches holds only `@astryxdesign/core`, so every `BAI*` wrapper this project mandates is invisible to it, and the tool confidently returns the component the rules say not to use.

Astryx CLI 0.5.0 has a third-party integration system for exactly this case (`pnpm run astryx docs cli-integrations`): a package declares an `astryx.integration.{ts,mjs,js}` manifest beside its `package.json`, the consumer lists it in `astryx.config.{ts,mjs,js}`, and from then on the package's components, doc topics, templates and codemods are served by the same commands as core's. `backend.ai-ui` is precisely that shape of package, so this PR registers it.

## What the CLI answers now

```
$ pnpm run astryx search "refresh"
name:        BAIFetchKeyButton
domain:      component
import:      backend.ai-ui
description: The refresh control for any data surface. It renders a BAIButton with a rotate
             icon and, on each click, calls `onChange` with a fresh ISO timestamp …
command:     pnpm exec astryx component BAIFetchKeyButton
```

```
$ pnpm run astryx component BAICard
# BAICard

The card container for every card surface in Backend.AI. It composes Astryx Card with a title
row, an extra action slot, an optional full-bleed tab strip, status border tints, a loading
skeleton, and a footer action row — none of which Astryx Card, a bare padded surface, provides
on its own. …

## Best Practices
- **Do:** Put card-scoped actions — refresh, the primary create button, edit configuration,
  export — in extra, grouped in a BAIFlex with the primary button rightmost.
- **Don't:** Pass styles={{ body: { paddingTop: 0 } }} — Astryx Card has one padding step for
  the whole surface, so the prop is accepted and ignored. …

## Props
| Prop | Type | Default | Description |
…
```

`astryx docs backend-ai-ui` is a new topic covering the layer itself: choosing a `BAI*` wrapper over a core primitive, the destructive-confirmation tiers, `useBAIi18n`, where a reusable component lives, and how to write a doc file.

## Wiring

| File | Why |
|---|---|
| `react/astryx.config.ts` | Registers the integration. The CLI resolves an integration from the config root's `node_modules`, and `@astryxdesign/cli` is a devDependency of the `react` workspace — which is also where the root `pnpm run astryx` proxy runs (FR-3490). |
| `packages/backend.ai-ui/astryx.integration.ts` | Declares `components: './src/components'` and `docs: './src/astryx-docs'`. BUI ships no templates or codemods, so neither is declared. |
| `packages/backend.ai-ui/package.json` | `@astryxdesign/cli` as a devDependency, so the doc files' `import type` resolves under pnpm's strict `node_modules`. |
| `packages/backend.ai-ui/vite.config.ts` | The doc files are excluded from `vite-plugin-dts`, so they stay out of the published `dist`. |
| `packages/backend.ai-ui/vitest.config.ts` | And out of the coverage denominator. |

Doc files sit **next to their component with the same stem** (`BAICard.tsx` + `BAICard.doc.ts`), inside `src/` on purpose: `react/tsconfig.json` includes `../packages/backend.ai-ui/src`, so `tsc --noEmit` type-checks every doc against `ComponentDoc` — which validates the doc's *shape* (unknown field, category outside the union, missing `usage.description`). Prop names and types are strings to the compiler, so name-level drift is caught by the vitest guard below instead.

This PR documents the twelve most-used components, by call site count: `BAIFlex` (364), `BAIModal` (130), `BAIText` (108), `BAITable` (88), `BAIButton` (83), `BAISkeleton` (82), `BAIUnmountAfterClose` (67), `BAICard` (65), `BAISelect` (61), `BAINameActionCell` (42), `BAIQuestionIconWithTooltip` (40), `BAIFetchKeyButton` (40). The remaining ~68 are #9129 (FR-3709), stacked on this branch — partial coverage is a trap, since a gap in an authoritative-looking catalog reads as "no `BAI*` component exists for this" rather than "not documented yet".

## Three things the authoring docs do not say

Found while wiring this up, all three recorded in the `backend-ai-ui` topic so the next person does not rediscover them:

1. **A doc must `export const docs`.** The CLI's component loader reads the *named* export and never falls back to `default`, while the authoring guide describes a default export. A default-only file loads as `undefined`, and `astryx component <Name>` dies with `Cannot read properties of undefined (reading 'import')`. Every doc file here exports both.
2. **A multi-component doc must be unstamped.** The stamped `type: 'component'` schema requires a top-level `props` array and has no multi-component variant, so `{type: 'component', components: [...]}` fails validation even though the TypeScript `ComponentDoc` union allows it. The unstamped, shape-sniffed path accepts the multi form — `BAISelect.doc.ts` (which documents `BAISelectOptionItem` and `BAISelectOptionGroup` alongside it) uses it and says why in a comment. The test asserts this both ways.
3. **The `**Import:**` line in `astryx component <Name>` is wrong for an integration component** — it prints `@astryxdesign/core`, because the human renderer recomputes the specifier against core (`clients/cli/commands/component/index.mjs`) instead of using the one the API already resolved. Cosmetic: `--json` and `astryx search` both report `backend.ai-ui`. Noted in the topic and in the agent block so nobody copies the wrong import.

## Guard rails

Discovery is deliberately fault-tolerant: a doc file that fails the authoring schema is skipped with a single warning on stderr rather than crashing the CLI. That is right for a CLI and wrong for us — a malformed doc silently drops its component out of the catalog, and the catalog still looks complete. So:

- **`bash scripts/verify.sh`** gains an `astryx validate-integration backend.ai-ui` step. It exits non-zero on error-severity issues (upstream documents that exit code as safe for a CI gate).
- **`packages/backend.ai-ui/src/astryx-docs/astryxIntegration.test.ts`** (87 assertions today) checks that every doc parses against the authoring schema, is named after its file (discovery keys on the stem — a mismatched `name` makes `astryx component <name>` miss it), has a sibling source file, is stamped iff it is single-component, documents each prop once with a non-empty description, and — the one that actually catches drift — **documents no prop name its component source never mentions**.

The last one is the cheap defence against these files going stale: it does not prove a type or a default is still right, but it catches renamed and deleted props, which is how doc files rot.

## Agent block

`react/AGENTS.md` was regenerated with `astryx init --features agents` (it now lists the `backend-ai-ui` topic), and the two project-specific RULES lines were re-applied — the pre-existing MIGRATION RELAXATION line plus a new BUI INTEGRATION line telling agents the `BAI*` components are in the catalog, that they import from `backend.ai-ui`, and that a new component ships a doc file. The root `AGENTS.md` block (which `CLAUDE.md` symlinks to) is synced to match.

## Verification

```
bash scripts/verify.sh
=== ALL PASS ===
```

Relay, Lint, Format, TypeScript, Vite warmup paths, StyleX cssInjectionTarget, Astryx theme build, **Astryx integration (backend.ai-ui)**, z-index ladder mirrors, Terminology.

```
pnpm --filter backend.ai-ui test    # 87 passed
pnpm --filter backend.ai-ui build   # dist carries no *.doc.* and no astryx-docs
pnpm run astryx validate-integration backend.ai-ui   # [ok] No issues found.
pnpm run astryx doctor              # 6 passed, 0 failures (1 pre-existing theme-wiring warning)
```

## Copilot review

Four findings, all real and all verified against the source before fixing (3af783d):

- `BAICard`'s tabbed example passed `<BAISkeleton active />`, but `BAISkeleton` drops `active` on purpose (Astryx skeletons are always animated), so the example would not have compiled. The same stale snippet lives in `.claude/rules/use-bai-card.md` — where it was copied from — so that is fixed too.
- `BAIFetchKeyButton`'s `hidden` claimed auto-refresh stops with the button. `if (hidden) return null` sits below `useInterval`, so the timer keeps calling `onChange` while hidden.
- `BAISelect`'s `onChange` claimed the option data always accompanies it and that `autoSelectOption` emits once on mount; multiple/tags mode passes `undefined`, and the emission is a layout effect keyed on the resolved value. `onSelect` never fires in multiple/tags mode at all, so a multi-select consumer wiring it would get silence.
- The `backend-ai-ui` topic told contributors `tsc` catches a drifting prop list. It does not — `satisfies ComponentDoc` validates the doc's *shape*, and the name-level drift guard is the vitest check. The topic now separates the three levels and says what neither catches: a prop whose type or default went stale, which stays a review concern.

Also folded in: `react/astryx.config.ts` was in no tsconfig `include`, so its `satisfies AstryxConfig` was decorative. It is now type-checked.

## CLI verification (measured on the stack tip)

Every command path the integration touches was exercised from the repository root through the `pnpm run astryx` proxy, i.e. the invocation `AGENTS.md` documents.

| Path | Result |
|---|---|
| `doctor` | 6 passed, 0 failures (the one warning is the pre-existing theme-wiring one, unrelated) |
| `validate-integration backend.ai-ui` | `[ok] No issues found.` |
| `component --list` | `Components (306)`; **143 BUI entries, and the listing matches the doc files exactly** — 150 docs − 7 marked `hidden: true` = 143, with zero expected-but-absent and zero listed-without-a-doc |
| `component <Name>` | verified across all four layers: `BAICard` (wrapper), `BAIUserSelect` (Relay fragment), `BAIConfigProvider` (provider), `BAIArtifactTable` (fragments) |
| `component BAISelect` | the multi-component doc renders its `## Components` section with `BAISelectOptionItem` / `BAISelectOptionGroup` and their props |
| `component BAITable --props` | props-only projection renders |
| `component BAICard --source` | resolves the swizzle-able source next to the doc |
| `search` | BUI components are indexed and returned; `search "refresh"` puts `BAIFetchKeyButton` at rank 1 with `import: backend.ai-ui` |
| `search --json` / `component --json` | valid envelopes; `package: backend.ai-ui`, `import: backend.ai-ui`, `sourceAvailable: true` |
| `docs` | `backend-ai-ui` is listed |
| `docs backend-ai-ui` | all 6 sections render, and `docs backend-ai-ui "<section>"` addresses one |
| `build "<idea>"` | the kit's DOMAIN COMPONENTS section pulls BUI in — e.g. `"delete confirmation modal"` → `BAIDeleteArtifactRevisionsModal`, `"vfolder picker"` → `BAIProjectVfolderSelect` |

### One thing the numbers say that the prose should not overstate

Ranking is the CLI's, and it treats BUI and core identically. Scores are: exact name 100 > exact keyword 90 > keyword substring 70 > description mention 50, ties broken by domain then **alphabetically**.

So when a query is a core component's exact name, core wins — `Card` (100) above `BAICard` (90) for `"card"` — and that is correct behaviour, not a defect. Where the two compete on equal footing, they land equal: `"progress bar"` scores `BAIProgressWithLabel` **97** and core's own `ProgressBar` **97**.

One wrinkle worth recording rather than papering over: when many BUI components share a bare generic keyword they all tie at 90, and alphabetical ordering then buries the generic one — `BAITable` lands at rank 20 for `"table"`, behind `BAIAdminUserV2Table`, `BAIAgentTable` and the rest. The direct path (`astryx component BAITable`) is unaffected. The fix is keyword curation — a specialised component should carry `"agent table"` rather than a bare `"table"`, leaving the generic term to the generic component — which is a separate pass over the existing docs, filed as a follow-up rather than smuggled into this PR.
