### PR TITLE
fix(FR-3702): render the storage-host Allowed column via BAITable's render contract

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
@@ -144,26 +144,6 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
               isAllowed: _.includes(
                 _.get(allowedVfolderHosts, storageHost || ''),
                 permission,
-              ) ? (
-                <BAIFlex justify="center">
-                  <CircleCheck
-                    style={{
-                      color: token.green5,
-                      fontSize: token.fontSizeLG,
-                    }}
-                    size="1em"
-                  />
-                </BAIFlex>
-              ) : (
-                <BAIFlex justify="center">
-                  <Ban
-                    style={{
-                      color: token.red5,
-                      fontSize: token.fontSizeLG,
-                    }}
-                    size="1em"
-                  />
-                </BAIFlex>
               ),
             }),
           )}
@@ -177,6 +157,27 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
               title: t('comp:AllowedVfolderHostsWithPermission.Allowed'),
               dataIndex: 'isAllowed',
               key: 'isAllowed',
+              render: (isAllowed: boolean) => (
+                <BAIFlex justify="center">
+                  {isAllowed ? (
+                    <CircleCheck
+                      style={{
+                        color: token.green5,
+                        fontSize: token.fontSizeLG,
+                      }}
+                      size="1em"
+                    />
+                  ) : (
+                    <Ban
+                      style={{
+                        color: token.red5,
+                        fontSize: token.fontSizeLG,
+                      }}
+                      size="1em"
+                    />
+                  )}
+                </BAIFlex>
+              ),
             },
           ]}
         />


### PR DESCRIPTION
Resolves #9114 (FR-3702)

## Mechanism

The **Allowed** column put a React element into the row **value**
(`dataSource[].isAllowed`) and declared no `render`. `BAITable`'s `renderCell`
stringifies any column value it has no renderer for:

```ts
// packages/backend.ai-ui/src/components/Table/BAITable.tsx
const content = column.render
  ? column.render(value, record, rowIndex)
  : value == null || value === '' ? null : String(value);
```

`String(<BAIFlex …/>)` is `[object Object]` — exactly what all 8 permission rows
showed. `rc-table` used to render a ReactNode value as-is, so the pattern was
valid before the migration; the current contract is `render(value, record, index)`
(pinned by `BAITable.cellValue.test.tsx`, and the same class of call site was
converted in #8639 — this component was missed by that sweep).

Fix: keep `isAllowed` a boolean and move the `CircleCheck` / `Ban` glyph into the
column's `render`. No token, theme, or `BAITable` change — the table was
behaving to contract. Centring is preserved (the `BAIFlex justify="center"`
moved into `render` rather than being dropped).

## Measured before / after

Live probe on a dev server against `10.82.130.172:8090`, Admin → Resource
Policies → `default` → `local:volume1`. Dark entered through the header toggle
with `document.documentElement.dataset.theme` asserted `'dark'`.

| | rows | glyphs in `tbody` | `[object Object]` |
|---|---|---|---|
| before — light | 8 | **0** | **yes, all 8 rows** |
| before — dark | 8 | **0** | **yes, all 8 rows** |
| after — light | 8 | **8** | no |
| after — dark | 8 | **8** | no |

`pageerror` count: **0** in all four passes.

Both branches exercised. The `default` policy allows all 8 permissions, so the
deny branch was driven by rewriting the GraphQL response client-side (route
interception only — no mutation on the shared cluster), trimming the allowed set
to `create-vfolder` / `modify-vfolder` / `delete-vfolder`:

| rows | icon | computed colour | token |
|---|---|---|---|
| the 3 kept | `lucide-circle-check` | `rgb(115, 209, 61)` | `token.green5` (`#73d13d`, light) |
| the other 5 | `lucide-ban` | `rgb(255, 77, 79)` | `token.red5` (`#ff4d4f`, light) |

### Screenshots

| Before (light) | After (light) |
|---|---|
| ![before light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9165/20260827-021822-before-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9165/20260827-021829-after-light.png) |

| After (dark) | After (deny branch) |
|---|---|
| ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9165/20260827-021835-after-dark.png) | ![deny](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9165/20260827-021840-deny-light.png) |

## Verification

Run in a clean worktree branched off `origin/main` (`d486c5b5c`):

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built, declarations emitted
- `pnpm --filter backend.ai-ui exec vitest run` → **1879 passed**, 1 skipped (71 files)
- `pnpm --prefix ./react exec vitest run` → **1627 passed** (102 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1,
  **pre-existing on `main`**: verified by re-running the gate with this change
  stashed — same exit, same findings. All findings are in files this PR does not
  touch (`BAIText.css`, `BAIResourceUnitGrid.tsx`, `theme-shim/astryxVars.ts`).

## Residue

- **Scope held to the render bug.** The icon cells still have no accessible name
  (icon-only, no `aria-label`). Adding one needs a new `NotAllowed` key across 22
  BUI locale files, so it is out of scope for a bug fix — worth a separate issue.
- **No sibling call site left.** Grepped `react/src` + `packages/backend.ai-ui/src`
  for `dataSource` entries built by `_.map`; the only other hit
  (`SessionLauncherPreview.tsx`) is a `BAIMetadataList`, not a table, and is
  unaffected.
- **Project page path not probed.** `BAIProjectTable.tsx` renders the same
  component, so it is fixed by the same change, but the probe only covered the
  Resource Policy path.
- **No regression test added.** The general contract is already pinned by
  `BAITable.cellValue.test.tsx`; a component-level test would need Relay mocking
  for two fragments plus a query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
