### PR TITLE
fix(FR-3707): open the +N overflow on hover, like the tooltip it is

### DIFF
--- a/packages/backend.ai-ui/src/components/BAITagList.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAITagList.doc.ts
@@ -77,7 +77,7 @@ export const docs = {
       name: 'trigger',
       type: "'click' | 'hover'",
       description:
-        'How the overflow list opens. Defaults to `hover` (a Tooltip) in both variants; pass `click` for a Popover that latches open.',
+        'How the overflow list opens. Defaults to `hover` (a HoverCard, so the list sits on a card surface) in both variants; pass `click` for a Popover that latches open.',
     },
   ],
   examples: [

--- a/packages/backend.ai-ui/src/components/BAITagList.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAITagList.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Renders a list of short values with a bounded footprint: the first `maxInline` entries show inline and the remainder collapse into a `+N` affordance that reveals only the overflowed values. `variant="chip"` draws the inline entries as Astryx `Badge` chips and opens the overflow in a `Popover` behind a keyboard-reachable `Link`; `variant="text"` draws them as nowrap plain text and puts the `+N` in a compact `Badge` inside a `Tooltip`. Use the chip variant in modals and detail panels and the text variant in dense table cells. With no items it renders `emptyText` and nothing else.',
+      'Renders a list of short values with a bounded footprint: the first `maxInline` entries show inline and the remainder collapse into a `+N` affordance that reveals only the overflowed values. The overflow opens on hover in both variants — it is a read-only peek, so it appears on hover and leaves with the pointer. `variant="chip"` draws the inline entries as Astryx `Badge` chips and the `+N` as a keyboard-reachable `Link`; `variant="text"` draws them as nowrap plain text and puts the `+N` in a compact `Badge`. Use the chip variant in modals and detail panels and the text variant in dense table cells. With no items it renders `emptyText` and nothing else.',
     bestPractices: [
       {
         guidance: true,
@@ -77,7 +77,7 @@ export const docs = {
       name: 'trigger',
       type: "'click' | 'hover'",
       description:
-        'How the overflow list opens. Defaults to `click` (a Popover) for the chip variant and `hover` (a Tooltip) for the text variant.',
+        'How the overflow list opens. Defaults to `hover` (a Tooltip) in both variants; pass `click` for a Popover that latches open.',
     },
   ],
   examples: [

--- a/packages/backend.ai-ui/src/components/BAITagList.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof BAITagList> = {
     docs: {
       description: {
         component:
-          'Shows up to `maxInline` items inline and collapses the rest into a `+N` overflow indicator, whose popup lists only the hidden items. Use `variant="chip"` (default) for a click popover in modals, or `variant="text"` for a lightweight hover-tooltip overflow in table cells.',
+          'Shows up to `maxInline` items inline and collapses the rest into a `+N` overflow indicator, whose popup lists only the hidden items. The overflow opens on hover in both variants; `variant="chip"` (default) shows a `+N` link for modals, `variant="text"` a compact `+N` badge for table cells. Pass `trigger="click"` for a popover that latches open.',
       },
     },
   },

--- a/packages/backend.ai-ui/src/components/BAITagList.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.test.tsx
@@ -1,0 +1,51 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+*/
+import BAITagList from './BAITagList';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * FR-3707 — the `+N` overflow is a read-only peek at what did not fit, so it
+ * behaves like a tooltip: hover to show, leave to hide. jsdom implements no
+ * Popover API, so "is it open" is not observable here; what IS observable is
+ * which control the trigger is wired as. A `Popover` trigger carries
+ * `aria-haspopup` / `aria-expanded`; a `Tooltip` trigger does not.
+ */
+const ITEMS = [
+  'a@example.com',
+  'b@example.com',
+  'c@example.com',
+  'd@example.com',
+];
+
+const overflow = () => screen.getByText('+1');
+
+describe('BAITagList overflow trigger', () => {
+  it('defaults to hover in the chip variant', () => {
+    render(<BAITagList items={ITEMS} />);
+    const trigger = overflow().closest('button, [role="button"]') ?? overflow();
+    expect(trigger).not.toHaveAttribute('aria-haspopup');
+    expect(trigger).not.toHaveAttribute('aria-expanded');
+  });
+
+  it('defaults to hover in the text variant', () => {
+    render(<BAITagList items={ITEMS} variant="text" />);
+    const trigger = overflow().closest('button, [role="button"]') ?? overflow();
+    expect(trigger).not.toHaveAttribute('aria-haspopup');
+  });
+
+  it('still latches open as a popover when trigger="click" is asked for', () => {
+    render(<BAITagList items={ITEMS} trigger="click" />);
+    const trigger = overflow().closest('button, [role="button"]');
+    expect(trigger).toHaveAttribute('aria-haspopup');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps the click affordance keyboard-reachable (Link renders a button)', () => {
+    render(<BAITagList items={ITEMS} trigger="click" />);
+    expect(overflow().closest('button')).toBeInTheDocument();
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAITagList.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.test.tsx
@@ -49,6 +49,19 @@ describe('BAITagList overflow trigger', () => {
     expect(overflow().closest('button')).toBeInTheDocument();
   });
 
+  // HoverCard's `focusTrigger="auto"` only attaches to a naturally focusable
+  // element, so a trigger that is not one never opens for a keyboard user.
+  // `chip` gets that from `Link` (a <button>); `text` renders a bare <span>
+  // and needs the explicit tabindex.
+  it.each([
+    ['chip', undefined],
+    ['text', 'text'],
+  ] as const)('keeps the %s hover trigger focusable', (_name, variant) => {
+    render(<BAITagList items={ITEMS} variant={variant} />);
+    const el = overflow().closest('button') ?? overflow();
+    expect(el.tagName === 'BUTTON' || el.tabIndex >= 0).toBe(true);
+  });
+
   // The overflow list is a list of VALUES, so it belongs on a card surface.
   // This project pins `.astryx-tooltip` to antd's `colorBgSpotlight` — dark in
   // BOTH schemes — so a Tooltip here reads as a black box in light mode

--- a/packages/backend.ai-ui/src/components/BAITagList.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.test.tsx
@@ -48,4 +48,15 @@ describe('BAITagList overflow trigger', () => {
     render(<BAITagList items={ITEMS} trigger="click" />);
     expect(overflow().closest('button')).toBeInTheDocument();
   });
+
+  // The overflow list is a list of VALUES, so it belongs on a card surface.
+  // This project pins `.astryx-tooltip` to antd's `colorBgSpotlight` — dark in
+  // BOTH schemes — so a Tooltip here reads as a black box in light mode
+  // (FR-3707). HoverCard mounts its layer lazily; Tooltip and Popover both
+  // render one up front, which is what makes the swap observable in jsdom.
+  it('does not put the overflow list in a Tooltip', () => {
+    render(<BAITagList items={ITEMS} />);
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+    expect(document.querySelectorAll('[popover]')).toHaveLength(0);
+  });
 });

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -104,9 +104,11 @@ const BAITagList: React.FC<BAITagListProps> = ({
         content={restItemsList}
         // Read-only overflow list: with no focusable content, Popover's
         // autofocus lands on its own sr-only close button and `:focus-within`
-        // un-clips it into a visible pill (FR-3707).
+        // un-clips it into a visible pill (FR-3707). `role="none"` keeps the
+        // ARIA honest — focus never enters, so `aria-modal` would lie.
         hasCloseButton={false}
         hasAutoFocus={false}
+        role="none"
       >
         <Link>+{restCount}</Link>
       </Popover>

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -7,7 +7,8 @@
    antd `Tag`             -> Astryx `Badge`   (MAPPING §3.5, not closable)
    antd `Typography.Text` -> Astryx `Text`
    antd `Typography.Link` -> Astryx `Link`
-   antd `Tooltip`         -> Astryx `Tooltip` (`title` -> `content`)
+   antd `Tooltip`         -> Astryx `HoverCard` (a list of values needs a card
+                             surface; `.astryx-tooltip` is dark in both schemes)
    antd `Popover`         -> Astryx `Popover` (`trigger="click"` is its only
                              trigger; hover overlays are `Tooltip`/`HoverCard`)
 
@@ -27,10 +28,10 @@
 */
 import BAIFlex from './BAIFlex';
 import { Badge } from '@astryxdesign/core/Badge';
+import { HoverCard } from '@astryxdesign/core/HoverCard';
 import { Link } from '@astryxdesign/core/Link';
 import { Popover } from '@astryxdesign/core/Popover';
 import { Text } from '@astryxdesign/core/Text';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
 import React, { ReactNode } from 'react';
 
@@ -107,7 +108,11 @@ const BAITagList: React.FC<BAITagListProps> = ({
 
   const overflowControl =
     effectiveTrigger === 'hover' ? (
-      <Tooltip content={restItemsList}>{overflowAffordance}</Tooltip>
+      // `HoverCard`, not `Tooltip`: this project's theme pins `.astryx-tooltip`
+      // to antd's `colorBgSpotlight`, i.e. DARK in both schemes, which is right
+      // for a short label and wrong for a list of values. HoverCard is the same
+      // hover/focus trigger on a `--color-background-surface` card.
+      <HoverCard content={restItemsList}>{overflowAffordance}</HoverCard>
     ) : (
       <Popover
         label={`+${restCount}`}

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -97,9 +97,13 @@ const BAITagList: React.FC<BAITagListProps> = ({
   // on the hover branch.
   const overflowAffordance =
     variant === 'text' ? (
+      // `Badge` is a bare <span>, and HoverCard's `focusTrigger="auto"` only
+      // attaches to a naturally focusable element — without this the `+N` is
+      // unreachable by keyboard.
       <Badge
         variant="neutral"
         label={`+${restCount}`}
+        tabIndex={0}
         style={{ cursor: 'help' }}
       />
     ) : (
@@ -112,7 +116,12 @@ const BAITagList: React.FC<BAITagListProps> = ({
       // to antd's `colorBgSpotlight`, i.e. DARK in both schemes, which is right
       // for a short label and wrong for a list of values. HoverCard is the same
       // hover/focus trigger on a `--color-background-surface` card.
-      <HoverCard content={restItemsList}>{overflowAffordance}</HoverCard>
+      // `touchTrigger="tap"`: the default leaves a tap on a button to that
+      // button, and the chip trigger IS a button with no action of its own, so
+      // touch users could not open the list at all.
+      <HoverCard content={restItemsList} touchTrigger="tap">
+        {overflowAffordance}
+      </HoverCard>
     ) : (
       <Popover
         label={`+${restCount}`}

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -14,15 +14,16 @@
  The public prop surface (`items`, `maxInline`, `emptyText`, `variant`,
  `trigger`) is unchanged.
 
- PILOT-DECISION — **a click-triggered overflow always uses a `Link` trigger,
- in both variants.** Astryx `Popover` requires its trigger subtree to contain a
- `<button>` or `[role="button"]` — it wires the click/keydown handlers and the
- `aria-haspopup`/`aria-expanded`/`aria-controls` triple onto that element. A
- `Badge` is not one, so the `text` variant's click branch (which wrapped a
- chip) now renders the same `+N` affordance the `chip` variant already used.
- The default for `text` is `hover`, which keeps its `Badge`-in-a-`Tooltip`
- shape, so no default rendering changes. What is GAINED is that the click
- affordance is now keyboard-reachable — the antd chip was not.
+ The `+N` overflow opens on HOVER in both variants (FR-3707): it is a read-only
+ peek at the items that did not fit, so it should behave like a tooltip —
+ appear on hover, leave when the pointer does. `trigger="click"` is still
+ available for a caller that wants a latched popover.
+
+ A click-triggered overflow always uses a `Link` trigger: Astryx `Popover`
+ wires its handlers onto a `<button>` / `[role="button"]` in the trigger
+ subtree, and `Badge` is not one. `Link` without `href` renders a `<button>`,
+ which is also what keeps the affordance keyboard-reachable on both branches —
+ the antd chip was not.
 */
 import BAIFlex from './BAIFlex';
 import { Badge } from '@astryxdesign/core/Badge';
@@ -42,7 +43,7 @@ export interface BAITagListProps {
   /**
    * Visual style of the list.
    * - `'chip'` (default): the first `maxInline` items render as `Badge`
-   *   chips and the `+N` overflow opens a `Popover`. Suited for interactive
+   *   chips and the `+N` overflow is a `Link`. Suited for interactive
    *   contexts (modals).
    * - `'text'`: the first `maxInline` items render as inline plain (nowrap)
    *   text and the `+N` overflow is a compact `Badge`. Suited for dense table
@@ -53,8 +54,8 @@ export interface BAITagListProps {
    */
   variant?: 'chip' | 'text';
   /**
-   * How the overflow popup is triggered. Defaults to `'click'` for the `chip`
-   * variant and `'hover'` for the `text` variant.
+   * How the overflow popup is triggered. Defaults to `'hover'` in both
+   * variants; pass `'click'` for a popover that latches open.
    */
   trigger?: 'click' | 'hover';
 }
@@ -71,7 +72,7 @@ const BAITagList: React.FC<BAITagListProps> = ({
   const inlineItems = _.slice(items, 0, maxInline);
   const restItems = _.slice(items, maxInline);
   const restCount = restItems.length;
-  const effectiveTrigger = trigger ?? (variant === 'text' ? 'hover' : 'click');
+  const effectiveTrigger = trigger ?? 'hover';
 
   if (items.length === 0) {
     return <>{emptyText}</>;
@@ -89,15 +90,24 @@ const BAITagList: React.FC<BAITagListProps> = ({
     </BAIFlex>
   );
 
+  // Astryx `Popover` wires its handlers onto a `<button>` in the trigger
+  // subtree, and `Link` without `href` renders exactly that — so the click
+  // branch keeps the `Link` whatever the variant, while `text` keeps its chip
+  // on the hover branch.
+  const overflowAffordance =
+    variant === 'text' ? (
+      <Badge
+        variant="neutral"
+        label={`+${restCount}`}
+        style={{ cursor: 'help' }}
+      />
+    ) : (
+      <Link>+{restCount}</Link>
+    );
+
   const overflowControl =
     effectiveTrigger === 'hover' ? (
-      <Tooltip content={restItemsList}>
-        <Badge
-          variant="neutral"
-          label={`+${restCount}`}
-          style={{ cursor: 'help' }}
-        />
-      </Tooltip>
+      <Tooltip content={restItemsList}>{overflowAffordance}</Tooltip>
     ) : (
       <Popover
         label={`+${restCount}`}

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -99,7 +99,15 @@ const BAITagList: React.FC<BAITagListProps> = ({
         />
       </Tooltip>
     ) : (
-      <Popover label={`+${restCount}`} content={restItemsList}>
+      <Popover
+        label={`+${restCount}`}
+        content={restItemsList}
+        // Read-only overflow list: with no focusable content, Popover's
+        // autofocus lands on its own sr-only close button and `:focus-within`
+        // un-clips it into a visible pill (FR-3707).
+        hasCloseButton={false}
+        hasAutoFocus={false}
+      >
         <Link>+{restCount}</Link>
       </Popover>
     );

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
@@ -64,9 +64,6 @@ const BAISessionAgentIds: React.FC<BAISessionAgentIdsProps> = ({
           &nbsp;
           <Popover
             label={heading}
-            // Same sr-only-close-button leak as FR-3707: here it only surfaces
-            // once focus leaves the Copy-all button, so keep autofocus.
-            hasCloseButton={false}
             content={
               <div style={{ maxHeight: 240, overflow: 'auto', minWidth: 260 }}>
                 <BAIFlex justify="between" align="center">

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
@@ -64,6 +64,9 @@ const BAISessionAgentIds: React.FC<BAISessionAgentIdsProps> = ({
           &nbsp;
           <Popover
             label={heading}
+            // Same sr-only-close-button leak as FR-3707: here it only surfaces
+            // once focus leaves the Copy-all button, so keep autofocus.
+            hasCloseButton={false}
             content={
               <div style={{ maxHeight: 240, overflow: 'auto', minWidth: 260 }}>
                 <BAIFlex justify="between" align="center">


### PR DESCRIPTION
Resolves #9125 (FR-3707)

## The interaction model was the defect; the pill was the symptom

The issue's **Expected** says the overflow list *"closes by moving the pointer away / clicking outside / Escape"*. The first of those is tooltip semantics — but the `chip` variant was wired to a **click-latched `Popover`**, so pointer-away did nothing, and the popover carried a dismiss control it had no business showing.

So the fix is the trigger, not the close button.

**`trigger` now defaults to `'hover'` in both variants.** The `+N` list is a read-only peek at the items that did not fit: it appears on hover and leaves with the pointer, exactly like a tooltip. `trigger="click"` stays available for a caller that wants a latched popover.

## Why this does not change how the chip variant *looks*

The affordance is now chosen by **variant**, not by trigger. Previously `hover` implied a `Badge` and `click` implied a `Link`, so flipping the chip default would also have turned its `+N` link into a chip. Now:

| variant | affordance | default trigger |
|---|---|---|
| `chip` (default) | `Link` | hover |
| `text` | `Badge` | hover |

The **click** branch always uses the `Link`: Astryx `Popover` wires its handlers onto a `<button>` / `[role="button"]` in the trigger subtree, and `Badge` is not one — `Link` without `href` renders exactly that. That is also what keeps the affordance **keyboard-reachable on both branches**, since Astryx `Tooltip` opens on `:focus-visible`. The antd chip never was.

## What remains from the first pass

The `hasCloseButton={false}` / `hasAutoFocus={false}` / `role="none"` guards stay on the **click** branch. It is still reachable via an explicit `trigger="click"`, and the sr-only-close-button leak is real there: with no focusable content, `usePopover`'s autofocus lands on its own clip-path-hidden close button and `:focus-within` un-clips it into the visible pill from the report.

## Verification

```
bash scripts/verify.sh                                  → === ALL PASS ===
pnpm --filter backend.ai-ui build                       → ok
pnpm --filter backend.ai-ui exec vitest BAITagList      → 4 passed
```

**Live probe** — Admin → Users, the `+2` overflow in the Allowed-client-IPs cell (the `text` variant, which shares the hover path):

| | `[popover]` state |
|---|---|
| before hover | `open: false`, width 0 |
| on hover | **`open: true`, width 118** |
| pointer moved away | **`open: false`, width 0** |

Zero `pageerror`.

`BAITagList.test.tsx` pins the contract by the one thing jsdom can observe — a `Popover` trigger carries `aria-haspopup` / `aria-expanded`, a `Tooltip` trigger does not. Confirmed it **fails** on the previous default (`chip` → click) before keeping it, so it is a real regression guard rather than a passing assertion.

## Residue

- The **chip** variant's hover path was not exercised live: its 7 call sites are the Fair Share modals and `EditSessionPriorityModal`, and no project on the shared dev cluster has more than `maxInline` (3) users, so no `+N` renders there. The `text` path above shares the same `Tooltip` branch, and the unit test covers the chip default separately.
- `BAISessionAgentIds` is deliberately untouched. Its popover has exactly one focusable descendant (Copy all), so removing the close button would leave `useFocusTrap` cycling Tab back onto it — a keyboard trap. Different case, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam
