### PR TITLE
fix(FR-3685): make the Credentials User ID column actually pin to the left

### DIFF
--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -364,9 +364,9 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
       <BAITable<Keypair>
         rowKey={'id'}
         loading={isPending}
-        // Without this the table never overflows (width-less columns fall to
-        // proportional(1)), so the pinned User ID column is unobservable.
-        // Restores what the antd file carried before the Astryx migration.
+        // Width-less columns otherwise fall to proportional(1) and its 120px
+        // floor, capping this table at ~892px — wide enough to hide the pin at
+        // desktop widths. Restores what the antd file carried pre-migration.
         scroll={{ x: 'max-content' }}
         dataSource={filterOutNullAndUndefined(keypair_list?.items)}
         rowSelection={{

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -364,6 +364,10 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
       <BAITable<Keypair>
         rowKey={'id'}
         loading={isPending}
+        // Without this the table never overflows (width-less columns fall to
+        // proportional(1)), so the pinned User ID column is unobservable.
+        // Restores what the antd file carried before the Astryx migration.
+        scroll={{ x: 'max-content' }}
         dataSource={filterOutNullAndUndefined(keypair_list?.items)}
         rowSelection={{
           type: 'checkbox',
@@ -380,14 +384,6 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
           },
         }}
         columns={filterOutEmpty([
-          {
-            key: 'accessKey',
-            title: t('credential.AccessKey'),
-            sorter: true,
-            render: (_value, record) => {
-              return <BAIText monospace>{record.access_key}</BAIText>;
-            },
-          },
           {
             key: 'userID',
             title: t('credential.UserID'),
@@ -543,6 +539,14 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
                   actions={actions}
                 />
               );
+            },
+          },
+          {
+            key: 'accessKey',
+            title: t('credential.AccessKey'),
+            sorter: true,
+            render: (_value, record) => {
+              return <BAIText monospace>{record.access_key}</BAIText>;
             },
           },
           {


### PR DESCRIPTION
Resolves #9075 (FR-3685)

## The report's premise is wrong, in a way that matters

> the fixed-left attribute is missing

It is not. `fixed: 'left'` sits on the User ID column and is **silently inert**.

`BAITable`'s `stickyConfig` builder walks `activeColumnKeys` from index 0 and `break`s at the **first** column that does not declare `fixed: 'left' | true` — because Astryx's `useTableStickyColumns` pins a contiguous **run** from the edge, not per-column like antd did. `accessKey` held index 0 unfixed, so the loop broke immediately, `startKeys` came out empty, `stickyConfig` returned `{}`, and `useTableStickyColumns({})` was a no-op. The prop never reached Astryx.

## A second, independent defect hid the first

The FR-3482 Astryx migration dropped `scroll={{ x: 'max-content' }}` from this table (it was there at `9afb622cd:react/src/components/AdminUserCredentialList.tsx:373`). Without it `isScrollX` is false, every width-less column falls to `proportional(1)` whose floor is `DEFAULT_MIN_COLUMN_WIDTH = 120px`, and the table's min width comes to roughly `52 + 120×7 ≈ 892px`.

Measured live on `main` before this change, at a 1600px viewport:

| | before |
|---|---|
| `.astryx-table-scroll-wrapper` `scrollWidth` | **1312** |
| `.astryx-table-scroll-wrapper` `clientWidth` | **1312** |
| horizontal scroll | **none** |
| column order | `[select] · Access Key · User ID · Permission · Key Age · Created At · Resource Policy · Allocation` |

So the table never overflowed at desktop widths and the pin would have been **unobservable even once repaired**. Both edits are required; either alone leaves the symptom.

## The fix

1. **User ID moves to index 0**, ahead of Access Key, keeping its `fixed: 'left'` untouched — which makes the pinned run start at the edge and also matches the app-wide convention: the `BAINameActionCell` identity column is column 0 with `fixed` in `StorageProxyList`, `KeypairResourcePolicyList`, `RoleAssignmentTab`, `DomainStoragePermissionTable` and `BAIUserNodes`. It also keeps the frozen block narrow (52px selection + the ~320px name/action cell).

   *Rejected alternative:* adding `fixed: 'left'` to `accessKey` instead is a one-line diff, but it freezes **two** columns (~550px), leaving under half a 1200px content area scrollable.

2. **`scroll={{ x: 'max-content' }}` restored**, exactly the value the antd file carried.

## Please sign off on two visible consequences

- The **leftmost data column changes** from Access Key to User ID.
- `max-content` sizing **re-widths the whole table**, so every column changes width and the table now scrolls horizontally at widths where it previously fit. That is the intended FR-3681 behaviour, but it is a whole-table visual change, not a User-ID-only one.

## Screenshots

### The pin — 1000px viewport, scrolled fully right

This is the only viewport where the defect is visible at all: before the fix the table's min width is ~892px, so at a normal desktop width it never overflows and nothing can be seen to scroll away.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9149/fr3685-before-narrow-scrolled.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9149/fr3685-after-narrow-scrolled.png) |

### Column order — 1600px

| before | after (light) | after (dark) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9149/fr3685-before-wide-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9149/fr3685-after-wide-light.png) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9149/fr3685-after-wide-dark.png) |

Email local parts are masked in the DOM before capture (public repo, real addresses on the shared cluster). The mask preserves length, so the `max-content` widths in the shots are honest.

## Verification

```
bash scripts/verify.sh → === ALL PASS ===
```

Live probe: measured at a **1000px** viewport, admin → Users → Credentials, scrolled fully right:

| | before | after |
|---|---|---|
| wrapper `scrollWidth` | **892** (= 52 + 120×7, the `proportional(1)` floor) | **1147** |
| wrapper `clientWidth` | 712 | 712 |
| first data column | Access Key | **User ID** |
| identity cell `left`, unscrolled | 316 | 316 |
| identity cell `left`, scrolled right | **136** — moved by exactly the 180px scrolled | **316** — unmoved across 435px of scroll |

At 1600px both before and after report `scrollWidth === clientWidth === 1312`: the table fits, so nothing scrolls and nothing pins. That is correct behaviour, not a partial fix. Zero `pageerror`s.

## Scope note — coordination with FR-3681

This deliberately claims `AdminUserCredentialList.tsx` **out of** the FR-3681 `scroll` sweep, so the two PRs do not both edit the same line. FR-3681 restores the prop on the other ~59 files.

## Residue

Two sibling tables have the identical inert-`fixed` mechanism, found by scanning all 44 `fixed: 'left' | true` occurrences. Neither is reported yet and neither is fixed here — and both also need FR-3681's `scroll.x` before pinning is observable, so they are worth one paired follow-up ticket:

- `react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx:146` — `fixed: 'left'` on the 4th column, behind three unfixed ones.
- `react/src/components/AutoScalingRuleListLegacy.tsx:169` — `fixed: 'left'` on the Condition column, with an unfixed Metric Source between it and the fixed Scaling Type, so the run stops early.

Also worth a drive-by in whichever sweep touches them: `AdminUserManagement.tsx:574-582` and `BAIUserNodes.tsx:297-304` still claim "BAITable accepts-and-ignores `scroll` by PILOT-DECISION", which FR-3500 (#8726) invalidated. That stale claim is what kept FR-3681 latent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam
