### PR TITLE
chore(FR-3720): print the team share URL (dev-gw) from dev.mjs

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -69,6 +69,30 @@ Portless then proxies `https://<name>.localhost:1355` to `http://localhost:9081`
 
 Each worktree picks up its own branch's FR number, so two worktrees on different issues (`fr-2701` and `fr-2890`) coexist on `fr-2701.localhost:1355` and `fr-2890.localhost:1355` without conflict. Two worktrees on the **same** branch will collide; `dev.mjs` passes `--force` so the second one overrides the first registration. Run only one of them at a time.
 
+## Sharing a dev server with the team (dev-gw)
+
+`*.localhost:1355` only resolves on the box that runs the dev server. To let anyone on the dev VPN open it as a plain link, the **box** joins the team gateway once:
+
+```bash
+dev-gw join <box>   # installed by fw:setup-remote-env
+```
+
+That registers the box with the gateway and writes `~/.config/fw/dev-gw.json`. From then on, every `pnpm run dev` prints the shareable URL alongside the local one:
+
+```
+-- Team share URL: http://fr-2701.jongeun.10-82-0-159.sslip.io (dev VPN, via dev-gw)
+```
+
+The pattern is `http://<app>.<box>.<gateway-domain>`, where `<app>` is the same Portless app name as in the local URL. The gateway rewrites the `Host` header to `<app>.localhost:<PORTLESS_PORT>` before forwarding, so **Portless, Vite, and `dev.mjs` need no configuration for it** — the URL is the only difference.
+
+Notes:
+
+- **HTTP only, dev VPN only.** The gateway deliberately serves plain HTTP (no CA to install on the viewer's machine, and the Backend.AI client signs requests in pure JS, so no secure-context dependency). It is reachable only from the VPN and dev-net ranges.
+- **The share URL is unauthenticated.** Anyone on the dev VPN or in dev-net can open it, and the dev bundle they receive contains every `VITE_*` value from your `.env.development.local` — including `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD` if you set them (see the `SECURITY:` note in `.env.development.local.sample`). Don't run a shared dev server with credentials you would not hand to the whole team.
+- **Changing `PORTLESS_PORT` requires re-running `dev-gw join`.** The gateway forwards to the port recorded at join time; when they differ, `dev.mjs` says so and prints no URL.
+- `dev.mjs` also exposes the URL to the React bundle as `VITE_DEV_SHARE_URL`. Set `DEV_GW_CONFIG` to read the config from a different path.
+- When the app name is auto-derived by `portless run` (no `FR-XXXX` branch, no `PORTLESS_APP_NAME`), `dev.mjs` prints the pattern instead of a concrete URL — substitute the name Portless prints.
+
 ## Theme color for visual differentiation
 
 Create `.env.development.local` (copy from `.env.development.local.sample`) and set:

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -102,7 +102,12 @@ try {
 } catch {
   // Not joined (ENOENT), unreadable, or malformed — no share URL to print.
 }
-const devGwShareBase = devGwConfig?.share_base ?? null;
+// A parseable file can still be the wrong shape; only a URL template is usable.
+const devGwShareBase =
+  typeof devGwConfig?.share_base === 'string' &&
+  /^https?:\/\/\{app\}\./.test(devGwConfig.share_base)
+    ? devGwConfig.share_base
+    : null;
 // The gateway forwards to the Portless port recorded at join time forever, so a
 // server on a different port would be proxied to nothing.
 const portlessPort = process.env.PORTLESS_PORT?.trim() || '1355';

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -6,7 +6,12 @@
 // Similarly, the resolved Portless app name is exposed via
 // VITE_DEV_SERVER_NAME so the React app can show it in the browser tab title
 // (dev only), keeping multiple dev-server tabs distinguishable.
+// When this box has joined the team dev gateway, the shareable URL is printed
+// at startup and exposed as VITE_DEV_SHARE_URL.
 import { spawn, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 const env = { ...process.env };
 
@@ -85,6 +90,39 @@ if (appName) {
   // Surface the app name to the React bundle for the dev-only tab title.
   env.VITE_DEV_SERVER_NAME = appName;
 }
+
+// Team share URL, present only when this box has run `dev-gw join` once.
+// The gateway rewrites Host to `<app>.localhost:<portless_port>`, so routing
+// works with no Portless/Vite change here — only the URL differs.
+const devGwConfigPath =
+  process.env.DEV_GW_CONFIG?.trim() || join(homedir(), '.config', 'fw', 'dev-gw.json');
+let devGwConfig = null;
+try {
+  devGwConfig = JSON.parse(readFileSync(devGwConfigPath, 'utf8'));
+} catch {
+  // Not joined (ENOENT), unreadable, or malformed — no share URL to print.
+}
+const devGwShareBase = devGwConfig?.share_base ?? null;
+// The gateway forwards to the Portless port recorded at join time forever, so a
+// server on a different port would be proxied to nothing.
+const portlessPort = process.env.PORTLESS_PORT?.trim() || '1355';
+const devGwPortMismatch =
+  devGwConfig?.portless_port != null && String(devGwConfig.portless_port) !== portlessPort;
+if (devGwShareBase && devGwPortMismatch) {
+  console.log(
+    `-- Team share URL unavailable: dev-gw was joined with Portless :${devGwConfig.portless_port}, this server uses :${portlessPort} — re-run \`dev-gw join\``,
+  );
+} else if (devGwShareBase && appName) {
+  const shareUrl = devGwShareBase.replace('{app}', appName);
+  env.VITE_DEV_SHARE_URL = shareUrl;
+  console.log(`-- Team share URL: ${shareUrl} (dev VPN, via dev-gw)`);
+} else if (devGwShareBase) {
+  // `portless run` derives the app name itself, so it is unknown until it prints.
+  console.log(
+    `-- Team share URL: ${devGwShareBase.replace('{app}', '<app>')} — <app> is the name Portless prints below (dev VPN, via dev-gw)`,
+  );
+}
+
 const portlessSpec = appName
   ? `portless ${appName} --force ${portFlag}`
   : `portless run --force ${portFlag}`;


### PR DESCRIPTION
Resolves #9155 (FR-3720)

## What

`scripts/dev.mjs` now prints a **team share URL** at dev-server startup when this box has joined the dev gateway, and exposes it to the bundle as `VITE_DEV_SHARE_URL`. `DEV_ENVIRONMENT.md` gains a "Sharing a dev server with the team (dev-gw)" section.

```
-- Team share URL: http://fr-2701.jongeun.10-82-0-159.sslip.io (dev VPN, via dev-gw)
```

## Why

The Portless dev URL (`*.localhost:1355`) only resolves on the box running the server, so sharing a running dev server with a reviewer meant handing out an SSH tunnel command. The **dev-gw** team gateway makes the same server reachable over the dev VPN as a plain HTTP link: a box opts in once with `dev-gw join <box>` (installed by `fw:setup-remote-env`), which writes `~/.config/fw/dev-gw.json`. The gateway rewrites `Host` to `<app>.localhost:<portless_port>` before forwarding, so **Portless, Vite, and the rest of `dev.mjs` need no change for routing** — only the printed URL differs.

## Behaviour

- Config path is `~/.config/fw/dev-gw.json`, overridable via `DEV_GW_CONFIG`.
- Missing / unreadable / malformed config, or one without `share_base` → **silent**. Boxes that have not joined are unaffected.
- App name known (`FR-XXXX` branch or `PORTLESS_APP_NAME`) → concrete URL + `VITE_DEV_SHARE_URL`.
- App name derived by `portless run` itself → the URL *pattern* is printed (the name is unknown until Portless prints it); no env var set.
- Joined Portless port ≠ this server's port → the gateway would proxy to nothing, so the mismatch is reported instead of a URL that cannot work.

No React-app change: the person who needs the URL is the box owner running `pnpm run dev`, and the terminal line is where they can copy it from. `VITE_DEV_SHARE_URL` is set and documented so a future in-app surface can consume it without touching `dev.mjs` again.

The docs section also flags that the share URL is **unauthenticated and HTTP-only** (dev VPN / dev-net ranges only, no CA to install on the viewer side) and that the dev bundle carries every `VITE_*` value from `.env.development.local`.

## How to see it

1. On the dev box, once: `dev-gw join <box>`
2. `pnpm run dev`
3. Read the `-- Team share URL: ...` line next to the local Portless URL, and open it from a machine on the dev VPN.

## Verification

`bash scripts/verify.sh` — tail:

```
=== z-index ladder mirrors ===
layers declared: 6  |  mismatches: 0
--- z-index ladder mirrors: PASS ---

=== Terminology ===
  CHECK 1 summary: 0 blocking, 1 warn-only.
  (pre-existing: BAIResourceUnitGrid^ChangeGroupColor "group" -> "project")

=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0
  warn-only terminology findings: 1

=== Terminology self-test (report-only here; hard gate in CI) ===
  PASS — 409 assertion(s) hold.

=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VE75bA6akGvcH167Fqsvo4

