### PR TITLE
fix(FR-3711): let the auto-scaling Created At sort reach ascending and unsorted

### DIFF
--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -5,11 +5,13 @@
 import { DeploymentAutoScalingCardDeleteMutation } from '../__generated__/DeploymentAutoScalingCardDeleteMutation.graphql';
 import {
   AutoScalingRuleFilter,
+  AutoScalingRuleOrderBy,
   DeploymentAutoScalingCardListQuery,
 } from '../__generated__/DeploymentAutoScalingCardListQuery.graphql';
 import { DeploymentAutoScalingCardPresetsQuery } from '../__generated__/DeploymentAutoScalingCardPresetsQuery.graphql';
 import { DeploymentAutoScalingCard_deployment$key } from '../__generated__/DeploymentAutoScalingCard_deployment.graphql';
 import { App } from '../app-shim';
+import { convertToOrderBy } from '../helper';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -147,11 +149,9 @@ const DeploymentAutoScalingCardContent: React.FC<
 
   // Card-local state, not URL state: this card is one section among several on
   // the detail page, so its sort/filter/page are not page-level navigation.
-  // BAITable order string: "createdAt" (ASC) | "-createdAt" (DESC) | null
-  // (unsorted).
   const [orderString, setOrderString] = useState<
     'createdAt' | '-createdAt' | null
-  >(null);
+  >('-createdAt');
   const [graphQLFilter, setGraphQLFilter] = useState<
     AutoScalingRuleFilter | undefined
   >(undefined);
@@ -162,21 +162,11 @@ const DeploymentAutoScalingCardContent: React.FC<
     setTablePaginationOption,
   } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
 
-  // Newest-first seeds the list while the sort is unset — on first load, and
-  // again once the header cycles back to unsorted.
-  const effectiveOrder = orderString || '-createdAt';
-
   const queryVariables = {
     deploymentId,
     offset: baiPaginationOption.offset,
     limit: baiPaginationOption.limit,
-    orderBy: [
-      {
-        field: 'CREATED_AT' as const,
-        direction: (effectiveOrder.startsWith('-') ? 'DESC' : 'ASC') as
-          'ASC' | 'DESC',
-      },
-    ],
+    orderBy: convertToOrderBy<AutoScalingRuleOrderBy>(orderString),
     filter: graphQLFilter ?? null,
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);

--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -11,7 +11,7 @@ import { DeploymentAutoScalingCardPresetsQuery } from '../__generated__/Deployme
 import { DeploymentAutoScalingCard_deployment$key } from '../__generated__/DeploymentAutoScalingCard_deployment.graphql';
 import { App } from '../app-shim';
 import { useCurrentUserInfo } from '../hooks/backendai';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AutoScalingRuleEditorModal from './AutoScalingRuleEditorModal';
 import AutoScalingRuleListNodes from './AutoScalingRuleListNodes';
@@ -33,7 +33,6 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
-import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, {
   Suspense,
   useDeferredValue,
@@ -146,29 +145,24 @@ const DeploymentAutoScalingCardContent: React.FC<
     'table_column_overrides.AutoScalingRuleList',
   );
 
+  // Card-local state, not URL state: this card is one section among several on
+  // the detail page, so its sort/filter/page are not page-level navigation.
   // BAITable order string: "createdAt" (ASC) | "-createdAt" (DESC) | null
-  // (unsorted). Nullable on purpose — a `withDefault` parser cannot represent
-  // the unsorted step of the header cycle, so the default lives below instead.
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      order: parseAsStringLiteral(['createdAt', '-createdAt'] as const),
-      filter: parseAsJson<AutoScalingRuleFilter>(
-        (value) => value as AutoScalingRuleFilter,
-      ),
-    },
-    { history: 'replace' },
-  );
-
-  const orderString = queryParams.order;
-  const graphQLFilter = queryParams.filter ?? undefined;
+  // (unsorted).
+  const [orderString, setOrderString] = useState<
+    'createdAt' | '-createdAt' | null
+  >(null);
+  const [graphQLFilter, setGraphQLFilter] = useState<
+    AutoScalingRuleFilter | undefined
+  >(undefined);
 
   const {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({ current: 1, pageSize: 10 });
+  } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
 
-  // Newest-first seeds the list while the param is absent — on first load, and
+  // Newest-first seeds the list while the sort is unset — on first load, and
   // again once the header cycles back to unsorted.
   const effectiveOrder = orderString || '-createdAt';
 
@@ -304,7 +298,7 @@ const DeploymentAutoScalingCardContent: React.FC<
             value={graphQLFilter}
             onChange={(filter) => {
               startRefetchTransition(() => {
-                setQueryParams({ filter: filter ?? null });
+                setGraphQLFilter(filter ?? undefined);
                 setTablePaginationOption({ current: 1 });
               });
             }}
@@ -341,9 +335,9 @@ const DeploymentAutoScalingCardContent: React.FC<
           }}
           onChangeOrder={(order) => {
             startRefetchTransition(() => {
-              setQueryParams({
-                order: order ? (order as 'createdAt' | '-createdAt') : null,
-              });
+              setOrderString(
+                order ? (order as 'createdAt' | '-createdAt') : null,
+              );
             });
           }}
           pagination={{

--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -146,13 +146,12 @@ const DeploymentAutoScalingCardContent: React.FC<
     'table_column_overrides.AutoScalingRuleList',
   );
 
-  // BAITable order string: "createdAt" (ASC) | "-createdAt" (DESC)
+  // BAITable order string: "createdAt" (ASC) | "-createdAt" (DESC) | null
+  // (unsorted). Nullable on purpose — a `withDefault` parser cannot represent
+  // the unsorted step of the header cycle, so the default lives below instead.
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      order: parseAsStringLiteral([
-        'createdAt',
-        '-createdAt',
-      ] as const).withDefault('-createdAt'),
+      order: parseAsStringLiteral(['createdAt', '-createdAt'] as const),
       filter: parseAsJson<AutoScalingRuleFilter>(
         (value) => value as AutoScalingRuleFilter,
       ),
@@ -169,6 +168,10 @@ const DeploymentAutoScalingCardContent: React.FC<
     setTablePaginationOption,
   } = useBAIPaginationOptionStateOnSearchParam({ current: 1, pageSize: 10 });
 
+  // Newest-first seeds the list while the param is absent — on first load, and
+  // again once the header cycles back to unsorted.
+  const effectiveOrder = orderString || '-createdAt';
+
   const queryVariables = {
     deploymentId,
     offset: baiPaginationOption.offset,
@@ -176,7 +179,7 @@ const DeploymentAutoScalingCardContent: React.FC<
     orderBy: [
       {
         field: 'CREATED_AT' as const,
-        direction: (orderString.startsWith('-') ? 'DESC' : 'ASC') as
+        direction: (effectiveOrder.startsWith('-') ? 'DESC' : 'ASC') as
           'ASC' | 'DESC',
       },
     ],


### PR DESCRIPTION
Resolves #9131 (FR-3711)

## Problem

On the deployment detail page → **Auto-Scaling** card, the **Created At** header was frozen on descending. Every click was a visual no-op and ascending was unreachable.

A three-state sort cycle was being written into a two-state URL parameter. `BAITable` hardcodes `allowUnsortedState: true`, so Astryx cycles the header `null → ascending → descending → null` and emits `onChangeOrder(undefined)` on the unsorted step. But the param was declared with a non-nullable default:

```ts
order: parseAsStringLiteral(['createdAt', '-createdAt'] as const)
  .withDefault('-createdAt'),
```

The handler mapped the unsorted emission to `order: null`, which clears the search param — and a `withDefault` parser reads a cleared key back as its default. So the state machine could never leave descending:

1. Initial state `-createdAt` → descending.
2. Click → `getNextDirection('descending', true)` → `null` → `onChangeOrder(undefined)`.
3. Handler writes `null` → param cleared → reads back `-createdAt` → descending again.

## Fix

Move the card's sort, filter, and pagination **off the URL and into component state**.

The Auto-Scaling card is one section among several on the deployment detail page, not a page in its own right, so its table state is not page-level navigation and does not belong in the search params. That was the review call on this PR, and it dissolves the bug instead of working around it: plain `useState` with a nullable order represents the unsorted step directly, so the `withDefault` trap has nothing to trap.

- `useQueryStates({ order, filter })` → two `useState` hooks, `order` typed `'createdAt' | '-createdAt' | null` and seeded with `'-createdAt'`, so the header arrow matches the rows on first load;
- `useBAIPaginationOptionStateOnSearchParam` → `useBAIPaginationOptionState`. Both return the same `BAIPaginationOptionState`, so no call site changed;
- `order={orderString}` passes the real `null` down, so the header arrow clears on the unsorted step (`BAITable`'s `order` prop is already `string | null`);
- `orderBy` is built with the shared `convertToOrderBy<AutoScalingRuleOrderBy>(orderString)` helper (the one `DeploymentReplicasCard` already uses) instead of a hand-rolled `{ field: 'CREATED_AT', direction }` literal. It maps `null` to `undefined`, so the query carries **no `orderBy` while the header is unsorted** — "unsorted" means unsorted, not a silently re-applied default;
- the `nuqs` import is gone from this module.

### Resulting header cycle

| Click | `order` state | Header | Rows |
|---|---|---|---|
| (load) | `-createdAt` | descending | newest-first |
| 1 | `null` | no arrow | server default order (no `orderBy`) |
| 2 | `createdAt` | ascending | oldest-first |
| 3 | `-createdAt` | descending | newest-first |

Every click changes the header state, and the header always reflects what the rows are actually sorted by. Ascending takes two clicks (through the unsorted step) — the cost of starting the cycle on the descending default rather than on an arrow-less newest-first seed.

## Scope

`react/src/components/DeploymentAutoScalingCard.tsx` only (17 insertions, 30 deletions).

- `AutoScalingRuleListNodes.tsx` is purely presentational — it spreads `order` / `onChangeOrder` onto `BAITable` and needed no change.
- `DeploymentDetailPage.tsx` holds no URL state, and nothing else on the page reads the `order` / `filter` / `current` / `pageSize` keys this card was writing, so removing them has no other consumer.
- The sibling `DeploymentReplicasCard` keeps its URL state, namespaced under an `r` prefix (`rOrder`, `rCurrent`, `rPageSize`, `rFilter`, `rStatusCategory`). Applying the same card-local treatment there is left to a follow-up — it carries five pieces of state, and the tab-like `rStatusCategory` may be worth keeping in the URL, so it needs its own decision.

Distinct from FR-3710 (Admin → Deployments → Deployment Presets), which fails because `order` is never passed down at all.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, StyleX, Astryx theme build, Astryx integration, z-index mirrors, Terminology).

Not verified in a live browser — reproducing needs a deployment carrying auto-scaling rules. A reviewer with suitable data should confirm the header cycle above.

