### PR TITLE
fix(FR-3710): feed the sort order back into the Deployment Presets table

### DIFF
--- a/react/src/components/AdminDeploymentPreset.tsx
+++ b/react/src/components/AdminDeploymentPreset.tsx
@@ -12,7 +12,7 @@ import { App } from '../app-shim';
 import AdminDeploymentPresetTable, {
   type DeploymentPresetNodeInList,
 } from '../components/AdminDeploymentPresetTable';
-import { convertToOrderBy } from '../helper';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
 import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { theme } from '../theme-shim';
@@ -91,6 +91,7 @@ const AdminDeploymentPreset = ({
     useState<DeploymentPresetNodeInList | null>(null);
 
   const filter = queryRef.variables.filter ?? undefined;
+  const order = convertFirstOrderByToString(queryRef.variables.orderBy);
   const pageSize = queryRef.variables.limit ?? 10;
   const offset = queryRef.variables.offset ?? 0;
   const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
@@ -186,6 +187,7 @@ const AdminDeploymentPreset = ({
             _.map(deploymentRevisionPresets?.edges, 'node'),
           )}
           loading={isRefetching}
+          order={order}
           onEdit={handleEditPreset}
           onDelete={handleDeletePreset}
           tableSettings={tableSettings}


### PR DESCRIPTION
Resolves #9130 (FR-3710)

## Problem

On **Admin → Deployments → Deployment Presets**, the sortable **Name** and **Created At** headers never showed an active sort indicator, and every click re-sorted **ascending** — descending was unreachable.

## Root cause

`BAITable` treats a table as server-sorted (controlled) as soon as `onChangeOrder` is wired:

```ts
// packages/backend.ai-ui/src/components/Table/BAITable.tsx
const isOrderControlled = !!onChangeOrder || order != null;
const activeOrder = isOrderControlled ? order : uncontrolledOrder;
```

`AdminDeploymentPreset.tsx` passed `onChangeOrder` but never passed `order` back down, so `activeOrder` was permanently `undefined`:

1. `sortState` is derived from `activeOrder`, so it was always `[]` → no header arrow.
2. `useTableSortable` therefore restarted every click from the unsorted state, so `onSortChange` always emitted `ascending` → the descending step of the cycle was unreachable.

The round trip itself was already fine — `convertToOrderBy` produced a valid `DeploymentRevisionPresetOrderBy` and the query refetched. Only the controlled `order` feedback edge was missing.

## Fix

Derive `order` from the query ref and pass it to the table, mirroring `AdminRuntimeVariantPreset.tsx:121` — the sibling tabs (`AdminDeployment.tsx:297`, `AdminPrometheusPreset.tsx:187`, `AdminRuntimeVariantPreset.tsx:201`) all already do this; this tab was the odd one out.

```diff
+ const order = convertFirstOrderByToString(queryRef.variables.orderBy);
...
  <AdminDeploymentPresetTable
    loading={isRefetching}
+   order={order}
```

`AdminDeploymentPresetTable` already spreads `...tableProps` into `BAITable` and does not `Omit` `order`, so it needed no change.

The unsorted step of the cycle round-trips correctly: `onChangeOrder(undefined)` → `orderBy: undefined` → `convertFirstOrderByToString` reads back `null` → `sortState` is `[]`. Unlike the sibling defect in FR-3711, the state lives in the Relay query variables rather than a nuqs parser carrying `.withDefault(...)`, so there is no default to swallow the unsorted state.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Astryx theme/integration, z-index, terminology). The one terminology warning is pre-existing and unrelated (`BAIResourceUnitGrid^ChangeGroupColor`).
- Control-flow traced end to end through `BAITable`'s `isOrderControlled` / `activeOrder` / `sortState` / `useTableSortable` path.
- Not exercised against a live cluster — the change is a three-line prop wiring that mirrors an already-working sibling component.

## Out of scope

`availablePresetSorterKeys` in `AdminDeploymentPresetTable.tsx` lists `rank`, but the table renders no Rank column. Noted in the issue as unrelated; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
