### PR TITLE
fix(FR-3681): restore scroll={{ x: 'max-content' }} on the two tables the batch sweeps left out

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -426,6 +426,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
         </BAIFlex>
 
         <BAITable
+          scroll={{ x: 'max-content' }}
           rowKey="name"
           dataSource={files?.items}
           columns={tableColumns}

--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -104,6 +104,7 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
         {/* No `scroll` prop: Astryx's scroll wrapper owns overflow here, and
             these columns take their floors from `minWidth`. */}
         <BAITable<KeypairType>
+          scroll={{ x: 'max-content' }}
           size="small"
           resizable
           pagination={false}


### PR DESCRIPTION
Resolves #9071 (FR-3681)

> **Scope note (after rebasing onto `main`).** This PR originally restored `scroll={{ x: 'max-content' }}` on all 63 `BAITable` call sites the Astryx migration had stripped. While it was open, #9153 (batch 1/2) and #9154 (batch 2/2) landed the same restoration on 61 of them. Rebased, what remains here is exactly the two files those sweeps **deliberately skipped** because in-progress tickets under another assignee own them:
>
> | File | Owning ticket | Status |
> |---|---|---|
> | `react/src/components/GeneratedKeypairListModal.tsx` | FR-3519 (Access Key copy button clipped) | In Progress — #8709 closed unmerged |
> | `packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx` | FR-3669 (⋮ action clipped by Controls width) | In Progress — related #9062 open |
>
> #9153's analysis: both tickets are the same 120px `proportional(1)` pin that `scroll.x` lifts. Whether these two hunks land here or through FR-3519 / FR-3669 is the ticket owners' call — this PR is parked as a draft until that is decided.

## What

Re-add `scroll={{ x: 'max-content' }}` to the two remaining `BAITable`s that carried it before `7d7b42388`. With it `BAITable` switches to `table-layout: auto` + `width: max-content` and releases the width-less columns' `max-width`, so the table grows to its content and Astryx's scroll wrapper scrolls it horizontally — the pre-migration behaviour (see `BAITable.scrollX.test.tsx`).

`GeneratedKeypairListModal` also carried `y: 500` pre-migration; the height cap is out of scope here (the issue is about width).

## Background (kept from the original description)

Pre-migration (`7d7b42388^`) there were 70 `scroll={{ x: 'max-content' }}` sites across 67 files; the migration removed all of them and FR-3500 (`788faeeb5`) revived the contract on `BAITable` without restoring any call site, so every one of those tables rendered with `table-layout: fixed` and equal-width columns. On the deployment Replicas card that was 7 × 142px — the clipping in the issue's screenshot. That mechanism is now fixed on `main` by #9153/#9154; the before/after below was measured on the original 63-file branch and still describes the mechanism.

## Screenshots (measured on the pre-rebase branch, deployment Replicas card, 992px)

| Before (`table-layout: fixed`, 7 × 142px) | After (`auto`, 1101px, scrolls) |
|---|---|
| ![replicas before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9175/20260827-074523-fr3681-replicas-before.png) | ![replicas after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9175/20260827-074523-fr3681-replicas-after.png) |

The remaining 100px ellipsis on Replica ID / Revision ID is `BAIId`'s own clamp (FR-3608), unchanged.

## Verification

- `bash scripts/verify.sh` on the rebased branch → `=== ALL PASS ===`
- `pnpm exec vitest run src/components/Table` (backend.ai-ui) → 7 files, 42 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFxXg7JLeHzWPvG5UQASwQ
