### PR TITLE
test: e2e auto-heal 2026-08-27 — Astryx locator drift in rbac, project, serving, start

### DIFF
--- a/e2e/project/project-crud.spec.ts
+++ b/e2e/project/project-crud.spec.ts
@@ -15,6 +15,23 @@ function projectName(label: string) {
   return `e2e-test-project-${TEST_RUN_ID}-${label}`;
 }
 
+// `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+// `<button>`s (BAITabList / Astryx `TabList`), never ARIA `tab` elements —
+// the same contract rbac-role-list.spec.ts and registry.spec.ts already use.
+// The active one carries `aria-current="true"` in place of `aria-selected`.
+function projectsTab(page: Page) {
+  return page
+    .getByRole('navigation', { name: 'Tabs' })
+    .getByRole('button', { name: 'Projects' });
+}
+
+// A BAITable column header's accessible NAME is built from its sort and
+// resize controls ("Sort by name Resize column name"), so it no longer equals
+// the visible label; match the header's TEXT instead.
+function projectColumnHeader(page: Page, label: string) {
+  return page.getByRole('columnheader').filter({ hasText: label });
+}
+
 // Not serial: each CRUD test provisions and cleans up its own uniquely-named
 // project, so the tests are order-independent and a failure in one does not
 // cascade-skip the others. `mode: 'default'` only removes serial's cascade-skip
@@ -41,21 +58,30 @@ async function cleanupTestProject(page: Page, projectName: string) {
     // the button's `aria-label` (BAINameActionCell), so target by name —
     // index-based selection breaks when optional actions (e.g. "Set Project
     // Admin" on managers >= 26.8) are prepended.
-    await activeProjectRow.hover();
-    await activeProjectRow
-      .getByRole('button', { name: 'Deactivate', exact: true })
-      .click();
-    // The deactivate confirm is an anchored `BAIPopconfirm`-style popover
-    // rendered with `role="dialog"` (`BAINameActionCell.tsx`), accessible
-    // name = the row action's title ("Deactivate").
-    const deactivatePopconfirm = page.getByRole('dialog', {
-      name: 'Deactivate',
-    });
-    await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
-    await deactivatePopconfirm
-      .getByRole('button', { name: 'Deactivate' })
-      .click();
-    await expect(activeProjectRow).toBeHidden({ timeout: 10000 });
+    //
+    // Go through `clickRowAction`: how many actions stay inline vs. collapse
+    // into the "More actions" overflow depends on the rendered column widths.
+    // BAINameActionCell only reveals them on hover, and this table is ~2500px
+    // wide against a 1280px viewport, so scroll the row into view first —
+    // otherwise `click()`'s own scroll moves the row out from under the
+    // pointer and the buttons hide again mid-click. Retry the whole
+    // reveal→confirm step, the same way rbac-role-detail.spec.ts's cleanup
+    // does.
+    await expect(async () => {
+      await activeProjectRow.scrollIntoViewIfNeeded();
+      await clickRowAction(page, activeProjectRow, 'Deactivate');
+      // The deactivate confirm is an anchored `BAIPopconfirm`-style popover
+      // rendered with `role="dialog"` (`BAINameActionCell.tsx`), accessible
+      // name = the row action's title ("Deactivate").
+      const deactivatePopconfirm = page.getByRole('dialog', {
+        name: 'Deactivate',
+      });
+      await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
+      await deactivatePopconfirm
+        .getByRole('button', { name: 'Deactivate' })
+        .click();
+      await expect(activeProjectRow).toBeHidden({ timeout: 10000 });
+    }).toPass({ timeout: 60000 });
   }
 
   // Switch to Inactive tab and purge. `BAIRadioGroup` renders on Astryx
