### PR TITLE
fix(FR-3703): restore BAITable's invalid-page empty state

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
@@ -116,48 +116,36 @@ describe('BAITable invalid page number (FR-3703)', () => {
     expect(onChange).toHaveBeenCalledWith(1, 10);
   });
 
-  it('hides a first page the server returned for a page below 1', () => {
+  it.each([
     // `?current=0` maps to offset 0, so the server answers with page 1; the
     // caller still holds an invalid page, so the rows stay hidden.
-    const onChange = vi.fn();
-    renderTable({
-      dataSource: makeRows(10),
-      pagination: { current: 0, pageSize: 10, total: 177, onChange },
-    });
+    ['server-sliced', { dataSource: makeRows(10), total: 177 }],
+    ['client-side', { dataSource: makeRows(25), total: undefined }],
+  ])(
+    'hides a %s list while the page is below 1',
+    (_label, { dataSource, total }) => {
+      renderTable({
+        dataSource,
+        pagination: { current: 0, pageSize: 10, total },
+      });
 
-    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
-    expect(screen.queryByText('row-1')).not.toBeInTheDocument();
-  });
+      expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+      expect(screen.queryByText('row-1')).not.toBeInTheDocument();
+    },
+  );
 
-  it('hides a client-side list too while the page is out of range', () => {
-    renderTable({
-      dataSource: makeRows(25),
-      pagination: { current: 0, pageSize: 10 },
-    });
-
-    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
-    expect(screen.queryByText('row-1')).not.toBeInTheDocument();
-  });
-
-  it('wins over a caller-provided empty state', () => {
+  it.each([
+    ['a string', 'Custom empty'],
+    ['false', false],
+  ])('wins over a caller-provided empty state of %s', (_label, emptyState) => {
     renderTable({
       dataSource: [],
-      emptyState: 'Custom empty',
+      emptyState,
       pagination: OUT_OF_RANGE,
     });
 
     expect(screen.getByText('Invalid page number')).toBeInTheDocument();
     expect(screen.queryByText('Custom empty')).not.toBeInTheDocument();
-  });
-
-  it('wins even over an opted-out empty state', () => {
-    renderTable({
-      dataSource: [],
-      emptyState: false,
-      pagination: OUT_OF_RANGE,
-    });
-
-    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
   });
 
   it('treats an empty result set as no data, not an invalid page', () => {

--- a/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
@@ -2,8 +2,10 @@
  Client-side slicing, plus the server-sliced case it must not re-slice.
  Mechanism + affected call sites: FR-3563.
 
- Also the out-of-range page empty state (FR-3703): a page past the last one
- shows a recovery affordance instead of "No data to display".
+ Also the out-of-range page state (FR-3703): a page outside [1, last] hides
+ whatever rows were handed over — on both bounds, server- or client-sliced —
+ behind a recovery affordance instead of "No data to display" or a silently
+ clamped page.
 */
 import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
@@ -81,17 +83,17 @@ describe('BAITable pagination (FR-3563)', () => {
     expect(screen.getByText('row-25')).toBeInTheDocument();
   });
 
-  it('clamps a page that a shrinking list left stranded', () => {
-    // Still longer than a page after the filter, so this reaches the slice
-    // instead of short-circuiting on `length <= pageSize` (which made it vacuous).
+  it('shows the recovery state, not a clamped page, when a shrinking list strands the page', () => {
+    // 25 rows on page 5 of 10: the page no longer exists, so the rows are
+    // hidden behind the invalid-page state instead of silently showing page 3.
     renderTable({
       dataSource: makeRows(25),
       pagination: { current: 5, pageSize: 10 },
     });
 
-    expect(screen.queryByText('row-20')).not.toBeInTheDocument();
-    expect(screen.getByText('row-21')).toBeInTheDocument();
-    expect(screen.getByText('row-25')).toBeInTheDocument();
+    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+    expect(screen.queryByText('row-21')).not.toBeInTheDocument();
+    expect(screen.queryByText('row-1')).not.toBeInTheDocument();
   });
 });
 
@@ -112,6 +114,29 @@ describe('BAITable invalid page number (FR-3703)', () => {
       screen.getByRole('button', { name: 'Go to first page' }),
     );
     expect(onChange).toHaveBeenCalledWith(1, 10);
+  });
+
+  it('hides a first page the server returned for a page below 1', () => {
+    // `?current=0` maps to offset 0, so the server answers with page 1; the
+    // caller still holds an invalid page, so the rows stay hidden.
+    const onChange = vi.fn();
+    renderTable({
+      dataSource: makeRows(10),
+      pagination: { current: 0, pageSize: 10, total: 177, onChange },
+    });
+
+    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+    expect(screen.queryByText('row-1')).not.toBeInTheDocument();
+  });
+
+  it('hides a client-side list too while the page is out of range', () => {
+    renderTable({
+      dataSource: makeRows(25),
+      pagination: { current: 0, pageSize: 10 },
+    });
+
+    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+    expect(screen.queryByText('row-1')).not.toBeInTheDocument();
   });
 
   it('wins over a caller-provided empty state', () => {

--- a/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
@@ -1,10 +1,14 @@
 /*
  Client-side slicing, plus the server-sliced case it must not re-slice.
  Mechanism + affected call sites: FR-3563.
+
+ Also the out-of-range page empty state (FR-3703): a page past the last one
+ shows a recovery affordance instead of "No data to display".
 */
 import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 interface Row {
   id: string;
@@ -88,5 +92,68 @@ describe('BAITable pagination (FR-3563)', () => {
     expect(screen.queryByText('row-20')).not.toBeInTheDocument();
     expect(screen.getByText('row-21')).toBeInTheDocument();
     expect(screen.getByText('row-25')).toBeInTheDocument();
+  });
+});
+
+describe('BAITable invalid page number (FR-3703)', () => {
+  const OUT_OF_RANGE = { current: 20, pageSize: 10, total: 177 };
+
+  it('offers a way back when a server-sliced page is past the last one', async () => {
+    const onChange = vi.fn();
+    renderTable({
+      dataSource: [],
+      pagination: { ...OUT_OF_RANGE, onChange },
+    });
+
+    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+    expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Go to first page' }),
+    );
+    expect(onChange).toHaveBeenCalledWith(1, 10);
+  });
+
+  it('wins over a caller-provided empty state', () => {
+    renderTable({
+      dataSource: [],
+      emptyState: 'Custom empty',
+      pagination: OUT_OF_RANGE,
+    });
+
+    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+    expect(screen.queryByText('Custom empty')).not.toBeInTheDocument();
+  });
+
+  it('wins even over an opted-out empty state', () => {
+    renderTable({
+      dataSource: [],
+      emptyState: false,
+      pagination: OUT_OF_RANGE,
+    });
+
+    expect(screen.getByText('Invalid page number')).toBeInTheDocument();
+  });
+
+  it('treats an empty result set as no data, not an invalid page', () => {
+    // A filter matching nothing while the caller sits on page 3.
+    renderTable({
+      dataSource: [],
+      pagination: { current: 3, pageSize: 10, total: 0 },
+    });
+
+    expect(screen.getByText('No data to display')).toBeInTheDocument();
+    expect(screen.queryByText('Invalid page number')).not.toBeInTheDocument();
+  });
+
+  it('leaves a valid last page alone', () => {
+    renderTable({
+      dataSource: makeRows(7),
+      pagination: { current: 18, pageSize: 10, total: 177 },
+    });
+
+    expect(screen.getByText('row-1')).toBeInTheDocument();
+    expect(screen.getByText('row-7')).toBeInTheDocument();
+    expect(screen.queryByText('Invalid page number')).not.toBeInTheDocument();
   });
 });

--- a/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
@@ -222,11 +222,14 @@ export const Default: Story = {
   },
 };
 
-const clientPagedData = Array.from({ length: 42 }, (_unused, index) => ({
-  ...sampleData[index % sampleData.length],
-  key: `p${index + 1}`,
-  name: `Person ${index + 1}`,
-}));
+const makePeople = (count: number, keyPrefix: string) =>
+  Array.from({ length: count }, (_unused, index) => ({
+    ...sampleData[index % sampleData.length],
+    key: `${keyPrefix}${index + 1}`,
+    name: `Person ${index + 1}`,
+  }));
+
+const clientPagedData = makePeople(42, 'p');
 
 export const ClientSidePagination: Story = {
   name: 'Client-side Pagination',
@@ -247,24 +250,7 @@ export const ClientSidePagination: Story = {
   },
 };
 
-const SERVER_TOTAL = 177;
-const serverPage = (page: number, pageSize: number) =>
-  Array.from(
-    {
-      length: Math.max(
-        0,
-        Math.min(pageSize, SERVER_TOTAL - (page - 1) * pageSize),
-      ),
-    },
-    (_unused, index) => {
-      const n = (page - 1) * pageSize + index + 1;
-      return {
-        ...sampleData[index % sampleData.length],
-        key: `s${n}`,
-        name: `Person ${n}`,
-      };
-    },
-  );
+const serverPagedData = makePeople(177, 's');
 
 export const InvalidPage: Story = {
   name: 'Invalid Page Number',
@@ -282,12 +268,15 @@ export const InvalidPage: Story = {
     return (
       <BAITable
         columns={sampleColumns}
-        dataSource={serverPage(page, pageSize)}
+        dataSource={serverPagedData.slice(
+          (page - 1) * pageSize,
+          page * pageSize,
+        )}
         pagination={{
           current: page,
           pageSize,
-          total: SERVER_TOTAL,
-          onChange: (nextPage) => setPage(nextPage),
+          total: serverPagedData.length,
+          onChange: setPage,
         }}
       />
     );

--- a/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
@@ -247,6 +247,27 @@ export const ClientSidePagination: Story = {
   },
 };
 
+export const InvalidPage: Story = {
+  name: 'Invalid Page Number',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A server-sliced page past the last one: the caller fetched page 20 of a 177-row result set and got nothing back. Instead of "No data to display", the body offers a way back to the first page (FR-3703).',
+      },
+    },
+  },
+  args: {
+    columns: sampleColumns,
+    dataSource: [],
+    pagination: {
+      current: 20,
+      pageSize: 10,
+      total: 177,
+    },
+  },
+};
+
 export const HorizontalScroll: Story = {
   name: 'Horizontal Scroll (scroll.x)',
   parameters: {

--- a/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
@@ -247,24 +247,50 @@ export const ClientSidePagination: Story = {
   },
 };
 
+const SERVER_TOTAL = 177;
+const serverPage = (page: number, pageSize: number) =>
+  Array.from(
+    {
+      length: Math.max(
+        0,
+        Math.min(pageSize, SERVER_TOTAL - (page - 1) * pageSize),
+      ),
+    },
+    (_unused, index) => {
+      const n = (page - 1) * pageSize + index + 1;
+      return {
+        ...sampleData[index % sampleData.length],
+        key: `s${n}`,
+        name: `Person ${n}`,
+      };
+    },
+  );
+
 export const InvalidPage: Story = {
   name: 'Invalid Page Number',
   parameters: {
     docs: {
       description: {
         story:
-          'A server-sliced page past the last one: the caller fetched page 20 of a 177-row result set and got nothing back. Instead of "No data to display", the body offers a way back to the first page (FR-3703).',
+          'A server-sliced page past the last one: the caller holds page 20 of a 177-row result set and the server returned nothing. Instead of "No data to display", the body offers a way back; "Go to first page" resets the caller\'s page through `pagination.onChange`, which is what refetches (FR-3703).',
       },
     },
   },
-  args: {
-    columns: sampleColumns,
-    dataSource: [],
-    pagination: {
-      current: 20,
-      pageSize: 10,
-      total: 177,
-    },
+  render: () => {
+    const [page, setPage] = useState(20);
+    const pageSize = 10;
+    return (
+      <BAITable
+        columns={sampleColumns}
+        dataSource={serverPage(page, pageSize)}
+        pagination={{
+          current: page,
+          pageSize,
+          total: SERVER_TOTAL,
+          onChange: (nextPage) => setPage(nextPage),
+        }}
+      />
+    );
   },
 };
 

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -661,11 +661,6 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     total > 0 &&
     (currentPage < 1 || currentPage > lastPage);
 
-  const goToPage = (page: number, pageSize = currentPageSize) => {
-    setCurrentPage(page);
-    if (pagination) pagination.onChange?.(page, pageSize);
-  };
-
   // A `total` larger than the rows we were handed is the caller declaring them
   // already sliced server-side, so honour that and never re-slice — otherwise
   // a page past the first indexes past the end and renders nothing.
@@ -1247,7 +1242,10 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
         <Button
           variant="primary"
           label={String(t('comp:BAITable.GoToFirstPage'))}
-          onClick={() => goToPage(1)}
+          onClick={() => {
+            setCurrentPage(1);
+            pagination?.onChange?.(1, currentPageSize);
+          }}
         />
       }
     />
@@ -1359,10 +1357,14 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
                 }
                 size={pagination?.size ?? 'sm'}
                 label={String(t('comp:BAITable.Pagination'))}
-                onChange={goToPage}
+                onChange={(page) => {
+                  setCurrentPage(page);
+                  pagination?.onChange?.(page, currentPageSize);
+                }}
                 onPageSizeChange={(pageSize) => {
+                  setCurrentPage(1);
                   setCurrentPageSize(pageSize);
-                  goToPage(1, pageSize);
+                  pagination?.onChange?.(1, pageSize);
                 }}
               />
             </>

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -37,6 +37,7 @@
 import { useControllableValue } from '../../hooks';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { theme } from '../../theme-shim';
+import BAIButton from '../BAIButton';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
 import BAIPaginationInfoText from './BAIPaginationInfoText';
 import './BAITable.css';
@@ -55,7 +56,6 @@ import {
   isColumnVisible,
   renderColumnTitle,
 } from './tableTypes';
-import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
@@ -1239,14 +1239,15 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
       icon={EMPTY_STATE_ICON}
       title={String(t('comp:BAITable.InvalidPageNumber'))}
       actions={
-        <Button
-          variant="primary"
-          label={String(t('comp:BAITable.GoToFirstPage'))}
+        <BAIButton
+          type="primary"
           onClick={() => {
             setCurrentPage(1);
             pagination?.onChange?.(1, currentPageSize);
           }}
-        />
+        >
+          {t('comp:BAITable.GoToFirstPage')}
+        </BAIButton>
       }
     />
   ) : resolvedEmptyState === false ? (

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -55,6 +55,7 @@ import {
   isColumnVisible,
   renderColumnTitle,
 } from './tableTypes';
+import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
@@ -656,6 +657,13 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     Math.max(1, Math.ceil(total / currentPageSize)),
   );
 
+  // The UNclamped page is what the caller's state / URL still holds. `total: 0`
+  // is "no data", not an invalid page (FR-3703).
+  const isPageOutOfRange =
+    pagination !== false &&
+    total > 0 &&
+    (currentPage < 1 || currentPage > Math.ceil(total / currentPageSize));
+
   // A `total` larger than the rows we were handed is the caller declaring them
   // already sliced server-side, so honour that and never re-slice — otherwise
   // a page past the first indexes past the end and renders nothing.
@@ -1225,18 +1233,35 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   // Korean UI. Owning the node moves the copy onto BUI's catalog and restores
   // the icon. `false` opts out; a ReactNode override passes through unwrapped.
   const resolvedEmptyState = emptyState ?? locale?.emptyText;
-  const emptyStateNode =
-    resolvedEmptyState === false ? (
-      false
-    ) : resolvedEmptyState == null || typeof resolvedEmptyState === 'string' ? (
-      <EmptyState
-        isCompact
-        icon={<Icon icon={Inbox} size="lg" color="secondary" />}
-        title={resolvedEmptyState ?? String(t('comp:BAITable.NoDataToDisplay'))}
-      />
-    ) : (
-      resolvedEmptyState
-    );
+  const emptyStateNode = isPageOutOfRange ? (
+    // Product decision (FR-3703): the recovery affordance outranks any
+    // caller-provided empty node, `false` included.
+    <EmptyState
+      isCompact
+      icon={<Icon icon={Inbox} size="lg" color="secondary" />}
+      title={String(t('comp:BAITable.InvalidPageNumber'))}
+      actions={
+        <Button
+          variant="primary"
+          label={String(t('comp:BAITable.GoToFirstPage'))}
+          onClick={() => {
+            setCurrentPage(1);
+            pagination?.onChange?.(1, currentPageSize);
+          }}
+        />
+      }
+    />
+  ) : resolvedEmptyState === false ? (
+    false
+  ) : resolvedEmptyState == null || typeof resolvedEmptyState === 'string' ? (
+    <EmptyState
+      isCompact
+      icon={<Icon icon={Inbox} size="lg" color="secondary" />}
+      title={resolvedEmptyState ?? String(t('comp:BAITable.NoDataToDisplay'))}
+    />
+  ) : (
+    resolvedEmptyState
+  );
 
   return (
     <div className={className} style={style}>

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -130,6 +130,8 @@ const EXPAND_COLUMN_WIDTH_AFTER_SELECTION = 40;
 /** Marker field placed on the synthetic detail rows. */
 const DETAIL_ROW_MARKER = '__bai_detail_for__';
 
+const EMPTY_STATE_ICON = <Icon icon={Inbox} size="lg" color="secondary" />;
+
 const isDetailRow = (item: unknown): item is Record<string, unknown> =>
   !!item &&
   typeof item === 'object' &&
@@ -648,37 +650,36 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     ? (pagination.total ?? sortedRows.length)
     : sortedRows.length;
 
-  // The pager and range text show a page that exists; the rows below decide
-  // separately whether the caller's page is valid.
-  const activePage = _.clamp(
-    currentPage,
-    1,
-    Math.max(1, Math.ceil(total / currentPageSize)),
-  );
-
-  // The UNclamped page is what the caller's state / URL still holds. `total: 0`
-  // is "no data", not an invalid page (FR-3703).
+  const lastPage = Math.max(1, Math.ceil(total / currentPageSize));
+  // Filtering can shrink the list under the page the user is on; clamp for
+  // display instead of setting state during render, as antd's `usePagination`
+  // does.
+  const activePage = _.clamp(currentPage, 1, lastPage);
+  // `total: 0` is "no data", not an invalid page (FR-3703).
   const isPageOutOfRange =
     pagination !== false &&
     total > 0 &&
-    (currentPage < 1 || currentPage > Math.ceil(total / currentPageSize));
+    (currentPage < 1 || currentPage > lastPage);
+
+  const goToPage = (page: number, pageSize = currentPageSize) => {
+    setCurrentPage(page);
+    if (pagination) pagination.onChange?.(page, pageSize);
+  };
 
   // A `total` larger than the rows we were handed is the caller declaring them
   // already sliced server-side, so honour that and never re-slice — otherwise
   // a page past the first indexes past the end and renders nothing.
   const isServerSliced = total > sortedRows.length;
-  // Out of range, whatever was handed over is not the page the caller holds:
-  // hide it behind the recovery state on both bounds (FR-3703).
-  const rows = isPageOutOfRange
-    ? []
-    : pagination !== false &&
-        !isServerSliced &&
-        sortedRows.length > currentPageSize
+  const pagedRows =
+    pagination !== false &&
+    !isServerSliced &&
+    sortedRows.length > currentPageSize
       ? sortedRows.slice(
           (activePage - 1) * currentPageSize,
           activePage * currentPageSize,
         )
       : sortedRows;
+  const rows = isPageOutOfRange ? [] : pagedRows;
 
   /* ---- expandable -------------------------------------------------------- */
 
@@ -1240,16 +1241,13 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     // caller-provided empty node, `false` included.
     <EmptyState
       isCompact
-      icon={<Icon icon={Inbox} size="lg" color="secondary" />}
+      icon={EMPTY_STATE_ICON}
       title={String(t('comp:BAITable.InvalidPageNumber'))}
       actions={
         <Button
           variant="primary"
           label={String(t('comp:BAITable.GoToFirstPage'))}
-          onClick={() => {
-            setCurrentPage(1);
-            pagination?.onChange?.(1, currentPageSize);
-          }}
+          onClick={() => goToPage(1)}
         />
       }
     />
@@ -1258,7 +1256,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   ) : resolvedEmptyState == null || typeof resolvedEmptyState === 'string' ? (
     <EmptyState
       isCompact
-      icon={<Icon icon={Inbox} size="lg" color="secondary" />}
+      icon={EMPTY_STATE_ICON}
       title={resolvedEmptyState ?? String(t('comp:BAITable.NoDataToDisplay'))}
     />
   ) : (
@@ -1361,14 +1359,10 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
                 }
                 size={pagination?.size ?? 'sm'}
                 label={String(t('comp:BAITable.Pagination'))}
