### PR TITLE
style(FR-3678): tint the My Environments delete action danger-red

### DIFF
--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -233,12 +233,13 @@ const CustomizedImageList: React.FC = () => {
       key: 'control',
       render: (_text, row) => (
         <BAIFlex direction="row" align="stretch" justify="center" gap="xxs">
-          {/* PILOT-DECISION: antd `type="text" danger` (red-tinted ghost) ->
-              Astryx ghost IconButton; IconButton's closed variant enum has no
-              ghost-destructive, and a solid `destructive` per row is louder
-              than the original — the red tint is dropped (P5/P11). */}
+          {/* antd `type="text" danger` -> ghost IconButton + the shared
+              `.bai-name-action-cell-danger` tint: Astryx IconButton has no
+              `color` prop (P5) and `destructive` is a solid fill, too loud for
+              a row action. */}
           <IconButton
             variant="ghost"
+            className="bai-name-action-cell-danger"
             icon={<Trash2 size="1em" />}
             label={t('button.Delete')}
             tooltip={t('button.Delete')}


### PR DESCRIPTION
Resolves #9067 (FR-3678)

## Only the colour half of the report reproduces

> the delete action ... renders with a glyph that is not the trash icon used elsewhere in the app

It already **is** the standard glyph. `CustomizedImageList.tsx` imports and renders lucide `Trash2` — the app-wide default, used in 29 files against 5 for `TrashIcon`. No icon swap is needed.

The likely source of the "different glyph" impression: this row used antd's **`DeleteFilled`** (a *solid* trash can) until FR-3482. Anyone comparing against the old build sees filled-vs-outline, not wrong-vs-right.

## Mechanism — the real defect

The button is `variant="ghost"`, and Astryx's ghost variant **hard-sets** `color: colorVars['--color-text-primary']`, so the trash glyph inherits the ordinary foreground (near-black in light, white in dark) through lucide's `currentColor`.

This was deliberate at migration time. The `PILOT-DECISION` comment this PR rewrites recorded that antd's `type="text" danger` (a red-tinted ghost) was mapped to a plain ghost `IconButton` and *"the red tint is dropped"*, because `IconButton` has no `color` prop and its closed variant enum has no ghost-destructive member. Pre-migration the same button was `icon={<DeleteFilled />} danger` — so the red was lost in the antd→Astryx conversion, not in a theme token.

The repo's established answer to exactly this is the shared `.bai-name-action-cell-danger` class (`packages/backend.ai-ui/src/styles/dangerAction.css`). It is imported **unlayered** from the BUI barrel, so it outranks Astryx's `@layer astryx-base` ghost colour **without `!important`**, and ghost hover only swaps `backgroundImage`, so the red survives hover. `className` reaches the real `<button>` through `IconButton → Button → mergeProps`. This PR copies `ProjectAdminDataPage.tsx:390-400` verbatim.

**Not** `variant="destructive"`: that is a solid `--color-error` fill with `--color-on-error` text — a per-row solid red button, far louder than the original.

## Screenshots

No screenshot: the My Environments image table is **empty** on the shared dev cluster — `customized_images` returns nothing for this tenant, so the Controls column and its delete button never render. Reproducing it needs a committed session image, which is a mutation on a shared backend and out of scope for a colour fix.

What is verified instead: the class ships unlayered from the BUI barrel (so it outranks `@layer astryx-base` without `!important`), `className` reaches the real `<button>` through `IconButton → Button → mergeProps`, and the exact same shape is already live at `ProjectAdminDataPage.tsx:390-400`. Manual steps in the checklist below.


## Verification

```
bash scripts/verify.sh → === ALL PASS ===
```

Live probe: not performed — the table is empty on this cluster (see Screenshots).

## For review — two reds coexist in this repo

This class resolves to `--color-text-red` = `light-dark(#89001a, #ffc6c1)`. The folder explorer (`FileItemControls.tsx`) and `BAINameActionCell` row actions instead use antd-parity `token.colorError` (~`#DC4446` / `#be3d3f`). `BAINameActionCell.css:23-45` documents that drift as QA finding **Q-15** and records that the row actions were deliberately moved *off* the text tier to antd parity.

So after this fix the My Environments delete is red but a **deeper** red than the folder explorer's. Flagging rather than "fixing" `dangerAction.css`, which is shared by six call sites and whose comment argues for the text tier on purpose.

## Residue

`react/src/components/ManageAppsModal.tsx:296-306` carries the identical stale note *and* uses the non-standard `Trash` glyph. It is the only true sibling — but its delete removes an unsaved form row (reversible), so the danger tint there is a judgement call, and it is left alone rather than swept in.

Nothing else: `grep -rn "red tint is dropped\|ghost-destructive"` over `react/src` + `packages` returns only these two files. Every other post-migration danger icon action already carries either `.bai-name-action-cell-danger` or `token.colorError`.

The `BAIDeleteConfirmModal` + `requireConfirmInput` flow on this row is already compliant and is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam
