### PR TITLE
fix(FR-3672): stop the SFTP button opening an empty tooltip pill

### DIFF
--- a/react/src/components/SFTPServerButtonV2.tsx
+++ b/react/src/components/SFTPServerButtonV2.tsx
@@ -189,12 +189,17 @@ const SFTPServerButtonWithProject: React.FC<
     reuseIfExists: true,
   });
 
+  // Empty in the ordinary healthy state, and Astryx `Tooltip` has no
+  // empty-content guard — an enabled one then opens a contentless dark pill
+  // over the whole button group (FR-3672).
+  const tooltipTitle = getTooltipTitle();
+
   return (
     // P18 caveat, unchanged from the antd original: the tooltip explains why
     // the control is disabled, and a disabled control swallows hover events.
     // It stays on the GROUP (never disabled itself), which is what made it
     // reachable under antd too. `Space.Compact` -> `ButtonGroup` (MAPPING §4).
-    <Tooltip content={getTooltipTitle()}>
+    <Tooltip content={tooltipTitle} isEnabled={!!tooltipTitle}>
       <ButtonGroup label={t('data.explorer.RunSSH/SFTPserver')}>
         <BAIButton
           disabled={


### PR DESCRIPTION
Resolves #9059 (FR-3672)

## There is no Popover and no toolbar in this control

The report names the symptom, not the component. "Run SSH/SFTP server" is an Astryx **`Tooltip`** wrapping a **`ButtonGroup`**, and the tooltip was mounted permanently enabled:

```tsx
<Tooltip content={getTooltipTitle()}>
  <ButtonGroup label={t('data.explorer.RunSSH/SFTPserver')}>
```

`getTooltipTitle()` returns **`''`** in the ordinary healthy state — mount permission present, an SFTP resource group present, a system-SSH image present, `showTitle` true. Astryx `Tooltip` has **no empty-content guard**, so hovering opens a `[popover]` layer whose only child is an empty div, and this project's theme paints `.astryx-tooltip` dark in *both* schemes (antd `colorBgSpotlight` parity). Result: a contentless dark pill.

Why it read as a *toolbar* rather than a stray box: the tooltip's trigger and CSS anchor are `wrapper.firstElementChild`, i.e. the whole `role="group"` strip. The pill therefore centres over the entire header action strip and visually merges with the modal header's own X close button and the `…` `DropdownMenu` trigger — which is exactly the "icon + label + … + close" the reporter described.

The FileBrowser twin one cell to the left is unaffected for exactly one reason: it carries the guard this one is missing, `isEnabled={!!tooltipTitle}`. This PR copies that shape verbatim.

The tip deliberately **stays on the ButtonGroup** rather than moving to the button: a disabled button swallows hover, which is what made the "why is this disabled" tooltip reachable under antd too, and `FolderExplorerModalV2.test.tsx` already encodes that. The `project === null` branch is left alone so that test's `'SSH / SFTP'` name query keeps passing.

## Screenshots

### Regression guard — the *useful* tooltip still works

The reported empty pill is not reproducible on this cluster (see the section below). What these do prove is that the guard did not switch off the tooltip that carries a real reason:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9150/fr3672-before-tooltip.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9150/fr3672-after-tooltip.png) |

Both show *"This folder's storage host has no SFTP resource group."* on hover — non-empty title, tooltip enabled, identical rendering.


## Verification

```
bash scripts/verify.sh → === ALL PASS ===
```

Live probe: hovering the button group on a folder whose host has no SFTP resource group still opens the tooltip with its real text, before and after. Zero `pageerror`s.

## Verification limits — read this before asking for a "before" screenshot of the empty pill

The buggy state is **not reachable on the shared dev cluster**, and it is not assertable in jsdom either. Both limits are real and neither is hidden:

1. **Live**: every folder on the test backend sits on a storage host with no SFTP resource group, so `getTooltipTitle()` returns the real string *"This folder's storage host has no SFTP resource group."* — a correct, non-empty tooltip. The empty-string branch needs a folder whose host **does** have an SFTP scaling group, which that cluster has none of. What the screenshots below *do* prove is the regression guard: the useful disabled-state tooltip still renders after the fix.
2. **Unit**: jsdom implements no Popover API (`typeof HTMLElement.prototype.showPopover === 'undefined'`, measured), and Astryx's tooltip layer element is present in the DOM whether or not it is shown. So "the tooltip did not open" has no observable signal there. I tried and deliberately did not land a test that would have asserted something else and looked like coverage.

What the fix rests on instead: the condition is exactly `getTooltipTitle() === ''`, `useTooltip` gates `scheduleShow()` and `handleFocusIn()` on `isEnabled` (so `layer.show()` never runs), and the guard is a verbatim copy of the FileBrowser twin's `isEnabled={!!tooltipTitle}` one cell to the left — which is why that button never had this symptom.

## Residue — deliberately not fixed here

Two things found in the same JSX that are **not** the reported symptom, so they are not widened into this PR:

1. `{showTitle && t('data.explorer.RunSSH/SFTPserver')}` passes `children={false}` below `lg`, and `BAIButton`'s icon-only test is `children === undefined || children === null`. So the narrow-viewport button renders a full `Button` with an empty label span and `aria-label=""` — no accessible name. The fix is to pass `undefined` instead of `false` plus an explicit `aria-label` (**not** `title`, which `BAIButton` maps to a second tooltip).

2. `react/src/components/Chat/CopyButton.tsx:59` is the identical unfiled defect — `content={isDisabled ? undefined : statusLabel}` with the tooltip left enabled — and needs the same one-line guard.

The dead V1 twin `SFTPServerButton.tsx` is unreachable code and is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam
