### PR TITLE
fix(FR-3682): keep each metric card's title visible while its chart loads

### DIFF
--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -16,10 +16,14 @@ import { theme } from '../theme-shim';
 import './SessionMetricGraph.css';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Heading } from '@astryxdesign/core/Heading';
-import { BAIQuestionIconWithTooltip, BAIFlex } from 'backend.ai-ui';
+import {
+  BAIQuestionIconWithTooltip,
+  BAIFlex,
+  BAISkeleton,
+} from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useMemo } from 'react';
+import { Suspense, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import {
@@ -50,14 +54,88 @@ interface PrometheusMetricGraphProps {
   tooltip?: string | React.ReactNode;
 }
 
-const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
-  queryProps: { startDate, endDate, metricName, userId, dayDiff },
-  fetchKey,
-  tooltip,
-}) => {
-  const { t } = useTranslation();
+// Split in two (FR-3682): the board item has no card chrome of its own, so
+// the title lives inside this component — and this component is also the one
+// that suspends. A boundary above it therefore unmounts the header on every
+// fetch. The shell below never suspends; only the body does.
+const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = (props) => {
+  'use memo';
+  const {
+    queryProps: { metricName },
+    tooltip,
+  } = props;
   const { token } = theme.useToken();
   const { mergedResourceSlots } = useResourceSlotsDetails();
+
+  const resourceSlotKey = useMemo(() => {
+    const parts = _.split(metricName, '_');
+    const devicePrefix =
+      parts.length > 1 ? parts.slice(0, -1).join('-') : parts[0];
+    return (
+      _.find(
+        _.keys(mergedResourceSlots),
+        (slotKey) =>
+          _.startsWith(slotKey, devicePrefix + '.') || slotKey === devicePrefix,
+      ) ?? ''
+    );
+  }, [mergedResourceSlots, metricName]);
+  const deviceDescription = mergedResourceSlots[resourceSlotKey]?.description;
+
+  const getMetricTitle = () => {
+    const [, ...rest] = _.split(metricName, '_');
+    const restLabel = _.startCase(rest.join(' '));
+
+    // TODO: Modify to use display name when display name is added to device metadata.
+    // Currently, cuda and rocm have the same human_readable_name in device_metadata.
+    if (deviceDescription) {
+      return `${deviceDescription} ${restLabel}`;
+    } else if (_.includes(metricName.toLowerCase(), 'io')) {
+      return `${_.startCase(metricName.replaceAll('io', 'IO').replaceAll('_', ' '))}`;
+    } else {
+      return `${_.startCase(metricName.replaceAll('_', ' '))}`;
+    }
+  };
+
+  return (
+    <BAIFlex
+      direction="column"
+      align="stretch"
+      gap="sm"
+      style={{
+        height: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      <BAIFlex align="center" style={{ height: 56, marginLeft: 52 }} gap="xs">
+        <Heading level={5}>{getMetricTitle()}</Heading>
+        {tooltip ? <BAIQuestionIconWithTooltip title={tooltip} /> : null}
+      </BAIFlex>
+      <Suspense
+        fallback={
+          // BAISkeleton spreads `style` onto every line box in paragraph
+          // mode, so the inset has to ride on a wrapper.
+          <BAIFlex
+            direction="column"
+            align="stretch"
+            style={{ padding: token.marginMD }}
+          >
+            <BAISkeleton />
+          </BAIFlex>
+        }
+      >
+        <SessionMetricGraphBody {...props} />
+      </Suspense>
+    </BAIFlex>
+  );
+};
+
+const SessionMetricGraphBody: React.FC<PrometheusMetricGraphProps> = ({
+  queryProps: { startDate, endDate, metricName, userId, dayDiff },
+  fetchKey,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
 
   const { capacity_metric, current_metric } =
     useLazyLoadQuery<SessionMetricGraphQuery>(
@@ -140,49 +218,8 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
     convertMetricFunction[metricName] ?? undefined,
   );
 
-  const resourceSlotKey = useMemo(() => {
-    const parts = _.split(metricName, '_');
-    const devicePrefix =
-      parts.length > 1 ? parts.slice(0, -1).join('-') : parts[0];
-    return (
-      _.find(
-        _.keys(mergedResourceSlots),
-        (slotKey) =>
-          _.startsWith(slotKey, devicePrefix + '.') || slotKey === devicePrefix,
-      ) ?? ''
-    );
-  }, [mergedResourceSlots, metricName]);
-  const deviceDescription = mergedResourceSlots[resourceSlotKey]?.description;
-
-  const getMetricTitle = () => {
-    const [, ...rest] = _.split(metricName, '_');
-    const restLabel = _.startCase(rest.join(' '));
-
-    // TODO: Modify to use display name when display name is added to device metadata.
-    // Currently, cuda and rocm have the same human_readable_name in device_metadata.
-    if (deviceDescription) {
-      return `${deviceDescription} ${restLabel}`;
-    } else if (_.includes(metricName.toLowerCase(), 'io')) {
-      return `${_.startCase(metricName.replaceAll('io', 'IO').replaceAll('_', ' '))}`;
-    } else {
-      return `${_.startCase(metricName.replaceAll('_', ' '))}`;
-    }
-  };
-
   return (
-    <BAIFlex
-      direction="column"
-      align="stretch"
-      gap="sm"
-      style={{
-        height: '100%',
-        overflow: 'hidden',
-      }}
-    >
-      <BAIFlex align="center" style={{ height: 56, marginLeft: 52 }} gap="xs">
-        <Heading level={5}>{getMetricTitle()}</Heading>
-        {tooltip ? <BAIQuestionIconWithTooltip title={tooltip} /> : null}
-      </BAIFlex>
+    <>
       {_.isEmpty(capacity_metric?.metrics) &&
       _.isEmpty(current_metric?.metrics) ? (
         <EmptyState isCompact title={t('autoScalingRule.NoDataAvailable')} />
@@ -230,7 +267,7 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
           </LineChart>
         </ResponsiveContainer>
       )}
-    </BAIFlex>
+    </>
   );
 };
 

--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -16,16 +16,11 @@ import type { ISODateString } from '@astryxdesign/core/Calendar';
 import { DateRangeInput } from '@astryxdesign/core/DateRangeInput';
 import type { DateRange } from '@astryxdesign/core/DateRangeInput';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
-import {
-  BAISkeleton,
-  useUpdatableState,
-  BAIFlex,
-  filterOutEmpty,
-} from 'backend.ai-ui';
+import { useUpdatableState, BAIFlex, filterOutEmpty } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { parseAsString, useQueryState } from 'nuqs';
-import { Suspense, useEffect, useMemo, useState, useTransition } from 'react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -138,20 +133,18 @@ const UserSessionsMetrics: React.FC<UserSessionsMetricsProps> = () => {
         columnSpan: windowWidth > 2160 ? 3 : 2,
         data: {
           content: (
-            <Suspense fallback={<BAISkeleton />}>
-              <SessionMetricGraph
-                key={metric}
-                queryProps={{
-                  startDate: dayjs(startDate).unix().toString(),
-                  endDate: dayjs(endDate).unix().toString(),
-                  metricName: metric,
-                  userId: userInfo[0]?.uuid ?? '',
-                  dayDiff: dayDiff,
-                }}
-                fetchKey={usageFetchKey}
-                tooltip={tooltip[metric] || undefined}
-              />
-            </Suspense>
+            <SessionMetricGraph
+              key={metric}
+              queryProps={{
+                startDate: dayjs(startDate).unix().toString(),
+                endDate: dayjs(endDate).unix().toString(),
+                metricName: metric,
+                userId: userInfo[0]?.uuid ?? '',
+                dayDiff: dayDiff,
+              }}
+              fetchKey={usageFetchKey}
+              tooltip={tooltip[metric] || undefined}
+            />
           ),
         },
       }),
@@ -295,20 +288,18 @@ const UserSessionsMetrics: React.FC<UserSessionsMetricsProps> = () => {
                       data: {
                         ...originalItem.data,
                         content: (
-                          <Suspense fallback={<BAISkeleton />}>
-                            <SessionMetricGraph
-                              key={`${item.id}-${Date.now()}`}
-                              queryProps={{
-                                startDate: dayjs(startDate).unix().toString(),
-                                endDate: dayjs(endDate).unix().toString(),
-                                metricName: item.id,
-                                userId: userInfo[0]?.uuid ?? '',
-                                dayDiff: dayDiff,
-                              }}
-                              fetchKey={usageFetchKey}
-                              tooltip={tooltip[item.id] || undefined}
-                            />
-                          </Suspense>
+                          <SessionMetricGraph
+                            key={`${item.id}-${Date.now()}`}
+                            queryProps={{
+                              startDate: dayjs(startDate).unix().toString(),
+                              endDate: dayjs(endDate).unix().toString(),
+                              metricName: item.id,
+                              userId: userInfo[0]?.uuid ?? '',
+                              dayDiff: dayDiff,
+                            }}
+                            fetchKey={usageFetchKey}
+                            tooltip={tooltip[item.id] || undefined}
+                          />
                         ),
                       },
                     };


### PR DESCRIPTION
Resolves #9072 (FR-3682)

## Mechanism

The report's framing names a component that is not on that page:

> the Suspense boundary wraps the whole BAICard

These chart cards are **not** `BAICard`s. They are `@cloudscape-design/board-components` `BoardItem`s, and `BAIBoard.tsx` never uses cloudscape's `header` slot — `renderItem` passes `item.data.content` as the item's *sole* child. So no card chrome owns a title; the "header" is just the first flex row inside the item's own content.

That content is `SessionMetricGraph`, which **renders its own title and is also the component that suspends** (`useLazyLoadQuery`). The `<Suspense fallback={<BAISkeleton />}>` sat *outside* it in `UserSessionsMetrics.tsx`, so while the query was in flight React unmounted the header along with the chart and painted only the skeleton.

The drag handle survived because it is board chrome — absolutely positioned at `z-index: 51` by `BAIBoard.css`, outside the item content. That is why the cards looked *anonymous* rather than merely empty, which is the part that made them indistinguishable.

The convention the report cites (`use-bai-card.md`, "header always visible, Skeleton in the body") is the right **target state**; the component and the file to change are just different from what it implies.

## The fix

Split `SessionMetricGraph` into a non-suspending shell and a suspending body:

- **shell** keeps `useResourceSlotsDetails()` (built on `useQuery`, not Relay — it never throws a promise), the `resourceSlotKey` / `deviceDescription` / `getMetricTitle` derivation, and the header row;
- **`SessionMetricGraphBody`** keeps `useLazyLoadQuery`, `getMetricData` and the `EmptyState` / `ResponsiveContainer` branch, behind a local `<Suspense>`.

The skeleton rides on a padded `BAIFlex` wrapper because `BAISkeleton` spreads `style` onto **every** line box in paragraph mode, so putting the inset on the skeleton itself would indent each bar instead of the block.

The two outer boundaries in `UserSessionsMetrics.tsx` — the initial board-item builder and the resize-workaround rebuild — are now dead (React resolves the *nearest* boundary), so they and the now-unused `Suspense` / `BAISkeleton` imports are removed. `StatisticsPage`'s page-level boundary stays as the backstop.

Kept the hand-rolled 56px/52px header row rather than swapping in `BAIBoardItemTitle`, which has no drag-handle inset — that swap is a separate visual change.

## Screenshots

### While six metric queries are held open

Captured by intercepting `SessionMetricGraphQuery` and delaying every response 12s, so the suspended state is stable rather than a race.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9152/fr3682-before-loading.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9152/fr3682-after-loading.png) |

### After the data lands (unchanged)

![loaded](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9152/fr3682-after-loaded.png)


## Verification

```
bash scripts/verify.sh → === ALL PASS ===
```

Live probe: with 6 `SessionMetricGraphQuery` responses held open, the headings visible on the board went from **`["Notifications"]`** to **`["Notifications", "CPU Util", "Memory", "Net Rx", "Net Tx", "IO Read", "IO Write"]`** — all six card titles present while 24 skeleton bars are still painting. After the data lands the heading set is identical in both builds, so nothing was added or lost once loaded. Zero `pageerror`s.

## Residue

The identical header-loss pattern exists on `DashboardPage` (`StorageStatusPanelCard`, `QuotaPerStorageVolumeDashboardItem`) — same `BAIBoard` construction, same outside-the-title boundary. Unreported, and deliberately not swept into this PR; worth a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam
