### PR TITLE
test: finish the Astryx locator heal #9043 scoped out

### DIFF
--- a/e2e/chat/chat-sync.spec.ts
+++ b/e2e/chat/chat-sync.spec.ts
@@ -149,12 +149,13 @@ test.describe(
 
       // In the first pane, click the attachment button. `ChatSender` labels it
       // t('chatui.Attachments'); the antd icon-derived name 'link' is gone.
-      // astryx-card nth(0)=page card, nth(1)=first chat card, nth(2)=second chat card
-      const firstChatCard = page.locator('.astryx-card').nth(1);
-      const secondChatCard = page.locator('.astryx-card').nth(2);
-      const attachButton = firstChatCard
-        .getByRole('button', { name: 'Attachments' })
-        .first();
+      // One such button per pane, in pane order.
+      const attachButtons = page.getByRole('button', {
+        name: 'Attachments',
+        exact: true,
+      });
+      await expect(attachButtons).toHaveCount(2, { timeout: 10000 });
+      const attachButton = attachButtons.nth(0);
 
       // Capture the file chooser before clicking the button
       const fileChooserPromise = page.waitForEvent('filechooser');
@@ -169,17 +170,21 @@ test.describe(
         { name: 'test.png', mimeType: 'image/png', buffer: smallPng },
       ]);
 
+      // `ChatSender` renders each attached image as an Astryx `Thumbnail` with
+      // `alt`/`label` set to the file name, inside a `ChatComposerDrawer`
+      // labelled t('chatui.Attachments'). `ChatCard` exposes no pane-level
+      // role, name or test id (Astryx `Card` renders a bare div), so pane
+      // membership is asserted by count and DOM order rather than by scoping
+      // to a container: exactly one `test.png` thumbnail per pane, meaning the
+      // attachment propagated from pane 1 to pane 2.
+      const attachmentThumbnails = page.getByRole('img', { name: 'test.png' });
+      await expect(attachmentThumbnails).toHaveCount(2, { timeout: 10000 });
+
       // Verify the attachment appears in the first pane
-      const firstPaneAttachArea = firstChatCard.locator(
-        '[class*="attachment"], [class*="Attachment"], [class*="file"]',
-      );
-      await expect(firstPaneAttachArea.first()).toBeVisible({ timeout: 10000 });
+      await expect(attachmentThumbnails.nth(0)).toBeVisible({ timeout: 10000 });
 
       // Verify the attachment also appears in the second pane (sync propagation)
-      const secondPaneAttachArea = secondChatCard.locator(
-        '[class*="attachment"], [class*="Attachment"], [class*="file"]',
-      );
-      await expect(secondPaneAttachArea.first()).toBeVisible({
+      await expect(attachmentThumbnails.nth(1)).toBeVisible({
         timeout: 10000,
       });
     });

--- a/e2e/chat/chat.spec.ts
+++ b/e2e/chat/chat.spec.ts
@@ -635,13 +635,14 @@ test.describe(
       await chatInput.fill('Trigger an error');
       await chatInput.press('Enter');
 
-      // Verify an error alert banner is visible within the chat card
-      await expect(
-        page
-          .locator('.ant-alert-error')
-          .or(page.locator('[role="alert"]'))
-          .first(),
-      ).toBeVisible({ timeout: 15000 });
+      // ChatCard renders the completion failure as an Astryx `Banner
+      // status="error"` (ChatCard.tsx), and Banner stamps `role="alert"` on
+      // error/warning. The old CSS `[role="alert"]` fallback resolved to a
+      // hidden, empty live region first; the role locator only matches the
+      // banner that is actually in the accessibility tree.
+      const errorAlert = page.getByRole('alert');
+      await expect(errorAlert).toBeVisible({ timeout: 15000 });
+      await expect(errorAlert).toContainText(/error/i);
     });
 
     test.fixme('User sees an error alert when the endpoint URL is invalid', async ({
@@ -932,45 +933,31 @@ test.describe(
         },
       );
 
-      // In the second pane, open the endpoint selector dropdown.
-      // `.astryx-card` nth(0)=page card, nth(1)=first chat card,
-      // nth(2)=second chat card (Astryx `Card` renders `astryx-card`; antd's
-      // `.ant-card` is gone).
-      // Click the endpoint text (not the combobox input) to open the dropdown
-      const secondCardEndpointText = page
-        .locator('.astryx-card')
-        .nth(2)
-        .getByText('mock-endpoint')
-        .first();
+      // One deployment selector per pane, in pane order. `DeploymentSelect`
+      // renders a `BAIComplexSelect` with `label={t('chatui.Deployment')}` +
+      // `isLabelHidden`, so its trigger button's accessible name is
+      // "Deployment" and its text content is the selected deployment name —
+      // no `.astryx-card` index and no `[title]` attribute needed.
+      const deploymentTriggers = page.getByRole('button', {
+        name: 'Deployment',
+        exact: true,
+      });
+      await expect(deploymentTriggers).toHaveCount(2, { timeout: 10000 });
 
-      await secondCardEndpointText.click();
+      // In the second pane, open the endpoint selector dropdown
+      await deploymentTriggers.nth(1).click();
 
-      // Select the second mock endpoint
-      await page
-        .getByRole('option', { name: 'mock-endpoint-b' })
-        .or(
-          page
-            .locator('.ant-select-item-option')
-            .filter({ hasText: 'mock-endpoint-b' }),
-        )
-        .first()
-        .click();
+      // Select the second mock endpoint (BAIComplexSelect popup rows are
+      // `role="option"` — see P26-2 in BAIComplexSelect.tsx)
+      await page.getByRole('option', { name: 'mock-endpoint-b' }).click();
 
       // The second pane's endpoint selector shows the second endpoint
-      // Use [title] to target the visible select display value (avoids hidden aria-live elements)
-      await expect(
-        page
-          .locator('.astryx-card')
-          .nth(2)
-          .locator('[title="mock-endpoint-b"]'),
-      ).toBeVisible({
+      await expect(deploymentTriggers.nth(1)).toHaveText('mock-endpoint-b', {
         timeout: 10000,
       });
 
       // The first pane's endpoint selector still shows the original endpoint
-      await expect(
-        page.locator('.astryx-card').nth(1).locator('[title="mock-endpoint"]'),
-      ).toBeVisible({
+      await expect(deploymentTriggers.nth(0)).toHaveText('mock-endpoint', {
         timeout: 5000,
       });
     });
@@ -1001,34 +988,37 @@ test.describe('Chat Parameters', { tag: ['@chat', '@functional'] }, () => {
       timeout: 10000,
     });
 
-    // Click the "Parameters" (ControlOutlined) button in the chat card header
-    const parametersButton = page.getByRole('button', { name: 'control' });
-    await parametersButton.first().click();
+    // The parameters trigger is a `SlidersHorizontal` IconButton labelled
+    // t('chatui.chat.parameter.Title') = "Parameters" (ChatHeader.tsx); the
+    // antd icon-derived name 'control' is gone.
+    const parametersButton = page.getByRole('button', { name: 'Parameters' });
+    await parametersButton.click();
 
-    // Verify a popover with parameter sliders appears (rendered as tooltip role)
-    const popover = page.getByRole('tooltip', { name: /parameters/i });
-    await expect(popover.first()).toBeVisible({ timeout: 10000 });
+    // Astryx `Popover` stamps role="dialog" on its content wrapper
+    // (usePopover.tsx, default role). ChatHeader passes no `label`, so the
+    // dialog is unnamed and has to be identified by its content.
+    const popover = page.getByRole('dialog').filter({ hasText: 'Parameters' });
+    await expect(popover).toBeVisible({ timeout: 10000 });
 
-    // Verify the "Use Parameters" switch is present (it's a switch with no accessible name)
-    const useParamsToggle = popover.first().getByRole('switch');
-    await expect(useParamsToggle.first()).toBeVisible({ timeout: 10000 });
+    // The "use parameters" toggle is an Astryx `Switch` (role="switch")
+    // labelled "Parameters" with `isLabelHidden` (ChatParametersSliders.tsx)
+    const useParamsToggle = popover.getByRole('switch', { name: 'Parameters' });
+    await expect(useParamsToggle).toBeVisible({ timeout: 10000 });
 
     // Enable the "Use Parameters" option by clicking the switch
-    await useParamsToggle.first().click();
+    await useParamsToggle.click();
 
-    // Verify "Temperature" slider is present (translation key resolves to "Temperature")
-    const temperatureLabel = popover.first().getByText(/temperature/i);
-    await expect(temperatureLabel.first()).toBeVisible({ timeout: 10000 });
+    // Verify the "Temperature" slider is present
+    // (chatui.chat.parameter.label.Temperature = "Temperature")
+    await expect(popover.getByText('Temperature')).toBeVisible({
+      timeout: 10000,
+    });
 
     // Close the popover by clicking somewhere outside of it (e.g., the chat message area)
     await page.getByLabel('Type your message here...').click();
 
-    // Verify the popover closed — check that its inner content is hidden
-    // (ant-popover-container stays in DOM; check the inner content div instead)
-    await expect(
-      page
-        .locator('.ant-popover:not(.ant-popover-hidden)')
-        .filter({ hasText: /parameters/i }),
-    ).not.toBeVisible({ timeout: 5000 });
+    // Verify the popover closed — the native popover leaves the subtree in the
+    // DOM, so assert it left the accessibility tree instead.
+    await expect(popover).toHaveCount(0, { timeout: 5000 });
   });
 });

--- a/e2e/credential/bulk-create-from-csv.spec.ts
+++ b/e2e/credential/bulk-create-from-csv.spec.ts
@@ -4,6 +4,13 @@ import test, { expect, Page } from '@playwright/test';
 import path from 'path';
 
 const SAMPLES_DIR = path.resolve(__dirname, '../../test-fixtures/csv-samples');
+/** `credential.UploadCSVFile` — the dropzone `FileInput`'s field label. */
+const UPLOAD_FIELD_LABEL = 'Click or drag a CSV file to this area to upload';
+
+/** Astryx `ToastViewport`'s `role="region"` — the visible toasts live here. */
+function toastViewport(page: Page) {
+  return page.getByRole('region', { name: 'Notifications' });
+}
 
 async function openBulkCreateCSVModal(page: Page) {
   await navigateTo(page, 'credential?tab=users');
@@ -28,12 +35,14 @@ async function uploadCSV(page: Page, filename: string) {
   const dialog = page.getByRole('dialog', {
     name: 'Bulk Create Users from CSV',
   });
-  // The empty-state picker is Astryx `FileInput` (`mode="dropzone"`); its
-  // internal `<input type="file">` is aria-hidden with no accessible name, so
-  // scope by the component's stable theme class (`astryx-file-input`) rather
-  // than by role. This also avoids the sibling hidden `<input type="file">`
-  // that backs the (post-upload) "Replace File" button.
-  const fileInput = dialog.locator('.astryx-file-input input[type="file"]');
+  // The empty-state picker is Astryx `FileInput` (`mode="dropzone"`), whose
+  // `<label>` points at its native `<input type="file">` (FieldLabel renders
+  // `htmlFor={inputID}`). The label also names FileInput's visually-hidden
+  // trigger button, so narrow to the input — that also excludes the sibling
+  // hidden `<input type="file">` backing the "Replace File" button.
+  const fileInput = dialog
+    .getByLabel(UPLOAD_FIELD_LABEL)
+    .and(dialog.locator('input[type="file"]'));
   await fileInput.setInputFiles(path.join(SAMPLES_DIR, filename));
 }
 
@@ -239,7 +248,7 @@ test.describe(
 
       // Toggle "Only show errors"
       await dialog.getByRole('switch').click();
-      const rows = dialog.locator('table tbody tr:not(.ant-table-measure-row)');
+      const rows = dialog.locator('table tbody tr');
       await expect.poll(() => rows.count(), { timeout: 5000 }).toBe(errorCount);
       await closeModal(page);
     });
@@ -249,12 +258,13 @@ test.describe(
     }) => {
       await openBulkCreateCSVModal(page);
       await uploadCSV(page, '12-error-missing-required-columns.csv');
-      // Toast error — the app-shim's `message.error` renders via Astryx
-      // `Toast` (stable theme class `astryx-toast`, `data-type="error"`).
-      // A plain role('alert') also matches the app's persistent (empty)
-      // ARIA live-region announcer, so scope to the toast itself.
+      // `message.error` renders an Astryx `Toast` with `role="alert"`. Scope to
+      // the toast viewport: a bare role('alert') also matches ToastViewport's
+      // visually-hidden `announce()` live region, which mirrors the same text.
       await expect(
-        page.locator('.astryx-toast[data-type="error"]'),
+        toastViewport(page)
+          .getByRole('alert')
+          .filter({ hasText: 'The CSV file is missing required columns' }),
       ).toBeVisible({
         timeout: 5000,
       });
@@ -273,13 +283,15 @@ test.describe(
     }) => {
       await openBulkCreateCSVModal(page);
       await uploadCSV(page, '15-error-empty-file.csv');
-      // The app-shim's `message.warning` maps onto Astryx Toast's `info`
-      // variant (PILOT-DECISION in message.tsx) — `data-type="info"`.
-      await expect(page.locator('.astryx-toast[data-type="info"]')).toBeVisible(
-        {
-          timeout: 5000,
-        },
-      );
+      // `message.warning` maps onto Astryx Toast's `info` variant
+      // (PILOT-DECISION in message.tsx), which carries `role="status"`.
+      await expect(
+        toastViewport(page)
+          .getByRole('status')
+          .filter({ hasText: 'The CSV file contains no user rows.' }),
+      ).toBeVisible({
+        timeout: 5000,
+      });
       const dialog = page.getByRole('dialog', {
         name: 'Bulk Create Users from CSV',
       });
@@ -346,8 +358,10 @@ test.describe(
       await expect(
         page.getByRole('button', { name: /Create \d+ user/ }),
       ).toBeDisabled();
-      // No blocking toast for this load.
-      await expect(page.locator('.astryx-toast')).not.toBeVisible();
+      // No blocking toast for this load — the viewport holds no toast of
+      // either severity (`role="alert"` for error, `role="status"` otherwise).
+      await expect(toastViewport(page).getByRole('alert')).toHaveCount(0);
+      await expect(toastViewport(page).getByRole('status')).toHaveCount(0);
       await closeModal(page);
     });
 

--- a/e2e/environment/environment.spec.ts
+++ b/e2e/environment/environment.spec.ts
@@ -1,19 +1,75 @@
 // spec: Image list and environment management E2E tests
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import {
-  findColumnIndex,
-  getFormItemControlByLabel,
-} from '../utils/test-util-antd';
 import { expect, test, Page, Locator } from '@playwright/test';
 
-// Astryx `Table` renders native <table><tbody><tr role="row">; a plain
-// getByRole('row') also matches the header row, so exclude it (same pattern
-// as rbac-role-list.spec.ts / registry.spec.ts).
-function imageDataRows(page: Page) {
-  return page
-    .getByRole('table')
-    .getByRole('row')
-    .filter({ hasNot: page.getByRole('columnheader') });
+/**
+ * The image list is a `BAITable`, i.e. a real `<table>` with a `<thead>` /
+ * `<tbody>` pair (`packages/backend.ai-ui/src/components/Table/BAITable.tsx`
+ * renders Astryx `Table`). `getByRole('table')` is the whole grid and
+ * `tbody tr` its data rows — there is no antd measure row to exclude.
+ */
+function imageListTableOf(page: Page) {
+  return page.getByRole('table');
+}
+
+function imageListRowsOf(page: Page) {
+  return imageListTableOf(page).locator('tbody tr');
+}
+
+/**
+ * Wait until the image list has actually rendered rows. The window is
+ * deliberately much wider than Playwright's 5s expect default: the initial
+ * `image_nodes` query runs against a shared cluster and the whole page is
+ * behind a Suspense boundary, so under concurrent load neither the `<table>`
+ * nor its first row is up within 5s.
+ */
+async function waitForImageListReady(page: Page) {
+  await expect(imageListTableOf(page)).toBeVisible({ timeout: 60000 });
+  await expect(imageListRowsOf(page).first()).toBeVisible({ timeout: 60000 });
+}
+
+/**
+ * `BAITable` has no spinner: while `loading` is true it dims its own wrapper
+ * and marks it `aria-busy` (`BAITable.tsx`, the `bai-table-astryx-dim-layer`
+ * div — a class this repo owns, not a framework-internal one).
+ */
+async function waitForImageListSettled(page: Page) {
+  await expect(
+    page.locator('.bai-table-astryx-dim-layer[aria-busy="true"]'),
+  ).toHaveCount(0, { timeout: 15000 });
+}
+
+/**
+ * `BAITable`'s pagination bar: an Astryx `Pagination` in a
+ * `navigation` landmark named "Pagination"
+ * (`label={String(t('comp:BAITable.Pagination'))}`, `BAITable.tsx`), whose
+ * page buttons are named "Go to page N" and whose current page carries
+ * `aria-current="page"` (`@astryxdesign/core/src/Pagination/Pagination.tsx`).
+ */
+function imageListPaginationOf(page: Page) {
+  return page.getByRole('navigation', { name: 'Pagination' });
+}
+
+/**
+ * Set a `BAIDynamicUnitInputNumber`'s "<number><unit>" pair. The unit goes
+ * first on purpose: the numeric field's `min` is expressed in whatever unit is
+ * currently selected, and `handleBlur` clamps an under-min entry UP rather
+ * than rejecting it (`packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumber.tsx`),
+ * so typing "1" while the field is still in MiB silently becomes 1024.
+ */
+async function setMemorySize(
+  page: Page,
+  numberInput: Locator,
+  unitSelector: Locator,
+  size: { value: string; unit: string },
+) {
+  await unitSelector.click();
+  await page.getByRole('option', { name: size.unit, exact: true }).click();
+  await expect(unitSelector).toHaveText(size.unit);
+  await numberInput.fill(size.value);
+  await numberInput.blur();
+  await expect(numberInput).toHaveValue(size.value);
+  await expect(unitSelector).toHaveText(size.unit);
 }
 
 test.describe(
@@ -25,70 +81,81 @@ test.describe(
       await page.getByRole('link', { name: 'Admin Settings' }).click();
       await page.getByRole('link', { name: 'Environments' }).click();
       await expect(page).toHaveURL(/\/environment/);
-      // Wait for the table to be visible
-      await expect(page.getByRole('table')).toBeVisible({ timeout: 10000 });
+      await waitForImageListReady(page);
     });
     test('Rendering Image List', async ({ page }) => {
-      await expect(page.getByRole('table')).toBeVisible();
+      await expect(imageListTableOf(page)).toBeVisible();
     });
 
-    // skip this test because there is no way to uninstall the image in WebUI
+    // skip this test because there is no way to uninstall the image in WebUI.
+    // NOTE: the body below was de-antd'ed against the component source
+    // (`ImageList.tsx` / `ImageInstallModal.tsx`) but has never been executed —
+    // the test has been permanently skipped since it was written, so treat the
+    // locators as unverified.
     test.skip('user can install image', async ({ page, request }) => {
       await loginAsAdmin(page, request);
       await navigateTo(page, 'environment');
-      const imageListTable = page.getByRole('table');
-      await expect(imageListTable).toBeVisible();
-      // Sort installation status
-      await page
-        .locator('.ant-table-cell.ant-table-column-sort')
-        .first()
-        .click();
+      await waitForImageListReady(page);
 
-      // Find uninstalled item and select
-      const uninstalledImage = page
-        .locator('.ant-table-cell.ant-table-column-sort')
-        .filter({
-          hasNot: page.locator('.ant-tag-gold'),
-        })
-        .nth(1);
+      // Find an uninstalled image and select it. `ImageList.tsx`'s `installed`
+      // column renders an "Installed" / "Installing" Badge only when the image
+      // is present on an agent, so an uninstalled image is a row carrying
+      // neither label.
+      const uninstalledImage = imageListRowsOf(page)
+        .filter({ hasNotText: 'Installed' })
+        .filter({ hasNotText: 'Installing' })
+        .first();
       // If all images are installed, skip the test
       const count = await uninstalledImage.count();
       if (count === 0) {
         test.skip();
       }
-      await uninstalledImage.click();
+      await uninstalledImage.getByRole('checkbox').check();
 
-      // Install image
+      // Install image. The list header button is `label={t('environment.InstallImage')}`
+      // = "Install Image"; the modal's confirm button is plain "Install".
+      await page.getByRole('button', { name: 'Install Image' }).click();
       await page
-        .getByRole('button', { name: 'vertical-align-bottom Install' })
+        .getByRole('dialog')
+        .getByRole('button', { name: 'Install', exact: true })
         .click();
-      await page.getByRole('button', { name: 'Install', exact: true }).click();
       await expect(
         page.getByText('It takes time so have a cup of coffee!'),
       ).toBeVisible();
 
       // Verify installing status
-      const rows = await imageListTable.locator('.ant-table-row');
-      const statusColumnIndex = await findColumnIndex(imageListTable, 'Status');
-
-      const installingItem = await rows
-        .locator('.ant-table-cell')
-        .nth(statusColumnIndex)
-        .first();
-      await expect(installingItem.getByText('installing')).toBeVisible();
+      await expect(
+        imageListRowsOf(page).filter({ hasText: 'Installing' }).first(),
+      ).toBeVisible();
     });
 
     test('user can modify image resource limit', async ({ page }) => {
       const CPU_CORE = '5';
       const MEMORY_SIZE = '1';
 
-      // Click resource limit button. FR-3331 gives the action a stable
-      // accessible name via aria-label, so a column-index button lookup is
-      // no longer needed.
-      const firstRow = imageDataRows(page).first();
-      await firstRow
-        .getByRole('button', { name: 'Edit Minimum Image Resource Limit' })
-        .click();
+      // Click resource limit button. `ImageList.tsx`'s Control column renders
+      // two `IconButton`s whose lucide glyphs are aria-hidden but whose
+      // `label` props are the modal titles they open, so both are reachable
+      // by accessible name with no column-index arithmetic.
+      const firstRow = imageListRowsOf(page).first();
+      // Saving the modal bumps the list's fetchKey, so the row this clicks is
+      // re-rendered underneath it; settle the table first, then retry the
+      // open until the dialog is actually on screen (a click that lands on a
+      // row mid-refetch is simply dropped).
+      const openResourceLimitModal = async () => {
+        await waitForImageListSettled(page);
+        await expect(async () => {
+          await firstRow
+            .getByRole('button', { name: 'Edit Minimum Image Resource Limit' })
+            .click();
+          await expect(
+            page.getByRole('dialog', {
+              name: /Edit Minimum Image Resource Limit/i,
+            }),
+          ).toBeVisible({ timeout: 5000 });
+        }).toPass({ timeout: 30000 });
+      };
+      await openResourceLimitModal();
       // get resource limit from control modal
       const resourceLimitControlModal = page.getByRole('dialog', {
         // FR-3339 renamed the modal from "Modify ..." to "Edit ..." as part of
@@ -98,85 +165,98 @@ test.describe(
 
       await expect(resourceLimitControlModal).toBeVisible();
 
-      // ManageImageResourceLimitModal.tsx renders each field via
-      // `BAIFormItem`; `BAIDynamicUnitInputNumber` ("mem") is now a plain
-      // Astryx numeric spinbutton plus a separate unit Selector, not a
-      // combined antd InputNumber+addon.
-      const cpuFormItemInput = getFormItemControlByLabel(page, 'CPU').getByRole(
-        'spinbutton',
+      // `ManageImageResourceLimitModal.tsx` renders each slot as a
+      // `BAIFormItem` (`[data-bai-form-item]`). The value controls are Astryx
+      // now: `AstryxFormNumberInput` / `BAIDynamicUnitInputNumber` both end in
+      // an Astryx `NumberInput`, which is `role="spinbutton"`
+      // (`@astryxdesign/core/src/NumberInput/NumberInput.tsx`), and the memory
+      // unit is an Astryx `Selector` labelled "Unit"
+      // (`BAIDynamicUnitInputNumber.tsx`).
+      const cpuFormItem = resourceLimitControlModal.locator(
+        '[data-bai-form-item]:has-text("CPU")',
       );
+      const cpuFormItemInput = cpuFormItem.getByRole('spinbutton');
       const cpuValue = await cpuFormItemInput.inputValue();
 
-      const memoryFormItem = getFormItemControlByLabel(page, 'Memory');
+      const memoryFormItem = resourceLimitControlModal.locator(
+        '[data-bai-form-item]:has-text("Memory")',
+      );
       const memoryFormItemInput = memoryFormItem.getByRole('spinbutton');
       const memoryValue = await memoryFormItemInput.inputValue();
-      const memorySize = (
-        await memoryFormItem.getByRole('combobox').innerText()
-      ).trim();
+      const memoryUnitSelector = memoryFormItem.getByRole('combobox', {
+        name: 'Unit',
+      });
+      const memorySize = (await memoryUnitSelector.textContent())?.trim() ?? '';
       // modify resource limit
       await cpuFormItemInput.fill(CPU_CORE);
       await expect(cpuFormItemInput).toHaveValue(CPU_CORE);
-      await memoryFormItemInput.fill(MEMORY_SIZE);
-      await expect(memoryFormItemInput).toHaveValue(MEMORY_SIZE);
+      // `BAIDynamicUnitInputNumber` splits "<number><unit>" across a numeric
+      // field and a unit Selector; the antd-era `fill('1g')` relied on the
+      // text-backed antd InputNumber re-parsing the unit letter, which the
+      // Astryx numeric field does not do. Set the two halves separately —
+      // UNIT FIRST, because the field's `min` is expressed in the CURRENT unit
+      // (the modal's `min='1g'` becomes 1024 while the field is in MiB) and
+      // `handleBlur` clamps an under-min entry up instead of keeping it.
+      await setMemorySize(page, memoryFormItemInput, memoryUnitSelector, {
+        value: MEMORY_SIZE,
+        unit: 'GiB',
+      });
       // click the modal's submit button (renamed "OK" -> "Save" by FR-3339)
       await resourceLimitControlModal
         .getByRole('button', { name: 'Save' })
         .click();
-      const reinstallationText = await page
-        .getByText('Image reinstallation required')
-        .count();
-      if (reinstallationText > 0) {
-        await page.getByRole('button', { name: 'OK' }).nth(1).click();
-      }
+      await expect(resourceLimitControlModal).toBeHidden();
+
       // verify resource limit is modified
-      await firstRow
-        .getByRole('button', { name: 'Edit Minimum Image Resource Limit' })
-        .click();
+      await openResourceLimitModal();
       const modifiedResourceLimitControlModal = page.getByRole('dialog', {
         // FR-3339 renamed the modal from "Modify ..." to "Edit ..." as part of
         // unifying edit terminology across the app.
         name: /Edit Minimum Image Resource Limit/i,
       });
       await expect(modifiedResourceLimitControlModal).toBeVisible();
-      const modifiedCpuFormItemInput = getFormItemControlByLabel(
-        page,
-        'CPU',
-      ).getByRole('spinbutton');
-      const modifiedMemoryFormItem = getFormItemControlByLabel(page, 'Memory');
+      const modifiedCpuFormItem = modifiedResourceLimitControlModal.locator(
+        '[data-bai-form-item]:has-text("CPU")',
+      );
+      const modifiedMemoryFormItem = modifiedResourceLimitControlModal.locator(
+        '[data-bai-form-item]:has-text("Memory")',
+      );
+      const modifiedCpuFormItemInput =
+        modifiedCpuFormItem.getByRole('spinbutton');
       const modifiedMemoryFormItemInput =
         modifiedMemoryFormItem.getByRole('spinbutton');
+      const modifiedMemoryUnitSelector = modifiedMemoryFormItem.getByRole(
+        'combobox',
+        { name: 'Unit' },
+      );
       await expect(modifiedCpuFormItemInput).toHaveValue(CPU_CORE);
       await expect(modifiedMemoryFormItemInput).toHaveValue(MEMORY_SIZE);
-      await expect(modifiedMemoryFormItem.getByRole('combobox')).toHaveText(
-        'GiB',
-      );
+      await expect(modifiedMemoryUnitSelector).toHaveText('GiB');
 
       // reset resource limit
       await modifiedCpuFormItemInput.fill(cpuValue);
       await expect(modifiedCpuFormItemInput).toHaveValue(cpuValue);
-      await modifiedMemoryFormItemInput.fill(memoryValue);
-      await expect(modifiedMemoryFormItemInput).toHaveValue(memoryValue);
-      // Reopen the unit Selector and pick the original unit back.
-      await modifiedMemoryFormItem.getByRole('combobox').click();
-      await page.getByRole('option', { name: memorySize, exact: true }).click();
+      await setMemorySize(
+        page,
+        modifiedMemoryFormItemInput,
+        modifiedMemoryUnitSelector,
+        { value: memoryValue, unit: memorySize },
+      );
       // click the modal's submit button (renamed "OK" -> "Save" by FR-3339)
       await modifiedResourceLimitControlModal
         .getByRole('button', { name: 'Save' })
         .click();
-      const reinstallationTextAfterReset = await page
-        .getByText('Image reinstallation required')
-        .count();
-      if (reinstallationTextAfterReset > 0) {
-        await page.getByRole('button', { name: 'OK' }).nth(1).click();
-      }
+      await expect(modifiedResourceLimitControlModal).toBeHidden();
     });
 
     test('user can manage apps', async ({ page }) => {
-      // Click manage apps button. BAINameActionCell exposes the action's
-      // title as the button's aria-label — "Manage Apps" — the antd
-      // `appstore` icon name no longer applies.
-      const firstRow = imageDataRows(page).first();
-      await firstRow.getByRole('button', { name: 'Manage Apps' }).click();
+      // Click manage apps button. `ImageList.tsx`'s Control column IconButton
+      // carries `label={t('environment.ManageApps')}` = "Manage Apps" — the
+      // antd `appstore` icon name it used to expose is gone with antd.
+      const firstRow = imageListRowsOf(page).first();
+      const openManageAppsModal = () =>
+        firstRow.getByRole('button', { name: 'Manage Apps' }).click();
+      await openManageAppsModal();
 
       // Add app
       const modal = page.getByRole('dialog', { name: /Manage Apps/i });
@@ -201,15 +281,16 @@ test.describe(
         protocol: 'tcp',
         port: '6006',
       };
-      // The new row's inputs no longer carry a predictable `#apps_N_app`
-      // id (React-generated ids now); scope by placeholder within the
-      // freshly-appended form-item instead.
-      const newRow = modal
+      // The three fields of the newly added row. `ManageAppsModal.tsx` gives
+      // each `AstryxFormTextInput` a label/placeholder pair ("App Name",
+      // "Protocol", "Port"); scope through the row's own form item so the
+      // names stay unambiguous across rows.
+      const addedAppRow = modal
         .locator('[data-bai-form-item]')
         .nth(numberOfAppsBeforeAdd);
-      await newRow.getByPlaceholder('App Name').fill(addInfo.app);
-      await newRow.getByPlaceholder('Protocol').fill(addInfo.protocol);
-      await newRow.getByPlaceholder('Port').fill(addInfo.port);
+      await addedAppRow.getByPlaceholder('App Name').fill(addInfo.app);
+      await addedAppRow.getByPlaceholder('Protocol').fill(addInfo.protocol);
+      await addedAppRow.getByPlaceholder('Port').fill(addInfo.port);
 
       // Click OK Button
       await modal.getByRole('button', { name: 'OK' }).click();
@@ -227,9 +308,11 @@ test.describe(
       // updating in place. Poll the full reopen+read+close cycle — not just
       // an assertion on an already-open modal — until the refetch lands.
       const openManageAppsModalAndCountApps = async () => {
-        await firstRow.getByRole('button', { name: 'Manage Apps' }).click();
+        await openManageAppsModal();
         const dialog = page.getByRole('dialog', { name: /Manage Apps/i });
         await expect(dialog).toBeVisible();
+        // One `[data-bai-form-item]` per app row (the 3 nested per-field
+        // items are `noStyle` and render no DOM of their own).
         const count = await dialog.locator('[data-bai-form-item]').count();
         await dialog.getByRole('button', { name: 'Cancel' }).click();
         await expect(dialog).toBeHidden();
@@ -244,17 +327,12 @@ test.describe(
 
       // Reopen once more now that the refetched data is confirmed fresh, to
       // assert on the added row's field values and perform cleanup.
-      await firstRow.getByRole('button', { name: 'Manage Apps' }).click();
+      await openManageAppsModal();
       const modalAfterAdd = page.getByRole('dialog', { name: /Manage Apps/i });
       await expect(modalAfterAdd).toBeVisible();
       // Retry the count assertion: the freshly-reopened modal renders its
       // app form-items asynchronously, so a one-shot `.count()` can read the
       // old total before the added row mounts (flaky off by one).
-      //
-      // The selector stays `[data-bai-form-item]`: main's `.ant-form-item`
-      // class does not exist on this branch — antd is gone and is not a
-      // dependency of this workspace at all — so that locator would match
-      // nothing and the assertion would fail on an empty set.
       await expect(modalAfterAdd.locator('[data-bai-form-item]')).toHaveCount(
         numberOfAppsBeforeAdd + 1,
       );
@@ -269,10 +347,13 @@ test.describe(
       );
       await expect(lastRow.getByPlaceholder('Port')).toHaveValue(addInfo.port);
 
-      // Reset apps
+      // Reset apps — scope the removal to the added row's own form item
+      // instead of indexing a flat button list (`ManageAppsModal.tsx` renders
+      // one ghost IconButton `label={t('button.Delete')}` per app row).
       await modalAfterAdd
-        .getByRole('button', { name: 'delete' })
+        .locator('[data-bai-form-item]')
         .nth(numberOfApps - 1)
+        .getByRole('button', { name: 'Delete' })
         .click();
       await modalAfterAdd.getByRole('button', { name: 'OK' }).click();
       if (reinstallationText > 0) {
@@ -297,23 +378,78 @@ test.describe(
 // ---------------------------------------------------------------------------
 
 /**
- * A committed filter token's accessible label — and so its "Remove {label}"
- * button name (`@astryxdesign/core`'s `Token` component: `aria-label={t(
- * '@astryx.token.remove', {label})}`) — is only `"<Field>: <operator>"`.
- * `PowerSearchToken.tsx`'s `tokenLabel` deliberately excludes the value (it
- * renders separately as the token's visible value content), so the `value`
- * param here is accepted for call-site readability but not part of the
- * returned string. `defaultOperator` per field comes from `ImageList.tsx`'s
- * `filterProperties` (`==` for strict-selection fields, the BUI default
- * `ilike` -> "contains" for free-text ones); the operator word itself is
- * `comp:BAIPropertyFilter.operator.*` (packages/backend.ai-ui/src/locale/en.json).
+ * A committed filter renders as an Astryx `Token` whose LABEL is
+ * `"<Field>: <operator>"` and whose VALUE is a separate `endContent` node
+ * (`PowerSearch.tsx` — `<Token label={tokenLabel} endContent={valueContent}>`).
+ * `@astryx.token.remove` interpolates only the label, so the remove button is
+ * `aria-label="Remove <Field>: <operator>"` — the value is NOT part of it.
+ *
+ * `defaultOperator` per field comes from `ImageList.tsx`'s `filterProperties`
+ * (`==` for the strict-selection fields, the BUI default `ilike` for free-text
+ * ones); the operator word is `comp:BAIPropertyFilter.operator.*`
+ * (packages/backend.ai-ui/src/locale/en.json — `==` -> "is", `ilike` ->
+ * "contains").
  */
 function imageFilterTokenLabel(
   propertyLabel: string,
   operatorWord: 'contains' | 'is',
-  _value: string,
 ): string {
   return `${propertyLabel}: ${operatorWord}`;
+}
+
+/** The tokenizer that holds every committed filter token. */
+function imageFilterTokenizerOf(page: Page) {
+  return page.getByRole('group', { name: 'Search filters' });
+}
+
+/**
+ * The token's value, rendered as the `Token`'s `endContent` beside the label.
+ * Asserted separately from the remove button because the two carry different
+ * halves of `"<Field>: <operator> <value>"`.
+ */
+function imageFilterTokenValue(page: Page, value: string) {
+  return imageFilterTokenizerOf(page).getByText(value, { exact: true });
+}
+
+/**
+ * PowerSearch's built-in "Clear all" (`t('@astryx.tokenizer.clearAll')`,
+ * `Tokenizer.tsx`). Scoped to the tokenizer and matched exactly, because the
+ * project selector beside it exposes "Clear All projects", which a loose
+ * (substring, case-insensitive) name match also hits.
+ */
+function imageFilterClearAllButtonOf(page: Page) {
+  return imageFilterTokenizerOf(page).getByRole('button', {
+    name: 'Clear all',
+    exact: true,
+  });
+}
+
+/**
+ * Open PowerSearch's typeahead and pick `propertyLabel`, which opens the edit
+ * popover for that field.
+ *
+ * Two hazards, both handled by retrying open-and-pick as one unit:
+ *  - committing a token leaves the suggestion list OPEN, so an unconditional
+ *    click on the bar would TOGGLE it shut (hence the `aria-expanded` guard);
+ *  - under load the bar can be in the DOM before PowerSearch has wired it up,
+ *    so the first click opens nothing.
+ */
+async function pickImageFilterField(page: Page, propertyLabel: string) {
+  // Scroll the search bar to the centre of the viewport so it is not obscured
+  // by the sticky header, and click with force:true because that header can
+  // still intercept pointer events afterwards.
+  const searchBar = page.getByRole('combobox', { name: 'Search filters' });
+  await searchBar.evaluate((el) =>
+    el.scrollIntoView({ block: 'center', inline: 'nearest' }),
+  );
+  await expect(async () => {
+    if ((await searchBar.getAttribute('aria-expanded')) !== 'true') {
+      await searchBar.click({ force: true });
+    }
+    await page
+      .getByRole('option', { name: propertyLabel, exact: true })
+      .click({ timeout: 5000 });
+  }).toPass({ timeout: 60000 });
 }
 
 /**
@@ -338,26 +474,7 @@ async function applyImageFilter(
   // `label={t('comp:BAIPropertyFilter.SearchLabel')}` = "Search filters"
   // (packages/backend.ai-ui/src/locale/en.json) names the combobox
   // (`role="combobox"`, `BaseTypeahead.tsx`).
-  const searchBar = page.getByRole('combobox', { name: 'Search filters' });
-  await searchBar.evaluate((el) =>
-    el.scrollIntoView({ block: 'center', inline: 'nearest' }),
-  );
-  const propertyOption = page.getByRole('option', {
-    name: propertyLabel,
-    exact: true,
-  });
-  // Use force:true because the sticky header (data-testid="label-selector-project")
-  // can intercept pointer events even after scrolling into view. When this
-  // is not the first filter applied in the test, the search bar can be left
-  // re-focused-but-collapsed after the previous commit, so a single click
-  // may toggle it shut instead of open; retry the click-and-check as a unit.
-  await expect(async () => {
-    if (!(await propertyOption.isVisible().catch(() => false))) {
-      await searchBar.click({ force: true });
-    }
-    await expect(propertyOption).toBeVisible({ timeout: 2000 });
-  }).toPass({ timeout: 15000 });
-  await propertyOption.click();
+  await pickImageFilterField(page, propertyLabel);
 
   // The value editor's accessible name is "Value"
   // (`t('@astryx.powersearch.valueEditor.value')`) regardless of which
@@ -374,20 +491,16 @@ async function applyImageFilter(
   }
 
   // Wait for table to reflect updated results
-  await page
-    .locator('.ant-spin-spinning')
-    .waitFor({ state: 'detached', timeout: 10000 })
-    .catch(() => {});
+  await waitForImageListSettled(page);
 }
 
 /**
- * Remove a committed filter token by its accessible label
- * (`"<Field>: <operator>"`, see `imageFilterTokenLabel`). Each
- * token's own remove control carries `aria-label="Remove {label}"`
- * (`t('@astryx.token.remove', {label})`, `Token.tsx` /
- * locales/en.json) — used directly as both the "is this filter still
- * present" probe and the click target, since the button and the token it
- * belongs to appear/disappear together.
+ * Remove a committed filter token by its label (`"<Field>: <operator>"`, see
+ * `imageFilterTokenLabel`). Each token's own remove control carries
+ * `aria-label="Remove {label}"` (`t('@astryx.token.remove', {label})`,
+ * `Token.tsx` / locales/en.json) — used directly as both the "is this filter
+ * still present" probe and the click target, since the button and the token
+ * it belongs to appear/disappear together.
  */
 async function removeFilterTag(page: Page, tokenLabel: string) {
   const removeButton = page.getByRole('button', {
@@ -406,11 +519,8 @@ async function removeFilterTag(page: Page, tokenLabel: string) {
     await expect(removeButton).not.toBeVisible({ timeout: 2000 });
   }).toPass({ timeout: 20000 });
 
-  // Wait for any loading spinner to disappear after filter removal
-  await page
-    .locator('.ant-spin-spinning')
-    .waitFor({ state: 'detached', timeout: 10000 })
-    .catch(() => {});
+  // Wait for the refetch triggered by the removal to settle
+  await waitForImageListSettled(page);
 }
 
 /**
@@ -418,8 +528,8 @@ async function removeFilterTag(page: Page, tokenLabel: string) {
  * (`t('@astryx.tokenizer.clearAll')`, `Tokenizer.tsx` / locales/en.json —
  * replaces the antd-era bespoke reset-all button, ticket 28 PILOT-DECISION
  * #6) and wait for it to disappear (it renders only while at least one
- * filter is active) and the loading spinner to detach, retrying the click if
- * it is swallowed by a concurrent re-render (see `removeFilterTag`).
+ * filter is active) and the table to settle, retrying the click if it is
+ * swallowed by a concurrent re-render (see `removeFilterTag`).
  */
 async function resetAllFilters(page: Page, resetAllButton: Locator) {
   await expect(async () => {
@@ -427,10 +537,7 @@ async function resetAllFilters(page: Page, resetAllButton: Locator) {
     await expect(resetAllButton).not.toBeVisible({ timeout: 2000 });
   }).toPass({ timeout: 20000 });
 
-  await page
-    .locator('.ant-spin-spinning')
-    .waitFor({ state: 'detached', timeout: 10000 })
-    .catch(() => {});
+  await waitForImageListSettled(page);
 }
 
 // ---------------------------------------------------------------------------
@@ -446,11 +553,11 @@ test.describe(
       await page.getByRole('link', { name: 'Admin Settings' }).click();
       await page.getByRole('link', { name: 'Environments' }).click();
       await expect(page).toHaveURL(/\/environment/);
-      // Wait for the BAIPropertyFilter (PowerSearch) and table to be ready
+      // Wait for the BAIPropertyFilter (PowerSearch) and the table to be ready.
       await expect(
         page.getByRole('combobox', { name: 'Search filters' }),
-      ).toBeVisible();
-      await expect(page.getByRole('table')).toBeVisible();
+      ).toBeVisible({ timeout: 60000 });
+      await waitForImageListReady(page);
     });
 
     // Scenario 2.1 — BAIPropertyFilter UI rendered
@@ -473,14 +580,16 @@ test.describe(
       await applyImageFilter(page, 'Name', 'python');
 
       // 2. Verify the committed token "Name: contains python" appears
-      const nameLabel = imageFilterTokenLabel('Name', 'contains', 'python');
+      const nameLabel = imageFilterTokenLabel('Name', 'contains');
       const nameTag = page.getByRole('button', {
         name: `Remove ${nameLabel}`,
       });
       await expect(nameTag).toBeVisible();
+      // The value lives in the token's `endContent`, beside the label.
+      await expect(imageFilterTokenValue(page, 'python')).toBeVisible();
 
       // 3. Verify the table is still visible (filtered results shown)
-      await expect(page.getByRole('table')).toBeVisible();
+      await expect(imageListTableOf(page)).toBeVisible();
 
       // 4. Cleanup: remove the filter token
       await removeFilterTag(page, nameLabel);
@@ -496,14 +605,15 @@ test.describe(
 
       // 2. Verify the committed token "Architecture: is x86_64" appears
       // (`defaultOperator: '=='` in ImageList.tsx's filterProperties -> "is")
-      const archLabel = imageFilterTokenLabel('Architecture', 'is', 'x86_64');
+      const archLabel = imageFilterTokenLabel('Architecture', 'is');
       const archTag = page.getByRole('button', {
         name: `Remove ${archLabel}`,
       });
       await expect(archTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'x86_64')).toBeVisible();
 
       // 3. Verify the table has at least one row with images
-      await expect(imageDataRows(page).first()).toBeVisible();
+      await expect(imageListRowsOf(page).first()).toBeVisible();
 
       // 4. Cleanup: remove the filter token
       await removeFilterTag(page, archLabel);
@@ -518,14 +628,15 @@ test.describe(
       await applyImageFilter(page, 'Status', 'ALIVE');
 
       // 2. Verify the committed token "Status: is ALIVE" appears
-      const statusLabel = imageFilterTokenLabel('Status', 'is', 'ALIVE');
+      const statusLabel = imageFilterTokenLabel('Status', 'is');
       const statusTag = page.getByRole('button', {
         name: `Remove ${statusLabel}`,
       });
       await expect(statusTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'ALIVE')).toBeVisible();
 
       // 3. Verify the table is not empty (all installed images should be ALIVE)
-      await expect(imageDataRows(page).first()).toBeVisible();
+      await expect(imageListRowsOf(page).first()).toBeVisible();
 
       // 4. Cleanup: remove the filter token
       await removeFilterTag(page, statusLabel);
@@ -540,14 +651,15 @@ test.describe(
       await applyImageFilter(page, 'Type', 'COMPUTE');
 
       // 2. Verify the committed token "Type: is COMPUTE" appears
-      const typeLabel = imageFilterTokenLabel('Type', 'is', 'COMPUTE');
+      const typeLabel = imageFilterTokenLabel('Type', 'is');
       const typeTag = page.getByRole('button', {
         name: `Remove ${typeLabel}`,
       });
       await expect(typeTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'COMPUTE')).toBeVisible();
 
       // 3. Verify the table has at least one row
-      await expect(imageDataRows(page).first()).toBeVisible();
+      await expect(imageListRowsOf(page).first()).toBeVisible();
 
       // 4. Cleanup: remove the filter token
       await removeFilterTag(page, typeLabel);
@@ -562,14 +674,15 @@ test.describe(
       await applyImageFilter(page, 'Registry', 'cr');
 
       // 2. Verify the committed token "Registry: contains cr" appears
-      const registryLabel = imageFilterTokenLabel('Registry', 'contains', 'cr');
+      const registryLabel = imageFilterTokenLabel('Registry', 'contains');
       const registryTag = page.getByRole('button', {
         name: `Remove ${registryLabel}`,
       });
       await expect(registryTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'cr')).toBeVisible();
 
       // 3. Verify the table content is visible (rows exist for the registry)
-      await expect(page.getByRole('table')).toBeVisible();
+      await expect(imageListTableOf(page)).toBeVisible();
 
       // 4. Cleanup: remove the filter token
       await removeFilterTag(page, registryLabel);
@@ -581,20 +694,22 @@ test.describe(
       page,
     }) => {
       // 1. Apply Name filter with value "python"
-      const nameLabel = imageFilterTokenLabel('Name', 'contains', 'python');
+      const nameLabel = imageFilterTokenLabel('Name', 'contains');
       await applyImageFilter(page, 'Name', 'python');
       const nameTag = page.getByRole('button', {
         name: `Remove ${nameLabel}`,
       });
       await expect(nameTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'python')).toBeVisible();
 
       // 2. Apply Architecture filter with strict selection "x86_64"
-      const archLabel = imageFilterTokenLabel('Architecture', 'is', 'x86_64');
+      const archLabel = imageFilterTokenLabel('Architecture', 'is');
       await applyImageFilter(page, 'Architecture', 'x86_64');
       const archTag = page.getByRole('button', {
         name: `Remove ${archLabel}`,
       });
       await expect(archTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'x86_64')).toBeVisible();
 
       // 3. Verify both tokens are visible
       await expect(nameTag).toBeVisible();
@@ -604,10 +719,7 @@ test.describe(
       // `hasClear` shows it whenever at least one filter is active (ticket 28
       // PILOT-DECISION #6 — antd's bespoke reset-all button, which only
       // appeared with 2+ filters, is gone).
-      const resetAllButton = page.getByRole('button', {
-        name: 'Clear all',
-        exact: true,
-      });
+      const resetAllButton = imageFilterClearAllButtonOf(page);
       await expect(resetAllButton).toBeVisible();
 
       // 5. Cleanup: click "Clear all" to remove all filters at once
@@ -621,26 +733,25 @@ test.describe(
       page,
     }) => {
       // 1. Apply Name filter with value "python"
-      const nameLabel = imageFilterTokenLabel('Name', 'contains', 'python');
+      const nameLabel = imageFilterTokenLabel('Name', 'contains');
       await applyImageFilter(page, 'Name', 'python');
       const nameTag = page.getByRole('button', {
         name: `Remove ${nameLabel}`,
       });
       await expect(nameTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'python')).toBeVisible();
 
       // 2. Apply Architecture filter with strict selection "x86_64"
-      const archLabel = imageFilterTokenLabel('Architecture', 'is', 'x86_64');
+      const archLabel = imageFilterTokenLabel('Architecture', 'is');
       await applyImageFilter(page, 'Architecture', 'x86_64');
       const archTag = page.getByRole('button', {
         name: `Remove ${archLabel}`,
       });
       await expect(archTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'x86_64')).toBeVisible();
 
       // 3. Verify the "Clear all" button appears with 2 active filters
-      const resetAllButton = page.getByRole('button', {
-        name: 'Clear all',
-        exact: true,
-      });
+      const resetAllButton = imageFilterClearAllButtonOf(page);
       await expect(resetAllButton).toBeVisible();
 
       // 4. Remove only the Architecture token
@@ -671,26 +782,25 @@ test.describe(
       page,
     }) => {
       // 1. Apply Name filter with value "python"
-      const nameLabel = imageFilterTokenLabel('Name', 'contains', 'python');
+      const nameLabel = imageFilterTokenLabel('Name', 'contains');
       await applyImageFilter(page, 'Name', 'python');
       const nameTag = page.getByRole('button', {
         name: `Remove ${nameLabel}`,
       });
       await expect(nameTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'python')).toBeVisible();
 
       // 2. Apply Architecture filter with strict selection "x86_64"
-      const archLabel = imageFilterTokenLabel('Architecture', 'is', 'x86_64');
+      const archLabel = imageFilterTokenLabel('Architecture', 'is');
       await applyImageFilter(page, 'Architecture', 'x86_64');
       const archTag = page.getByRole('button', {
         name: `Remove ${archLabel}`,
       });
       await expect(archTag).toBeVisible();
+      await expect(imageFilterTokenValue(page, 'x86_64')).toBeVisible();
 
       // 3. Verify both filter tokens and the "Clear all" button are visible
-      const resetAllButton = page.getByRole('button', {
-        name: 'Clear all',
-        exact: true,
-      });
+      const resetAllButton = imageFilterClearAllButtonOf(page);
       await expect(resetAllButton).toBeVisible();
 
       // 4. Click "Clear all" to clear all filters at once
@@ -702,7 +812,7 @@ test.describe(
       await expect(resetAllButton).not.toBeVisible({ timeout: 10000 });
 
       // 6. Verify the table shows results (returns to unfiltered state)
-      await expect(imageDataRows(page).first()).toBeVisible();
+      await expect(imageListRowsOf(page).first()).toBeVisible();
     });
 
     // Scenario 2.10 — Pagination resets to page 1 when filter applied
@@ -710,8 +820,13 @@ test.describe(
       'Admin sees pagination reset to page 1 when a filter is applied on page 2',
       { tag: ['@requires-seeded-data'] },
       async ({ page }) => {
-        // 1. Check total row count to determine if there are enough images for page 2
-        const paginationTotal = page.getByText(/of\s+\d+\s+items/);
+        // 1. Check total row count to determine if there are enough images for page 2.
+        // `BAITable`'s bottom bar renders `BAIPaginationInfoText`, i.e.
+        // `comp:PaginationInfoText.Total` = "{{start}} - {{end}} of {{total}} items".
+        const paginationTotal = page.getByText(
+          /^\d+\s*-\s*\d+\s+of\s+\d+\s+items$/,
+        );
+        // Ensure pagination total text is present and readable; fail if it is not.
         await expect(paginationTotal).toBeVisible();
         const totalText = await paginationTotal.textContent();
         if (!totalText) {
@@ -734,28 +849,31 @@ test.describe(
           `Pagination scenario requires more than 20 images in the image list (found ${total}; default page size 20, @requires-seeded-data)`,
         );
 
-        const pagination = page.getByRole('navigation', { name: 'Pagination' });
+        const visiblePagination = imageListPaginationOf(page);
+        // Astryx's `Pagination` marks the current page button with
+        // `aria-current="page"`; there is no active-item class any more.
+        const activePage = visiblePagination.locator('[aria-current="page"]');
 
         // 2. Navigate to page 2 by clicking the page 2 button in pagination
-        await pagination.getByRole('button', { name: 'Go to page 2' }).click();
+        await visiblePagination
+          .getByRole('button', { name: 'Go to page 2' })
+          .click();
+        await waitForImageListSettled(page);
 
         // 3. Verify we are on page 2
-        await expect(
-          pagination.getByRole('button', { name: 'Go to page 2' }),
-        ).toHaveAttribute('aria-current', 'page');
+        await expect(activePage).toHaveText('2');
 
         // 4. Apply a Name filter with value "python"
-        const nameLabel = imageFilterTokenLabel('Name', 'contains', 'python');
+        const nameLabel = imageFilterTokenLabel('Name', 'contains');
         await applyImageFilter(page, 'Name', 'python');
         const nameTag = page.getByRole('button', {
           name: `Remove ${nameLabel}`,
         });
         await expect(nameTag).toBeVisible();
+        await expect(imageFilterTokenValue(page, 'python')).toBeVisible();
 
         // 5. Verify pagination has reset to page 1
-        await expect(
-          pagination.getByRole('button', { name: 'Go to page 1' }),
-        ).toHaveAttribute('aria-current', 'page');
+        await expect(activePage).toHaveText('1');
 
         // 6. Cleanup: remove the filter token
         await removeFilterTag(page, nameLabel);
@@ -777,14 +895,7 @@ test.describe(
       page,
     }) => {
       // 1. Select "Architecture" as the filter field — opens the edit popover.
-      const searchBar = page.getByRole('combobox', { name: 'Search filters' });
-      await searchBar.evaluate((el) =>
-        el.scrollIntoView({ block: 'center', inline: 'nearest' }),
-      );
-      await searchBar.click({ force: true });
-      await page
-        .getByRole('option', { name: 'Architecture', exact: true })
-        .click();
+      await pickImageFilterField(page, 'Architecture');
 
       // 2. The value editor is a closed Selector, not a free-text input.
       await expect(
@@ -793,19 +904,28 @@ test.describe(
       const valueSelector = page.getByRole('combobox', { name: 'Value' });
       await expect(valueSelector).toBeVisible();
 
-      // 3. The Selector has no typing surface to fill — opening it exposes
-      // only the fixed, registered options, so an unregistered architecture
-      // never appears as a selectable option.
+      // 3. The Selector's trigger is a `<button role="combobox">`, not a text
+      // field, so there is nothing to type INTO. Opening it offers exactly the
+      // registered architectures (`ImageList.tsx` filterProperties: x86_64 /
+      // aarch64), and type-to-select cannot synthesise a new option — so an
+      // unregistered value stays unselectable and Apply stays disabled.
       await valueSelector.click();
+      const valueOptions = page.getByRole('listbox').getByRole('option');
+      await expect(valueOptions).toHaveText(['x86_64', 'aarch64']);
+      await page.keyboard.type('arm64-unregistered-e2e-probe');
       await expect(
         page.getByRole('option', { name: 'arm64-unregistered-e2e-probe' }),
       ).toHaveCount(0);
-      // Close the still-open options listbox — its popup overlaps the
-      // popover's Cancel button and would otherwise intercept the click.
-      await page.keyboard.press('Escape');
+      await expect(valueOptions).toHaveText(['x86_64', 'aarch64']);
+      await expect(
+        page.getByRole('button', { name: 'Apply', exact: true }),
+      ).toBeDisabled();
 
       // 4. Close the popover without committing (Cancel — no value was ever
-      // selectable, so there is nothing to Apply).
+      // selectable, so there is nothing to Apply). The Selector's option list
+      // overlays the popover footer, so collapse it first.
+      await valueSelector.press('Escape');
+      await expect(valueOptions).toHaveCount(0);
       await page.getByRole('button', { name: 'Cancel', exact: true }).click();
 
       // 5. Verify no filter token was created and the table remains
@@ -813,7 +933,7 @@ test.describe(
       await expect(page.getByRole('button', { name: /^Remove / })).toHaveCount(
         0,
       );
-      await expect(imageDataRows(page).first()).toBeVisible();
+      await expect(imageListRowsOf(page).first()).toBeVisible();
     });
 
     // Scenario 2.12 — Empty results when filtering non-existent name
@@ -821,11 +941,7 @@ test.describe(
       page,
     }) => {
       // 1. Apply a Name filter with a value that matches no images
-      const noResultsLabel = imageFilterTokenLabel(
-        'Name',
-        'contains',
-        'zzz-nonexistent-image-000',
-      );
+      const noResultsLabel = imageFilterTokenLabel('Name', 'contains');
       await applyImageFilter(page, 'Name', 'zzz-nonexistent-image-000');
 
       // 2. Verify the committed filter token is visible
@@ -833,11 +949,22 @@ test.describe(
         name: `Remove ${noResultsLabel}`,
       });
       await expect(noResultsTag).toBeVisible();
-
-      // 3. Verify the table shows an empty state
       await expect(
-        page.getByRole('heading', { name: 'No data to display' }),
+        imageFilterTokenValue(page, 'zzz-nonexistent-image-000'),
       ).toBeVisible();
+
+      // 3. Verify the table shows its empty state. `BAITable` owns the node
+      // (an Astryx `EmptyState` titled `comp:BAITable.NoDataToDisplay` =
+      // "No data to display") instead of Astryx's own `@astryx.table.noData`.
+      // It renders as a single full-width `<tr><td colSpan>` inside the tbody
+      // (`@astryxdesign/core/src/Table/BaseTable.tsx`), so it replaces — not
+      // accompanies — the data rows.
+      await expect(
+        imageListTableOf(page).getByRole('heading', {
+          name: 'No data to display',
+        }),
+      ).toBeVisible();
+      await expect(imageListRowsOf(page)).toHaveCount(1);
 
       // 4. Cleanup: remove the filter token
       await removeFilterTag(page, noResultsLabel);


### PR DESCRIPTION
Follow-up to #9043 (merged). No Jira issue — test-side maintenance only.
Nothing under `react/` or `packages/` is touched.

## Why

#9043 healed five locator clusters and was explicit about which ones it left
red. Running the specs it touches against a live cluster (a dev server built
from that branch, backed by `10.82.130.172:8090`) gave **37 passed / 19
failed / 7 skipped**. This PR picks up the 19.

Every locator below was checked against the component source and the failure's
accessibility snapshot, not guessed, and every test marked fixed was re-run and
observed to pass.

## `environment.spec.ts` — 14 failing → **15 passed / 1 skipped / 0 failed**

The cluster #9043's "Known scope boundaries" section names.

**The 11 `BAIPropertyFilter` tests shared one cause.** `imageFilterTokenLabel()`
assumed a token reads `"Field: op value"`, but Astryx `PowerSearch` renders the
value as a separate `endContent` node, so `@astryx.token.remove` interpolates
only the label — the remove button is `aria-label="Field: op"`. Fixed in the
shared helper; the value half is now asserted separately, so no coverage is
lost.

Three secondary causes surfaced once multiple filters could be applied:

- Committing a token leaves PowerSearch's suggestion list **open**, so the next
  `searchBar.click()` toggled it shut. `pickImageFilterField()` guards on
  `aria-expanded` and retries.
- `getByRole('button', { name: 'Clear all' })` was ambiguous — the project
  selector exposes `"Clear All projects"`. Scoped to the tokenizer, `exact`.
- `:826` called `fill()` on a `<button role="combobox">`. Replaced with the
  assertion the test title actually claims: the option list is exactly
  `['x86_64', 'aarch64']`, an unregistered value synthesises no option, and
  **Apply stays disabled**.

**Dead table locators** (`:21`, `:72`, `:202`, plus the table assertions inside
every filter test): `.ant-table-content` → `getByRole('table')`,
`.ant-table-row` → `tbody tr`. `.ant-table-placeholder` → `BAITable`'s own
"No data to display" node — Astryx renders it as a single `<tr><td colSpan>`,
so the empty-state row count is **1**, not 0. `.ant-spin-spinning` →
`BAITable` dims with `aria-busy` rather than rendering a spinner. Row actions
are now located by accessible name (`"Edit Minimum Image Resource Limit"`,
`"Manage Apps"`), which drops the stale `findColumnIndex` helper import.

**`:72` was also asserting the wrong thing.** The antd-era `fill('1g')`
silently produced **1024 GiB**: `BAIDynamicUnitInputNumber`'s `min` is
expressed in the *currently selected* unit, and `handleBlur` clamps an
under-min entry **upward**. A `setMemorySize()` helper sets the unit first,
then the number, then blurs, and asserts both halves.

`:744` (`@requires-seeded-data`) passes for real — the cluster has 154 images,
so its `total <= 20` skip gate does not trip.

`grep -n "ant-" e2e/environment/environment.spec.ts` now returns nothing.

## `chat.spec.ts` / `chat-sync.spec.ts` — 4 failing → passing

- **`:592`** — `.ant-alert-error` with a raw `[role="alert"]` CSS fallback was
  matching a **hidden, empty live region** before the `Banner`
  (`18 × locator resolved to <div role="alert" …></div>`, "unexpected value
  hidden"). `getByRole('alert')` only sees the accessibility tree. The app was
  never broken — the failing snapshot showed the error banner rendered
  correctly.
- **`:909`** — half-healed by #9043: `.ant-card` → `.astryx-card` fixed the
  pane container but left antd's `[title="…"]` display-value assertion, which
  `BAIComplexSelect` does not emit, so it failed at the same line. Panes are
  now indexed by their `Deployment` trigger's role+name, which **removes the
  `.astryx-card` + `nth()` indexing entirely**.
- **`:993`** — antd's icon-derived name `'control'`, antd's `role="tooltip"`
  popover (Astryx `Popover` defaults to `role="dialog"`), and
  `.ant-popover:not(.ant-popover-hidden)`.
- **`chat-sync.spec.ts:138`** — the failure #9043 discloses and left alone. Its
  `[class*="attachment"], [class*="file"]` was near-vacuous: it matched whether
  or not anything was attached. `ChatSender` renders each attachment as an
  Astryx `Thumbnail` (a non-decorative `<img alt>`), so
  `getByRole('img', { name: 'test.png' })` with `toHaveCount(2)` is strictly
  stronger.

## `bulk-create-from-csv.spec.ts` — no test was failing; guideline compliance

`:199` failed in the verification run, but **not because of locator drift**,
and #9043's "20/20 pass (full file)" claim holds. Its `error-context.md` showed
the whole page replaced by the react-router `errorElement` (`ErrorView` from
`BAIErrorBoundary.tsx`) — the app had crashed at route level before the first
assertion. Re-runs isolated it as shared-box contention:

| Run | Conditions | Result |
|---|---|---|
| Full file, **unmodified** | load ~25 | **20/20** (8.9m) |
| Full file, unmodified | quiet | **20/20** (6.4m) |
| Full file, unmodified | moderate | **20/20** (5.9m) |
| Full file, unmodified | load ~30, 3–4 concurrent suites | 13/20 (16.4m) |

All 7 failures in the bad run landed on the same pre-existing line 18
(`getByRole('button', { name: 'Create User' })` after `navigateTo`), and that
run logged `test-util.ts`'s own diagnostic: the browser login was rejected
while a direct API login with the same credentials returned 200. Runtime
scaled 5.9m → 16.4m under load.

What this PR does change is the `.astryx-file-input` and
`.astryx-toast[data-type=…]` selectors #9043 introduced.
`.github/instructions/e2e.instructions.md` forbids framework-internal classes
outright; #9043's comments justified these as a "stable theme class", but
`themeProps()` (`@astryxdesign/core/src/utils/themeProps.ts`) generates them
and its own docstring calls theme target names public API *subject to renaming
with a deprecation window*.

- File input → `getByLabel(…)` `.and(input[type="file"])`. `FieldLabel` renders
  `htmlFor={inputID}` and `FileInput` puts `id` on the native input; the `.and()`
  is needed because the visually-hidden trigger button repeats the label as its
  `aria-label`.
- Toasts → `getByRole('alert' | 'status')` **scoped to the Notifications
  region** and filtered on the message text. Scoping is required:
  `ToastViewport` also announces assertively, so a bare `getByRole('alert')`
  matches two nodes. Filtering on text is stronger than asserting that some
  toast exists.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript **PASS**. The
`Astryx theme build` step fails identically on a clean `main` with these
changes stashed (unbuilt local `backend.ai-ui` dist on this box), so it is
unrelated to this diff. This PR touches only `e2e/**/*.ts`.

No assertion was weakened, skipped, or deleted anywhere in this PR. Several are
strictly stronger than what they replace: the filter-token value check, the
`:826` option-list assertion, the `:72` unit assertion, the chat attachment
count, and the toast message text.

## Not covered

Reported rather than papered over:

- `rbac-role-list.spec.ts` / `rbac-role-detail.spec.ts` and
  `rbac-role-crud.spec.ts`'s remaining tests are still full of dead antd
  locators.
- `registry.spec.ts`'s other tests (11 failures) — #9043 fixed only its nav
  link and tab helper, as it said.
- `bulk-create-from-csv-submit.spec.ts:117` still uses `input[name="file"]` and
  line 134 `.ant-message`. #9043 healed the sibling file but not this one.
- `.astryx-card` remains in chat specs outside the four tests fixed here.
  `ChatCard` renders a bare Astryx `Card` with no role, name, or test id, so
  **there is genuinely no way to scope a locator to one pane** — #9043's reply
  to Copilot was accurate. The fixes here route around it by indexing controls
  by role+name, which works but asserts by DOM order rather than containment.
  The minimal app-side fix is `role="group"` + `aria-label` on that `Card`;
  separately, `ChatHeader`'s parameters `Popover` passes no `label`, so it
  renders an unnamed `role="dialog"` that Astryx's own `usePopover` dev-warns
  about.

Related: #9043 (merged), #9099 (merged — the same exercise on dashboard,
resource-policy and rbac).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
