### PR TITLE
docs: update admin_menu docs (2026-08-26)

### DIFF
--- a/packages/backend.ai-webui-docs/src/en/admin_menu/admin_menu.md
+++ b/packages/backend.ai-webui-docs/src/en/admin_menu/admin_menu.md
@@ -1399,19 +1399,20 @@ would not be shown.
 The resource preset dialog includes:
 
 - **Preset Name**: A unique name for the preset (only alphanumeric characters, periods, hyphens, and underscores allowed).
-- **Resource Group**: (Conditional) Associate the preset with a specific resource group.
+- **Resource Group**: Associate the preset with a specific resource group. This field is optional — leave it empty (or clear it) to keep the preset global, so it applies regardless of the resource group.
 - **Resource Preset**: Dynamic fields for each available resource type (CPU, Memory, GPU, etc.). Memory fields support dynamic unit input (`MiB`, `GiB`, `TiB`, `PiB`).
 - **Shared Memory**: The amount of shared memory allocated for the preset. This value must be less than the **Memory** value.
 
 ![](../images/modify_resource_preset_dialog.png)
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Edit (pencil) action on a preset, showing the Edit Resource Preset modal with the Resource Group field. Not captured: the screenshot environment was unreachable on this run. -->
 
 You can also create a resource preset by clicking the **Create Preset** button in the
-right top of the Resource Presets tab. You cannot create the same resource
-preset name that already exists, since it is the key value for distinguishing
-each resource preset.
+right top of the Resource Presets tab. Resource preset names must still be
+unique. If you enter a name that already exists, the server rejects the request
+when you click **Create** and an error message is displayed.
 
 ![](../images/create_resource_preset_dialog.png)
-<!-- TODO: Re-capture create_resource_preset_dialog.png — needs update. -->
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Create Preset button, showing the Create Resource Preset modal with the Resource Group field now always visible. Not captured: the screenshot environment was unreachable on this run. -->
 
 <a id="manage-agent-nodes"></a>
 

--- a/packages/backend.ai-webui-docs/src/ja/admin_menu/admin_menu.md
+++ b/packages/backend.ai-webui-docs/src/ja/admin_menu/admin_menu.md
@@ -1318,16 +1318,17 @@ GitLabコンテナレジストリを追加する場合、追加情報フィー�
 リソースプリセットダイアログには以下の項目が含まれます：
 
 - **プリセット名**: プリセットの一意の名前です（英数字、ピリオド、ハイフン、アンダースコアのみ使用可能）。
-- **リソースグループ**: （条件付き）プリセットを特定のリソースグループに関連付けます。
+- **リソースグループ**: プリセットを特定のリソースグループに関連付けます。このフィールドは任意です。空のままにするか値をクリアすると、リソースグループに関係なく適用されるグローバルプリセットになります。
 - **リソースプリセット**: 利用可能な各リソースタイプ（CPU、メモリ、GPUなど）を入力する動的フィールドのまとまりです。メモリフィールドは動的な単位入力（MiB、GiB、TiB、PiB）をサポートしています。
 - **共有メモリ**: プリセットに割り当てられた共有メモリの量です。この値は**メモリ**の値より少なくなければなりません。
 
 ![](../images/modify_resource_preset_dialog.png)
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Edit (pencil) action on a preset, showing the Edit Resource Preset modal with the Resource Group field. Not captured: the screenshot environment was unreachable on this run. -->
 
-「リソースプリセット」タブの右上にある **プリセットの作成** ボタンをクリックしてリソースプリセットを作成することもできます。既に存在する名前と同じリソースプリセットは作成できません。名前は各リソースプリセットを区別するキー値です。
+「リソースプリセット」タブの右上にある **プリセットの作成** ボタンをクリックしてリソースプリセットを作成することもできます。リソースプリセット名は引き続き一意である必要があります。既に存在する名前を入力すると、**作成** をクリックした際にサーバーがリクエストを拒否し、エラーメッセージが表示されます。
 
 ![](../images/create_resource_preset_dialog.png)
-<!-- TODO: Re-capture create_resource_preset_dialog.png — needs update. -->
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Create Preset button, showing the Create Resource Preset modal with the Resource Group field now always visible. Not captured: the screenshot environment was unreachable on this run. -->
 
 <a id="manage-agent-nodes"></a>
 

--- a/packages/backend.ai-webui-docs/src/ko/admin_menu/admin_menu.md
+++ b/packages/backend.ai-webui-docs/src/ko/admin_menu/admin_menu.md
@@ -1179,16 +1179,17 @@ GitLab 컨테이너 레지스트리를 추가할 때는 추가 정보 필드에 
 자원 프리셋 대화 상자에는 다음 항목이 포함됩니다:
 
 - **자원 프리셋 이름**: 프리셋의 고유 이름입니다 (영숫자, 마침표, 하이픈, 밑줄만 허용됩니다).
