### PR TITLE
fix(FR-3681): restore scroll on the minWidth-workaround tables (batch 2/2)

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
@@ -163,7 +163,6 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
         title: t('comp:UserNodes.DomainName'),
         dataIndex: 'domainName',
         exportKey: 'domain_name',
-        minWidth: 100,
         sorter: isEnableSorter('domainName'),
         render: (__, record) => record.organization?.domainName || '-',
       },
@@ -340,6 +339,7 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
 
   return (
     <BAITable<UserV2InList>
+      scroll={{ x: 'max-content' }}
       resizable
       rowKey="id"
       size="small"

--- a/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
@@ -148,7 +148,6 @@ const BAIUserNodes: React.FC<BAIUserNodesProps> = ({
         key: 'domain_name',
         title: t('comp:UserNodes.DomainName'),
         dataIndex: 'domain_name',
-        minWidth: 100,
         sorter: isEnableSorter('domain_name'),
       },
       {
@@ -295,10 +294,8 @@ const BAIUserNodes: React.FC<BAIUserNodesProps> = ({
     : baseColumns;
 
   return (
-    // to-astryx ticket 25: migrated to the Astryx engine. antd's
-    // `scroll={{ x: 'max-content' }}` is gone — Astryx's own scroll wrapper
-    // already handles horizontal overflow.
     <BAITable
+      scroll={{ x: 'max-content' }}
       resizable
       rowKey={'id'}
       size="small"

--- a/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
@@ -774,6 +774,7 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
 
   return (
     <BAITable<AgentNodeInList>
+      scroll={{ x: 'max-content' }}
       {...tableProps}
       rowKey={(record) => record.id}
       dataSource={agents}

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.tsx
@@ -79,7 +79,6 @@ const BAIArtifactRevisionTable = ({
         title: t('comp:BAIArtifactRevisionTable.Version'),
         dataIndex: 'version',
         key: 'version',
-        width: '30%',
         render: (version: string, record: ArtifactRevision) => (
           <div>
             <BAIFlex align="center" gap={'xs'}>
@@ -103,7 +102,6 @@ const BAIArtifactRevisionTable = ({
         title: t('comp:BAIArtifactRevisionTable.Status'),
         dataIndex: 'status',
         key: 'status',
-        width: '15%',
         render: (_value: string, record: ArtifactRevision) => {
           return <BAIArtifactStatusTag artifactRevisionFrgmt={record} />;
         },
@@ -112,7 +110,6 @@ const BAIArtifactRevisionTable = ({
         title: t('comp:BAIArtifactRevisionTable.Size'),
         dataIndex: 'size',
         key: 'size',
-        width: '15%',
         render: (size: number) => {
           if (!size) return <BAIText monospace>N/A</BAIText>;
           return (
@@ -126,7 +123,6 @@ const BAIArtifactRevisionTable = ({
         title: t('comp:BAIArtifactTable.Updated'),
         dataIndex: 'updatedAt',
         key: 'updatedAt',
-        width: '15%',
         render: (updated_at: string) =>
           updated_at ? (
             <BAIText type="secondary" title={dayjs(updated_at).toString()}>
@@ -145,6 +141,10 @@ const BAIArtifactRevisionTable = ({
 
   return (
     <BAITable<ArtifactRevision>
+      // Restores the pre-migration pairing. The percentage column widths that
+      // used to sit alongside it are gone: BAITable keeps only NUMERIC widths
+      // in x mode, so they were inert. Use numbers if proportions are wanted.
+      scroll={{ x: 'max-content' }}
       rowKey={(record) => record.id}
       resizable
       columns={allColumns}

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -555,31 +555,6 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = ({
             {
               ...columns[0],
               render: renderEmailWithActions,
-              // This override is what puts the row's action buttons in the
-              // E-Mail cell, so it owns the width they need — not
-              // `BAIUserNodes`, whose plain email column is reused by tables
-              // that render no actions.
-              //
-              // Reported as "default email column width 가 좁아서 컨트롤 버튼이
-              // 모두 보이지 않음" (QA-FINDINGS Q-16). The column carries no
-              // width, so `BAITable` falls through to `proportional(1)`,
-              // whose documented minimum is 120px; with 21 columns that is
-              // 2452px against a 1600px viewport, so the flex share never
-              // activates and EVERY column pins to that 120px floor. 120 minus
-              // the cell's 16px padding leaves 104, minus
-              // `BAINameActionCell`'s 44px title reserve leaves 60 — and three
-              // 24px buttons with 2px gaps need 76, so all but one collapse
-              // into the overflow menu.
-              //
-              // Legacy sized this column to its content: the antd table ran
-              // `scroll={{ x: 'max-content' }}`, which puts rc-table in `auto`
-              // layout (`git show origin/main:packages/backend.ai-ui/src/
-              // components/BAIAdminUserV2Table.tsx`), and `BAITable`
-              // accepts-and-ignores `scroll` by PILOT-DECISION. 320 = 200px of
-              // email text + 8 gap + four 24px buttons with 2px gaps (102) +
-              // 16 padding. The table already scrolls, so this takes nothing
-              // from the other columns.
-              minWidth: 320,
             },
             ...columns.slice(1),
           ];

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -428,6 +428,7 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
         </BAIFlex>
       </BAIFlex>
       <BAITable
+        scroll={{ x: 'max-content' }}
         bordered
         rowKey={'id'}
         dataSource={filterOutNullAndUndefined(agent_summary_list?.items)}

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -1427,6 +1427,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
                 state is already carried by the validity icon column plus the
                 per-cell error background that `onCell` paints. */}
             <BAITable<ValidatedRow>
+              scroll={{ x: 'max-content' }}
               size="small"
               rowKey="key"
               dataSource={displayRows}

--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -254,6 +254,13 @@ const ErrorLogList: React.FC<{
         </BAIFlex>
       </BAIFlex>
       <BAITable
+        scroll={{
+          x: 'max-content',
+          y:
+            _.filter(filteredLogData, (log) => log.isError).length === 0
+              ? undefined
+              : 'calc(100vh - 400px)',
+        }}
         pagination={{
           showSizeChanger: false,
         }}

--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -268,9 +268,6 @@ const ErrorLogList: React.FC<{
         // a refetch is in flight but has no spinner slot, so the antd
         // `{ indicator }` object collapses to a boolean.
         loading={isPendingSearchTransition}
-        // PILOT-DECISION (ticket 25 §5): `scroll.y` — a fixed body height with
-        // a sticky header — is DROPPED. This log list now scrolls with the
-        // page instead of inside its own viewport-height box.
         dataSource={
           checkedShowOnlyError
             ? _.filter(filteredLogData, (log) => {

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -598,6 +598,7 @@ const ImageListInScope: React.FC<ImageListInScopeProps> = ({
           </BAIFlex>
         </BAIFlex>
         <BAITable
+          scroll={{ x: 'max-content' }}
           resizable
           rowKey="id"
           pagination={{

--- a/react/src/components/RoleScopePermissionEditModal.tsx
+++ b/react/src/components/RoleScopePermissionEditModal.tsx
@@ -849,6 +849,7 @@ const RoleScopePermissionEditModal: React.FC<
             <EmptyState title={t('rbac.NoPermissionsToDisplay')} />
           ) : (
             <BAITable
+              scroll={{ x: 'max-content' }}
               rowKey="entityType"
               columns={columns}
               dataSource={entities}

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -225,18 +225,6 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         key: 'status',
         title: t('session.Status'),
         dataIndex: 'status',
-        // QA-FINDINGS Q-35 — a column that declares neither `width` nor
-        // `minWidth` is handed `proportional(1)`, i.e. a STRICT 1/N equal share
-        // of the table, and the cell clips (`overflow: hidden`) rather than
-        // pushing back. The worst real cell here is `PENDING` + `#n` + the
-        // "Queue Position" tooltip label, which needs 124px of content box;
-        // the equal share gives 120px minus 8/8 cell padding = 104px, so the
-        // tag was cut mid-glyph on `/admin-session` at every width and on
-        // `/session` below 1600. antd's engine measured content and grew the
-        // column, so the column definition itself is byte-identical to legacy's
-        // — the fallback is what changed. 140 = 124 content + the 16px of cell
-        // padding the engine does not add on its own.
-        minWidth: 140,
         render: (__, session) => {
           // TODO: Display idle checker if imminentExpirationTime as Icon(clock-alert).
           return <SessionStatusTag sessionFrgmt={session} />;
@@ -425,6 +413,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
   return (
     <>
       <BAITable
+        scroll={{ x: 'max-content' }}
         resizable
         rowKey={'id'}
         size="small"


### PR DESCRIPTION
Resolves #9071 (FR-3681)

> **Batch 2 of 2.** Batch 1 restores the prop on the 51 files where the change is purely mechanical. These 9 grew a workaround after the migration, so each needed a look — `BAITable.tsx:806` deliberately ignores `column.minWidth` in x mode, which means restoring `scroll.x` silently disables them.

See batch 1 for the full mechanism. The short version: commit `7d7b42388` (`feat(FR-3482)`) stripped `scroll` from **every** `BAITable` call site — 67 removals across 65 files — and `788faeeb5` (`feat(FR-3500)`, #8726) revived the contract on the component two days later without restoring the call sites. Width-less columns then fall to `proportional(1)` with a 120px floor and ellipsize.

## What the per-file look actually found

Most of the `minWidth` hits in these files are **inline styles on cell content** (`style={{ minWidth: 200 }}` inside a `render`), which `scroll.x` does not touch. Only **four** were column-level, and all four exist solely to compensate for the very pin this PR removes:

| File | Workaround | Verdict |
|---|---|---|
| `SessionNodes.tsx` | `minWidth: 140` | **Removed.** Its own QA-FINDINGS Q-35 comment states that antd measured content and grew the column, and that `140 = 124 content + 16 padding` was a hand-computed stand-in for exactly that. `scroll.x` restores content sizing, so the constant *and* its 12-line comment are dead. |
| `BAIUserNodes.tsx` | `minWidth: 100` (Domain Name) | **Removed.** Superseded, no comment. |
| `BAIAdminUserV2Table.tsx` | `minWidth: 100` (Domain Name) | **Removed.** Same. |
| `AdminUserManagement.tsx` | `minWidth: 320` (email + actions) | **Removed**, with the 25-line block explaining it. |

## The two stale claims that kept this latent

Both are deleted here, because both are false and both were load-bearing for *not* fixing this:

1. `AdminUserManagement.tsx` — *"`BAITable` accepts-and-ignores `scroll` by PILOT-DECISION."* Untrue since FR-3500 (#8726).
2. `BAIUserNodes.tsx` — *"antd's `scroll={{ x: 'max-content' }}` is gone — Astryx's own scroll wrapper already handles horizontal overflow."* Untrue: without the prop the wrapper never overflows, because every width-less column is pinned to 120px first.

## Two files done by hand

- **`ErrorLogList.tsx`** — the only non-trivial value in the entire sweep: a conditional `y`, `_.filter(filteredLogData, (log) => log.isError).length === 0 ? undefined : 'calc(100vh - 400px)'`. Copied verbatim from `7d7b42388^`; a blind sed would have mangled it.
- **`BulkCreateUserFromCSVModal.tsx`** — had **two** tables pre-migration and has **one** today. The surviving `<BAITable<ValidatedRow>>` gets the prop; the removed table's value is dropped rather than misapplied to the wrong table. This is the single count mismatch the pre-flight validation flagged (`tags=1 values=2`).

## Verification

```
bash scripts/verify.sh          → === ALL PASS ===
pnpm --filter backend.ai-ui build → ok
```

## Honest coverage limit

Nine tables changed; I did not eyeball all nine live. What *was* checked is the thing that could go wrong: every `minWidth` in these files was read and classified as column-level (4, all superseded) or content-level (the rest, unaffected). The remaining risk is cosmetic re-widthing on tables whose content is wider than the old 120px pin — which is the intended effect.

Reviewers who want a targeted look, in rough order of how much the layout moves: Sessions list (`SessionNodes`, the Status column loses its 140px floor), admin → Users (`AdminUserManagement` / `BAIAdminUserV2Table`, the email+actions column loses its 320px floor and should now size to content — its own comment predicts the four row actions stop collapsing into the overflow menu), and admin → Diagnostics → error log (`ErrorLogList`, the conditional `y` reintroduces a capped body height — worth a check on a short viewport).

## Residue

- `GeneratedKeypairListModal.tsx` (**FR-3519**) and `BAIFileExplorer.tsx` (**FR-3669**) stay excluded from both batches — In Progress under another assignee, and the same 120px pin, so they are covered once those land.
- `AdminUserCredentialList.tsx` is covered by **FR-3685**.
- Columns with an explicit pixel `width` keep truncating in x mode by design; this sweep does not close every truncation report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7hrQrsBD2rsad6sEQgVam
