### PR TITLE
fix(FR-3712): stop accelerator slot fields failing as "not a valid undefined"

### DIFF
--- a/packages/backend.ai-ui/src/form-engine/validate.test.ts
+++ b/packages/backend.ai-ui/src/form-engine/validate.test.ts
@@ -1,0 +1,44 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ FR-3712 — `${type}` interpolation for rules whose type is inferred rather
+ than declared. `validateRule` normalises `{}` to a `string`-typed rule before
+ validating, so the failure message must interpolate the normalised type, not
+ the raw rule's `undefined`.
+ */
+import { defaultValidateMessages } from './messages';
+import { validateRules } from './validate';
+import { describe, expect, it } from 'vitest';
+
+// Default (parallel) mode always rejects with the per-rule summaries.
+const collectErrors = (value: unknown, rules: any[]) =>
+  validateRules(['resource_slots', 'cuda.device'], value, rules, {
+    ...defaultValidateMessages,
+  }).then(
+    () => {
+      throw new Error('validateRules resolved in parallel mode');
+    },
+    (summaries: { errors: any[] }[]) => summaries.flatMap((s) => s.errors),
+  );
+
+describe('validateRules — inferred-type message interpolation (FR-3712)', () => {
+  it('interpolates ${type} as the normalised type for an empty rule', async () => {
+    const errors = await collectErrors(1, [{}]);
+    expect(errors).toEqual([
+      "'resource_slots.cuda.device' is not a valid string",
+    ]);
+  });
+
+  it('still resolves ${type} for an explicitly typed rule', async () => {
+    const errors = await collectErrors('one', [{ type: 'number' }]);
+    expect(errors).toEqual([
+      "'resource_slots.cuda.device' is not a valid number",
+    ]);
+  });
+
+  it('accepts a number under a declared number rule', async () => {
+    const errors = await collectErrors(1, [{ type: 'number' }]);
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/backend.ai-ui/src/form-engine/validate.ts
+++ b/packages/backend.ai-ui/src/form-engine/validate.ts
@@ -405,6 +405,9 @@ async function validateRule(
   messageVariables?: Record<string, string>,
 ): Promise<any[]> {
   let rawErrors: any[] = [];
+  // Kept in sync with the declarative branch so `${type}` interpolates the
+  // normalised type, not `undefined`, when the rule's type was inferred.
+  let effectiveRule: NormalizedRule = rule;
 
   if (rule.validator) {
     const cbArg = await runCustomValidator(rule, value);
@@ -414,7 +417,7 @@ async function validateRule(
     const method = pickMethod(rule);
     // `getType` normalises the rule's own `type` before the validators read
     // it — `undefined` becomes `'string'`, a bare RegExp becomes `'pattern'`.
-    const effectiveRule: NormalizedRule = {
+    effectiveRule = {
       ...rule,
       type: method === 'required' ? rule.type : method,
     };
@@ -451,7 +454,7 @@ async function validateRule(
   });
 
   const kv: Record<string, any> = {
-    ...rule,
+    ...effectiveRule,
     name,
     ...messageVariables,
   };

--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -358,12 +358,16 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                     }
                     name={['resource_slots', resourceSlotKey]}
                     rules={[
-                      _.includes(['cpu', 'mem'], resourceSlotKey)
-                        ? {
-                            required: true,
-                            message: t('data.explorer.ValueRequired'),
-                          }
-                        : {},
+                      // No `{}` placeholder: the form engine types an empty
+                      // rule as `string`, which rejects NumberInput's number.
+                      ...(_.includes(['cpu', 'mem'], resourceSlotKey)
+                        ? [
+                            {
+                              required: true,
+                              message: t('data.explorer.ValueRequired'),
+                            },
+                          ]
+                        : []),
                       {
                         validator(__, value) {
                           if (


### PR DESCRIPTION
Resolves #9133 (FR-3712)

## Problem

In the resource preset create/edit modal, typing any value into an accelerator slot field (`cuda.device`, `cuda.shares`, `rocm.device`, …) immediately failed validation with `CUDA-capable GPU is not a valid undefined`, so presets could not be created or edited on any cluster exposing an accelerator slot. CPU/RAM validated fine.

## Fix

Two stacked defects, fixed at both levels:

1. **Call site** (`ResourcePresetSettingModal.tsx`) — non-cpu/mem slots got an empty `{}` placeholder rule. The form engine's `pickMethod` types an empty rule as `string`, and since the Astryx migration dropped antd `InputNumber` `stringMode`, `AstryxFormNumberInput` emits a **number** — so the implicit string check always failed. The placeholder is replaced with a conditional spread, so accelerator slots now carry no type rule at all.

2. **Engine** (`packages/backend.ai-ui/src/form-engine/validate.ts`) — the `${type}` message interpolation map was built from the **raw** rule, which has no `type` when the type is inferred, so the template printed the literal string `undefined`. The map is now built from the normalised rule (`effectiveRule`), so an inferred type resolves to its actual name for **any** rule relying on type inference, not just this call site.

## Tests

- New `packages/backend.ai-ui/src/form-engine/validate.test.ts` — 3 regression tests for `${type}` interpolation with inferred/declared types (all pass).
- All existing form-engine tests pass (15/15).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, terminology)
- `pnpm vitest run src/form-engine` in `packages/backend.ai-ui` → 3 files, 15 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)