-- **자원 그룹**: (조건부) 프리셋을 특정 자원 그룹에 연결합니다.
+- **자원 그룹**: 프리셋을 특정 자원 그룹에 연결합니다. 이 필드는 선택 사항이며, 비워 두거나 값을 지우면 자원 그룹과 관계없이 적용되는 전역 프리셋이 됩니다.
 - **자원 프리셋**: 사용 가능한 각 자원 유형(CPU, 메모리, GPU 등)에 대한 동적 필드 묶음입니다. 메모리 필드는 동적 단위 입력(MiB, GiB, TiB, PiB)을 지원합니다.
 - **공유 메모리**: 프리셋에 할당된 공유 메모리 양입니다. 이 값은 **메모리** 값보다 작아야 합니다.
 
 ![](../images/modify_resource_preset_dialog.png)
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Edit (pencil) action on a preset, showing the Edit Resource Preset modal with the Resource Group field. Not captured: the screenshot environment was unreachable on this run. -->
 
-또한 자원 프리셋 탭 오른쪽 상단의 **프리셋 생성** 버튼을 클릭하여 자원 프리셋을 생성할 수 있습니다. 이미 존재하는 것과 동일한 자원 프리셋 이름으로는 생성할 수 없습니다. 이름은 각 자원 프리셋을 구분하는 키 값이기 때문입니다.
+또한 자원 프리셋 탭 오른쪽 상단의 **프리셋 생성** 버튼을 클릭하여 자원 프리셋을 생성할 수 있습니다. 자원 프리셋 이름은 여전히 고유해야 합니다. 이미 존재하는 이름을 입력하면 **생성**을 클릭할 때 서버에서 요청을 거부하고 오류 메시지가 표시됩니다.
 
 ![](../images/create_resource_preset_dialog.png)
-<!-- TODO: Re-capture create_resource_preset_dialog.png — needs update. -->
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Create Preset button, showing the Create Resource Preset modal with the Resource Group field now always visible. Not captured: the screenshot environment was unreachable on this run. -->
 
 <a id="manage-agent-nodes"></a>
 

--- a/packages/backend.ai-webui-docs/src/th/admin_menu/admin_menu.md
+++ b/packages/backend.ai-webui-docs/src/th/admin_menu/admin_menu.md
@@ -1275,16 +1275,17 @@ Resource preset ที่กำหนดไว้ล่วงหน้าจะ�
 ไดอะล็อกค่าที่กำหนดไว้ล่วงหน้าของทรัพยากรประกอบด้วย:
 
 - **ชื่อค่าที่กำหนดไว้ล่วงหน้า**: ชื่อเฉพาะสำหรับค่าที่กำหนดไว้ล่วงหน้า (อนุญาตเฉพาะตัวอักษรและตัวเลข, จุด, ขีดกลาง และขีดล่าง)
-- **กลุ่มทรัพยากร**: (แบบมีเงื่อนไข) เชื่อมโยง preset กับกลุ่มทรัพยากรเฉพาะ
+- **กลุ่มทรัพยากร**: เชื่อมโยง preset กับกลุ่มทรัพยากรเฉพาะ ฟิลด์นี้ไม่บังคับ หากปล่อยว่างไว้หรือล้างค่า preset จะเป็น preset ส่วนกลางที่ใช้ได้โดยไม่ขึ้นกับกลุ่มทรัพยากร
 - **ค่าที่กำหนดไว้ล่วงหน้าของทรัพยากร**: ฟิลด์แบบไดนามิกสำหรับทรัพยากรแต่ละประเภทที่มี (CPU, หน่วยความจำ, GPU เป็นต้น) ฟิลด์หน่วยความจำรองรับการป้อนหน่วยแบบไดนามิก (MiB, GiB, TiB, PiB)
 - **หน่วยความจำที่ใช้ร่วมกัน**: ปริมาณหน่วยความจำที่ใช้ร่วมกันที่จัดสรรให้กับค่าที่กำหนดไว้ล่วงหน้า ค่านี้ต้องน้อยกว่าค่า**หน่วยความจำ**
 
 ![](../images/modify_resource_preset_dialog.png)
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Edit (pencil) action on a preset, showing the Edit Resource Preset modal with the Resource Group field. Not captured: the screenshot environment was unreachable on this run. -->
 
-คุณยังสามารถสร้าง resource preset ได้โดยคลิกปุ่ม **สร้างพรีเซต** ที่มุมบนขวาของแท็บค่าที่กำหนดไว้ล่วงหน้าของทรัพยากร คุณไม่สามารถสร้าง resource preset ที่มีชื่อเดียวกันกับที่มีอยู่แล้วได้ เนื่องจากเป็นค่าคีย์สำหรับแยกแยะแต่ละ resource preset
+คุณยังสามารถสร้าง resource preset ได้โดยคลิกปุ่ม **สร้างค่าที่กำหนดไว้ล่วงหน้า** ที่มุมบนขวาของแท็บค่าที่กำหนดไว้ล่วงหน้าของทรัพยากร ชื่อของ resource preset ยังคงต้องไม่ซ้ำกัน หากคุณป้อนชื่อที่มีอยู่แล้ว เซิร์ฟเวอร์จะปฏิเสธคำขอเมื่อคุณคลิก **สร้าง** และจะแสดงข้อความแสดงข้อผิดพลาด
 
 ![](../images/create_resource_preset_dialog.png)
-<!-- TODO: Re-capture create_resource_preset_dialog.png — needs update. -->
+<!-- TODO(screenshot): /environment -> Resource Presets tab -> Create Preset button, showing the Create Resource Preset modal with the Resource Group field now always visible. Not captured: the screenshot environment was unreachable on this run. -->
 
 <a id="manage-agent-nodes"></a>
 


### PR DESCRIPTION

## What changed and why

**fix(FR-3718): target resource presets by id in delete and modify mutations (#9143)** — commit `71b7a41f` — changed the resource-preset admin UX in two user-visible ways:

1. The `resource-presets-per-resource-group` capability gate around the **Resource Group** field in `ResourcePresetSettingModal.tsx` was removed — the field now always renders, stays clearable, and an empty value makes the preset the manager's *global* preset (per the code comment retained on the field).
2. The client-side duplicate-name validator (and its `resourcePreset.PresetNameAlreadyExists` key, deleted from all locales) is gone; mutations now target the preset **id**. Names must still be unique, but a duplicate is now rejected server-side and surfaced as an error message on **Create**, not as an inline field error.

The "Manage resource preset" section still described the old behavior in all four languages. This PR updates it:

- **Resource Group** bullet: dropped "(Conditional)"; documents the field as optional/clearable with the global-preset semantics.
- Replaced "You cannot create the same resource preset name that already exists, since it is the key value…" with: names must be unique, and a duplicate is rejected by the server with an error message on **Create**.
- **th only**: corrected the Create Preset button name from **สร้างพรีเซต** (matches no live label in this namespace) to **สร้างค่าที่กำหนดไว้ล่วงหน้า** (`resourcePreset.CreatePreset` in `resources/i18n/th.json`), per the terminology-precedence rule.

Scope: `src/{en,ko,ja,th}/admin_menu/admin_menu.md`.

## Deliberately skipped

- Six recapture-only images planned for this chapter (`detailed_agent_node_usage_information.png`, `information_page.png`, `user_detail_dialog.png`, `keypair_detail_dialog.png`, `storage_host_detail_drawer.png`, `fair_share_usage_bucket_modal.png`, all FR-3694 `BAIMetadataList` restyles, `c16477c9e`) — the screenshot environment (`http://10.82.1.75:8090`) was unreachable this run, so the batch produced no files. Existing images left in place; re-queue on the next nightly run with a live environment.
- No other prose in this chapter is affected by the range; other FR-3718 hunks (e.g. `QuotaScopeTable.tsx` id ellipsis) were assessed and skipped per the plan.

## Review findings (independent, by Reporter)

- **Prose claims verified against source.** I confirmed in commit `71b7a41f` and the current `ResourcePresetSettingModal.tsx`: the capability gate is removed and the field renders unconditionally with `allowClear`; the duplicate-name validator and its i18n key are deleted; the only create-failure path is `message.error(...)` driven by server errors. Both new claims are supported; no unsupported behavior is asserted.
- **Translation parity: OK.** All four languages carry the same two edits and both `TODO(screenshot)` markers with matching structure.
- **UI labels verified** against live i18n in all four languages (**Create** = 作成/생성/สร้าง; **Create Preset** = プリセットの作成/프리셋 생성/สร้างค่าที่กำหนดไว้ล่วงหน้า). The Thai label fix is correct.
- **No scope creep** — 4 files, this chapter only, no image churn.
- ⚠️ **Screenshots owed**: `create_resource_preset_dialog.png` and `modify_resource_preset_dialog.png` were **not** recaptured (environment unreachable). The existing captures predate FR-3718, so on servers that gated the field they may not show the Resource Group field the updated prose now describes. Both locations carry explicit `<!-- TODO(screenshot): … -->` markers naming the route and required content; a human capture is needed. Same for the six FR-3694 manifest images above. Not a merge blocker, but the markers should not be forgotten.
- Minor nit (non-blocking): "names must **still** be unique" reads slightly changelog-relative for a fresh manual reader; consistent across all four languages, safe to keep or smooth in review.

## Verified by the wrapper

- Diff touches only `packages/backend.ai-webui-docs/` within this chapter's scope.
- `bash scripts/verify.sh` passes (`=== ALL PASS ===`).

## Convention note

This nightly docs-sync PR carries no `FR-` number by design; it deviates from the repo's `prefix(FR-XXXX)` title convention and will not be linked by `project-status-sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