-                onChange={(page) => {
-                  setCurrentPage(page);
-                  pagination?.onChange?.(page, currentPageSize);
-                }}
+                onChange={goToPage}
                 onPageSizeChange={(pageSize) => {
-                  setCurrentPage(1);
                   setCurrentPageSize(pageSize);
-                  pagination?.onChange?.(1, pageSize);
+                  goToPage(1, pageSize);
                 }}
               />
             </>

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -648,9 +648,8 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     ? (pagination.total ?? sortedRows.length)
     : sortedRows.length;
 
-  // Filtering can shrink the list under the page the user is on; clamp for
-  // display instead of setting state during render, as antd's `usePagination`
-  // does.
+  // The pager and range text show a page that exists; the rows below decide
+  // separately whether the caller's page is valid.
   const activePage = _.clamp(
     currentPage,
     1,
@@ -668,10 +667,13 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   // already sliced server-side, so honour that and never re-slice — otherwise
   // a page past the first indexes past the end and renders nothing.
   const isServerSliced = total > sortedRows.length;
-  const rows =
-    pagination !== false &&
-    !isServerSliced &&
-    sortedRows.length > currentPageSize
+  // Out of range, whatever was handed over is not the page the caller holds:
+  // hide it behind the recovery state on both bounds (FR-3703).
+  const rows = isPageOutOfRange
+    ? []
+    : pagination !== false &&
+        !isServerSliced &&
+        sortedRows.length > currentPageSize
       ? sortedRows.slice(
           (activePage - 1) * currentPageSize,
           activePage * currentPageSize,


### PR DESCRIPTION
Resolves #9115 (FR-3703)

applied test server: https://fr-3703.seungwon.10-82-0-159.sslip.io/

## Problem

The "Invalid page number" + "Go to first page" empty state that FR-1678 (#4834) added to `BAITable` was dropped in the Astryx migration (#8626). Only the display clamp on the pager survived, so a table whose page fell out of range — deleting every row on the last page (the issue's repro), or a stale `?current=` in the URL — showed **"No data to display"** (or, below page 1, silently rendered the first page the server answered with) while the pager highlighted a valid-looking page. The caller's state / URL still held the invalid page, and nothing told the user why or how to get back. Both i18n keys were still shipped in all 21 BUI locales as dead keys.

## Fix (`packages/backend.ai-ui/src/components/Table/BAITable.tsx`)

- `isPageOutOfRange` is judged from the **unclamped** `currentPage` (what the caller actually holds) against `[1, ceil(total / pageSize)]`. `total === 0` is "no data", not an invalid page.
- **While out of range — either bound, server- or client-sliced — the rows are hidden** and the body renders an Astryx `EmptyState` titled `comp:BAITable.InvalidPageNumber` with a primary `comp:BAITable.GoToFirstPage` action that calls `setCurrentPage(1)` + `pagination.onChange(1, pageSize)`, so URL-backed callers (`useBAIPaginationOptionStateOnSearchParam`) refetch page 1. This is the antd-era contract: the inner antd `Table` had no `total`, so an out-of-range `current` sliced to nothing and the recovery state showed on both bounds.
- **The invalid-page state outranks any caller-provided `emptyState` / `locale.emptyText`, `false` included.** Product decision: a recovery affordance must never be suppressed by a custom empty node.
- The pager / range text keep the display clamp (antd's rc-pagination clamped its display too). Client-side slicing of a *valid* page is untouched; the FR-3563 "clamp a stranded page" test now expects the recovery state instead of a silently clamped page 3, per the rule above.

Note: the issue's "Expected" describes an automatic fall-back to the previous page. This PR restores the explicit recovery affordance FR-1678 chose instead; auto-correction (extra fetch, risk of resetting on a transiently stale `total`, silent URL change) is left as a separate discussion.

## Tests

`BAITable.pagination.test.tsx` — 7 cases under FR-3703: out-of-range server-sliced page shows the affordance and the button calls `onChange(1, 10)`; a page below 1 hides the first-page rows the server returned (server- and client-sliced); it wins over `emptyState: 'Custom empty'` and `emptyState: false`; `total: 0` on page 3 stays "No data to display"; a valid last page renders its rows. Storybook: `BAITable › Invalid Page Number` (stateful — the button walks the demo back to a populated page 1).

## Review

Copilot pass 1 (story button non-functional) and pass 2 (lower bound never reached the recovery state) both applied; pass 2's fix was not itself re-reviewed by Copilot (two-pass cap).

## Verification

- `pnpm exec vitest run` (BAITable pagination + emptyState): 2 files, 20 tests passed
- `bash scripts/verify.sh`: `=== ALL PASS ===`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
