### PR TITLE
fix(FR-3700): paint failure toasts as errors and contain their detail body

### DIFF
--- a/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
@@ -251,6 +251,11 @@ const BAINotificationStackItemView: React.FC<{
         onDismiss={() => onClose?.(key)}
         // POLISH-3 item 1 (supersedes ticket 29 PILOT-DECISION 3).
         endContent={hasActions ? actions : undefined}
+        // Astryx ships only a bare icon-only chevron here, so nothing signals
+        // that an error's detail exists. Open it up front instead (FR-3700).
+        collapsible={
+          (item.status ?? 'info') === 'error' ? { defaultIsOpen: true } : true
+        }
         description={
           hasOwnContent ? undefined : item.description || hasProgress ? (
             <VStack gap={2} align="stretch">

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
@@ -143,6 +143,19 @@ const BAINotificationStackItemView: React.FC<{
   // `isPaused` also covers focus, so a keyboard user tabbing into the action
   // buttons gets the same reprieve a mouse user does.
   const [isPaused, setIsPaused] = useState(false);
+
+  // Error detail is opened for the reader (FR-3700). Derived, not
+  // `defaultIsOpen`: a background task is updated IN PLACE under the same key
+  // (`pending` -> `rejected`), so the item never remounts and an initial-only
+  // default would leave the newly-arrived error detail collapsed. `null` means
+  // the reader has not touched the disclosure, so it follows the status; once
+  // they do, their choice wins.
+  const isError = (item.status ?? 'info') === 'error';
+  const [detailOpenByUser, setDetailOpenByUser] = useState<boolean | null>(
+    null,
+  );
+  const isDetailOpen = detailOpenByUser ?? isError;
+
   // `0` is antd's "stay open" value, not "close immediately".
   const autoCloseMs =
     typeof duration === 'number' && duration > 0 ? duration * 1000 : null;
@@ -252,10 +265,12 @@ const BAINotificationStackItemView: React.FC<{
         // POLISH-3 item 1 (supersedes ticket 29 PILOT-DECISION 3).
         endContent={hasActions ? actions : undefined}
         // Astryx ships only a bare icon-only chevron here, so nothing signals
-        // that an error's detail exists. Open it up front instead (FR-3700).
-        collapsible={
-          (item.status ?? 'info') === 'error' ? { defaultIsOpen: true } : true
-        }
+        // that an error's detail exists. Open it up front instead (FR-3700);
+        // `onOpenChange` keeps the user's collapse.
+        collapsible={{
+          isOpen: isDetailOpen,
+          onOpenChange: setDetailOpenByUser,
+        }}
         description={
           hasOwnContent ? undefined : item.description || hasProgress ? (
             <VStack gap={2} align="stretch">

--- a/react/src/astryx-theme/backendAiTheme.ts
+++ b/react/src/astryx-theme/backendAiTheme.ts
@@ -64,7 +64,7 @@ import { ANTD_ALIGN_TOKENS, ANTD_DARK_ALGORITHM_OUTPUT } from 'backend.ai-ui';
 export { ANTD_ALIGN_TOKENS, ANTD_DARK_ALGORITHM_OUTPUT };
 
 /** Bump when the static recipe (align tokens, formulas) changes. */
-export const THEME_NAME_REV = 19;
+export const THEME_NAME_REV = 20;
 
 /**
  * NEUTRAL BACKGROUND FAMILY — pinned to the measured legacy antd values.
@@ -516,11 +516,30 @@ const STATUS_TEXT_COLORS = {
 // theme points at `--color-background-blue` — dark-only alpha (`#9eb7ff3D` =
 // 24%), so page content read through the notification cards. `#393f50` is that
 // fill composited over the dark page: same colour, opaque (FR-3554).
+const BANNER_INFO_SURFACE = 'light-dark(#c4ddfb, #393f50)';
+
 const BANNER_OPAQUE_INFO_SURFACE = {
   banner: {
     'status:info': {
-      '--color-accent-muted': 'light-dark(#c4ddfb, #393f50)',
+      '--color-accent-muted': BANNER_INFO_SURFACE,
     },
+  },
+};
+
+// Banner renders its content area as a SIBLING of the coloured header, on
+// `--color-background-card`, so a detail body reads as a detached white block
+// (FR-3700). Set the TOKEN, never `backgroundColor`: StyleX's priority4 layer
+// outranks `@layer astryx-theme` and a plain declaration silently no-ops.
+const BANNER_CONTENT_STATUS_SURFACE = {
+  'banner-content': {
+    'status:info': { '--color-background-card': BANNER_INFO_SURFACE },
+    'status:success': {
+      '--color-background-card': 'var(--color-success-muted)',
+    },
+    'status:warning': {
+      '--color-background-card': 'var(--color-warning-muted)',
+    },
+    'status:error': { '--color-background-card': 'var(--color-error-muted)' },
   },
 };
 
@@ -968,6 +987,7 @@ export const computeThemeName = (
       ANTD_DROPDOWN_DENSITY,
       COMPLEX_SELECTOR_HEIGHT_PARITY,
       FIELD_PAGE_OVERLAYS,
+      BANNER_CONTENT_STATUS_SURFACE,
     ]),
   );
   // `h` prefix: every name segment must start with a letter — `astryx theme
@@ -1084,6 +1104,7 @@ export function buildBackendAiTheme(
       ...SIDE_NAV_DENSITY,
       ...STATUS_TEXT_COLORS,
       ...BANNER_OPAQUE_INFO_SURFACE,
+      ...BANNER_CONTENT_STATUS_SURFACE,
       ...ANTD_DIALOG_SURFACE,
       ...ANTD_DROPDOWN_DENSITY,
       ...COMPLEX_SELECTOR_HEIGHT_PARITY,

--- a/react/src/astryx-theme/built/backendai-default-built.css
+++ b/react/src/astryx-theme/built/backendai-default-built.css
@@ -7,7 +7,7 @@
  */
 
 @layer reset {
-@scope ([data-astryx-theme="bai-r19-default-brand-h15soup"]) to ([data-astryx-theme]) {
+@scope ([data-astryx-theme="bai-r20-default-brand-h1t5xmly"]) to ([data-astryx-theme]) {
   :where(h1, h2, h3, h4, h5, h6) {
     font-family: var(--font-family-heading);
     color: var(--color-text-primary);
@@ -82,7 +82,7 @@
   html[data-theme="light"] { color-scheme: light; }
   html[data-theme="dark"] { color-scheme: dark; }
 
-@scope ([data-astryx-theme="bai-r19-default-brand-h15soup"]) to ([data-astryx-theme]) {
+@scope ([data-astryx-theme="bai-r20-default-brand-h1t5xmly"]) to ([data-astryx-theme]) {
   :scope {
     --font-size-4xs: 0.375rem;
     --font-size-3xs: 0.4375rem;
@@ -572,6 +572,22 @@
     padding-block-start: 16px;
   }
 
+  .astryx-banner-content.info {
+    --color-background-card: light-dark(#c4ddfb, #393f50);
+  }
+
+  .astryx-banner-content.success {
+    --color-background-card: var(--color-success-muted);
+  }
+
+  .astryx-banner-content.warning {
+    --color-background-card: var(--color-warning-muted);
+  }
+
+  .astryx-banner-content.error {
+    --color-background-card: var(--color-error-muted);
+  }
+
   .astryx-dialog {
     background-color: var(--color-background-popover);
     --text-heading-2-size: 16px;
@@ -666,7 +682,7 @@
 }
 
 @layer astryx-theme {
-@scope ([data-astryx-theme="bai-r19-default-brand-h15soup"]) to ([data-astryx-theme]) {
+@scope ([data-astryx-theme="bai-r20-default-brand-h1t5xmly"]) to ([data-astryx-theme]) {
   [data-astryx-media="dark"] {
     color-scheme: dark;
     --color-text-primary: var(--color-on-dark);

--- a/react/src/astryx-theme/built/bai-r20-default-brand-h1t5xmly.d.ts
+++ b/react/src/astryx-theme/built/bai-r20-default-brand-h1t5xmly.d.ts
@@ -6,6 +6,6 @@
  * Core: @astryxdesign/core@0.5.0
  */
 
-/// <reference path="./bai-r19-default-brand-h15soup.variants.d.ts" />
+/// <reference path="./bai-r20-default-brand-h1t5xmly.variants.d.ts" />
 import type { DefinedTheme } from '@astryxdesign/core/theme';
-export declare const baiR19DefaultBrandH15soupTheme: DefinedTheme;
+export declare const baiR20DefaultBrandH1t5xmlyTheme: DefinedTheme;

--- a/react/src/astryx-theme/built/bai-r20-default-brand-h1t5xmly.js
+++ b/react/src/astryx-theme/built/bai-r20-default-brand-h1t5xmly.js
@@ -7,14 +7,14 @@
  */
 
 /**
- * bai-r19-default-brand-h15soup theme — built by `pnpm exec astryx theme build`
+ * bai-r20-default-brand-h1t5xmly theme — built by `pnpm exec astryx theme build`
  * Import the CSS file alongside this module:
  *
- *   import { baiR19DefaultBrandH15soupTheme } from './bai-r19-default-brand-h15soup';
- *   import './bai-r19-default-brand-h15soup.css';
+ *   import { baiR20DefaultBrandH1t5xmlyTheme } from './bai-r20-default-brand-h1t5xmly';
+ *   import './bai-r20-default-brand-h1t5xmly.css';
  */
-export const baiR19DefaultBrandH15soupTheme = {
-  name: 'bai-r19-default-brand-h15soup',
+export const baiR20DefaultBrandH1t5xmlyTheme = {
+  name: 'bai-r20-default-brand-h1t5xmly',
   __built: true,
   tokens: {
     "--font-size-4xs": "0.375rem",
@@ -469,6 +469,20 @@ export const baiR19DefaultBrandH15soupTheme = {
     "side-nav-section": {
       "base": {
         "paddingBlockStart": "16px"
+      }
+    },
+    "banner-content": {
+      "status:info": {
+        "--color-background-card": "light-dark(#c4ddfb, #393f50)"
+      },
+      "status:success": {
+        "--color-background-card": "var(--color-success-muted)"
+      },
+      "status:warning": {
+        "--color-background-card": "var(--color-warning-muted)"
+      },
+      "status:error": {
+        "--color-background-card": "var(--color-error-muted)"
       }
     },
     "dialog": {

--- a/react/src/astryx-theme/built/bai-r20-default-brand-h1t5xmly.variants.d.ts
+++ b/react/src/astryx-theme/built/bai-r20-default-brand-h1t5xmly.variants.d.ts
@@ -30,3 +30,12 @@ declare module '@astryxdesign/core/Badge' {
     'gray': true;
   }
 }
+
+declare module '@astryxdesign/core/Banner' {
+  interface BannerStatusMap {
+    'info': true;
+    'success': true;
+    'warning': true;
+    'error': true;
+  }
+}

--- a/react/src/astryx-theme/built/index.ts
+++ b/react/src/astryx-theme/built/index.ts
@@ -21,4 +21,4 @@ import './backendai-default-built.css';
       drift apart (built name ≠ derived default name), and
       `scripts/verify.sh` runs the CLI's `--check` for artifact staleness.
  */
-export { baiR19DefaultBrandH15soupTheme as builtBackendAiBrandTheme } from './bai-r19-default-brand-h15soup';
+export { baiR20DefaultBrandH1t5xmlyTheme as builtBackendAiBrandTheme } from './bai-r20-default-brand-h1t5xmly';

--- a/react/src/components/FolderCreateModalV2.tsx
+++ b/react/src/components/FolderCreateModalV2.tsx
@@ -333,6 +333,9 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
           : undefined;
       upsertNotification({
         key: `folder-create-failure-${folderName}-${Date.now()}`,
+        // Without this the stack falls back to 'info' and a failure paints as
+        // a blue notice (FR-3700).
+        type: 'error',
         icon: 'folder',
         message: `${t('general.Folder')}: ${folderName}`,
         description: t('data.folders.FolderCreationFailed'),

--- a/react/src/components/ImportRepoForm.tsx
+++ b/react/src/components/ImportRepoForm.tsx
@@ -260,6 +260,9 @@ const ImportRepoForm: React.FC<ImportFromURLFormProps> = ({
           : undefined;
       upsertNotification({
         key: `folder-create-failure-${folderName}-${Date.now()}`,
+        // Without this the stack falls back to 'info' and a failure paints as
+        // a blue notice (FR-3700).
+        type: 'error',
         icon: 'folder',
         message: `${t('general.Folder')}: ${folderName}`,
         description: t('data.folders.FolderCreationFailed'),


### PR DESCRIPTION
Resolves #9112 (FR-3700)

## Mechanism — three independent causes behind one screenshot

The report treats this as one bug in `BAINotificationStack`. It is three, at three different levels, and only one of them is in that component.

### 1. Severity — the caller, not the stack

`BAINotificationStackAdapter.resolveStatus()` maps `backgroundTask.status` first, then `notification.type`, then falls back to `'info'`. The folder-create failure path never set `type` and carries no `backgroundTask`, so **`'info'` is the correct answer for the data it was given** — the caller dropped the severity, the stack did not. (Background-task failures already resolve to `'error'` via `backgroundTask.status === 'rejected'`, which is why only direct `try/catch` toasts looked blue.) The caller's `icon: 'folder'` is dropped too — `BAINotificationSource` has no `icon` field — so the blue ⓘ was Banner's default info glyph.

Measured before this change, on the Data page with a duplicate folder name:

```
[data-status]  →  "info"
text           →  "Folder: <name>  Failed to create folder.  Expand  Dismiss"
```

### 2. White detail block — Astryx Banner's documented anatomy, not a lost style

Astryx `Banner` renders **two sibling elements**: a status-tinted header (`.astryx-banner`, `background-color: var(--color-{status}-muted)`) and a separate content area (`.astryx-banner-content`, `background-color: var(--color-background-card)` + a 1px border). `children` — our `extraDescription` — lands in that card-coloured sibling *by design*, and neither `@astryxdesign/theme-neutral` nor `backendAiTheme` carries a `banner-content` rule, so it painted plain card white.

Fixed at level 1 (theme defaults): a `banner-content` target beside the existing `banner` one, setting the **token** per status. It must be the token, never `backgroundColor` — StyleX's priority4 layer outranks `@layer astryx-theme` and a plain declaration silently no-ops. The info branch reuses the FR-3554 opaque fill so dark mode does not go translucent again.

Generated output (`backendai-default-built.css`):

```css
.astryx-banner-content.info    { --color-background-card: light-dark(#c4ddfb, #393f50); }
.astryx-banner-content.success { --color-background-card: var(--color-success-muted); }
.astryx-banner-content.warning { --color-background-card: var(--color-warning-muted); }
.astryx-banner-content.error   { --color-background-card: var(--color-error-muted); }
```

`THEME_NAME_REV` 19 → 20, `BANNER_CONTENT_STATUS_SURFACE` added to the seed-hash array, artifacts regenerated (`bai-r19-*` deleted, `built/index.ts` repointed to `bai-r20-default-brand-h1t5xmly`).

### 3. Expand affordance — the prop that exists

Astryx's disclosure control is a hardcoded `isIconOnly` ghost `Button` with a chevron and only an aria-label; there is no labelled-toggle knob. The only knobs are `collapsible`: `true` / `{defaultIsOpen}` / `{isOpen,onOpenChange}` / `false`. So an error's detail now opens up front and the chevron reads as *collapse*; every other notice keeps today's collapsed default.

## Blast radius

`BAINotificationStack` is mounted **once** app-wide (`NotificationHost.tsx` → `BAINotificationStackHost`), so causes 2 and 3 cover every toast in the app with no per-page work. Banner `children` is passed by only two components repo-wide — this stack and `BAIAlert` — and `BAIAlert` has zero call sites passing children today, so the theme rule's real reach is the notification stack alone.

Cause 1 is held to the **2** reported call sites (`FolderCreateModalV2.tsx`, and its byte-identical twin `ImportRepoForm.tsx` — same key prefix, same i18n key, same `extraDescription`; without it the bug reappears from the import-repo flow).

## Screenshots

### Failed folder creation — light

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9148/fr3700-before-light.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9148/fr3700-after-light.png) |

Blue ⓘ info banner → red ⊗ error banner.

### Same, dark

Superseded — see the round-2 shots below. The two images originally posted here were captured in **light** mode by mistake: the probe wrote a raw string into `backendaiwebui.settings.themeMode`, which `useStorageState` JSON-encodes, so the app silently stayed light. Fixed in the harness and re-shot.


## Verification

```
bash scripts/verify.sh          → === ALL PASS ===
pnpm --filter backend.ai-ui build → ok
react vitest src/astryx-theme    → 2 files, 28 tests passed
```

Live probe: the failing folder-create toast's `data-status` went **`"info"` → `"error"`**, measured in both light and dark. Zero `pageerror`s in every pass.

## Residue

- **~11 other failure toasts have the same missing `type`** and still render blue: `FileUploadManager.tsx:335,415`, `VFolderNodesV2.tsx:596,677`, `VFolderNodes.tsx:464,519,711`, `RestoreVFolderModalV2.tsx:95`, `RestoreVFolderModal.tsx:74`, `FolderExplorerModalV2.tsx:346`, `useBackendAIAppLauncher.tsx:769`. Deliberately **not** swept into this PR; follow-up ticket. The theme rule already fixes their detail body.
- FR-3701 ("Resource Presets: failed delete shows an empty red error banner") looks like a sibling but is a **different** mechanism — `message.error(undefined)` in `ResourcePresetList.tsx`, the app-shim, not this stack. Not closed by this PR.
- Setting `--color-background-card` on `.astryx-banner-content` **inherits** into anything inside the detail body that reads that token. Harmless today: every live `extraDescription` is a plain string.
- An expanded-by-default long stack trace makes a taller toast; there is no `max-height` on the content area today.

---

# Round 2 — notification design defects found while reviewing this PR

Three more, all on the same surface, all measured on the dev server.

## 1. The background was translucent at every status

Astryx fills `.astryx-banner.<status>` from `--color-{status}-muted`, and those tokens carry **alpha**. FR-3554 had already composited the *info* fill to an opaque value; the other three were never done, so page content read straight through a floating notification — visible in the report as table rows showing through the toast.

Each is now the same colour composited over `--color-background-card`:

| status | light | dark |
|---|---|---|
| error | `#FF4D4F` @ 0.20 → **`#FFDBDC`** | `#be3d3f` @ 0.247 → **`#3E1E1F`** |
| success | `#00BD9B` @ 0.20 → **`#CCF2EB`** | `#068e76` @ 0.247 → **`#11322C`** |
| warning | `#FAAD14` @ 0.20 → **`#FEEFD0`** | `#d89614` @ 0.247 → **`#443414`** |

The content area takes its fill by **literal**, not `var(--color-{status}-muted)`: it is a *sibling* of the coloured header, so the token would resolve at its own scope.

## 2. A border around the expanded half only

Astryx's content area draws inline-start / inline-end / block-end borders in `--color-border` while the header band draws none — so an expanded error detail looked boxed while the header did not. The `banner-content` theme target now pins `--color-border: transparent`.

## 3. Two body type scales in one stack

`BAINotificationStack` renders `description` through `<Text type="supporting">` (12px secondary), but the `node` renderers drew the same outcome sentence in plain `BAIText` (14px primary) — which is exactly why *"Failed to create folder."* and *"Folder created"* did not match.

**52 of the 59 `upsertNotification` call sites take the stack path**, so the 7 node-path ones move to it rather than the other way round. `BAIText` cannot express it — its own `type` maps to **colour** only (`TYPE_TO_COLOR`) — so the Astryx primitive the stack already uses is used directly.

The same measurement turned up a fourth: `extraDescription` rendered at **16px**. It was handed to `Banner` as a bare string with no `Text` wrapper and inherited Banner's own base size, towering over the description above it. It now gets the same treatment `description` does, string-guarded identically.

## Measured, both modes

| | before | after |
|---|---|---|
| error band background (light) | `rgba(255, 77, 79, 0.2)` | **`rgb(255, 219, 220)`** |
| error band background (dark) | `rgba(190, 61, 63, 0.247)` | **`rgb(62, 30, 31)`** |
| content area background | same translucent value | same **opaque** value as the band |
| content area border (light / dark) | `rgb(240, 240, 240)` / `rgb(48, 48, 48)` | **`rgba(0, 0, 0, 0)`** |
| "Folder created" | 14px | **12px** |
| "Failed to create folder." | 12px | 12px |
| expanded error detail | **16px** | **12px** |

Zero `pageerror` in all four passes.

### Screenshots — success and failure toasts on screen together

| | before | after |
|---|---|---|
| light | ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9148/fr3700-v2-before-light.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9148/fr3700-v2-after-light.png) |
| dark | ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9148/fr3700-v2-before-dark.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9148/fr3700-v2-after-dark.png) |

Dark mode is genuinely dark this time — asserted via `document.documentElement.dataset.theme === 'dark'` and `color-scheme: dark` before shooting.

`THEME_NAME_REV` 20 → 21, artifacts regenerated, `bai-r20-*` deleted.

## Verification

```
bash scripts/verify.sh          → === ALL PASS ===
pnpm --filter backend.ai-ui build → ok
```

## Residue

- The four probe folders this needed (`fr3700-*`) were created on the shared cluster and **moved to trash afterwards**; the Active list was re-checked and reports 0 remaining.
- `--color-{status}-muted` is only overridden **inside the banner scope**, so every other consumer of those tokens keeps the translucent fill. That is deliberate — a chip or a badge sitting on a page wants the alpha; a floating notice does not.
- The composites are over `--color-background-card`. A notification that floats over a *darker* element than the card will still not match it exactly — it is opaque, so nothing reads through, but the hue is tuned for the common case.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam