### PR TITLE
fix(FR-3695): stop `keep-all` removing every line break in Japanese and Chinese

### DIFF
--- a/react/src/components/BAIPanelItem.tsx
+++ b/react/src/components/BAIPanelItem.tsx
@@ -47,7 +47,6 @@ const BAIPanelItem: React.FC<BAIPanelItemProps> = ({
         <Text
           style={{
             fontSize: token.fontSizeHeading5,
-            wordBreak: 'keep-all',
             textAlign: 'left',
           }}
         >

--- a/react/src/components/BrandingSettingItems/LogoPreviewer.tsx
+++ b/react/src/components/BrandingSettingItems/LogoPreviewer.tsx
@@ -62,9 +62,7 @@ const LogoPreviewer: React.FC<LogoPreviewerProps> = ({ mode }) => {
   return (
     <BAIFlex gap="sm" align="stretch" direction="column">
       <BAIFlex gap="sm">
-        <Text color="secondary" style={{ wordBreak: 'keep-all' }}>
-          {t('userSettings.logo.ImagePath')}:
-        </Text>
+        <Text color="secondary">{t('userSettings.logo.ImagePath')}:</Text>
         {/* PILOT-DECISION: antd `Space.Compact` fused the text input and the
             upload trigger into one bordered unit (MAPPING §4: Space.Compact
             -> ButtonGroup, but these are two DIFFERENT field types, not a

--- a/react/src/components/BrandingSettingItems/LogoSizeSettingItem.tsx
+++ b/react/src/components/BrandingSettingItems/LogoSizeSettingItem.tsx
@@ -71,9 +71,7 @@ const LogoSizeSettingItem: React.FC<LogoSizeSettingItemProps> = ({
           wrap="nowrap"
           style={{ color: token.colorTextTertiary }}
         >
-          <Text color="secondary" style={{ wordBreak: 'keep-all' }}>
-            {t('userSettings.logo.size.Width')}:
-          </Text>
+          <Text color="secondary">{t('userSettings.logo.size.Width')}:</Text>
           <BAIUncontrolledInput
             type="number"
             defaultValue={logoSizeConfig.width?.toString() ?? ''}
@@ -88,9 +86,7 @@ const LogoSizeSettingItem: React.FC<LogoSizeSettingItemProps> = ({
           wrap="nowrap"
           style={{ color: token.colorTextTertiary }}
         >
-          <Text color="secondary" style={{ wordBreak: 'keep-all' }}>
-            {t('userSettings.logo.size.Height')}:
-          </Text>
+          <Text color="secondary">{t('userSettings.logo.size.Height')}:</Text>
           <BAIUncontrolledInput
             type="number"
             defaultValue={logoSizeConfig.height?.toString() ?? ''}

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -391,10 +391,7 @@ export const DefaultProvidersForReactRoot: React.FC<{
                         {!required && (
                           <BAIText
                             type="secondary"
-                            style={{
-                              marginLeft: token.marginXXS,
-                              wordBreak: 'keep-all',
-                            }}
+                            style={{ marginLeft: token.marginXXS }}
                           >
                             ({t('general.Optional')})
                           </BAIText>

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -95,8 +95,17 @@
   vertical-align: -0.125em !important;
 }
 
-:lang(ko) *,
-:lang(ja) *,
-:lang(zh) * {
+/* `keep-all` is a Korean-specific prescription: it stops a break landing
+   between Hangul syllables, leaving the space as the only break point.
+   Japanese and Chinese have no inter-word spaces, so the same rule left them
+   with NO break opportunity at all and the text overflowed its container
+   instead of wrapping (FR-3695). */
+:lang(ko) * {
   word-break: keep-all;
+}
+
+/* `strict` keeps CJ-class characters (ー, small kana) off the start of a line;
+   UAX #14 leaves them breakable under the `auto`/`normal` default. */
+:lang(ja) * {
+  line-break: strict;
 }

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -86,11 +86,9 @@ const NOT_FINISHED_STATUS_FILTER =
   'status != "TERMINATED" & status != "CANCELLED"';
 
 const styles = stylex.create({
-  // antd `Typography.Text style={{maxWidth:120, wordBreak:'keep-all'}}` — the
-  // title only renders on >=lg, where maxWidth was always 120.
+  // The title only renders on >=lg, where maxWidth was always 120.
   actionCardTitle: {
     maxWidth: 120,
-    wordBreak: 'keep-all',
   },
 });
 


### PR DESCRIPTION
Resolves #9103 (FR-3695)

With the UI in Japanese, the dashboard's folder-status counters painted on top of
each other — `プロジェクトフォルダー` ran 28px into `招待されたフォルダー`, and
`マイフォルダー` crossed its own column divider.

## Mechanism

`react/src/index.css` applied `word-break: keep-all` to every element under
`:lang(ko)`, `:lang(ja)` **and** `:lang(zh)`.

`keep-all` is a **Korean-specific** prescription: it suppresses the break
opportunities that would otherwise land between Hangul syllables, so a Korean
word can only break at a space. Japanese and Chinese have no inter-word spaces,
and CSS Text prohibits breaks between ID-class (ideographic) characters under
`keep-all` — so those scripts were left with **no break opportunity at all**.
The text's min-content width became the entire string, and it overflowed its
container instead of wrapping.

That is one bug with two faces:

- **width-capped container** → the text overflows sideways and paints over its
  neighbour (the dashboard counters, `PANEL_ITEM_MAX_WIDTH` = 90px);
- **clipping container** → the text runs off the edge and is cut (the Start page
  action-card descriptions, reported separately while this PR was open).

The fix scopes `keep-all` to `:lang(ko)`, which is the only language that wants
it, and adds `line-break: strict` for Japanese so a CJ-class character (`ー`, a
small kana) cannot start a line — UAX #14 leaves those breakable under the
`auto`/`normal` default.

Six inline `wordBreak: 'keep-all'` copies are also removed. Each duplicated the
global rule, so they were redundant for Korean; being inline they **outrank**
the language-scoped rule, so leaving them would have kept the bug alive at those
call sites. (`keep-all` behaves as `normal` for non-CJK text, so English and
other Latin locales are provably unaffected by their removal.)

## Measured live, `/dashboard`, ja, 1280×720

| | label widths | overlap | spill past own 90px column |
|---|---|---|---|
| before (`main` @ 6ed97ebdb) | 97 / 150 / 147px | **28px** | 7 / 60 / 57px |
| after | 90 / 90 / 90px | **0** | **0 / 0 / 0** |

Columns land at 803–893, 925–1015, 1047–1137, every panel item 90×110px, all
three values bottom-aligned at y=530 — dividers sit clear in the gaps and the
counters keep one baseline.

Re-measured in dark mode entered through the header toggle
(`document.documentElement.dataset.theme === 'dark'`): overlap 0, identical
geometry. No `pageerror` in either pass. The console errors present are
pre-existing environment noise (Google Fonts CSP from dev-only `react-grab`, the
Relay `Group`/`UserGroup` `__typename` conflict from the server, `/func/totp`
404), unrelated to this change.

### Line quality, not just "no overlap"

`line-break: strict` is what makes the wrap read correctly rather than merely
fit. Measured line splits at the same 90px column:

| | `マイフォルダー` | `招待されたフォルダー` |
|---|---|---|
| `keep-all` + `overflow-wrap: anywhere` (rejected) | `マイフォルダ` / `ー` | `招待されたフ` / `ォルダー` |
| `word-break: normal`, default `line-break` | `マイフォルダ` / `ー` | `招待されたフ` / `ォルダー` |
| **shipped** (`normal` + `line-break: strict`) | `マイフォル` / `ダー` | `招待された` / `フォルダー` |

The first row is worth recording: `overflow-wrap: anywhere` closes the overlap
just as well, but its emergency break opportunities **outrank** the kinsoku
rules, so `line-break: strict` has no effect while it is set. It was measured
and rejected on that basis, not on taste.

### Start page (the second report)

Same root cause, fixed by the same change — the `URLから開始` card description:

| | label width | card width | spill left / right |
|---|---|---|---|
| before | one unbroken line, clipped at both card edges | 233px | clipped |
| after | 193px, 3 lines | 233px | **0 / 0** |

## No regression in other locales

| locale | after the fix | overlap / spill |
|---|---|---|
| ko | `body` still computes `word-break: keep-all`; `line-break: auto`. `프로젝트` / `폴더` — breaks at the space, never mid-word. Start card: 193px in a 233px card. | 0 |
| en | `Project ` / `Folders`, `Invited ` / `Folders` — unchanged from `main`. | 0 |

Korean was the real risk here, so it was checked explicitly: dropping `keep-all`
globally would have split `프로젝트 폴더` as `프로젝트 폴` / `더` (measured). It
does not, because the rule still applies under `:lang(ko)`.

`SessionCountDashboardItem`, the other `BAIPanelItem` consumer on the same
dashboard, is pixel-identical before and after.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format,
  TypeScript, Vite warmup, StyleX `cssInjectionTarget`, Astryx theme build,
  Astryx integration, z-index ladder mirrors, Terminology — all PASS).
  A first run failed on `Astryx theme build` purely because the fresh worktree
  had no `backend.ai-ui/dist`; `pnpm --filter backend.ai-ui build` fixed it and
  the check has nothing to do with this diff.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exit 0. Its
  reported items (`BAIText.css`, `BAIResourceUnitGrid`, `astryxVars`) are
  pre-existing in `backend.ai-ui` and untouched here; this diff adds no tokens.
- `pnpm --prefix ./react exec vitest run` → 102 test files, 1629 tests, all passing.
- Live probe on `https://fr-3695.localhost:1336`, ja / ko / en, light and dark.

### Chinese — probed live, both scripts

`:lang(zh)` matches `zh-CN` and `zh-TW` by prefix, and `DefaultProviders` sets
`document.documentElement.lang` to the full tag. Both were measured on
`/dashboard` at the same 90px column:

| locale | on `main` (`keep-all`) | after |
|---|---|---|
| zh-CN | `邀请的文件夹` unbroken, 96px — **6px past its own column** | `邀请的文件` / `夹`, 90px, spill **0** |
| zh-TW | `邀請的文件夾` unbroken, 96px — **6px past its own column** | `邀請的文件` / `夾`, 90px, spill **0** |

Chinese is genuinely affected, but less visibly than Japanese: the 6px
overflow crosses the column divider without reaching the neighbouring label,
because the 32px column gap absorbs it (overlap stays 0 even on `main`). Many
Chinese strings also escape the bug entirely — they carry ASCII spaces and CJK
punctuation (`、`, `（`) that still offer break points under `keep-all`. The
Start page description measures identically before and after for that reason
(193px in a 233px card, spill 0/0), which is why the dashboard label — pure Han
with no punctuation — is the case that shows it.

## Residue

- `line-break: strict` is added for `:lang(ja)` only. That is measured, not
  assumed: applying it to the Chinese labels changes nothing, because Han
  characters are ID-class and break freely under every `line-break` value —
  the CJ class it constrains (`ー`, small kana) is Japanese-only.
- The Invited Folders **badge** branch (`invitationCount > 0`) was not exercised
  — the test cluster has no pending invitations. The zero-invitation branch of
  the same custom title node was exercised and wraps correctly.

## Screenshots — dashboard, ja

| before | after (dark) |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9181/20260827-091648-dashboard-ja-before.png" alt="dashboard folder counters in Japanese before the fix" /> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9181/20260827-091653-dashboard-ja-after-dark.png" alt="dashboard folder counters in Japanese after the fix, dark mode" /> |

## Screenshot — Start page, ja, after

![Start page in Japanese after the fix](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9181/20260827-091700-start-page-ja-after.png)