@@ -107,9 +133,11 @@ async function createProject(page: Page, name: string, description: string) {
   await modal.getByRole('textbox', { name: 'Name' }).fill(name);
   await modal.getByRole('textbox', { name: 'Description' }).fill(description);
 
-  // Select Domain 'default'. `BAIDomainSelect` renders as a Selector
-  // trigger `button` (not a `combobox`), accessible name "Domain".
-  await modal.getByRole('button', { name: 'Domain', exact: true }).click();
+  // Select Domain 'default'. `BAIDomainSelect` renders as a Selector trigger
+  // `button` (not a `combobox`) whose accessible name concatenates the field
+  // label with the placeholder ("Domain Select Domain") — match the label as
+  // a substring rather than exactly.
+  await modal.getByRole('button', { name: 'Domain' }).click();
   await page.getByRole('option', { name: 'default', exact: true }).click();
 
   // Click OK to create and verify the modal closes
@@ -140,23 +168,14 @@ test.describe(
 
       // 2. Verify the Projects tab is selected (BAICard tabList label renamed
       // "Project" -> "Projects", see webui.menu.Projects in ProjectPage.tsx)
-      await expect(
-        page.getByRole('tab', { name: 'Projects', selected: true }),
-      ).toBeVisible({ timeout: 10000 });
+      await expect(projectsTab(page)).toBeVisible({ timeout: 30000 });
+      await expect(projectsTab(page)).toHaveAttribute('aria-current', 'true');
 
       // 3. Verify table columns are visible
-      await expect(
-        page.getByRole('columnheader', { name: 'Name' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Domain' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Description' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Type' }),
-      ).toBeVisible();
+      await expect(projectColumnHeader(page, 'Name')).toBeVisible();
+      await expect(projectColumnHeader(page, 'Domain')).toBeVisible();
+      await expect(projectColumnHeader(page, 'Description')).toBeVisible();
+      await expect(projectColumnHeader(page, 'Type')).toBeVisible();
 
       // 4. Verify the default project row
       const defaultRow = page
@@ -169,7 +188,10 @@ test.describe(
       // (Active is a filter tab, not a table column; the default project is active by default).
       // `ProjectPage.tsx`'s status toggle is `BAIRadioGroup`, rendered on
       // Astryx `SegmentedControl` since ticket 10 (`BAIRadioGroup.tsx`).
-      await expect(page.getByRole('radio', { name: 'Active' })).toBeChecked();
+      // `exact` matters: a substring match on "Active" also hits "Inactive".
+      await expect(
+        page.getByRole('radio', { name: 'Active', exact: true }),
+      ).toBeChecked();
       await expect(
         defaultRow.getByRole('cell', { name: 'GENERAL' }),
       ).toBeVisible();
@@ -279,6 +301,13 @@ test.describe(
       const dataRows = page.locator('tbody tr');
       await expect(dataRows).toHaveCount(1);
 
+      // Self-cleanup runs HERE, while the filter is still applied and the
+      // table holds this one row. On the unfiltered list the row can land
+      // anywhere across a paginated, ~2500px-wide table, and BAINameActionCell
+      // only reveals its row actions on hover — which makes the cleanup's
+      // hover→click depend on where the row happens to sit.
+      await cleanupTestProject(page, name);
+
       // Clear the filter by clicking its token's remove button. Token labels
       // follow `"<Field>: <operator>"` (`PowerSearch.tsx` `tokenizerValue` ->
       // `displayLabel`) -- the value itself is not part of the accessible
@@ -290,9 +319,6 @@ test.describe(
       await expect(
         page.getByRole('cell', { name: 'default', exact: true }).first(),
       ).toBeVisible({ timeout: 10000 });
-
-      // Self-cleanup.
-      await cleanupTestProject(page, name);
     });
 
     test('Admin can delete a project', async ({ page, request }) => {

--- a/e2e/project/project-crud.spec.ts
+++ b/e2e/project/project-crud.spec.ts
@@ -1,5 +1,6 @@
 // spec: e2e/.agent-output/test-plan-project.md
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import { clickRowAction } from '../utils/user-profile-util';
 import test, { expect, Page } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
@@ -44,7 +45,12 @@ async function cleanupTestProject(page: Page, projectName: string) {
     await activeProjectRow
       .getByRole('button', { name: 'Deactivate', exact: true })
       .click();
-    const deactivatePopconfirm = page.locator('.ant-popconfirm');
+    // The deactivate confirm is an anchored `BAIPopconfirm`-style popover
+    // rendered with `role="dialog"` (`BAINameActionCell.tsx`), accessible
+    // name = the row action's title ("Deactivate").
+    const deactivatePopconfirm = page.getByRole('dialog', {
+      name: 'Deactivate',
+    });
     await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
     await deactivatePopconfirm
       .getByRole('button', { name: 'Deactivate' })
@@ -52,12 +58,10 @@ async function cleanupTestProject(page: Page, projectName: string) {
     await expect(activeProjectRow).toBeHidden({ timeout: 10000 });
   }
 
-  // Switch to Inactive tab and purge
-  // Use the label wrapper (not the hidden radio input) to click the radio button
-  await page
-    .locator('label')
-    .filter({ hasText: /^Inactive$/ })
-    .click();
+  // Switch to Inactive tab and purge. `BAIRadioGroup` renders on Astryx
+  // `SegmentedControl`, whose options are `<button role="radio">` with no
+  // `<label>` wrapper (see `BAIRadioGroup.tsx`).
+  await page.getByRole('radio', { name: 'Inactive', exact: true }).click();
   const inactiveProjectRow = page
     .getByRole('row')
     .filter({ hasText: projectName });
@@ -66,22 +70,24 @@ async function cleanupTestProject(page: Page, projectName: string) {
     .catch(() => false);
 
   if (isInactiveVisible) {
-    await inactiveProjectRow.hover();
-    await inactiveProjectRow
-      .getByRole('button', { name: 'Purge', exact: true })
-      .click();
+    // The Inactive tab shows 3 row actions (Edit, Activate, Purge), one more
+    // than the Active tab fits directly, so Purge collapses into the
+    // "More actions" overflow menu (`BAINameActionCell`). `clickRowAction`
+    // handles both the directly-visible and overflowed cases.
+    await clickRowAction(page, inactiveProjectRow, 'Purge');
     const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
     await expect(purgeDialog).toBeVisible({ timeout: 5000 });
-    await purgeDialog.locator('#confirmText').fill(projectName);
+    // `BAIDeleteConfirmModal`'s confirm input has no `#confirmText` id in the
+    // DOM; it is the dialog's only textbox, labeled "Type {name} to confirm.".
+    await purgeDialog.getByRole('textbox').fill(projectName);
     await purgeDialog.getByRole('button', { name: 'Purge' }).click();
     await expect(inactiveProjectRow).toBeHidden({ timeout: 10000 });
   }
 
-  // Return to Active tab for subsequent tests
-  await page
-    .locator('label')
-    .filter({ hasText: /^Active$/ })
-    .click();
+  // Return to Active tab for subsequent tests. `exact: true` is required —
+  // Playwright's accessible-name match is substring-based, so a bare
+  // { name: 'Active' } also matches the "Inactive" radio.
+  await page.getByRole('radio', { name: 'Active', exact: true }).click();
 }
 
 // Creation helper — extracted so each test can provision its own project.
@@ -94,21 +100,17 @@ async function createProject(page: Page, name: string, description: string) {
   await page.getByRole('button', { name: 'Create Project' }).click();
 
   // Verify Create Project dialog appears
-  const modal = page.locator('.ant-modal');
+  const modal = page.getByRole('dialog', { name: 'Create Project' });
   await expect(modal).toBeVisible();
-  await expect(modal.getByText('Create Project')).toBeVisible();
 
   // Fill in the project name and description
   await modal.getByRole('textbox', { name: 'Name' }).fill(name);
   await modal.getByRole('textbox', { name: 'Description' }).fill(description);
 
-  // Select Domain 'default'
-  await modal.getByRole('combobox', { name: 'Domain' }).click();
-  await page.locator('.ant-select-dropdown').waitFor({ state: 'visible' });
-  await page
-    .locator('.ant-select-item-option')
-    .filter({ hasText: 'default' })
-    .click();
+  // Select Domain 'default'. `BAIDomainSelect` renders as a Selector
+  // trigger `button` (not a `combobox`), accessible name "Domain".
+  await modal.getByRole('button', { name: 'Domain', exact: true }).click();
+  await page.getByRole('option', { name: 'default', exact: true }).click();
 
   // Click OK to create and verify the modal closes
   await modal.getByRole('button', { name: 'OK' }).click();
@@ -213,9 +215,8 @@ test.describe(
         .click();
 
       // Verify Update Project dialog appears
-      const modal = page.locator('.ant-modal');
+      const modal = page.getByRole('dialog', { name: 'Update Project' });
       await expect(modal).toBeVisible();
-      await expect(modal.getByText('Update Project')).toBeVisible();
 
       // Verify the name field contains the test project name
       await expect(modal.getByRole('textbox', { name: 'Name' })).toHaveValue(
@@ -273,19 +274,17 @@ test.describe(
         { timeout: 10000 },
       );
 
-      // Verify only one data row is visible (excluding header rows)
-      const dataRows = page.locator('tbody tr:not(.ant-table-measure-row)');
+      // Verify only one data row is visible (excluding header rows). There is
+      // no measure row in the Astryx table, so plain `tbody tr` is sufficient.
+      const dataRows = page.locator('tbody tr');
       await expect(dataRows).toHaveCount(1);
 
       // Clear the filter by clicking its token's remove button. Token labels
-      // follow `"<Field>: <operator> <value>"` (`PowerSearch.tsx`
-      // `tokenizerValue` -> `displayLabel`); "name" has no `defaultOperator`
-      // override, so it uses the BUI default `ilike` = "contains". The
-      // remove control carries `aria-label="Remove {label}"`
-      // (`t('@astryx.token.remove', {label})`, `Token.tsx` / locales/en.json).
-      await page
-        .getByRole('button', { name: `Remove Name: contains ${name}` })
-        .click();
+      // follow `"<Field>: <operator>"` (`PowerSearch.tsx` `tokenizerValue` ->
+      // `displayLabel`) -- the value itself is not part of the accessible
+      // name; "name" has no `defaultOperator` override, so it uses the BUI
+      // default `ilike` = "contains".
+      await page.getByRole('button', { name: 'Remove Name: contains' }).click();
 
       // Verify the default project is visible again (filter cleared)
       await expect(
@@ -317,8 +316,11 @@ test.describe(
         .getByRole('button', { name: 'Deactivate', exact: true })
         .click();
 
-      // Confirm the antd Popconfirm for deactivation
-      const deactivatePopconfirm = page.locator('.ant-popconfirm');
+      // Confirm the anchored deactivate popover (role="dialog", see
+      // `cleanupTestProject` above for details).
+      const deactivatePopconfirm = page.getByRole('dialog', {
+        name: 'Deactivate',
+      });
       await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
       await deactivatePopconfirm
         .getByRole('button', { name: 'Deactivate' })
@@ -328,10 +330,7 @@ test.describe(
       await expect(projectRow).toBeHidden({ timeout: 10000 });
 
       // Switch to the Inactive tab to find the deactivated project
-      await page
-        .locator('label')
-        .filter({ hasText: /^Inactive$/ })
-        .click();
+      await page.getByRole('radio', { name: 'Inactive', exact: true }).click();
 
       // Find the deactivated project row in the Inactive tab
       const inactiveProjectRow = page
@@ -339,18 +338,19 @@ test.describe(
         .filter({ hasText: name });
       await expect(inactiveProjectRow).toBeVisible({ timeout: 10000 });
 
-      // Hover the row and click the Purge button by its accessible name
-      await inactiveProjectRow.hover();
-      await inactiveProjectRow
-        .getByRole('button', { name: 'Purge', exact: true })
-        .click();
+      // Click the Purge action. The Inactive tab shows 3 row actions (Edit,
+      // Activate, Purge), so Purge collapses into the "More actions"
+      // overflow menu; `clickRowAction` handles both cases.
+      await clickRowAction(page, inactiveProjectRow, 'Purge');
 
       // Verify the Purge Project confirmation dialog appears
       const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
       await expect(purgeDialog).toBeVisible({ timeout: 5000 });
 
-      // Type the project name into the confirmation input to enable the Purge button
-      await purgeDialog.locator('#confirmText').fill(name);
+      // Type the project name into the confirmation input to enable the
+      // Purge button. `BAIDeleteConfirmModal`'s confirm input has no
+      // `#confirmText` id in the DOM; it is the dialog's only textbox.
+      await purgeDialog.getByRole('textbox').fill(name);
 
       // Click the Purge button to permanently delete the project
       await purgeDialog.getByRole('button', { name: 'Purge' }).click();

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -205,6 +205,11 @@ test.describe(
         .first()
         .getByRole('cell')
         .first()
+        // The drawer handler sits on `BAINameActionCell`'s title, which
+        // `BAILink` renders as a `<button>` (Astryx `Link`, no `href`) — not on
+        // the cell, whose centre can fall outside that fit-content button.
+        .getByRole('button')
+        .first()
         .click();
 
       // 5. Verify a drawer with title "RBAC Role Info" slides open from the right
@@ -246,6 +251,11 @@ test.describe(
         .filter({ hasNotText: /monitor/i })
         .first()
         .getByRole('cell')
+        .first()
+        // The drawer handler sits on `BAINameActionCell`'s title, which
+        // `BAILink` renders as a `<button>` (Astryx `Link`, no `href`) — not on
+        // the cell, whose centre can fall outside that fit-content button.
+        .getByRole('button')
         .first()
         .click();
 
@@ -321,6 +331,11 @@ test.describe(
         .filter({ hasNotText: /monitor/i })
         .first()
         .getByRole('cell')
+        .first()
+        // The drawer handler sits on `BAINameActionCell`'s title, which
+        // `BAILink` renders as a `<button>` (Astryx `Link`, no `href`) — not on
+        // the cell, whose centre can fall outside that fit-content button.
+        .getByRole('button')
         .first()
         .click();
 

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -13,18 +13,17 @@ const TEST_RUN_ID = Date.now().toString(36);
 const ROLE_NAME = `e2e-detail-role-${TEST_RUN_ID}`;
 const ROLE_DESCRIPTION = `E2E detail test role created at ${new Date().toISOString()}`;
 
+// BAIPropertyFilter (Astryx PowerSearch): the RBAC page has multiple filter
+// fields (Role Name, Source), so typing opens a Field/Operator/Value edit
+// popover rather than auto-committing (contrast with a single-field page's
+// content-search shortcut) -- see `environment.spec.ts`'s
+// `applyImageFilter` for the canonical pattern this mirrors.
 async function searchForRole(page: Page, roleName: string) {
-  // Use the property filter to search for the role by name
-  const filterContainer = page.locator('.ant-space-compact').first();
-  const propertySelect = filterContainer.locator('.ant-select').first();
-  await propertySelect.click();
-  await page.getByRole('option', { name: 'Role Name' }).click();
-  const searchInput = filterContainer
-    .locator('.ant-select')
-    .last()
-    .locator('input');
-  await searchInput.fill(roleName);
-  await page.getByRole('button', { name: 'search' }).click();
+  const searchBar = page.getByRole('combobox', { name: 'Search filters' });
+  await searchBar.click();
+  await page.getByRole('option', { name: 'Role Name', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Value' }).fill(roleName);
+  await page.getByRole('button', { name: 'Apply', exact: true }).click();
   await expect(
     page.getByRole('row').filter({ hasText: roleName }).first(),
   ).toBeVisible({ timeout: 10000 });
@@ -32,74 +31,56 @@ async function searchForRole(page: Page, roleName: string) {
 
 async function createTestRole(page: Page) {
   await page.getByRole('button', { name: 'Create Role' }).click();
-  const modal = page.locator('.ant-modal').filter({ hasText: 'Create Role' });
+  const modal = page.getByRole('dialog', { name: 'Create Role' });
   await expect(modal).toBeVisible();
   await modal.getByLabel('Role Name').fill(ROLE_NAME);
   await modal.getByLabel('Description').fill(ROLE_DESCRIPTION);
 
-  // Fill in the required "Scope Type / Target" field.
-  // AntD Form.List generates input IDs: scopes_0_scopeType and scopes_0_scopeId.
-  const scopeTypeContainer = modal
-    .locator('input#scopes_0_scopeType')
-    .locator('xpath=ancestor::div[contains(@class,"ant-select")][1]');
-  await scopeTypeContainer.click();
-  await page
-    .locator(
-      '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-    )
-    .filter({ hasText: 'Domain' })
-    .first()
-    .click();
+  // Fill in the required "Scope Type / Target" field. Both are Astryx
+  // Selector triggers. "Target" starts out disabled (rendered as a
+  // `combobox`, `aria-busy="true"`, while it fetches the domain list after
+  // "Scope Type" is picked) and re-renders as an enabled `button` once
+  // ready -- so target it by role `button`, whose `.click()` naturally
+  // waits out that role/attribute transition.
+  await modal.getByRole('button', { name: 'Scope Type', exact: true }).click();
+  await page.getByRole('option', { name: 'Domain', exact: true }).click();
 
-  // Wait for Scope Type dropdown to fully close before interacting with Target
-  await expect(
-    page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-  ).toHaveCount(0, { timeout: 5000 });
-
-  // Wait for Target (scopeId) container to become enabled
-  const scopeIdContainer = modal
-    .locator('input#scopes_0_scopeId')
-    .locator('xpath=ancestor::div[contains(@class,"ant-select")][1]');
-  await expect(scopeIdContainer).not.toHaveClass(/ant-select-disabled/, {
-    timeout: 5000,
-  });
-  // Click the combobox to open the dropdown; retry if it doesn't open because the
-  // component may still be mounting after Domain was selected.
-  const domainDropdownOptions = page.locator(
-    '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-  );
-  await expect(async () => {
-    await scopeIdContainer.click();
-    await expect(domainDropdownOptions.first()).toBeVisible({ timeout: 2000 });
-  }).toPass({ timeout: 15000 });
-  await domainDropdownOptions.first().click();
-
-  // Wait for Target dropdown to fully close before submitting
-  await expect(
-    page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-  ).toHaveCount(0, { timeout: 5000 });
+  await modal
+    .getByRole('button', { name: 'Target', exact: true })
+    .click({ timeout: 15000 });
+  const targetOptions = page.getByRole('option');
+  await expect(targetOptions.first()).toBeVisible({ timeout: 10000 });
+  await targetOptions.first().click();
 
   await modal.getByRole('button', { name: 'OK' }).click();
   await expect(modal).toBeHidden({ timeout: 10000 });
   // Verify success notification instead of row visibility (pagination may hide the new row)
   await expect(
-    page
-      .locator('.ant-message-notice-wrapper')
-      .filter({ hasText: /Role created successfully/i }),
+    page.getByRole('alert').filter({ hasText: /Role created successfully/i }),
   ).toBeVisible({ timeout: 10000 });
 }
 
+// Same PowerSearch interaction as `searchForRole`, without asserting the
+// row appears — cleanup callers branch on `isVisible` themselves since the
+// role may not exist yet (first run) or may already be gone.
+async function applyRoleNameFilter(page: Page, roleName: string) {
+  const searchBar = page.getByRole('combobox', { name: 'Search filters' });
+  await searchBar.click();
+  await page.getByRole('option', { name: 'Role Name', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Value' }).fill(roleName);
+  await page.getByRole('button', { name: 'Apply', exact: true }).click();
+}
+
 async function clearRoleSearch(page: Page) {
-  // Remove any active filter chip — scope to the filter-chip area so we
-  // don't accidentally click tag close icons in the table itself.
-  const filterChip = page
-    .locator('.ant-space-compact')
-    .first()
-    .locator('.ant-tag-close-icon')
-    .first();
-  if (await filterChip.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await filterChip.click();
-    await expect(filterChip).toBeHidden({ timeout: 5000 });
+  // PowerSearch ships its own "Clear all" button, gated on there being at
+  // least one committed filter token.
+  const clearAllButton = page.getByRole('button', {
+    name: 'Clear all',
+    exact: true,
+  });
+  if (await clearAllButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await clearAllButton.click();
+    await expect(clearAllButton).toBeHidden({ timeout: 5000 });
   }
 }
 
@@ -122,16 +103,7 @@ async function cleanupTestRole(page: Page) {
   await statusFilterOption(page, 'Active').click();
   await clearRoleSearch(page);
   // Use name filter to find the role even if it's on a later page
-  const filterContainer = page.locator('.ant-space-compact').first();
-  const propertySelect = filterContainer.locator('.ant-select').first();
-  await propertySelect.click();
-  await page.getByRole('option', { name: 'Role Name' }).click();
-  const activeSearchInput = filterContainer
-    .locator('.ant-select')
-    .last()
-    .locator('input');
-  await activeSearchInput.fill(ROLE_NAME);
-  await page.getByRole('button', { name: 'search' }).click();
+  await applyRoleNameFilter(page, ROLE_NAME);
 
   const activeRow = page
     .getByRole('row')
@@ -162,18 +134,10 @@ async function cleanupTestRole(page: Page) {
     }).toPass({ timeout: 20000 });
   }
 
-  // Check Inactive tab
+  // Check Inactive tab. The Role Name filter set above persists across the
+  // Active/Inactive status switch (it's carried in the URL's `filter` query
+  // param), so there's no need to reapply it here.
   await statusFilterOption(page, 'Inactive').click();
-  await clearRoleSearch(page);
-  const inactivePropertySelect = filterContainer.locator('.ant-select').first();
-  await inactivePropertySelect.click();
-  await page.getByRole('option', { name: 'Role Name' }).click();
-  const inactiveSearchInput = filterContainer
-    .locator('.ant-select')
-    .last()
-    .locator('input');
-  await inactiveSearchInput.fill(ROLE_NAME);
-  await page.getByRole('button', { name: 'search' }).click();
 
   // Purge every inactive row matching the role name. A parallel describe block
   // in this file may share the same ROLE_NAME and create additional roles while
@@ -228,18 +192,18 @@ test.describe(
       await expect(
         page.getByRole('tab', { name: 'RBAC Management' }),
       ).toBeVisible({ timeout: 10000 });
-      await expect(page.locator('.ant-table-row').first()).toBeVisible({
+      const roleRows = page
+        .getByRole('row')
+        .filter({ hasNot: page.getByRole('columnheader') });
+      await expect(roleRows.first()).toBeVisible({
         timeout: 10000,
       });
 
       // 4. Click any role name in the first column of the table (excluding "monitor" role — known bug)
-      await page
-        .locator('.ant-table-row')
+      await roleRows
         .filter({ hasNotText: /monitor/i })
         .first()
         .getByRole('cell')
-        .first()
-        .locator('.ant-typography')
         .first()
         .click();
 
@@ -272,22 +236,27 @@ test.describe(
       await navigateTo(page, 'rbac');
 
       // 3. Wait for the table to load and click any role name (excluding "monitor" role — known bug)
-      await expect(page.locator('.ant-table-row').first()).toBeVisible({
+      const roleRows = page
+        .getByRole('row')
+        .filter({ hasNot: page.getByRole('columnheader') });
+      await expect(roleRows.first()).toBeVisible({
         timeout: 10000,
       });
-      await page
-        .locator('.ant-table-row')
+      await roleRows
         .filter({ hasNotText: /monitor/i })
         .first()
         .getByRole('cell')
         .first()
-        .locator('.ant-typography')
-        .first()
         .click();
 
-      const drawer = page.locator('.ant-drawer');
-      const drawerPanel = page.locator('.ant-drawer-content-wrapper');
-      await expect(drawerPanel).toBeVisible({ timeout: 10000 });
+      // `RoleDetailDrawer` renders as an Astryx `Dialog` (`role="dialog"`,
+      // accessible name "RBAC Role Info") rather than an antd Drawer.
+      const drawer = page.getByRole('dialog', { name: 'RBAC Role Info' });
+      await expect(drawer).toBeVisible({ timeout: 10000 });
+      // `BAITabs`/`BAITabList` renders tab items as plain `<button>`s inside
+      // a `navigation "Tabs"` landmark, not `role="tab"` (see
+      // `start-page.spec.ts`). The active tab carries `aria-current="true"`.
+      const tabs = drawer.getByRole('navigation', { name: 'Tabs' });
 
       // 4. Verify two tabs are visible: "Permissions" and "Role Assignments".
       // Managers below 26.8.0 (the nightly manager under test) don't support
@@ -299,33 +268,33 @@ test.describe(
       // click instead of assuming it's the default, so this passes on both
       // legacy and merged-view managers.
       await expect(
-        drawer.getByRole('tab', { name: 'Permissions' }),
+        tabs.getByRole('button', { name: 'Permissions' }),
       ).toBeVisible();
       await expect(
-        drawer.getByRole('tab', { name: 'Role Assignments' }),
+        tabs.getByRole('button', { name: 'Role Assignments' }),
       ).toBeVisible();
 
       // 5. Click the "Permissions" tab and verify it becomes active
-      await drawer.getByRole('tab', { name: 'Permissions' }).click();
+      await tabs.getByRole('button', { name: 'Permissions' }).click();
       await expect(
-        drawer.getByRole('tab', { name: 'Permissions' }),
-      ).toHaveAttribute('aria-selected', 'true');
+        tabs.getByRole('button', { name: 'Permissions' }),
+      ).toHaveAttribute('aria-current', 'true');
 
-      // 6. Verify the active tab content area is visible. Confirmed live
-      // (via DOM inspection) that this antd/rc-tabs version marks the active
-      // pane with `.ant-tabs-content-active` on the `role="tabpanel"`
-      // element itself -- there is no `.ant-tabs-tabpane-active` class here.
-      await expect(drawer.locator('.ant-tabs-content-active')).toBeVisible({
+      // 6. Verify the active tab's content area is visible -- the
+      // Permissions panel's own "Add Permission" button.
+      await expect(
+        drawer.getByRole('button', { name: 'Add Permission' }),
+      ).toBeVisible({
         timeout: 10000,
       });
 
       // 7. Click the "Role Assignments" tab
-      await drawer.getByRole('tab', { name: 'Role Assignments' }).click();
+      await tabs.getByRole('button', { name: 'Role Assignments' }).click();
 
       // 8. Verify the Role Assignments tab becomes active
       await expect(
-        drawer.getByRole('tab', { name: 'Role Assignments' }),
-      ).toHaveAttribute('aria-selected', 'true');
+        tabs.getByRole('button', { name: 'Role Assignments' }),
+      ).toHaveAttribute('aria-current', 'true');
 
       // Close the drawer
       await drawer.getByRole('button', { name: 'close' }).click();
@@ -342,33 +311,34 @@ test.describe(
       await navigateTo(page, 'rbac');
 
       // 3. Open the detail drawer by clicking a role name (excluding "monitor" role — known bug)
-      await expect(page.locator('.ant-table-row').first()).toBeVisible({
+      const roleRows = page
+        .getByRole('row')
+        .filter({ hasNot: page.getByRole('columnheader') });
+      await expect(roleRows.first()).toBeVisible({
         timeout: 10000,
       });
-      await page
-        .locator('.ant-table-row')
+      await roleRows
         .filter({ hasNotText: /monitor/i })
         .first()
         .getByRole('cell')
         .first()
-        .locator('.ant-typography')
-        .first()
         .click();
 
-      const drawer = page.locator('.ant-drawer');
-      const drawerPanel = page.locator('.ant-drawer-content-wrapper');
+      // `RoleDetailDrawer` renders as an Astryx `Dialog` (`role="dialog"`,
+      // accessible name "RBAC Role Info") rather than an antd Drawer.
+      const drawer = page.getByRole('dialog', { name: 'RBAC Role Info' });
 
       // 4. Verify the drawer is visible
-      await expect(drawerPanel).toBeVisible({ timeout: 10000 });
+      await expect(drawer).toBeVisible({ timeout: 10000 });
 
       // 5. Click the close (X) button on the drawer
       await drawer.getByRole('button', { name: 'close' }).click();
 
       // 6. Verify the drawer closes (is hidden)
-      await expect(drawerPanel).toBeHidden({ timeout: 5000 });
+      await expect(drawer).toBeHidden({ timeout: 5000 });
 
       // 7. Verify the underlying role list is still visible
-      await expect(page.locator('.ant-table-row').first()).toBeVisible();
+      await expect(roleRows.first()).toBeVisible();
     });
   },
 );

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -7,7 +7,12 @@ import {
   UserSettingModal,
 } from '../utils/classes/user/UserSettingModal';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import test, { expect, Page, type APIRequestContext } from '@playwright/test';
+import test, {
+  expect,
+  Locator,
+  Page,
+  type APIRequestContext,
+} from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
 const ROLE_NAME = `e2e-detail-role-${TEST_RUN_ID}`;
@@ -91,9 +96,54 @@ function statusFilterOption(page: Page, status: 'Active' | 'Inactive') {
   return page.getByRole('radiogroup').getByText(status, { exact: true });
 }
 
+// `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+// `<button>`s (BAITabList / Astryx `TabList`), never ARIA `tab` elements —
+// the same contract rbac-role-list.spec.ts already uses.
+function rbacManagementTab(page: Page) {
+  return page
+    .getByRole('navigation', { name: 'Tabs' })
+    .getByRole('button', { name: 'RBAC Management' });
+}
+
+// `RoleDetailDrawer` renders as an Astryx `Dialog` (`role="dialog"`,
+// accessible name "RBAC Role Info"), not an antd Drawer.
+function roleDrawer(page: Page) {
+  return page.getByRole('dialog', { name: 'RBAC Role Info' });
+}
+
+// The drawer carries its own BAITabList ("Scopes" / "Permissions" /
+// "Role Assignments"); the active button carries `aria-current="true"`.
+function drawerTab(page: Page, name: string) {
+  return roleDrawer(page)
+    .getByRole('navigation', { name: 'Tabs' })
+    .getByRole('button', { name });
+}
+
+// Astryx `Table` renders native <table><tbody><tr role="row">; a plain
+// getByRole('row') also matches the header row, so exclude it.
+function dataRows(page: Page, scope: Locator | Page = page) {
+  return scope
+    .getByRole('row')
+    .filter({ hasNot: page.getByRole('columnheader') });
+}
+
+// Astryx `Selector` triggers are plain `<button>`s whose accessible name
+// concatenates the field label with its placeholder — which on these fields is
+// the label again ("Permission Permission"). Match that doubled form exactly:
+// a substring "Permission" would also hit "Permission Type" and the drawer's
+// own "Add Permission" button.
+function selectorTrigger(scope: Locator, label: string) {
+  return scope.getByRole('button', { name: `${label} ${label}`, exact: true });
+}
+
+// The role table (900+ roles in the shared nightly env) can take a while to
+// render on a busy shared backend; give the page chrome more headroom than
+// the default wait.
+const SLOW_PAGE_TIMEOUT = 30000;
+
 async function cleanupTestRole(page: Page) {
   // Close any lingering drawer from a previous test so it doesn't block clicks.
-  const openDrawer = page.locator('.ant-drawer-open');
+  const openDrawer = roleDrawer(page);
   if (await openDrawer.isVisible().catch(() => false)) {
     await openDrawer.getByRole('button', { name: 'close' }).first().click();
     await expect(openDrawer).toBeHidden({ timeout: 5000 });
@@ -127,7 +177,7 @@ async function cleanupTestRole(page: Page) {
       await deactivateBtn.click();
       // Confirm the Popconfirm that appears after clicking the deactivate button
       await page
-        .locator('.ant-popconfirm')
+        .getByRole('dialog', { name: 'Deactivate' })
         .getByRole('button', { name: 'Deactivate' })
         .click({ timeout: 5000 });
       await expect(activeRow).toBeHidden({ timeout: 5000 });
@@ -157,13 +207,12 @@ async function cleanupTestRole(page: Page) {
         .locator('.bai-name-action-cell-actions button')
         .last()
         .click();
-      const purgeModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Purge Role' });
+      const purgeModal = page.getByRole('dialog', { name: 'Purge Role' });
       await expect(purgeModal).toBeVisible({ timeout: 5000 });
-      // BAIDeleteConfirmModal requires typing the role name into its dedicated
-      // #confirmText textbox before the Delete button is enabled.
-      await purgeModal.locator('#confirmText').fill(ROLE_NAME);
+      // BAIDeleteConfirmModal requires typing the role name before the Delete
+      // button enables. Its confirm input is the dialog's only textbox — the
+      // Astryx build carries no `#confirmText` id (see project-crud.spec.ts).
+      await purgeModal.getByRole('textbox').fill(ROLE_NAME);
       await purgeModal.getByRole('button', { name: 'Delete' }).click();
       await expect(inactiveRow).toBeHidden({ timeout: 5000 });
     }).toPass({ timeout: 20000 });
@@ -189,14 +238,12 @@ test.describe(
       await navigateTo(page, 'rbac');
 
       // 3. Wait for the table to load
-      await expect(
-        page.getByRole('tab', { name: 'RBAC Management' }),
-      ).toBeVisible({ timeout: 10000 });
-      const roleRows = page
-        .getByRole('row')
-        .filter({ hasNot: page.getByRole('columnheader') });
+      await expect(rbacManagementTab(page)).toBeVisible({
+        timeout: SLOW_PAGE_TIMEOUT,
+      });
+      const roleRows = dataRows(page);
       await expect(roleRows.first()).toBeVisible({
-        timeout: 10000,
+        timeout: SLOW_PAGE_TIMEOUT,
       });
 
       // 4. Click any role name in the first column of the table (excluding "monitor" role — known bug)
@@ -212,22 +259,22 @@ test.describe(
         .first()
         .click();
 
-      // 5. Verify a drawer with title "RBAC Role Info" slides open from the right
-      const drawer = page.locator('.ant-drawer');
-      const drawerPanel = page.locator('.ant-drawer-content-wrapper');
-      await expect(drawerPanel).toBeVisible({ timeout: 10000 });
-      await expect(drawer.getByText('RBAC Role Info')).toBeVisible();
+      // 5. Verify the "RBAC Role Info" drawer slides open from the right
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
 
-      // 6. Verify a Refresh button is visible in the drawer header.
-      // `RoleDetailDrawer.tsx` uses `BAIFetchKeyButton`, whose icon is lucide
-      // `RotateCw` (no antd `.anticon-reload` class since ticket 12); the
-      // button carries the native `title="Refresh"` attribute instead
-      // (`packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx`).
-      await expect(drawer.locator('button[title="Refresh"]')).toBeVisible();
+      // 6. Verify a Refresh button is visible in the drawer.
+      // `RoleDetailDrawer.tsx` uses `BAIFetchKeyButton`, which renders an
+      // Astryx icon button whose accessible name is "Refresh". The drawer
+      // holds two — one in the header, one above the tab's table — so take
+      // the first rather than tripping strict mode.
+      await expect(
+        drawer.getByRole('button', { name: 'Refresh' }).first(),
+      ).toBeVisible();
 
-      // 7. Close the drawer
-      await drawer.getByRole('button', { name: 'close' }).click();
-      await expect(drawerPanel).toBeHidden({ timeout: 5000 });
+      // 7. Close the drawer (Astryx `Dialog`'s close control is named "Close")
+      await drawer.getByRole('button', { name: 'Close' }).click();
+      await expect(drawer).toBeHidden({ timeout: 5000 });
     });
 
     test('Drawer shows "Role Assignments" and "Permissions" tabs', async ({
@@ -241,11 +288,9 @@ test.describe(
       await navigateTo(page, 'rbac');
 
       // 3. Wait for the table to load and click any role name (excluding "monitor" role — known bug)
-      const roleRows = page
-        .getByRole('row')
-        .filter({ hasNot: page.getByRole('columnheader') });
+      const roleRows = dataRows(page);
       await expect(roleRows.first()).toBeVisible({
-        timeout: 10000,
+        timeout: SLOW_PAGE_TIMEOUT,
       });
       await roleRows
         .filter({ hasNotText: /monitor/i })
@@ -261,7 +306,7 @@ test.describe(
 
       // `RoleDetailDrawer` renders as an Astryx `Dialog` (`role="dialog"`,
       // accessible name "RBAC Role Info") rather than an antd Drawer.
-      const drawer = page.getByRole('dialog', { name: 'RBAC Role Info' });
+      const drawer = roleDrawer(page);
       await expect(drawer).toBeVisible({ timeout: 10000 });
       // `BAITabs`/`BAITabList` renders tab items as plain `<button>`s inside
       // a `navigation "Tabs"` landmark, not `role="tab"` (see
@@ -321,11 +366,9 @@ test.describe(
       await navigateTo(page, 'rbac');
 
       // 3. Open the detail drawer by clicking a role name (excluding "monitor" role — known bug)
-      const roleRows = page
-        .getByRole('row')
-        .filter({ hasNot: page.getByRole('columnheader') });
+      const roleRows = dataRows(page);
       await expect(roleRows.first()).toBeVisible({
-        timeout: 10000,
+        timeout: SLOW_PAGE_TIMEOUT,
       });
       await roleRows
         .filter({ hasNotText: /monitor/i })
@@ -341,7 +384,7 @@ test.describe(
 
       // `RoleDetailDrawer` renders as an Astryx `Dialog` (`role="dialog"`,
       // accessible name "RBAC Role Info") rather than an antd Drawer.
-      const drawer = page.getByRole('dialog', { name: 'RBAC Role Info' });
+      const drawer = roleDrawer(page);
 
       // 4. Verify the drawer is visible
       await expect(drawer).toBeVisible({ timeout: 10000 });
@@ -390,26 +433,24 @@ test.describe(
         .first();
       await roleRow.getByText(ROLE_NAME).click();
 
-      const drawer = page.locator('.ant-drawer');
-      await expect(page.locator('.ant-drawer-content-wrapper')).toBeVisible({
-        timeout: 10000,
-      });
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
 
       // 5. Click the "Permissions" tab
-      await drawer.getByRole('tab', { name: 'Permissions' }).click();
+      await drawerTab(page, 'Permissions').click();
 
       // 6. Click the "Add Permission" button
       await drawer.getByRole('button', { name: 'Add Permission' }).click();
 
       // 7. Verify a modal titled "Add Permission" appears
-      const addModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Add Permission' });
+      const addModal = page.getByRole('dialog', { name: 'Add Permission' });
       await expect(addModal).toBeVisible();
 
       // 8. The role has a Domain scope, so the modal shows a single "Scope Type / Target"
       // field (roleScopeKey) instead of separate Scope Type and Target fields.
-      await expect(addModal.getByLabel('Scope Type / Target')).toBeVisible();
+      await expect(
+        selectorTrigger(addModal, 'Scope Type / Target'),
+      ).toBeVisible();
 
       // 9. Attempt to click OK without filling any fields – verify validation error
       await addModal.getByRole('button', { name: 'Add' }).click();
@@ -421,45 +462,39 @@ test.describe(
 
       // 10. Select the role scope from the "Scope Type / Target" dropdown
       // The dropdown shows combined scope entries like "Domain / <domain-name>"
-      await addModal.getByLabel('Scope Type / Target').click();
-      const roleScopeOptions = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
+      await selectorTrigger(addModal, 'Scope Type / Target').click();
+      const roleScopeOptions = page.getByRole('option');
       await expect(roleScopeOptions.first()).toBeVisible({ timeout: 10000 });
       await roleScopeOptions.first().click();
 
       // Wait for the scope dropdown to fully close
-      await expect(
-        page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-      ).toHaveCount(0, { timeout: 5000 });
+      await expect(page.getByRole('option').first()).toBeHidden({
+        timeout: 5000,
+      });
 
       // 11. Verify the Permission Type field becomes enabled
-      await expect(addModal.locator('#entityType')).toBeEnabled({
+      await expect(selectorTrigger(addModal, 'Permission Type')).toBeEnabled({
         timeout: 5000,
       });
 
       // 12. Select a Permission Type from the dropdown
-      await addModal.locator('#entityType').click();
-      const entityTypeOptions = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
+      await selectorTrigger(addModal, 'Permission Type').click();
+      const entityTypeOptions = page.getByRole('option');
       await expect(entityTypeOptions.first()).toBeVisible({ timeout: 5000 });
       await entityTypeOptions.first().click();
 
       // Wait for the entityType dropdown to fully close so the next dropdown
       // query doesn't resolve to the previous (stale) options.
-      await expect(
-        page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-      ).toHaveCount(0);
-
-      // 13. Select a permission (operation) from the Permission dropdown
-      await expect(addModal.locator('#operation')).toBeEnabled({
+      await expect(page.getByRole('option').first()).toBeHidden({
         timeout: 5000,
       });
-      await addModal.locator('#operation').click();
-      const operationOptions = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
+
+      // 13. Select a permission (operation) from the Permission dropdown
+      await expect(selectorTrigger(addModal, 'Permission')).toBeEnabled({
+        timeout: 5000,
+      });
+      await selectorTrigger(addModal, 'Permission').click();
+      const operationOptions = page.getByRole('option');
       await expect(operationOptions.first()).toBeVisible({ timeout: 5000 });
       await operationOptions.first().click();
 
@@ -472,16 +507,16 @@ test.describe(
       // 18. Verify a success notification "Permission created successfully." appears
       await expect(
         page
-          .locator('.ant-message-notice-wrapper')
+          .getByRole('alert')
           .filter({ hasText: /Permission created successfully/i }),
       ).toBeVisible({ timeout: 10000 });
 
       // 19. Verify the new permission row appears in the Permissions tab table.
       // Scope to the active tab panel so we don't match rows rendered in the
       // Scopes tab (which remains in the DOM but is hidden).
-      await expect(
-        drawer.locator('.ant-tabs-tabpane-active .ant-table-row').first(),
-      ).toBeVisible({ timeout: 10000 });
+      await expect(dataRows(page, drawer).first()).toBeVisible({
+        timeout: 10000,
+      });
     });
 
     test('Superadmin can delete a permission from a role', async ({
@@ -506,47 +541,37 @@ test.describe(
         .filter({ hasText: ROLE_NAME })
         .first();
       await roleRow.getByText(ROLE_NAME).click();
-      const drawer = page.locator('.ant-drawer');
-      await expect(page.locator('.ant-drawer-content-wrapper')).toBeVisible({
-        timeout: 10000,
-      });
-      await drawer.getByRole('tab', { name: 'Permissions' }).click();
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
+      await drawerTab(page, 'Permissions').click();
       await drawer.getByRole('button', { name: 'Add Permission' }).click();
 
-      const addModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Add Permission' });
+      const addModal = page.getByRole('dialog', { name: 'Add Permission' });
       await expect(addModal).toBeVisible();
       // The role has a Domain scope, so the modal shows "Scope Type / Target" as a single field
-      await addModal.getByLabel('Scope Type / Target').click();
-      const roleScopeOpts = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
+      await selectorTrigger(addModal, 'Scope Type / Target').click();
+      const roleScopeOpts = page.getByRole('option');
       await expect(roleScopeOpts.first()).toBeVisible({ timeout: 10000 });
       await roleScopeOpts.first().click();
       // Wait for scope dropdown to close
-      await expect(
-        page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-      ).toHaveCount(0, { timeout: 5000 });
-      await expect(addModal.locator('#entityType')).toBeEnabled({
+      await expect(page.getByRole('option').first()).toBeHidden({
         timeout: 5000,
       });
-      await addModal.locator('#entityType').click();
-      const entityTypeOpts = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
+      await expect(selectorTrigger(addModal, 'Permission Type')).toBeEnabled({
+        timeout: 5000,
+      });
+      await selectorTrigger(addModal, 'Permission Type').click();
+      const entityTypeOpts = page.getByRole('option');
       await expect(entityTypeOpts.first()).toBeVisible({ timeout: 5000 });
       await entityTypeOpts.first().click();
-      await expect(
-        page.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)'),
-      ).toHaveCount(0);
-      await expect(addModal.locator('#operation')).toBeEnabled({
+      await expect(page.getByRole('option').first()).toBeHidden({
         timeout: 5000,
       });
-      await addModal.locator('#operation').click();
-      const operationOpts = page.locator(
-        '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-      );
+      await expect(selectorTrigger(addModal, 'Permission')).toBeEnabled({
+        timeout: 5000,
+      });
+      await selectorTrigger(addModal, 'Permission').click();
+      const operationOpts = page.getByRole('option');
       await expect(operationOpts.first()).toBeVisible({ timeout: 5000 });
       await operationOpts.first().click();
       // Use dispatchEvent to ensure the click reaches React's event handler
@@ -557,15 +582,13 @@ test.describe(
       await expect(addModal).toBeHidden({ timeout: 10000 });
       await expect(
         page
-          .locator('.ant-message-notice-wrapper')
+          .getByRole('alert')
           .filter({ hasText: /Permission created successfully/i }),
       ).toBeVisible({ timeout: 10000 });
 
       // 4. Locate the permission row and hover to reveal action buttons.
       // Scope to the active tab panel to skip rows rendered in other (hidden) tabs.
-      const permissionRow = drawer
-        .locator('.ant-tabs-tabpane-active .ant-table-row')
-        .first();
+      const permissionRow = dataRows(page, drawer).first();
       await expect(permissionRow).toBeVisible({ timeout: 10000 });
       await permissionRow.hover();
 
@@ -577,9 +600,9 @@ test.describe(
 
       // 6. Verify a confirmation modal titled "Remove Permission" appears
       // (the modal title uses t('rbac.RemovePermission') = "Remove Permission")
-      const deleteModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Remove Permission' });
+      const deleteModal = page.getByRole('dialog', {
+        name: 'Remove Permission',
+      });
       await expect(deleteModal).toBeVisible();
 
       // 7. Click "Remove Permission" to confirm
@@ -594,7 +617,7 @@ test.describe(
       // 9. Verify a success notification "Permission removed from role successfully." appears
       await expect(
         page
-          .locator('.ant-message-notice-wrapper')
+          .getByRole('alert')
           .filter({ hasText: /Permission removed from role successfully/i }),
       ).toBeVisible({ timeout: 10000 });
     });
@@ -621,17 +644,15 @@ test.describe(
         .first();
       await roleRow.getByText(ROLE_NAME).click();
 
-      const drawer = page.locator('.ant-drawer');
-      await expect(page.locator('.ant-drawer-content-wrapper')).toBeVisible({
-        timeout: 10000,
-      });
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
 
       // 5. Click the "Permissions" tab
-      await drawer.getByRole('tab', { name: 'Permissions' }).click();
+      await drawerTab(page, 'Permissions').click();
 
       // 6. Verify an empty state message is shown
       await expect(
-        drawer.locator('.ant-tabs-tabpane-active .ant-empty-description'),
+        drawer.getByRole('heading', { name: 'No data to display' }),
       ).toBeVisible({ timeout: 10000 });
 
       // 7. Verify the "Add Permission" button is still present and enabled
@@ -680,9 +701,11 @@ test.describe(
       try {
         await loginAsAdmin(adminPage, adminRequest);
         await navigateTo(adminPage, 'credential');
-        await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible(
-          { timeout: 10000 },
-        );
+        await expect(
+          adminPage
+            .getByRole('navigation', { name: 'Tabs' })
+            .getByRole('button', { name: 'Users' }),
+        ).toBeVisible({ timeout: 10000 });
         await adminPage.getByRole('button', { name: 'Create User' }).click();
         const userSettingModal = new UserSettingModal(adminPage);
         await userSettingModal.createUser(
@@ -749,24 +772,21 @@ test.describe(
         .first();
       await roleRow.getByText(ROLE_NAME).click();
 
-      const drawer = page.locator('.ant-drawer');
-      await expect(page.locator('.ant-drawer-content-wrapper')).toBeVisible({
-        timeout: 10000,
-      });
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
 
       // 5. Click the "Role Assignments" tab (default tab is "Scopes" since the UI update)
-      await drawer.getByRole('tab', { name: 'Role Assignments' }).click();
-      await expect(
-        drawer.getByRole('tab', { name: 'Role Assignments' }),
-      ).toHaveAttribute('aria-selected', 'true');
+      await drawerTab(page, 'Role Assignments').click();
+      await expect(drawerTab(page, 'Role Assignments')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
 
       // 6. Click the "Add User" button
       await drawer.getByRole('button', { name: 'Add User' }).click();
 
       // 7. Verify a modal titled "Add User" appears with a multi-select "Users" field
-      const assignModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Add User' });
+      const assignModal = page.getByRole('dialog', { name: 'Add User' });
       await expect(assignModal).toBeVisible();
       await expect(assignModal.getByLabel('Users')).toBeVisible();
 
@@ -782,9 +802,7 @@ test.describe(
 
       // 10. Wait for the dropdown option to appear and select it
       await page
-        .locator(
-          '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-        )
+        .getByRole('option')
         .filter({ hasText: TEST_USER_EMAIL })
         .first()
         .click({ timeout: 10000 });
@@ -801,7 +819,7 @@ test.describe(
       // 13. Verify a success notification "Users assigned to role successfully." appears
       await expect(
         page
-          .locator('.ant-message-notice-wrapper')
+          .getByRole('alert')
           .filter({ hasText: /Users assigned to role successfully/i }),
       ).toBeVisible({ timeout: 10000 });
 
@@ -834,24 +852,18 @@ test.describe(
         .filter({ hasText: ROLE_NAME })
         .first();
       await roleRow.getByText(ROLE_NAME).click();
-      const drawer = page.locator('.ant-drawer');
-      await expect(page.locator('.ant-drawer-content-wrapper')).toBeVisible({
-        timeout: 10000,
-      });
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
       // Navigate to Role Assignments tab (default tab is "Scopes" since the UI update)
-      await drawer.getByRole('tab', { name: 'Role Assignments' }).click();
+      await drawerTab(page, 'Role Assignments').click();
       await drawer.getByRole('button', { name: 'Add User' }).click();
 
-      const assignModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Add User' });
+      const assignModal = page.getByRole('dialog', { name: 'Add User' });
       await expect(assignModal).toBeVisible();
       await assignModal.getByLabel('Users').click();
       await assignModal.getByLabel('Users').fill(TEST_USER_EMAIL);
       await page
-        .locator(
-          '.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item-option',
-        )
+        .getByRole('option')
         .filter({ hasText: TEST_USER_EMAIL })
         .first()
         .click({ timeout: 10000 });
@@ -861,7 +873,7 @@ test.describe(
       await expect(assignModal).toBeHidden({ timeout: 10000 });
       await expect(
         page
-          .locator('.ant-message-notice-wrapper')
+          .getByRole('alert')
           .filter({ hasText: /Users assigned to role successfully/i }),
       ).toBeVisible({ timeout: 10000 });
 
@@ -881,9 +893,7 @@ test.describe(
         .click();
 
       // 7. Verify a confirmation modal titled "Revoke User" appears
-      const deleteModal = page
-        .locator('.ant-modal')
-        .filter({ hasText: 'Revoke User' });
+      const deleteModal = page.getByRole('dialog', { name: 'Revoke User' });
       await expect(deleteModal).toBeVisible();
 
       // 8. Verify the description mentions revoking user(s)
@@ -900,7 +910,7 @@ test.describe(
       // 11. Verify a success notification "User removed from role successfully." appears
       await expect(
         page
-          .locator('.ant-message-notice-wrapper')
+          .getByRole('alert')
           .filter({ hasText: /User removed from role successfully/i }),
       ).toBeVisible({ timeout: 10000 });
     });
@@ -927,19 +937,20 @@ test.describe(
         .first();
       await roleRow.getByText(ROLE_NAME).click();
 
-      const drawer = page.locator('.ant-drawer');
-      await expect(page.locator('.ant-drawer-content-wrapper')).toBeVisible({
-        timeout: 10000,
-      });
+      const drawer = roleDrawer(page);
+      await expect(drawer).toBeVisible({ timeout: 10000 });
 
       // 5. Click the "Role Assignments" tab (default tab is "Scopes" since the UI update)
-      await drawer.getByRole('tab', { name: 'Role Assignments' }).click();
-      await expect(
-        drawer.getByRole('tab', { name: 'Role Assignments' }),
-      ).toHaveAttribute('aria-selected', 'true');
+      await drawerTab(page, 'Role Assignments').click();
+      await expect(drawerTab(page, 'Role Assignments')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
 
       // 6. Verify an empty state message is shown
-      await expect(drawer.locator('.ant-empty-description')).toBeVisible({
+      await expect(
+        drawer.getByRole('heading', { name: 'No data to display' }),
+      ).toBeVisible({
         timeout: 10000,
       });
 

--- a/e2e/serving/admin-preset-service-config.spec.ts
+++ b/e2e/serving/admin-preset-service-config.spec.ts
@@ -220,11 +220,11 @@ async function setupPresetCreatePage(
   // The Runtime field is an Astryx Selector: its trigger is a plain <button>
   // named by the field label, and the popup hosts plain, clickable
   // `role="option"` rows. Only one option exists (the mock resolves exactly
-  // one variant). Unlike the Add-Revision modal's Runtime select, this
-  // BAIFormItem carries a tooltip, whose help glyph contributes " info" to the
-  // trigger's accessible name — so the button is named "Runtime info", not
-  // just "Runtime".
-  await page.getByRole('button', { name: 'Runtime info', exact: true }).click();
+  // one variant). This BAIFormItem carries a tooltip, so the trigger's
+  // accessible name concatenates the label, the help glyph and the label
+  // again ("Runtime info Runtime") — match the label as a substring rather
+  // than pinning the exact composition.
+  await page.getByRole('button', { name: 'Runtime' }).click();
   const customOption = page.getByRole('option', {
     name: 'custom',
     exact: true,
@@ -292,8 +292,8 @@ async function setupLegacyPresetCreatePage(
 
   // Astryx Selector: plain trigger button + clickable option rows (same
   // idiom as setupPresetCreatePage above — incl. the tooltip glyph joining
-  // the accessible name, so the trigger is 'Runtime info').
-  await page.getByRole('button', { name: 'Runtime info', exact: true }).click();
+  // the accessible name, so match the label as a substring).
+  await page.getByRole('button', { name: 'Runtime' }).click();
   const customOption = page.getByRole('option', {
     name: 'custom',
     exact: true,
@@ -302,9 +302,10 @@ async function setupLegacyPresetCreatePage(
   await customOption.click();
   // Wait for the selection to commit before asserting the negative below —
   // otherwise "not visible yet" and "legacy layout" are indistinguishable.
-  await expect(
-    page.getByRole('button', { name: 'Runtime info', exact: true }),
-  ).toContainText('custom', { timeout: 10000 });
+  await expect(page.getByRole('button', { name: 'Runtime' })).toContainText(
+    'custom',
+    { timeout: 10000 },
+  );
 
   // Legacy: unlike the nullable-capable path, Service Configuration is NOT
   // independently visible in Basic Info — it only appears once Model

--- a/e2e/serving/admin-preset-service-config.spec.ts
+++ b/e2e/serving/admin-preset-service-config.spec.ts
@@ -157,8 +157,9 @@ async function installLegacyPresetFlagOverride(page: Page): Promise<void> {
  * trigger is a plain `<button>` whose accessible name is the field label
  * (`aria-haspopup="dialog"`, NOT a combobox); its popup is a `role="dialog"`
  * (aria-labelled with the same field label) hosting a search `TextInput` with
- * `role="combobox"` named "Search" and a `role="listbox"` of plain, clickable
- * `role="option"` rows — so the option is clicked directly.
+ * `role="combobox"` named "Search options" (`comp:BAIComplexSelect.SearchOptions`,
+ * FR-3603 / #8914) and a `role="listbox"` of plain, clickable `role="option"`
+ * rows — so the option is clicked directly.
  */
 async function selectComplexSelectOption(
   page: Page,
@@ -170,7 +171,7 @@ async function selectComplexSelectOption(
   await expect(popup).toBeVisible({ timeout: 10000 });
   // Narrow the (server-side) search to the wanted option, then click it.
   await popup
-    .getByRole('combobox', { name: 'Search', exact: true })
+    .getByRole('combobox', { name: 'Search options', exact: true })
     .fill(optionLabel);
   const option = popup.getByRole('option', { name: optionLabel, exact: true });
   await expect(option).toBeVisible({ timeout: 15000 });

--- a/e2e/start/import-huggingface-model-tab.spec.ts
+++ b/e2e/start/import-huggingface-model-tab.spec.ts
@@ -19,6 +19,16 @@ const openStartFromURLModal = async (page: Page) => {
   ).toBeVisible();
 };
 
+// `BAITabs`/`BAITabList` renders Astryx `TabList` items as plain `<button>`s
+// (class `astryx-tab`) inside a `navigation "Tabs"` landmark, not
+// `role="tab"` (see `start-page.spec.ts`). The active tab carries
+// `aria-current="true"` (no `aria-selected`).
+const getTabs = (page: Page) =>
+  page
+    .getByRole('dialog')
+    .filter({ hasText: 'Start From URL' })
+    .getByRole('navigation', { name: 'Tabs' });
+
 // The user-settings atom reads localStorage at app boot, so write the flag
 // and reload instead of toggling through the settings UI.
 const enableHuggingFaceImportSetting = async (page: Page) => {
@@ -44,13 +54,14 @@ test.describe(
       await navigateTo(page, 'start');
       await openStartFromURLModal(page);
 
-      await expect(page.getByRole('tab', { name: HF_TAB_NAME })).toHaveCount(0);
+      const tabs = getTabs(page);
+      await expect(tabs.getByRole('button', { name: HF_TAB_NAME })).toHaveCount(
+        0,
+      );
       // The Import Notebook tab stays the default active tab.
       await expect(
-        page
-          .locator('.ant-tabs-tab-active')
-          .filter({ hasText: /Import Notebook/i }),
-      ).toBeVisible();
+        tabs.getByRole('button', { name: /Import Notebook/i }),
+      ).toHaveAttribute('aria-current', 'true');
     });
 
     test('User sees the Hugging Face import tab first and active after enabling the experimental setting', async ({
@@ -62,11 +73,9 @@ test.describe(
       await navigateTo(page, 'start');
       await openStartFromURLModal(page);
 
-      const tabs = page.getByRole('dialog').getByRole('tab');
+      const tabs = getTabs(page).getByRole('button');
       await expect(tabs.first()).toHaveText(HF_TAB_NAME);
-      await expect(
-        page.locator('.ant-tabs-tab-active').filter({ hasText: HF_TAB_NAME }),
-      ).toBeVisible();
+      await expect(tabs.first()).toHaveAttribute('aria-current', 'true');
 
       // The form renders its key fields.
       await expect(
@@ -91,9 +100,12 @@ test.describe(
       await navigateTo(page, 'start');
       await openStartFromURLModal(page);
 
-      await expect(page.getByRole('tab', { name: HF_TAB_NAME })).toHaveCount(0);
+      const tabs = getTabs(page);
+      await expect(tabs.getByRole('button', { name: HF_TAB_NAME })).toHaveCount(
+        0,
+      );
       await expect(
-        page.getByRole('tab', { name: /Import Notebook/i }),
+        tabs.getByRole('button', { name: /Import Notebook/i }),
       ).toBeVisible();
     });
 

--- a/e2e/start/start-page.spec.ts
+++ b/e2e/start/start-page.spec.ts
@@ -311,36 +311,38 @@ test.describe(
         await card.getByRole('button', { name: 'Start Now' }).click();
 
         // 2. Verify the "Start From URL" modal opens
+        const modal = page
+          .getByRole('dialog')
+          .filter({ hasText: 'Start From URL' });
+        await expect(modal).toBeVisible();
+
+        // 3. Verify three tabs are visible. `BAITabs`/`BAITabList` renders
+        // Astryx `TabList` items as plain `<button>`s (class `astryx-tab`)
+        // inside a `navigation "Tabs"` landmark, not `role="tab"` — scope
+        // through that landmark to avoid matching the modal's other buttons.
+        const tabs = modal.getByRole('navigation', { name: 'Tabs' });
         await expect(
-          page.getByRole('dialog').filter({ hasText: 'Start From URL' }),
+          tabs.getByRole('button', { name: /Import Notebook/i }),
+        ).toBeVisible();
+        await expect(
+          tabs.getByRole('button', { name: /Import GitHub Repository/i }),
+        ).toBeVisible();
+        await expect(
+          tabs.getByRole('button', { name: /Import GitLab Repository/i }),
         ).toBeVisible();
 
-        // 3. Verify three tabs are visible
+        // 4. Verify the "Import Notebook" tab is active by default. The
+        // active tab carries `aria-current="true"` (no `aria-selected`).
         await expect(
-          page.getByRole('tab', { name: /Import Notebook/i }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('tab', { name: /Import GitHub Repository/i }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('tab', { name: /Import GitLab Repository/i }),
-        ).toBeVisible();
-
-        // 4. Verify the "Import Notebook" tab is active by default
-        await expect(
-          page
-            .locator('.ant-tabs-tab-active')
-            .filter({ hasText: /Import Notebook/i }),
-        ).toBeVisible();
+          tabs.getByRole('button', { name: /Import Notebook/i }),
+        ).toHaveAttribute('aria-current', 'true');
 
         // 5. Close the modal
         await page
           .getByRole('dialog')
           .getByRole('button', { name: 'close' })
           .click();
-        await expect(
-          page.getByRole('dialog').filter({ hasText: 'Start From URL' }),
-        ).not.toBeVisible();
+        await expect(modal).not.toBeVisible();
       });
 
       test('Admin can switch between tabs in the Start From URL modal', async ({
@@ -351,39 +353,39 @@ test.describe(
           .locator('.bai_grid_item')
           .filter({ hasText: 'Start From URL' });
         await card.getByRole('button', { name: 'Start Now' }).click();
-        await expect(
-          page.getByRole('dialog').filter({ hasText: 'Start From URL' }),
-        ).toBeVisible();
+        const modal = page
+          .getByRole('dialog')
+          .filter({ hasText: 'Start From URL' });
+        await expect(modal).toBeVisible();
+        const tabs = modal.getByRole('navigation', { name: 'Tabs' });
 
         // 2. Click the "Import GitHub Repository" tab
-        await page
-          .getByRole('tab', { name: /Import GitHub Repository/i })
+        await tabs
+          .getByRole('button', { name: /Import GitHub Repository/i })
           .click();
 
         // 3. Verify the GitHub tab is active
         await expect(
-          page.locator('.ant-tabs-tab-active').filter({ hasText: /GitHub/i }),
-        ).toBeVisible();
+          tabs.getByRole('button', { name: /GitHub/i }),
+        ).toHaveAttribute('aria-current', 'true');
 
         // 4. Click the "Import GitLab Repository" tab
-        await page
-          .getByRole('tab', { name: /Import GitLab Repository/i })
+        await tabs
+          .getByRole('button', { name: /Import GitLab Repository/i })
           .click();
 
         // 5. Verify the GitLab tab is active
         await expect(
-          page.locator('.ant-tabs-tab-active').filter({ hasText: /GitLab/i }),
-        ).toBeVisible();
+          tabs.getByRole('button', { name: /GitLab/i }),
+        ).toHaveAttribute('aria-current', 'true');
 
         // 6. Click the "Import Notebook" tab to return to default
-        await page.getByRole('tab', { name: /Import Notebook/i }).click();
+        await tabs.getByRole('button', { name: /Import Notebook/i }).click();
 
         // 7. Verify the notebook tab is active
         await expect(
-          page
-            .locator('.ant-tabs-tab-active')
-            .filter({ hasText: /Import Notebook/i }),
-        ).toBeVisible();
+          tabs.getByRole('button', { name: /Import Notebook/i }),
+        ).toHaveAttribute('aria-current', 'true');
 
         // 8. Close the modal
         await page
@@ -405,16 +407,16 @@ test.describe(
         );
 
         // 2. Verify the "Start From URL" modal opens automatically
-        await expect(
-          page.getByRole('dialog').filter({ hasText: 'Start From URL' }),
-        ).toBeVisible();
+        const modal = page
+          .getByRole('dialog')
+          .filter({ hasText: 'Start From URL' });
+        await expect(modal).toBeVisible();
 
         // 3. Verify the "Import Notebook" tab is active
+        const tabs = modal.getByRole('navigation', { name: 'Tabs' });
         await expect(
-          page
-            .locator('.ant-tabs-tab-active')
-            .filter({ hasText: /Import Notebook/i }),
-        ).toBeVisible();
+          tabs.getByRole('button', { name: /Import Notebook/i }),
+        ).toHaveAttribute('aria-current', 'true');
 
         // 4. Verify the URL input field is pre-filled with the notebook URL
         const urlInput = page.getByRole('dialog').getByRole('textbox').first();

--- a/e2e/start/start-page.spec.ts
+++ b/e2e/start/start-page.spec.ts
@@ -406,11 +406,13 @@ test.describe(
           `start?type=url&data=${encodeURIComponent(data)}`,
         );
 
-        // 2. Verify the "Start From URL" modal opens automatically
-        const modal = page
-          .getByRole('dialog')
-          .filter({ hasText: 'Start From URL' });
-        await expect(modal).toBeVisible();
+        // 2. Verify the "Start From URL" modal opens automatically. The modal
+        // is driven by the query params on first render, so it can lag a
+        // plain navigation by more than the default expect timeout — and the
+        // dialog carries "Start From URL" as its accessible name, so match on
+        // that rather than filtering the whole dialog by text.
+        const modal = page.getByRole('dialog', { name: 'Start From URL' });
+        await expect(modal).toBeVisible({ timeout: 20000 });
 
         // 3. Verify the "Import Notebook" tab is active
         const tabs = modal.getByRole('navigation', { name: 'Tabs' });

--- a/e2e/utils/deployment-fixtures.ts
+++ b/e2e/utils/deployment-fixtures.ts
@@ -663,8 +663,9 @@ export async function cleanupDeploymentFixtures(
  * plain `<button>` whose accessible name is the field label
  * (`aria-haspopup="dialog"`, NOT a combobox), and its popup is a
  * `role="dialog"` (aria-labelled with the same field label) hosting a search
- * `TextInput` with `role="combobox"` named "Search" plus a `role="listbox"`
- * of plain, clickable `role="option"` rows.
+ * `TextInput` with `role="combobox"` named "Search options"
+ * (`comp:BAIComplexSelect.SearchOptions`, FR-3603 / #8914) plus a
+ * `role="listbox"` of plain, clickable `role="option"` rows.
  *
  * Both selects search SERVER-side (the search text drives a refetch), so
  * after typing, the row for `optionName` only exists once the search
@@ -685,7 +686,7 @@ export async function selectRevisionModalOption(
   const popup = page.getByRole('dialog', { name: fieldLabel, exact: true });
   await expect(popup).toBeVisible({ timeout: 10000 });
   await popup
-    .getByRole('combobox', { name: 'Search', exact: true })
+    .getByRole('combobox', { name: 'Search options', exact: true })
     .fill(optionName);
   const option = popup.getByRole('option', { name: optionName }).first();
   await expect(option).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
Produced automatically by the **daily digest auto-heal** (2026-08-27 run), then **rebased onto main and re-healed on 2026-09-01** after the original measurements went stale. No Jira issue — this is test-side maintenance only.

All changes are confined to `e2e/**`. No application source was touched.

## Why this was re-done

The 2026-08-27 heal was measured that day and the branch then sat **76 commits behind main**. Re-run against the live app on 2026-09-01, only 5 of the 16 tests it claimed to have fixed still passed: the app had drifted again, and the first pass had also left `rbac-role-detail.spec.ts` full of antd selectors it reported as healed (46 `.ant-*` locators, which cannot match anything — antd is not a dependency).

Every locator in this PR has now been **measured against the running app**, not inferred.

## Measured contract changes

| What | Was | Is |
|---|---|---|
| Page + drawer tab strips | `getByRole('tab', …)` | `BAICard`'s `tabList` renders `nav[aria-label="Tabs"]` of plain `<button>`s; active one carries `aria-current="true"` (the contract `rbac-role-list.spec.ts` already uses) |
| Project Domain trigger | `button` named `Domain` | Astryx Selector names itself label+placeholder → `"Domain Select Domain"` |
| Preset Runtime trigger | `"Runtime info"` | `"Runtime info Runtime"` |
| Add Permission fields | antd selects `#entityType` / `#operation` | Astryx Selector buttons that double their label (`"Permission Permission"`) |
| BAITable column headers | name == visible label | name absorbs the sort/resize controls (`"Sort by name Resize column name"`) → match text |
| `radio` "Active" | `{ name: 'Active' }` | accessible-name matching is substring-based and also hits **"Inactive"** → `exact: true` required |
| Role drawer | `.ant-drawer` / `.ant-drawer-content-wrapper` | `dialog` named `"RBAC Role Info"`; close control is `"Close"`; two `"Refresh"` buttons exist, so `.first()` |
| Confirm / purge modals | `.ant-modal` + `#confirmText` | `dialog` named for the action; the confirm input is the dialog's only `textbox` |
| Toasts / empty state / rows | `.ant-message-notice-wrapper`, `.ant-empty-description`, `.ant-tabs-tabpane-active .ant-table-row` | `getByRole('alert')`, `heading "No data to display"`, `getByRole('row')` minus the header row |

Two cleanup paths were failing on **state**, not locators, and were stabilised: the project row actions are hover-revealed on a ~2500px-wide table against a 1280px viewport, so hovering the row scrolls its centre into view and pushes the action buttons off-screen. `project-crud`'s filter test now self-cleans while its filter still narrows the table to a single row.

## Verification

Run against the live app (all 34 tests in the five specs), same runner, back to back:

| | passed | failed |
|---|---|---|
| `main` | 9 | 21 (+4 did not run) |
| this branch, before the re-heal | 14 | 16 (+4 did not run) |
| **this branch now** | **27** | **7** |

No regressions: nothing that passes on `main` fails here.

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript **PASS**. (`Astryx theme build` fails on a stale `backend.ai-ui` dist in the runner's checkout, identically to a clean `main`; this diff touches only `e2e/**` `.ts` files.)

## Still red — app-side, not locator drift

These seven are **not** fixable from the test side, and the heal deliberately stops at the app boundary:

- **6 × RBAC** (`Permissions Management` ×3, `Role Assignments` ×3) — every one depends on `createTestRole()`, and creating a role is broken. Filling the modal correctly (Scope Type = Domain, Target = default) and pressing OK leaves the dialog open with no visible error. This is the same failure the 2026-08-27 run reported as `scope_id must be a valid UUID for scope_type 'domain', got 'default'`, still unfixed five days later, and still the likely root cause of the long-open `rbac create-role-modal-stuck` ledger item. Their locators have been healed against the measured Add Permission / drawer contract, but **could not be verified end to end** behind this blocker.
- **1 × `start-page` "User can see all expected quick-action cards"** — the regular user's Start page renders `heading "An error has occurred."` behind *"No resource group is assigned to this project. Session creation and deployment creation will be restricted."* The cards never render.

## Separate finding for a human

The **Create Project** modal's name field exposes a raw i18n key as its accessible name: `comp:BAIProjectSettingModal.ProjectName`. The translation key is missing, so the untranslated key is what screen readers announce and what sits next to the visible "Name" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
