### PR TITLE
feat(FR-3730): restore PowerSearch on Resource Policy admin tabs

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIKeypairResourcePolicyV2TableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIKeypairResourcePolicyV2TableFragment.graphql.ts
@@ -1,0 +1,201 @@
+/**
+ * @generated SignedSource<<ac8dee02b0468df1a5d7c431554660b5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type VFolderHostPermissionV2 = "CREATE_VFOLDER" | "DELETE_VFOLDER" | "DOWNLOAD_FILE" | "INVITE_OTHERS" | "MODIFY_VFOLDER" | "MOUNT_IN_SESSION" | "SET_USER_PERM" | "UPLOAD_FILE" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAIKeypairResourcePolicyV2TableFragment$data = ReadonlyArray<{
+  readonly allowedVfolderHosts: ReadonlyArray<{
+    readonly host: string;
+    readonly permissions: ReadonlyArray<VFolderHostPermissionV2>;
+  }>;
+  readonly createdAt: string | null | undefined;
+  readonly defaultForUnspecified: string;
+  readonly id: string;
+  readonly idleTimeout: number;
+  readonly maxConcurrentSessions: number;
+  readonly maxConcurrentSftpSessions: number;
+  readonly maxContainersPerSession: number;
+  readonly maxPendingSessionCount: number | null | undefined;
+  readonly maxPendingSessionResourceSlots: ReadonlyArray<{
+    readonly quantity: any | null | undefined;
+    readonly resourceType: string;
+    readonly unlimited: boolean;
+  }> | null | undefined;
+  readonly maxSessionLifetime: number;
+  readonly name: string;
+  readonly totalResourceSlots: ReadonlyArray<{
+    readonly quantity: any | null | undefined;
+    readonly resourceType: string;
+    readonly unlimited: boolean;
+  }>;
+  readonly " $fragmentType": "BAIKeypairResourcePolicyV2TableFragment";
+}>;
+export type BAIKeypairResourcePolicyV2TableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIKeypairResourcePolicyV2TableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIKeypairResourcePolicyV2TableFragment">;
+}>;
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "resourceType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "quantity",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "unlimited",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAIKeypairResourcePolicyV2TableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "defaultForUnspecified",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ResourceLimitEntry",
+      "kind": "LinkedField",
+      "name": "totalResourceSlots",
+      "plural": true,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxSessionLifetime",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxConcurrentSessions",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxPendingSessionCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ResourceLimitEntry",
+      "kind": "LinkedField",
+      "name": "maxPendingSessionResourceSlots",
+      "plural": true,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxConcurrentSftpSessions",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxContainersPerSession",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "idleTimeout",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "VFolderHostPermissionEntry",
+      "kind": "LinkedField",
+      "name": "allowedVfolderHosts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "host",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "permissions",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "KeypairResourcePolicyV2",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "1a19df2e16d3bde603641cb63be4eec7";
+
+export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIProjectResourcePolicyV2TableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIProjectResourcePolicyV2TableFragment.graphql.ts
@@ -1,0 +1,97 @@
+/**
+ * @generated SignedSource<<f8a051d53c482ea6da0b34043a1b606a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type BAIProjectResourcePolicyV2TableFragment$data = ReadonlyArray<{
+  readonly createdAt: string | null | undefined;
+  readonly id: string;
+  readonly maxNetworkCount: number;
+  readonly maxQuotaScopeSize: {
+    readonly expr: string;
+  };
+  readonly maxVfolderCount: number;
+  readonly name: string;
+  readonly " $fragmentType": "BAIProjectResourcePolicyV2TableFragment";
+}>;
+export type BAIProjectResourcePolicyV2TableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIProjectResourcePolicyV2TableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIProjectResourcePolicyV2TableFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAIProjectResourcePolicyV2TableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxVfolderCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "BinarySizeInfo",
+      "kind": "LinkedField",
+      "name": "maxQuotaScopeSize",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "expr",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxNetworkCount",
+      "storageKey": null
+    }
+  ],
+  "type": "ProjectResourcePolicyV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "991ef65e96e8516fd0f0e2bde5cf3434";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -205,6 +205,63 @@ const PAGE_FIXTURES: Array<{
     ],
   },
   {
+    page: 'KeypairResourcePolicyV2',
+    filterProperties: [
+      {
+        key: 'name',
+        propertyLabel: 'Name',
+        type: 'string',
+        fixedOperator: 'contains',
+      },
+      {
+        key: 'createdAt',
+        propertyLabel: 'Created at',
+        type: 'datetime',
+        defaultOperator: 'after',
+      },
+      {
+        key: 'maxConcurrentSessions',
+        propertyLabel: 'Concurrent sessions',
+        type: 'number',
+      },
+    ],
+    filters: [
+      { name: { contains: 'default' } },
+      { createdAt: { after: '2026-01-02T03:04:05.000Z' } },
+      { maxConcurrentSessions: { greaterThanOrEqual: 5 } },
+      {
+        AND: [
+          { name: { contains: 'gpu' } },
+          { maxConcurrentSessions: { lessThan: 10 } },
+        ],
+      },
+    ],
+  },
+  {
+    page: 'ProjectResourcePolicyV2',
+    filterProperties: [
+      {
+        key: 'name',
+        propertyLabel: 'Name',
+        type: 'string',
+        fixedOperator: 'contains',
+      },
+      { key: 'maxVfolderCount', propertyLabel: 'Max folders', type: 'number' },
+      { key: 'maxNetworkCount', propertyLabel: 'Max networks', type: 'number' },
+    ],
+    filters: [
+      { name: { contains: 'default' } },
+      { maxVfolderCount: { greaterThanOrEqual: 10 } },
+      { maxNetworkCount: { greaterThanOrEqual: 1 } },
+      {
+        AND: [
+          { name: { contains: 'gpu' } },
+          { maxVfolderCount: { lessThan: 100 } },
+        ],
+      },
+    ],
+  },
+  {
     page: 'ReservoirPage / ModelStoreListPageV2',
     filterProperties: [
       {

--- a/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.doc.ts
@@ -1,0 +1,113 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIKeypairResourcePolicyV2Table',
+  displayName: 'BAI Keypair Resource Policy V2 Table',
+  category: 'Table & List',
+  keywords: [
+    'resource policy',
+    'keypair',
+    'quota',
+    'limit',
+    'table',
+    'grid',
+    'data table',
+    'policy',
+  ],
+  usage: {
+    description:
+      'The presentational table over a plural `KeypairResourcePolicyV2` Relay fragment, used by the keypair resource policy admin page. It renders the policy name, the default-for-unspecified mode (with the tooltip explaining LIMITED vs UNLIMITED), the total resource slots as resource chips, concurrent sessions, cluster size, idle timeout, max session lifetime, the allowed storage hosts with their permission summary, max pending session count, max concurrent SFTP sessions, the pending-session resource slots, and the creation time. Unlimited values are shown as an infinity sign — a zero or null count, and a cluster size equal to the signed 32-bit ceiling, all mean "no limit". The columns the V2 order-by enum covers are server-sortable and the choice is emitted as an order string rather than sorted locally. Filtering, pagination, query orchestration and row actions belong to the consuming surface: it renders BAITable, and every remaining BAITableProps prop passes straight through.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Add the edit and delete row actions by overriding the `name` column in `customizeColumns` with a BAINameActionCell, keeping the deletion behind BAIDeleteConfirmModal with `requireConfirmInput`.',
+      },
+      {
+        guidance: true,
+        description:
+          'Translate `onChangeOrder` into the query `orderBy` and reset the offset to 0, so a re-sort starts from the first page.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep a Suspense boundary above the table — the storage-host column fetches the vfolder host permission catalog to colour each host.',
+      },
+      {
+        guidance: false,
+        description:
+          'Render an unlimited value as 0, null or 2147483647 in a custom column renderer — the built-in columns already normalize those sentinels to the infinity sign, and a second spelling of "unlimited" reads as a different setting.',
+      },
+      {
+        guidance: false,
+        description:
+          'Run pagination or filtering inside this component; pass `pagination`, `loading` and the filtered fragment references down from the page that owns the query.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'keypairResourcePoliciesFrgmt',
+      type: 'BAIKeypairResourcePolicyV2TableFragment$key',
+      description:
+        'Plural fragment reference for the `KeypairResourcePolicyV2` rows to render. Null and undefined entries are dropped before the table sees them.',
+      required: true,
+    },
+    {
+      name: 'customizeColumns',
+      type: '(baseColumns: BAIColumnsType<KeypairResourcePolicyV2InList>) => BAIColumnsType<KeypairResourcePolicyV2InList>',
+      description:
+        'Transforms the built-in column list before render — the hook for adding row actions, removing columns, or setting widths. Receives the columns in display order and must return the full list.',
+    },
+    {
+      name: 'disableSorter',
+      type: 'boolean',
+      description:
+        'Strips the `sorter` flag from every column, turning the table into a fixed-order view. Use it where the surrounding query cannot re-order.',
+    },
+    {
+      name: 'onChangeOrder',
+      type: "(order: 'name' | '-name' | 'createdAt' | … | null) => void",
+      description:
+        'Fired when the user sorts, with a key optionally prefixed by "-" for descending, or null when sorting is cleared. Convert it to the query `orderBy`; the table does not sort its own rows.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Policy list with row actions',
+      code: `<BAIKeypairResourcePolicyV2Table
+  keypairResourcePoliciesFrgmt={filterOutNullAndUndefined(
+    _.map(data.adminKeypairResourcePoliciesV2?.edges, 'node'),
+  )}
+  loading={isRefetching}
+  order={order}
+  onChangeOrder={(nextOrder) =>
+    onReload({
+      ...queryRef.variables,
+      orderBy: convertToOrderBy<KeypairResourcePolicyV2OrderBy>(nextOrder),
+      offset: 0,
+    })
+  }
+  customizeColumns={(columns) =>
+    _.map(columns, (column) =>
+      column.key === 'name'
+        ? {
+            ...column,
+            render: (name: string, record) => (
+              <BAINameActionCell
+                title={name}
+                showActions="always"
+                actions={rowActions(record)}
+              />
+            ),
+          }
+        : column,
+    )
+  }
+/>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.doc.ts
@@ -37,7 +37,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Render an unlimited value as 0, null or 2147483647 in a custom column renderer — the built-in columns already normalize those sentinels to the infinity sign, and a second spelling of "unlimited" reads as a different setting.',
+          'Render an unlimited value in a custom column renderer — the built-in columns already normalize each field\'s own sentinel (0 for the non-null Int! fields, null for maxPendingSessionCount, which allows 0 as a real value) to the infinity sign, and a second spelling of "unlimited" reads as a different setting.',
       },
       {
         guidance: false,

--- a/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.tsx
@@ -223,7 +223,7 @@ const BAIKeypairResourcePolicyV2Table = ({
         dataIndex: 'maxPendingSessionCount',
         key: 'maxPendingSessionCount',
         sorter: isEnableSorter('maxPendingSessionCount'),
-        render: (text) => (text ? text : '∞'),
+        render: (text) => (text == null ? '∞' : text),
       },
       {
         title: t(

--- a/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIKeypairResourcePolicyV2Table.tsx
@@ -1,0 +1,281 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  BAIAllowedVfolderHostsWithPermission,
+  BAIColumnsType,
+  BAIColumnType,
+  BAIFlex,
+  BAIQuestionIconWithTooltip,
+  BAIResourceNumberWithIcon,
+  BAITable,
+  BAITableProps,
+  BAIText,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  ResourceTypeIcon,
+} from '..';
+import type {
+  BAIKeypairResourcePolicyV2TableFragment$data,
+  BAIKeypairResourcePolicyV2TableFragment$key,
+} from '../__generated__/BAIKeypairResourcePolicyV2TableFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
+import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export type KeypairResourcePolicyV2InList = NonNullable<
+  BAIKeypairResourcePolicyV2TableFragment$data[number]
+>;
+
+type ResourceLimitEntry =
+  KeypairResourcePolicyV2InList['totalResourceSlots'][number];
+
+// `max_containers_per_session` is stored as the signed 32-bit ceiling when the
+// operator means "no limit", so that exact value renders as ∞.
+const SIGNED_32BIT_MAX_INT = 2147483647;
+
+const availableKeypairResourcePolicySorterKeys = [
+  'name',
+  'createdAt',
+  'maxSessionLifetime',
+  'maxConcurrentSessions',
+  'maxContainersPerSession',
+  'idleTimeout',
+  'maxConcurrentSftpSessions',
+  'maxPendingSessionCount',
+] as const;
+
+export const availableKeypairResourcePolicySorterValues = [
+  ...availableKeypairResourcePolicySorterKeys,
+  ...availableKeypairResourcePolicySorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableKeypairResourcePolicySorterKeys, key);
+};
+
+export interface BAIKeypairResourcePolicyV2TableProps extends Omit<
+  BAITableProps<KeypairResourcePolicyV2InList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  keypairResourcePoliciesFrgmt: BAIKeypairResourcePolicyV2TableFragment$key;
+  disableSorter?: boolean;
+  customizeColumns?: (
+    baseColumns: BAIColumnsType<KeypairResourcePolicyV2InList>,
+  ) => BAIColumnsType<KeypairResourcePolicyV2InList>;
+  onChangeOrder?: (
+    order: (typeof availableKeypairResourcePolicySorterValues)[number] | null,
+  ) => void;
+}
+
+const BAIKeypairResourcePolicyV2Table = ({
+  keypairResourcePoliciesFrgmt,
+  disableSorter,
+  customizeColumns,
+  onChangeOrder,
+  ...tableProps
+}: BAIKeypairResourcePolicyV2TableProps) => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  const keypairResourcePolicies =
+    useFragment<BAIKeypairResourcePolicyV2TableFragment$key>(
+      graphql`
+        fragment BAIKeypairResourcePolicyV2TableFragment on KeypairResourcePolicyV2
+        @relay(plural: true) {
+          id
+          name
+          createdAt
+          defaultForUnspecified
+          totalResourceSlots {
+            resourceType
+            quantity
+            unlimited
+          }
+          maxSessionLifetime
+          maxConcurrentSessions
+          maxPendingSessionCount
+          maxPendingSessionResourceSlots {
+            resourceType
+            quantity
+            unlimited
+          }
+          maxConcurrentSftpSessions
+          maxContainersPerSession
+          idleTimeout
+          allowedVfolderHosts {
+            host
+            permissions
+          }
+        }
+      `,
+      keypairResourcePoliciesFrgmt,
+    );
+
+  const renderResourceSlots = (
+    entries: ReadonlyArray<ResourceLimitEntry> | null | undefined,
+  ) =>
+    _.isEmpty(entries) ? (
+      '-'
+    ) : (
+      <BAIFlex gap="xxs" wrap="wrap">
+        {_.map(entries, (entry) =>
+          entry.unlimited ? (
+            <BAIFlex key={entry.resourceType} gap="xxs" align="center">
+              <ResourceTypeIcon type={entry.resourceType} />
+              <BAIText>∞</BAIText>
+            </BAIFlex>
+          ) : (
+            <BAIResourceNumberWithIcon
+              key={entry.resourceType}
+              type={entry.resourceType}
+              value={_.toString(entry.quantity)}
+            />
+          ),
+        )}
+      </BAIFlex>
+    );
+
+  const baseColumns = _.map(
+    filterOutEmpty<BAIColumnType<KeypairResourcePolicyV2InList>>([
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.Name'),
+        dataIndex: 'name',
+        key: 'name',
+        fixed: 'left',
+        sorter: isEnableSorter('name'),
+      },
+      {
+        title: (
+          <BAIFlex gap="xxs" align="center">
+            {t('comp:BAIKeypairResourcePolicyV2Table.DefaultForUnspecified')}
+            <BAIQuestionIconWithTooltip
+              title={
+                <>
+                  {t(
+                    'comp:BAIKeypairResourcePolicyV2Table.DefaultForUnspecifiedTooltipDesc1',
+                  )}
+                  <br />
+                  <br />
+                  {t(
+                    'comp:BAIKeypairResourcePolicyV2Table.DefaultForUnspecifiedTooltipDesc2',
+                  )}
+                </>
+              }
+            />
+          </BAIFlex>
+        ),
+        dataIndex: 'defaultForUnspecified',
+        key: 'defaultForUnspecified',
+        render: (text) => text ?? '-',
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.TotalResourceSlots'),
+        dataIndex: 'totalResourceSlots',
+        key: 'totalResourceSlots',
+        render: (__, row) => renderResourceSlots(row.totalResourceSlots),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.Concurrency'),
+        dataIndex: 'maxConcurrentSessions',
+        key: 'maxConcurrentSessions',
+        sorter: isEnableSorter('maxConcurrentSessions'),
+        render: (text) => (text ? text : '∞'),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.ClusterSize'),
+        dataIndex: 'maxContainersPerSession',
+        key: 'maxContainersPerSession',
+        sorter: isEnableSorter('maxContainersPerSession'),
+        render: (text) => (text === SIGNED_32BIT_MAX_INT ? '∞' : text),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.IdleTimeout'),
+        dataIndex: 'idleTimeout',
+        key: 'idleTimeout',
+        sorter: isEnableSorter('idleTimeout'),
+        render: (text) => (text ? text : '∞'),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.MaxSessionLifetime'),
+        dataIndex: 'maxSessionLifetime',
+        key: 'maxSessionLifetime',
+        sorter: isEnableSorter('maxSessionLifetime'),
+        render: (text) => (text ? text : '∞'),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.StorageNodes'),
+        dataIndex: 'allowedVfolderHosts',
+        key: 'allowedVfolderHosts',
+        render: (__, row) =>
+          _.isEmpty(row.allowedVfolderHosts) ? (
+            '-'
+          ) : (
+            <BAIAllowedVfolderHostsWithPermission
+              allowedVfolderHostEntries={row.allowedVfolderHosts}
+            />
+          ),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.MaxPendingSessionCount'),
+        dataIndex: 'maxPendingSessionCount',
+        key: 'maxPendingSessionCount',
+        sorter: isEnableSorter('maxPendingSessionCount'),
+        render: (text) => (text ? text : '∞'),
+      },
+      {
+        title: t(
+          'comp:BAIKeypairResourcePolicyV2Table.MaxConcurrentSFTPSessions',
+        ),
+        dataIndex: 'maxConcurrentSftpSessions',
+        key: 'maxConcurrentSftpSessions',
+        sorter: isEnableSorter('maxConcurrentSftpSessions'),
+        render: (text) => (text ? text : '∞'),
+      },
+      {
+        title: t(
+          'comp:BAIKeypairResourcePolicyV2Table.MaxPendingSessionResourceSlots',
+        ),
+        dataIndex: 'maxPendingSessionResourceSlots',
+        key: 'maxPendingSessionResourceSlots',
+        render: (__, row) =>
+          renderResourceSlots(row.maxPendingSessionResourceSlots),
+      },
+      {
+        title: t('comp:BAIKeypairResourcePolicyV2Table.CreatedAt'),
+        dataIndex: 'createdAt',
+        key: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
+        render: (text) => (text ? dayjs(text).format('lll') : '-'),
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  const allColumns = customizeColumns
+    ? customizeColumns(baseColumns)
+    : baseColumns;
+
+  return (
+    <BAITable
+      scroll={{ x: 'max-content' }}
+      resizable
+      rowKey="id"
+      dataSource={filterOutNullAndUndefined(keypairResourcePolicies)}
+      columns={allColumns}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableKeypairResourcePolicySorterValues)[number]) ||
+            null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default BAIKeypairResourcePolicyV2Table;

--- a/packages/backend.ai-ui/src/components/BAIProjectResourcePolicyV2Table.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIProjectResourcePolicyV2Table.doc.ts
@@ -1,0 +1,113 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIProjectResourcePolicyV2Table',
+  displayName: 'BAI Project Resource Policy V2 Table',
+  category: 'Table & List',
+  keywords: [
+    'resource policy',
+    'project',
+    'quota',
+    'limit',
+    'table',
+    'grid',
+    'data table',
+    'policy',
+  ],
+  usage: {
+    description:
+      'The presentational table over a plural `ProjectResourcePolicyV2` Relay fragment, used by the project resource policy admin page. It renders the policy name, max vfolder count, max quota scope size, max network count, the node ID, and the creation time. Unlimited values are shown as an infinity sign — a zero vfolder count, a network count of -1, and a quota scope expression of "-1" all mean "no limit" — and the quota size itself is humanized through `convertToDecimalUnit`. Every column except the ID is server-sortable and the choice is emitted as an order string rather than sorted locally. Filtering, pagination, query orchestration and row actions belong to the consuming surface: it renders BAITable, and every remaining BAITableProps prop passes straight through.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Add the edit and delete row actions by overriding the `name` column in `customizeColumns` with a BAINameActionCell, keeping the deletion behind BAIDeleteConfirmModal with `requireConfirmInput`.',
+      },
+      {
+        guidance: true,
+        description:
+          'Translate `onChangeOrder` into the query `orderBy` and reset the offset to 0, so a re-sort starts from the first page.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass `tableSettings` from persisted state when the page offers column customization, so an admin keeps their column layout between visits.',
+      },
+      {
+        guidance: false,
+        description:
+          'Render an unlimited value as 0 or -1 in a custom column renderer — the built-in columns already normalize those sentinels to the infinity sign, and a second spelling of "unlimited" reads as a different setting.',
+      },
+      {
+        guidance: false,
+        description:
+          'Run pagination or filtering inside this component; pass `pagination`, `loading` and the filtered fragment references down from the page that owns the query.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'projectResourcePoliciesFrgmt',
+      type: 'BAIProjectResourcePolicyV2TableFragment$key',
+      description:
+        'Plural fragment reference for the `ProjectResourcePolicyV2` rows to render. Null and undefined entries are dropped before the table sees them.',
+      required: true,
+    },
+    {
+      name: 'customizeColumns',
+      type: '(baseColumns: BAIColumnsType<ProjectResourcePolicyV2InList>) => BAIColumnsType<ProjectResourcePolicyV2InList>',
+      description:
+        'Transforms the built-in column list before render — the hook for adding row actions, removing columns, or setting widths. Receives the columns in display order and must return the full list.',
+    },
+    {
+      name: 'disableSorter',
+      type: 'boolean',
+      description:
+        'Strips the `sorter` flag from every column, turning the table into a fixed-order view. Use it where the surrounding query cannot re-order.',
+    },
+    {
+      name: 'onChangeOrder',
+      type: "(order: 'name' | '-name' | 'createdAt' | … | null) => void",
+      description:
+        'Fired when the user sorts, with a key optionally prefixed by "-" for descending, or null when sorting is cleared. Convert it to the query `orderBy`; the table does not sort its own rows.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Policy list with row actions',
+      code: `<BAIProjectResourcePolicyV2Table
+  projectResourcePoliciesFrgmt={filterOutNullAndUndefined(
+    _.map(data.adminProjectResourcePoliciesV2?.edges, 'node'),
+  )}
+  loading={isRefetching}
+  order={order}
+  onChangeOrder={(nextOrder) =>
+    onReload({
+      ...queryRef.variables,
+      orderBy: convertToOrderBy<ProjectResourcePolicyV2OrderBy>(nextOrder),
+      offset: 0,
+    })
+  }
+  customizeColumns={(columns) =>
+    _.map(columns, (column) =>
+      column.key === 'name'
+        ? {
+            ...column,
+            render: (name: string, record) => (
+              <BAINameActionCell
+                title={name}
+                showActions="always"
+                actions={rowActions(record)}
+              />
+            ),
+          }
+        : column,
+    )
+  }
+/>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIProjectResourcePolicyV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIProjectResourcePolicyV2Table.tsx
@@ -1,0 +1,157 @@
+import {
+  BAIColumnsType,
+  BAIColumnType,
+  BAITable,
+  BAITableProps,
+  convertToDecimalUnit,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+} from '..';
+import type {
+  BAIProjectResourcePolicyV2TableFragment$data,
+  BAIProjectResourcePolicyV2TableFragment$key,
+} from '../__generated__/BAIProjectResourcePolicyV2TableFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
+import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export type ProjectResourcePolicyV2InList = NonNullable<
+  BAIProjectResourcePolicyV2TableFragment$data[number]
+>;
+
+const availableProjectResourcePolicySorterKeys = [
+  'name',
+  'maxVfolderCount',
+  'maxQuotaScopeSize',
+  'maxNetworkCount',
+  'createdAt',
+] as const;
+
+export const availableProjectResourcePolicySorterValues = [
+  ...availableProjectResourcePolicySorterKeys,
+  ...availableProjectResourcePolicySorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableProjectResourcePolicySorterKeys, key);
+};
+
+export interface BAIProjectResourcePolicyV2TableProps extends Omit<
+  BAITableProps<ProjectResourcePolicyV2InList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  projectResourcePoliciesFrgmt: BAIProjectResourcePolicyV2TableFragment$key;
+  disableSorter?: boolean;
+  customizeColumns?: (
+    baseColumns: BAIColumnsType<ProjectResourcePolicyV2InList>,
+  ) => BAIColumnsType<ProjectResourcePolicyV2InList>;
+  onChangeOrder?: (
+    order: (typeof availableProjectResourcePolicySorterValues)[number] | null,
+  ) => void;
+}
+
+const BAIProjectResourcePolicyV2Table = ({
+  projectResourcePoliciesFrgmt,
+  disableSorter,
+  customizeColumns,
+  onChangeOrder,
+  ...tableProps
+}: BAIProjectResourcePolicyV2TableProps) => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  const projectResourcePolicies =
+    useFragment<BAIProjectResourcePolicyV2TableFragment$key>(
+      graphql`
+        fragment BAIProjectResourcePolicyV2TableFragment on ProjectResourcePolicyV2
+        @relay(plural: true) {
+          id
+          name
+          createdAt
+          maxVfolderCount
+          maxQuotaScopeSize {
+            expr
+          }
+          maxNetworkCount
+        }
+      `,
+      projectResourcePoliciesFrgmt,
+    );
+
+  const baseColumns = _.map(
+    filterOutEmpty<BAIColumnType<ProjectResourcePolicyV2InList>>([
+      {
+        title: t('comp:BAIProjectResourcePolicyV2Table.Name'),
+        dataIndex: 'name',
+        key: 'name',
+        fixed: 'left',
+        sorter: isEnableSorter('name'),
+      },
+      {
+        title: t('comp:BAIProjectResourcePolicyV2Table.MaxVFolderCount'),
+        dataIndex: 'maxVfolderCount',
+        key: 'maxVfolderCount',
+        sorter: isEnableSorter('maxVfolderCount'),
+        render: (text) => (_.toNumber(text) === 0 ? '∞' : text),
+      },
+      {
+        title: t('comp:BAIProjectResourcePolicyV2Table.MaxQuotaScopeSize'),
+        dataIndex: 'maxQuotaScopeSize',
+        key: 'maxQuotaScopeSize',
+        sorter: isEnableSorter('maxQuotaScopeSize'),
+        render: (__, row) =>
+          row.maxQuotaScopeSize.expr === '-1'
+            ? '∞'
+            : (convertToDecimalUnit(row.maxQuotaScopeSize.expr, 'auto')
+                ?.displayValue ?? '-'),
+      },
+      {
+        title: t('comp:BAIProjectResourcePolicyV2Table.MaxNetworkCount'),
+        dataIndex: 'maxNetworkCount',
+        key: 'maxNetworkCount',
+        sorter: isEnableSorter('maxNetworkCount'),
+        render: (text) => (_.toNumber(text) === -1 ? '∞' : text),
+      },
+      {
+        title: 'ID',
+        dataIndex: 'id',
+        key: 'id',
+        sorter: isEnableSorter('id'),
+      },
+      {
+        title: t('comp:BAIProjectResourcePolicyV2Table.CreatedAt'),
+        dataIndex: 'createdAt',
+        key: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
+        render: (text) => (text ? dayjs(text).format('lll') : '-'),
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  const allColumns = customizeColumns
+    ? customizeColumns(baseColumns)
+    : baseColumns;
+
+  return (
+    <BAITable
+      scroll={{ x: 'max-content' }}
+      resizable
+      rowKey="id"
+      dataSource={filterOutNullAndUndefined(projectResourcePolicies)}
+      columns={allColumns}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableProjectResourcePolicySorterValues)[number]) ||
+            null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default BAIProjectResourcePolicyV2Table;

--- a/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.doc.ts
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.doc.ts
@@ -57,6 +57,12 @@ export const docs = {
       description:
         'Fragment reference on GroupNode, read for the same allowed_vfolder_hosts field. Give this or allowedHostPermissionFrgmtFromKeyPair, never both.',
     },
+    {
+      name: 'allowedVfolderHostEntries',
+      type: 'ReadonlyArray<{ host: string; permissions: ReadonlyArray<string> }>',
+      description:
+        'The Strawberry V2 allowedVfolderHosts list, passed as plain data instead of a fragment reference. Permission values may be V2 enum names (MOUNT_IN_SESSION) — they are normalized to the canonical kebab keys internally. Mutually exclusive with the two fragment props.',
+    },
   ],
   examples: [
     {

--- a/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
@@ -1,7 +1,11 @@
 import { BAIAllowedVfolderHostsWithPermissionFromGroupFragment$key } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionFromGroupFragment.graphql';
 import { BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment$key } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment.graphql';
 import { BAIAllowedVfolderHostsWithPermissionQuery } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionQuery.graphql';
-import { SemanticColor } from '../../helper';
+import {
+  SemanticColor,
+  v2AllowedVfolderHostsToRecord,
+  type V2AllowedVfolderHostEntry,
+} from '../../helper';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { theme } from '../../theme-shim';
 import BAIFlex from '../BAIFlex';
@@ -17,10 +21,21 @@ export type BAIAllowedVfolderHostsWithPermissionProps =
   | {
       allowedHostPermissionFrgmtFromKeyPair: BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment$key;
       allowedHostPermissionFrgmtFromGroup?: never;
+      allowedVfolderHostEntries?: never;
     }
   | {
       allowedHostPermissionFrgmtFromKeyPair?: never;
       allowedHostPermissionFrgmtFromGroup: BAIAllowedVfolderHostsWithPermissionFromGroupFragment$key;
+      allowedVfolderHostEntries?: never;
+    }
+  | {
+      allowedHostPermissionFrgmtFromKeyPair?: never;
+      allowedHostPermissionFrgmtFromGroup?: never;
+      /**
+       * The Strawberry V2 `[VFolderHostPermissionEntry!]` shape, for callers
+       * on a V2 node that has no JSONString field to spread a fragment from.
+       */
+      allowedVfolderHostEntries: ReadonlyArray<V2AllowedVfolderHostEntry>;
     };
 
 const BAIAllowedVfolderHostsWithPermission: React.FC<
@@ -28,6 +43,7 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
 > = ({
   allowedHostPermissionFrgmtFromKeyPair,
   allowedHostPermissionFrgmtFromGroup,
+  allowedVfolderHostEntries,
 }) => {
   const { t } = useBAIi18n();
   const { token } = theme.useToken();
@@ -53,11 +69,14 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
       allowedHostPermissionFrgmtFromGroup,
     );
 
-  const allowedVfolderHosts = JSON.parse(
-    keypairResourcePolicy?.allowed_vfolder_hosts ||
-      groupNode?.allowed_vfolder_hosts ||
-      '{}',
-  );
+  const allowedVfolderHosts: Record<string, string[]> =
+    allowedVfolderHostEntries
+      ? v2AllowedVfolderHostsToRecord(allowedVfolderHostEntries)
+      : JSON.parse(
+          keypairResourcePolicy?.allowed_vfolder_hosts ||
+            groupNode?.allowed_vfolder_hosts ||
+            '{}',
+        );
 
   const { vfolder_host_permissions } =
     useLazyLoadQuery<BAIAllowedVfolderHostsWithPermissionQuery>(

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -174,6 +174,22 @@ export type {
   BAIUserResourcePolicyV2TableProps,
   UserResourcePolicyV2InList,
 } from './BAIUserResourcePolicyV2Table';
+export {
+  default as BAIKeypairResourcePolicyV2Table,
+  availableKeypairResourcePolicySorterValues,
+} from './BAIKeypairResourcePolicyV2Table';
+export type {
+  BAIKeypairResourcePolicyV2TableProps,
+  KeypairResourcePolicyV2InList,
+} from './BAIKeypairResourcePolicyV2Table';
+export {
+  default as BAIProjectResourcePolicyV2Table,
+  availableProjectResourcePolicySorterValues,
+} from './BAIProjectResourcePolicyV2Table';
+export type {
+  BAIProjectResourcePolicyV2TableProps,
+  ProjectResourcePolicyV2InList,
+} from './BAIProjectResourcePolicyV2Table';
 export type { BAIUncontrolledInputProps } from './BAIUncontrolledInput';
 export { default as BAIUncontrolledInput } from './BAIUncontrolledInput';
 export { default as BAITag } from './BAITag';

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash-es';
 
 export * from './astryxTagVariant';
 export * from './runtimeVariantPresetUI';
+export * from './vfolderHostPermission';
 
 /*
  to-astryx TICKET 30-D — `transformSorterToOrderString` was removed here.

--- a/packages/backend.ai-ui/src/helper/vfolderHostPermission.ts
+++ b/packages/backend.ai-ui/src/helper/vfolderHostPermission.ts
@@ -1,0 +1,44 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+
+/**
+ * V2 (`VFolderHostPermissionV2`) enum value → the canonical V1 kebab key used
+ * by the permission catalog (`vfolder_host_permissions`) and the V1 mutations.
+ *
+ * `SET_USER_PERM` ↔ `set-user-specific-permission` is asymmetric: a naive
+ * lowercase-and-dash yields `set-user-perm`, which matches no catalog key, so
+ * the permission silently reads as "not granted".
+ */
+const V2_TO_V1_PERMISSION: Record<string, string> = {
+  CREATE_VFOLDER: 'create-vfolder',
+  MODIFY_VFOLDER: 'modify-vfolder',
+  DELETE_VFOLDER: 'delete-vfolder',
+  MOUNT_IN_SESSION: 'mount-in-session',
+  UPLOAD_FILE: 'upload-file',
+  DOWNLOAD_FILE: 'download-file',
+  INVITE_OTHERS: 'invite-others',
+  SET_USER_PERM: 'set-user-specific-permission',
+};
+
+/** Convert a V2 permission enum value to the canonical V1 kebab key. */
+export const v2PermissionToKey = (perm: string): string =>
+  V2_TO_V1_PERMISSION[perm] ?? perm.toLowerCase().replace(/_/g, '-');
+
+/** V2 `VFolderHostPermissionEntry` shape (host name + permission enum list). */
+export interface V2AllowedVfolderHostEntry {
+  readonly host: string;
+  readonly permissions: ReadonlyArray<string>;
+}
+
+/** The V2 entry list flattened to the `{ host: kebabPermissions[] }` record. */
+export const v2AllowedVfolderHostsToRecord = (
+  entries: ReadonlyArray<V2AllowedVfolderHostEntry> | null | undefined,
+): Record<string, string[]> => {
+  const record: Record<string, string[]> = {};
+  for (const entry of entries ?? []) {
+    record[entry.host] = entry.permissions.map(v2PermissionToKey);
+  }
+  return record;
+};

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Erfolgreich angeforderte Pull für {{count}} -Versionen.",
     "Version": "Version"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Clustergröße",
+    "Concurrency": "Gleichzeitige Sitzungen",
+    "CreatedAt": "Hergestellt in",
+    "DefaultForUnspecified": "Standard für nicht spezifizierte",
+    "DefaultForUnspecifiedTooltipDesc1": "Legt die Standardrichtlinie fest, wenn keine bestimmte CPU oder kein bestimmter Speicher angefordert wird.",
+    "DefaultForUnspecifiedTooltipDesc2": "'UNLIMITED' erlaubt die Nutzung bis zur Kapazität des Agent-Knotens, während 'LIMITED' Ressourcen verweigert, sofern sie nicht explizit festgelegt sind. In den meisten Fällen wird 'UNLIMITED' empfohlen.",
+    "IdleTimeout": "Leerlauf-Timeout",
+    "MaxConcurrentSFTPSessions": "Max gleichzeitige SFTP -Sitzungen",
+    "MaxPendingSessionCount": "Maximal ausstehende Sitzungsanzahl",
+    "MaxPendingSessionResourceSlots": "Maxe ausstehende Sitzungsressourcenschlitze",
+    "MaxSessionLifetime": "Maximale Lebensdauer der Sitzung",
+    "Name": "Name",
+    "StorageNodes": "Speicherknoten",
+    "TotalResourceSlots": "Ressourcenrichtlinie"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Schlüsselpaar auswählen"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Die folgenden Projekte werden aktualisiert.",
     "ProjectResourcePolicy": "Projektressourcenrichtlinie",
     "UpdateMultipleProjects": "Mehrere Projekte aktualisieren"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Hergestellt in",
+    "MaxNetworkCount": "Maximale Netzwerkanzahl",
+    "MaxQuotaScopeSize": "Maximale Größe des Ordners",
+    "MaxVFolderCount": "Maximale Ordneranzahl",
+    "Name": "Name"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Projekt auswählen"

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "nach",
       "Before": "vor",
+      "Contains": "enthält",
+      "EndsWith": "endet mit",
       "Equals": "gleich",
       "GreaterThan": "größer als",
       "GreaterThanOrEqual": "größer oder gleich",
@@ -193,8 +195,12 @@
       "In": "enthalten in",
       "LessThan": "kleiner als",
       "LessThanOrEqual": "kleiner oder gleich",
+      "NotContains": "enthält nicht",
+      "NotEndsWith": "endet nicht mit",
       "NotEquals": "ungleich",
-      "NotIn": "nicht enthalten in"
+      "NotIn": "nicht enthalten in",
+      "NotStartsWith": "beginnt nicht mit",
+      "StartsWith": "beginnt mit"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Ζήτησε με επιτυχία την έλξη {{count}}}.",
     "Version": "Εκδοχή"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Μέγεθος συμπλέγματος",
+    "Concurrency": "Ταυτόχρονες συνεδρίες",
+    "CreatedAt": "Δημιουργήθηκε στο",
+    "DefaultForUnspecified": "Προεπιλογή για απροσδιόριστο",
+    "DefaultForUnspecifiedTooltipDesc1": "Ορίζει την προεπιλεγμένη πολιτική όταν δεν ζητείται συγκεκριμένη CPU ή μνήμη.",
+    "DefaultForUnspecifiedTooltipDesc2": "Το «Unlimited» επιτρέπει τη χρήση της χωρητικότητας του κόμβου του πράκτορα, ενώ ο «περιορισμένος» αρνείται τους πόρους εκτός εάν ορίσει ρητά. \nΣτις περισσότερες περιπτώσεις, συνιστάται η «απεριόριστη».",
+    "IdleTimeout": "Χρονικό όριο αδράνειας",
+    "MaxConcurrentSFTPSessions": "Max ταυτόχρονες συνεδρίες SFTP",
+    "MaxPendingSessionCount": "Μέγιστο μέτρο εκκρεμούσης",
+    "MaxPendingSessionResourceSlots": "Max εκκρεμείς υποδοχές πόρων συνεδρίας",
+    "MaxSessionLifetime": "Μέγιστη διάρκεια ζωής συνόδου",
+    "Name": "Ονομα",
+    "StorageNodes": "Κόμβοι αποθήκευσης",
+    "TotalResourceSlots": "Πολιτική πόρων"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Επιλέξτε ζεύγος κλειδιών"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Τα ακόλουθα έργα θα ενημερωθούν.",
     "ProjectResourcePolicy": "Πολιτική πόρων έργου",
     "UpdateMultipleProjects": "Ενημέρωση πολλαπλών έργων"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Δημιουργήθηκε στο",
+    "MaxNetworkCount": "Μέγιστος αριθμός δικτύου",
+    "MaxQuotaScopeSize": "Μέγιστο μέγεθος φακέλου",
+    "MaxVFolderCount": "Μέγιστος αριθμός φακέλων",
+    "Name": "Ονομα"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Επιλέξτε έργο"

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "μετά",
       "Before": "πριν",
+      "Contains": "περιέχει",
+      "EndsWith": "τελειώνει με",
       "Equals": "ίσο με",
       "GreaterThan": "μεγαλύτερο από",
       "GreaterThanOrEqual": "μεγαλύτερο ή ίσο",
@@ -193,8 +195,12 @@
       "In": "σε",
       "LessThan": "μικρότερο από",
       "LessThanOrEqual": "μικρότερο ή ίσο",
+      "NotContains": "δεν περιέχει",
+      "NotEndsWith": "δεν τελειώνει με",
       "NotEquals": "όχι ίσο με",
-      "NotIn": "όχι σε"
+      "NotIn": "όχι σε",
+      "NotStartsWith": "δεν αρχίζει με",
+      "StartsWith": "αρχίζει με"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -228,6 +228,22 @@
     "SuccessFullyPulled": "Successfully requested pull for {{count}} versions.",
     "Version": "Version"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Cluster Size",
+    "Concurrency": "Concurrent Sessions",
+    "CreatedAt": "Created At",
+    "DefaultForUnspecified": "Default For Unspecified",
+    "DefaultForUnspecifiedTooltipDesc1": "Sets the default policy when no specific CPU or memory is requested.",
+    "DefaultForUnspecifiedTooltipDesc2": "'UNLIMITED' allows usage up to the agent node’s capacity, while 'LIMITED' denies resources unless explicitly set. In most cases, 'UNLIMITED' is recommended.",
+    "IdleTimeout": "Idle Timeout",
+    "MaxConcurrentSFTPSessions": "Max Concurrent SFTP Sessions",
+    "MaxPendingSessionCount": "Max Pending Session Count",
+    "MaxPendingSessionResourceSlots": "Max Pending Session Resource Slots",
+    "MaxSessionLifetime": "Max Session Lifetime",
+    "Name": "Name",
+    "StorageNodes": "Storage Nodes",
+    "TotalResourceSlots": "Resource Policy"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Select Keypair"
   },
@@ -288,6 +304,13 @@
     "FollowingProjectsWillBeUpdated": "The following project(s) will be updated.",
     "ProjectResourcePolicy": "Project Resource Policy",
     "UpdateMultipleProjects": "Update Multiple Projects"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Created At",
+    "MaxNetworkCount": "Max Network Count",
+    "MaxQuotaScopeSize": "Max Folder Size",
+    "MaxVFolderCount": "Max Folder Count",
+    "Name": "Name"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Select Project"

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "después",
       "Before": "antes",
+      "Contains": "contiene",
+      "EndsWith": "termina con",
       "Equals": "igual a",
       "GreaterThan": "mayor que",
       "GreaterThanOrEqual": "mayor o igual",
@@ -193,8 +195,12 @@
       "In": "en",
       "LessThan": "menor que",
       "LessThanOrEqual": "menor o igual",
+      "NotContains": "no contiene",
+      "NotEndsWith": "no termina con",
       "NotEquals": "no igual a",
-      "NotIn": "no en"
+      "NotIn": "no en",
+      "NotStartsWith": "no empieza con",
+      "StartsWith": "empieza con"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Solicitud solicitada con éxito para las versiones {{count}}.",
     "Version": "Versión"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Tamaño del grupo",
+    "Concurrency": "Sesiones simultáneas",
+    "CreatedAt": "Creado en",
+    "DefaultForUnspecified": "Predeterminado para no especificado",
+    "DefaultForUnspecifiedTooltipDesc1": "Establece la política predeterminada cuando no se solicita una CPU o memoria específica.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Unlimited' permite el uso a la capacidad del nodo del agente, mientras que 'limitado' niega los recursos a menos que estén explícitamente. \nEn la mayoría de los casos, se recomienda 'ilimitado'.",
+    "IdleTimeout": "Tiempo de inactividad",
+    "MaxConcurrentSFTPSessions": "Sesiones SFTP concurrentes máximas",
+    "MaxPendingSessionCount": "Recuento de sesión pendiente máximo",
+    "MaxPendingSessionResourceSlots": "MAX PENDO PENDAS DE RECURSOS DE RECURSOS DE SESIÓN",
+    "MaxSessionLifetime": "Duración máxima de la sesión",
+    "Name": "Nombre",
+    "StorageNodes": "Nodos de almacenamiento",
+    "TotalResourceSlots": "Política de recursos"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Seleccionar par de claves"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Se actualizará(n) el(los) siguiente(s) proyecto(s).",
     "ProjectResourcePolicy": "Política de recursos del proyecto",
     "UpdateMultipleProjects": "Actualizar varios proyectos"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Creado en",
+    "MaxNetworkCount": "Recuento máximo de red",
+    "MaxQuotaScopeSize": "Tamaño máximo de carpeta",
+    "MaxVFolderCount": "Número máximo de carpetas",
+    "Name": "Nombre"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Seleccionar proyecto"

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "jälkeen",
       "Before": "ennen",
+      "Contains": "sisältää",
+      "EndsWith": "päättyy",
       "Equals": "yhtä suuri",
       "GreaterThan": "suurempi kuin",
       "GreaterThanOrEqual": "suurempi tai yhtä suuri",
@@ -193,8 +195,12 @@
       "In": "sisällä",
       "LessThan": "pienempi kuin",
       "LessThanOrEqual": "pienempi tai yhtä suuri",
+      "NotContains": "ei sisällä",
+      "NotEndsWith": "ei pääty",
       "NotEquals": "ei yhtä suuri",
-      "NotIn": "ei sisällä"
+      "NotIn": "ei sisällä",
+      "NotStartsWith": "ei ala",
+      "StartsWith": "alkaa"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Onnistuneesti pyydetty veto {{count}} versioille.",
     "Version": "Versio"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Klusterin koko",
+    "Concurrency": "Samanaikaiset istunnot",
+    "CreatedAt": "Luotu klo",
+    "DefaultForUnspecified": "Määrittelemättömän oletus",
+    "DefaultForUnspecifiedTooltipDesc1": "Asettaa oletuskäytäntö, kun tiettyä suorittimen tai muistia ei pyydetä.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Rajoittamaton' sallii käytön Agent -solmun kapasiteettiin saakka, kun taas 'rajoitettu' kieltää resursseja, ellei nimenomaisesti ole asetettu. \nUseimmissa tapauksissa suositellaan 'rajoittamatonta'.",
+    "IdleTimeout": "Idle Timeout",
+    "MaxConcurrentSFTPSessions": "Max samanaikaiset SFTP -istunnot",
+    "MaxPendingSessionCount": "Maxin vireillä oleva istuntomäärä",
+    "MaxPendingSessionResourceSlots": "Max odottavat istunnon resurssipaikat",
+    "MaxSessionLifetime": "Istunnon enimmäiskestoikä",
+    "Name": "Nimi",
+    "StorageNodes": "Varastointisolmut",
+    "TotalResourceSlots": "Resurssipolitiikka"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Valitse avainpari"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Seuraavat projektit päivitetään.",
     "ProjectResourcePolicy": "Projektin resurssipolitiikka",
     "UpdateMultipleProjects": "Päivitä useita projekteja"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Luotu klo",
+    "MaxNetworkCount": "Verkkojen enimmäismäärä",
+    "MaxQuotaScopeSize": "Kansioiden enimmäiskoko",
+    "MaxVFolderCount": "Kansioiden enimmäismäärä",
+    "Name": "Nimi"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Valitse projekti"

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "après",
       "Before": "avant",
+      "Contains": "contient",
+      "EndsWith": "se termine par",
       "Equals": "égal à",
       "GreaterThan": "supérieur à",
       "GreaterThanOrEqual": "supérieur ou égal",
@@ -193,8 +195,12 @@
       "In": "dans",
       "LessThan": "inférieur à",
       "LessThanOrEqual": "inférieur ou égal",
+      "NotContains": "ne contient pas",
+      "NotEndsWith": "ne se termine pas par",
       "NotEquals": "différent de",
-      "NotIn": "pas dans"
+      "NotIn": "pas dans",
+      "NotStartsWith": "ne commence pas par",
+      "StartsWith": "commence par"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Pull demandé avec succès pour les versions {{count}}.",
     "Version": "Version"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Taille de cluster",
+    "Concurrency": "Sessions simultanées",
+    "CreatedAt": "Créé à",
+    "DefaultForUnspecified": "Par défaut pour non spécifié",
+    "DefaultForUnspecifiedTooltipDesc1": "Définit la stratégie par défaut lorsqu'aucun processeur ou mémoire spécifique n'est demandé.",
+    "DefaultForUnspecifiedTooltipDesc2": "`` Unlimited '' permet l'utilisation de la capacité du nœud d'agent, tandis que «Limited» nie les ressources à moins d'être définies explicitement. \nDans la plupart des cas, «illimité» est recommandé.",
+    "IdleTimeout": "Délai d'inactivité",
+    "MaxConcurrentSFTPSessions": "Sessions SFTP max simultanées",
+    "MaxPendingSessionCount": "Compte de session en attente maximum",
+    "MaxPendingSessionResourceSlots": "Emplacements de ressources de session en attente maximale",
+    "MaxSessionLifetime": "Durée de vie maximale de la session",
+    "Name": "Nom",
+    "StorageNodes": "Nœuds de stockage",
+    "TotalResourceSlots": "Politique de ressources"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Sélectionner une paire de clés"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Le(s) projet(s) suivant(s) sera(ont) mis à jour.",
     "ProjectResourcePolicy": "Politique de ressources du projet",
     "UpdateMultipleProjects": "Mettre à jour plusieurs projets"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Créé à",
+    "MaxNetworkCount": "Nombre maximum de réseaux",
+    "MaxQuotaScopeSize": "Taille maximale du dossier",
+    "MaxVFolderCount": "Nombre maximum de dossiers",
+    "Name": "Nom"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Sélectionner un projet"

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "setelah",
       "Before": "sebelum",
+      "Contains": "mengandung",
+      "EndsWith": "diakhiri dengan",
       "Equals": "sama dengan",
       "GreaterThan": "lebih besar dari",
       "GreaterThanOrEqual": "lebih besar atau sama",
@@ -193,8 +195,12 @@
       "In": "dalam",
       "LessThan": "kurang dari",
       "LessThanOrEqual": "kurang dari atau sama",
+      "NotContains": "tidak berisi",
+      "NotEndsWith": "tidak diakhiri dengan",
       "NotEquals": "tidak sama dengan",
-      "NotIn": "tidak dalam"
+      "NotIn": "tidak dalam",
+      "NotStartsWith": "tidak dimulai dengan",
+      "StartsWith": "dimulai dengan"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Berhasil meminta tarik untuk versi {{count}}.",
     "Version": "Versi"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Ukuran Klaster",
+    "Concurrency": "Sesi Serentak",
+    "CreatedAt": "Dibuat di",
+    "DefaultForUnspecified": "Default untuk tidak ditentukan",
+    "DefaultForUnspecifiedTooltipDesc1": "Menetapkan kebijakan default ketika tidak ada CPU atau memori tertentu yang diminta.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Unlimited' memungkinkan penggunaan hingga kapasitas agen node, sementara 'Limited' menolak sumber daya kecuali diatur secara eksplisit. \nDalam kebanyakan kasus, 'tidak terbatas' direkomendasikan.",
+    "IdleTimeout": "Batas Waktu Diam",
+    "MaxConcurrentSFTPSessions": "Sesi SFTP Max Concurrent",
+    "MaxPendingSessionCount": "Hitungan sesi Max Tertunda",
+    "MaxPendingSessionResourceSlots": "Slot sumber daya sesi maks yang tertunda",
+    "MaxSessionLifetime": "Sesi Maksimal Seumur Hidup",
+    "Name": "Nama",
+    "StorageNodes": "Node Penyimpanan",
+    "TotalResourceSlots": "Kebijakan Sumber Daya"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Pilih Keypair"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Proyek berikut akan diperbarui.",
     "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",
     "UpdateMultipleProjects": "Perbarui Beberapa Proyek"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Dibuat di",
+    "MaxNetworkCount": "Jumlah Jaringan Maks",
+    "MaxQuotaScopeSize": "Ukuran Folder Maks",
+    "MaxVFolderCount": "Jumlah Folder Maks",
+    "Name": "Nama"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Pilih Proyek"

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "dopo",
       "Before": "prima",
+      "Contains": "Contiene",
+      "EndsWith": "termina con",
       "Equals": "uguale a",
       "GreaterThan": "maggiore di",
       "GreaterThanOrEqual": "maggiore o uguale",
@@ -193,8 +195,12 @@
       "In": "in",
       "LessThan": "minore di",
       "LessThanOrEqual": "minore o uguale",
+      "NotContains": "non contiene",
+      "NotEndsWith": "non termina con",
       "NotEquals": "diverso da",
-      "NotIn": "non in"
+      "NotIn": "non in",
+      "NotStartsWith": "non inizia con",
+      "StartsWith": "inizia con"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Pullo correttamente richiesto per le versioni {{count}}.",
     "Version": "Versione"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Dimensione del cluster",
+    "Concurrency": "Sessioni simultanee",
+    "CreatedAt": "Creato a",
+    "DefaultForUnspecified": "Predefinito per non specificato",
+    "DefaultForUnspecifiedTooltipDesc1": "Imposta il criterio predefinito quando non è richiesta alcuna CPU o memoria specifica.",
+    "DefaultForUnspecifiedTooltipDesc2": "\"Unlimited\" consente l'utilizzo fino alla capacità del nodo dell'agente, mentre \"limitato\" nega le risorse se non esplicitamente fissate. \nNella maggior parte dei casi, si consiglia \"illimitato\".",
+    "IdleTimeout": "Timeout di inattività",
+    "MaxConcurrentSFTPSessions": "Sessioni SFTP con contenitori massimi",
+    "MaxPendingSessionCount": "Conteggio delle sessioni massimo in sospeso",
+    "MaxPendingSessionResourceSlots": "Slot di risorse sessioni massime in sospeso",
+    "MaxSessionLifetime": "Durata massima della sessione",
+    "Name": "Nome",
+    "StorageNodes": "Nodi di archiviazione",
+    "TotalResourceSlots": "Politica delle risorse"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Seleziona coppia di chiavi"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Il/I seguente/i progetto/i verrà/verranno aggiornato/i.",
     "ProjectResourcePolicy": "Politica delle risorse del progetto",
     "UpdateMultipleProjects": "Aggiorna più progetti"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Creato a",
+    "MaxNetworkCount": "Conteggio massimo della rete",
+    "MaxQuotaScopeSize": "Dimensione massima della cartella",
+    "MaxVFolderCount": "Conteggio massimo cartelle",
+    "Name": "Nome"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Seleziona progetto"

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "後",
       "Before": "前",
+      "Contains": "含む",
+      "EndsWith": "で終わる",
       "Equals": "等しい",
       "GreaterThan": "より大きい",
       "GreaterThanOrEqual": "以上",
@@ -193,8 +195,12 @@
       "In": "含まれる",
       "LessThan": "より小さい",
       "LessThanOrEqual": "以下",
+      "NotContains": "含まない",
+      "NotEndsWith": "で終わらない",
       "NotEquals": "等しくない",
-      "NotIn": "含まれない"
+      "NotIn": "含まれない",
+      "NotStartsWith": "で始まらない",
+      "StartsWith": "で始まる"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "{{count}}バージョンのプルを正常に要求しました。",
     "Version": "バージョン"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "クラスターサイズ",
+    "Concurrency": "同時実行セッション数",
+    "CreatedAt": "作成日",
+    "DefaultForUnspecified": "不特定のデフォルト",
+    "DefaultForUnspecifiedTooltipDesc1": "特定のCPUまたはメモリが要求されていない場合、デフォルトのポリシーを設定します。",
+    "DefaultForUnspecifiedTooltipDesc2": "「Unlimited」により、エージェントノードの容量までの使用が可能になり、「Limited」は明示的に設定しない限りリソースを拒否します。\nほとんどの場合、「無制限」が推奨されます。",
+    "IdleTimeout": "アイドルタイムアウト",
+    "MaxConcurrentSFTPSessions": "Max Concurrent SFTPセッション",
+    "MaxPendingSessionCount": "最大保留中のセッションカウント",
+    "MaxPendingSessionResourceSlots": "最大保留中のセッションリソーススロット",
+    "MaxSessionLifetime": "最大セッション寿命時間",
+    "Name": "名前",
+    "StorageNodes": "ストレージノード",
+    "TotalResourceSlots": "リソースポリシー"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "キーペアを選択"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "以下のプロジェクトが更新されます.",
     "ProjectResourcePolicy": "プロジェクトのリソースポリシー",
     "UpdateMultipleProjects": "プロジェクトを一括更新"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "作成日",
+    "MaxNetworkCount": "最大ネットワーク数",
+    "MaxQuotaScopeSize": "最大フォルダサイズ",
+    "MaxVFolderCount": "最大フォルダ数",
+    "Name": "名前"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "プロジェクトを選択"

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "이후",
       "Before": "이전",
+      "Contains": "포함",
+      "EndsWith": "끝남",
       "Equals": "같음",
       "GreaterThan": "초과",
       "GreaterThanOrEqual": "이상",
@@ -193,8 +195,12 @@
       "In": "포함됨",
       "LessThan": "미만",
       "LessThanOrEqual": "이하",
+      "NotContains": "포함하지 않음",
+      "NotEndsWith": "끝나지 않음",
       "NotEquals": "같지 않음",
-      "NotIn": "포함되지 않음"
+      "NotIn": "포함되지 않음",
+      "NotStartsWith": "시작하지 않음",
+      "StartsWith": "시작"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {
@@ -215,6 +221,22 @@
     "Size": "크기",
     "SuccessFullyPulled": "{{count}}개 버전에 대한 가져오기 요청을 보냈습니다.",
     "Version": "버전"
+  },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "클러스터 크기",
+    "Concurrency": "동시실행 세션 수",
+    "CreatedAt": "생성 날짜",
+    "DefaultForUnspecified": "기본값",
+    "DefaultForUnspecifiedTooltipDesc1": "특정 CPU 또는 메모리가 요청되지 않은 경우 기본 정책을 설정합니다.",
+    "DefaultForUnspecifiedTooltipDesc2": "'UNLIMITED'을 사용하면 에이전트 노드의 용량까지 사용을 허용하는 반면, 'LIMITED'는 명시적으로 설정되지 않는 한 리소스를 거부합니다. \n대부분의 경우 'UNLIMITED'을 권장합니다.",
+    "IdleTimeout": "유휴 대기 시간",
+    "MaxConcurrentSFTPSessions": "최대 동시 SFTP 세션",
+    "MaxPendingSessionCount": "최대 대기 세션",
+    "MaxPendingSessionResourceSlots": "최대 대기 세션 리소스 슬롯",
+    "MaxSessionLifetime": "최대 세션 수명 시간",
+    "Name": "이름",
+    "StorageNodes": "저장소 노드",
+    "TotalResourceSlots": "자원 정책"
   },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "키페어를 선택해주세요"
@@ -276,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "다음 프로젝트(들)이 업데이트됩니다.",
     "ProjectResourcePolicy": "프로젝트 리소스 정책",
     "UpdateMultipleProjects": "프로젝트 일괄 업데이트"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "생성 날짜",
+    "MaxNetworkCount": "최대 네트워크 수",
+    "MaxQuotaScopeSize": "최대 폴더 크기",
+    "MaxVFolderCount": "최대 폴더 수",
+    "Name": "이름"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "프로젝트를 선택해주세요"

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "дараа",
       "Before": "өмнө",
+      "Contains": "агуулсан",
+      "EndsWith": "төгсдөг",
       "Equals": "тэнцүү",
       "GreaterThan": "их",
       "GreaterThanOrEqual": "их эсвэл тэнцүү",
@@ -193,8 +195,12 @@
       "In": "дотор",
       "LessThan": "бага",
       "LessThanOrEqual": "бага эсвэл тэнцүү",
+      "NotContains": "агуулаагүй",
+      "NotEndsWith": "төгсдөггүй",
       "NotEquals": "тэнцүү биш",
-      "NotIn": "дотор биш"
+      "NotIn": "дотор биш",
+      "NotStartsWith": "эхэлдэггүй",
+      "StartsWith": "эхэлдэг"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "{{count} хувилбарыг амжилттай хийхийг хүсч байна.",
     "Version": "Таамаглал"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Кластерийн хэмжээ",
+    "Concurrency": "Зэрэгцээ сессүүд",
+    "CreatedAt": "Үүсгэсэн",
+    "DefaultForUnspecified": "Тодорхойлогдоогүй тохиолдолд анхдагч",
+    "DefaultForUnspecifiedTooltipDesc1": "Тодорхой CPU эсвэл санах ой байхгүй үед үндсэн бодлогыг тохируулна.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Хязгааргүй' нь агент зангилааны хүчин чадлыг ашиглах боломжийг олгодог бөгөөд 'Хязгаарлагдмал' нөөцийг ашиглахгүй бол нөөцийг үгүйсгэхгүй. \nИхэнх тохиолдолд 'Хязгааргүй' зөвлөж байна.",
+    "IdleTimeout": "Сул зогсолтын хугацаа",
+    "MaxConcurrentSFTPSessions": "Макс тохиролцсон SFTP хуралдаанууд",
+    "MaxPendingSessionCount": "Макс хүлээгдэж буй хуралдааны тоо",
+    "MaxPendingSessionResourceSlots": "Макс хүлээгдэж буй сешний нөөцийн слотууд",
+    "MaxSessionLifetime": "Хамгийн их сессийн ашиглалтын хугацаа",
+    "Name": "Нэр",
+    "StorageNodes": "Хадгалах цэгүүд",
+    "TotalResourceSlots": "Нөөцийн бодлого"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Түлхүүрийн хос сонгох"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Дараах төсөл(үүд) шинэчлэгдэх болно.",
     "ProjectResourcePolicy": "Төслийн нөөцийн бодлого",
     "UpdateMultipleProjects": "Олон төслийг шинэчлэх"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Үүсгэсэн",
+    "MaxNetworkCount": "Хамгийн их сүлжээний тоо",
+    "MaxQuotaScopeSize": "Хавтасны хамгийн их хэмжээ",
+    "MaxVFolderCount": "Хамгийн их хавтасны тоо",
+    "Name": "Нэр"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Төсөл сонгох"

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "selepas",
       "Before": "sebelum",
+      "Contains": "mengandungi",
+      "EndsWith": "berakhir dengan",
       "Equals": "sama dengan",
       "GreaterThan": "lebih besar daripada",
       "GreaterThanOrEqual": "lebih besar atau sama",
@@ -193,8 +195,12 @@
       "In": "dalam",
       "LessThan": "kurang daripada",
       "LessThanOrEqual": "kurang atau sama",
+      "NotContains": "tidak mengandungi",
+      "NotEndsWith": "tidak berakhir dengan",
       "NotEquals": "tidak sama dengan",
-      "NotIn": "tidak dalam"
+      "NotIn": "tidak dalam",
+      "NotStartsWith": "tidak bermula dengan",
+      "StartsWith": "bermula dengan"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Berjaya meminta tarik untuk {{count}} versi.",
     "Version": "Versi"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Saiz Kluster",
+    "Concurrency": "Sesi Serentak",
+    "CreatedAt": "Dicipta Pada",
+    "DefaultForUnspecified": "Lalai untuk tidak ditentukan",
+    "DefaultForUnspecifiedTooltipDesc1": "Menetapkan dasar lalai apabila tiada CPU atau memori tertentu diminta.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Unlimited' membolehkan penggunaan sehingga kapasiti node ejen, sementara 'Limited' menafikan sumber kecuali secara jelas ditetapkan. \nDalam kebanyakan kes, 'tidak terhad' disyorkan.",
+    "IdleTimeout": "Tamat Masa Terbiar",
+    "MaxConcurrentSFTPSessions": "Sesi SFTP bersamaan Max",
+    "MaxPendingSessionCount": "Kiraan sesi maksimum yang belum selesai",
+    "MaxPendingSessionResourceSlots": "Slot sumber sesi maksimum yang belum selesai",
+    "MaxSessionLifetime": "Sepanjang Hayat Sesi Maks",
+    "Name": "Nama",
+    "StorageNodes": "Nod Penyimpanan",
+    "TotalResourceSlots": "Dasar Sumber"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Pilih Pasangan Kunci"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Projek berikut akan dikemas kini.",
     "ProjectResourcePolicy": "Polisi Sumber Projek",
     "UpdateMultipleProjects": "Kemas kini Beberapa Projek"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Dicipta Pada",
+    "MaxNetworkCount": "Kiraan Rangkaian Maks",
+    "MaxQuotaScopeSize": "Saiz Folder Maks",
+    "MaxVFolderCount": "Kiraan Folder Maks",
+    "Name": "Nama"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Pilih Projek"

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Pomyślnie żądane Pull dla wersji {{count}}.",
     "Version": "Wersja"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Wielkość klastra",
+    "Concurrency": "Równoczesne sesje",
+    "CreatedAt": "Utworzono o godz",
+    "DefaultForUnspecified": "Domyślnie dla nieokreślonego",
+    "DefaultForUnspecifiedTooltipDesc1": "Ustawia domyślne zasady, gdy nie wymaga się konkretnego procesora ani pamięci.",
+    "DefaultForUnspecifiedTooltipDesc2": "„Unlimited” pozwala na wykorzystanie pojemności węzła agenta, podczas gdy „ograniczony” zaprzecza zasobom, chyba że wyraźnie ustalono. \nW większości przypadków zaleca się „nieograniczone”.",
+    "IdleTimeout": "Limit czasu bezczynności",
+    "MaxConcurrentSFTPSessions": "Max równoległe sesje SFTP",
+    "MaxPendingSessionCount": "Max oczekujący na liczbę sesji",
+    "MaxPendingSessionResourceSlots": "Max oczekujący szczeliny zasobów sesji",
+    "MaxSessionLifetime": "Maksymalny czas trwania sesji",
+    "Name": "Nazwa",
+    "StorageNodes": "Węzły magazynowania",
+    "TotalResourceSlots": "Polityka zasobów"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Wybierz parę kluczy"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Poniższe projekty zostaną zaktualizowane.",
     "ProjectResourcePolicy": "Polityka zasobów projektu",
     "UpdateMultipleProjects": "Aktualizuj wiele projektów"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Utworzono o godz",
+    "MaxNetworkCount": "Maksymalna liczba sieci",
+    "MaxQuotaScopeSize": "Maksymalny rozmiar folderu",
+    "MaxVFolderCount": "Maksymalna liczba folderów",
+    "Name": "Nazwa"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Wybierz projekt"

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "po",
       "Before": "przed",
+      "Contains": "zawiera",
+      "EndsWith": "kończy się na",
       "Equals": "równe",
       "GreaterThan": "większe niż",
       "GreaterThanOrEqual": "większe lub równe",
@@ -193,8 +195,12 @@
       "In": "w",
       "LessThan": "mniejsze niż",
       "LessThanOrEqual": "mniejsze lub równe",
+      "NotContains": "nie zawiera",
+      "NotEndsWith": "nie kończy się na",
       "NotEquals": "nierówne",
-      "NotIn": "nie w"
+      "NotIn": "nie w",
+      "NotStartsWith": "nie zaczyna się od",
+      "StartsWith": "zaczyna się od"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "depois",
       "Before": "antes",
+      "Contains": "contém",
+      "EndsWith": "termina com",
       "Equals": "igual a",
       "GreaterThan": "maior que",
       "GreaterThanOrEqual": "maior ou igual",
@@ -193,8 +195,12 @@
       "In": "em",
       "LessThan": "menor que",
       "LessThanOrEqual": "menor ou igual",
+      "NotContains": "não contém",
+      "NotEndsWith": "não termina com",
       "NotEquals": "diferente de",
-      "NotIn": "não em"
+      "NotIn": "não em",
+      "NotStartsWith": "não começa com",
+      "StartsWith": "começa com"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -228,6 +228,22 @@
     "Type": "Tipo",
     "Version": "Versão"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Tamanho do Cluster",
+    "Concurrency": "Sessões simultâneas",
+    "CreatedAt": "Criado em",
+    "DefaultForUnspecified": "Padrão para não especificado",
+    "DefaultForUnspecifiedTooltipDesc1": "Define a política padrão quando nenhuma CPU ou memória específica é solicitada.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Unlimited' permite o uso até a capacidade do nó do agente, enquanto 'limitado' nega recursos, a menos que seja explicitamente definido. \nNa maioria dos casos, recomenda -se 'ilimitado'.",
+    "IdleTimeout": "Tempo limite ocioso",
+    "MaxConcurrentSFTPSessions": "Sessões SFTP simultâneas máximas",
+    "MaxPendingSessionCount": "Contagem máxima de sessão pendente",
+    "MaxPendingSessionResourceSlots": "Slots de recurso de sessão pendente máximo",
+    "MaxSessionLifetime": "Duração máxima da sessão",
+    "Name": "Nome",
+    "StorageNodes": "Nós de Armazenamento",
+    "TotalResourceSlots": "Política de Recursos"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Selecionar par de chaves"
   },
@@ -288,6 +304,13 @@
     "FollowingProjectsWillBeUpdated": "O(s) projeto(s) a seguir será(ão) atualizado(s).",
     "ProjectResourcePolicy": "Política de Recursos do Projeto",
     "UpdateMultipleProjects": "Atualizar vários projetos"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Criado em",
+    "MaxNetworkCount": "Contagem máxima de rede",
+    "MaxQuotaScopeSize": "Tamanho máximo da pasta",
+    "MaxVFolderCount": "Contagem máxima de pastas",
+    "Name": "Nome"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Selecionar projeto"

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Pull solicitado com sucesso para {{count}} versões.",
     "Version": "Versão"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Tamanho do Cluster",
+    "Concurrency": "Sessões simultâneas",
+    "CreatedAt": "Criado em",
+    "DefaultForUnspecified": "Padrão para não especificado",
+    "DefaultForUnspecifiedTooltipDesc1": "Define a política padrão quando nenhuma CPU ou memória específica é solicitada.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Unlimited' permite o uso até a capacidade do nó do agente, enquanto 'limitado' nega recursos, a menos que seja explicitamente definido. \nNa maioria dos casos, recomenda -se 'ilimitado'.",
+    "IdleTimeout": "Tempo limite ocioso",
+    "MaxConcurrentSFTPSessions": "Sessões SFTP simultâneas máximas",
+    "MaxPendingSessionCount": "Contagem máxima de sessão pendente",
+    "MaxPendingSessionResourceSlots": "Slots de recurso de sessão pendente máximo",
+    "MaxSessionLifetime": "Duração máxima da sessão",
+    "Name": "Nome",
+    "StorageNodes": "Nós de Armazenamento",
+    "TotalResourceSlots": "Política de Recursos"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Selecionar par de chaves"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "O(s) projeto(s) a seguir será(ão) atualizado(s).",
     "ProjectResourcePolicy": "Política de Recursos do Projeto",
     "UpdateMultipleProjects": "Atualizar vários projetos"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Criado em",
+    "MaxNetworkCount": "Contagem máxima de rede",
+    "MaxQuotaScopeSize": "Tamanho máximo da pasta",
+    "MaxVFolderCount": "Contagem máxima de pastas",
+    "Name": "Nome"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Selecionar projeto"

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "depois",
       "Before": "antes",
+      "Contains": "contém",
+      "EndsWith": "termina com",
       "Equals": "igual a",
       "GreaterThan": "maior que",
       "GreaterThanOrEqual": "maior ou igual",
@@ -193,8 +195,12 @@
       "In": "em",
       "LessThan": "menor que",
       "LessThanOrEqual": "menor ou igual",
+      "NotContains": "não contém",
+      "NotEndsWith": "não termina com",
       "NotEquals": "diferente de",
-      "NotIn": "não em"
+      "NotIn": "não em",
+      "NotStartsWith": "não começa com",
+      "StartsWith": "começa com"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Успешно запрошенные тяги для {{count}} версий.",
     "Version": "Версия"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Размер кластера",
+    "Concurrency": "Одновременные сессии",
+    "CreatedAt": "Создан в",
+    "DefaultForUnspecified": "По умолчанию для неопределенного",
+    "DefaultForUnspecifiedTooltipDesc1": "Устанавливает политику по умолчанию, когда не запрашивается конкретный процессор или память.",
+    "DefaultForUnspecifiedTooltipDesc2": "«Неограниченное» позволяет использовать емкость узла агента, в то время как «ограниченное» отрицает ресурсы, если только явно не установлен. \nВ большинстве случаев рекомендуется «Unlimited».",
+    "IdleTimeout": "Тайм-аут простоя",
+    "MaxConcurrentSFTPSessions": "Максимальные параллельные сеансы SFTP",
+    "MaxPendingSessionCount": "Максимальный счет в ожидании сессии",
+    "MaxPendingSessionResourceSlots": "Максимальный ожидающий сессионные слоты ресурсов",
+    "MaxSessionLifetime": "Максимальное время жизни сеанса",
+    "Name": "Имя",
+    "StorageNodes": "Узлы хранения",
+    "TotalResourceSlots": "Политика ресурсов"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Выберите пару ключей"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Будут обновлены следующие проекты.",
     "ProjectResourcePolicy": "Политика ресурсов проекта",
     "UpdateMultipleProjects": "Обновить несколько проектов"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Создан в",
+    "MaxNetworkCount": "Максимальное количество сетей",
+    "MaxQuotaScopeSize": "Максимальный размер папки",
+    "MaxVFolderCount": "Максимальное количество папок",
+    "Name": "Имя"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Выберите проект"

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "после",
       "Before": "до",
+      "Contains": "содержит",
+      "EndsWith": "заканчивается на",
       "Equals": "равно",
       "GreaterThan": "больше",
       "GreaterThanOrEqual": "больше или равно",
@@ -193,8 +195,12 @@
       "In": "в",
       "LessThan": "меньше",
       "LessThanOrEqual": "меньше или равно",
+      "NotContains": "не содержит",
+      "NotEndsWith": "не заканчивается на",
       "NotEquals": "не равно",
-      "NotIn": "не в"
+      "NotIn": "не в",
+      "NotStartsWith": "не начинается с",
+      "StartsWith": "начинается с"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "ขอให้ดึงได้สำเร็จสำหรับรุ่น {{count}}",
     "Version": "รุ่น"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "ขนาดคลัสเตอร์",
+    "Concurrency": "เซสชันที่ทำงานพร้อมกัน",
+    "CreatedAt": "สร้างเมื่อ",
+    "DefaultForUnspecified": "ค่าเริ่มต้นสำหรับการไม่ระบุ",
+    "DefaultForUnspecifiedTooltipDesc1": "ตั้งค่านโยบายเริ่มต้นเมื่อไม่มีการร้องขอ CPU หรือหน่วยความจำเฉพาะ",
+    "DefaultForUnspecifiedTooltipDesc2": "'ไม่ จำกัด ' ช่วยให้การใช้งานตามความจุของเอเจนต์โหนดในขณะที่ 'จำกัด ' ปฏิเสธทรัพยากรเว้นแต่จะตั้งค่าไว้อย่างชัดเจน \nในกรณีส่วนใหญ่แนะนำให้ 'ไม่ จำกัด '",
+    "IdleTimeout": "หมดเวลาเมื่อไม่มีการใช้งาน",
+    "MaxConcurrentSFTPSessions": "เซสชัน SFTP ที่เกิดขึ้นพร้อมกันสูงสุด",
+    "MaxPendingSessionCount": "จำนวนเซสชันที่ค้างอยู่สูงสุด",
+    "MaxPendingSessionResourceSlots": "ช่องทรัพยากรเซสชันที่รออยู่สูงสุด",
+    "MaxSessionLifetime": "อายุการใช้งานสูงสุดของเซสชัน",
+    "Name": "ชื่อ",
+    "StorageNodes": "โหนดจัดเก็บ",
+    "TotalResourceSlots": "นโยบายทรัพยากร"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "เลือกคู่คีย์"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "โครงการต่อไปนี้จะถูกอัปเดต.",
     "ProjectResourcePolicy": "นโยบายทรัพยากรโครงการ",
     "UpdateMultipleProjects": "อัปเดตหลายโครงการ"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "สร้างเมื่อ",
+    "MaxNetworkCount": "จำนวนเครือข่ายสูงสุด",
+    "MaxQuotaScopeSize": "ขนาดโฟลเดอร์สูงสุด",
+    "MaxVFolderCount": "จำนวนโฟลเดอร์สูงสุด",
+    "Name": "ชื่อ"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "เลือกโปรเจกต์"

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "หลัง",
       "Before": "ก่อน",
+      "Contains": "ประกอบด้วย",
+      "EndsWith": "ลงท้ายด้วย",
       "Equals": "เท่ากับ",
       "GreaterThan": "มากกว่า",
       "GreaterThanOrEqual": "มากกว่าหรือเท่ากับ",
@@ -193,8 +195,12 @@
       "In": "ใน",
       "LessThan": "น้อยกว่า",
       "LessThanOrEqual": "น้อยกว่าหรือเท่ากับ",
+      "NotContains": "ไม่มี",
+      "NotEndsWith": "ไม่ลงท้ายด้วย",
       "NotEquals": "ไม่เท่ากับ",
-      "NotIn": "ไม่ใน"
+      "NotIn": "ไม่ใน",
+      "NotStartsWith": "ไม่เริ่มต้นด้วย",
+      "StartsWith": "เริ่มต้นด้วย"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "sonra",
       "Before": "önce",
+      "Contains": "içerir",
+      "EndsWith": "ile biter",
       "Equals": "eşit",
       "GreaterThan": "daha büyük",
       "GreaterThanOrEqual": "büyük veya eşit",
@@ -193,8 +195,12 @@
       "In": "içinde",
       "LessThan": "daha küçük",
       "LessThanOrEqual": "küçük veya eşit",
+      "NotContains": "içermez",
+      "NotEndsWith": "ile bitmez",
       "NotEquals": "eşit değil",
-      "NotIn": "içinde değil"
+      "NotIn": "içinde değil",
+      "NotStartsWith": "ile başlamaz",
+      "StartsWith": "ile başlar"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "{{count}} sürümleri için başarıyla talep edildi.",
     "Version": "Versiyon"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Küme boyutu",
+    "Concurrency": "Eşzamanlı Oturumlar",
+    "CreatedAt": "Oluşturulma Tarihi",
+    "DefaultForUnspecified": "Belirtilmemiş için varsayılan",
+    "DefaultForUnspecifiedTooltipDesc1": "Belirli bir CPU veya bellek istendiğinde varsayılan ilkeyi ayarlar.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Sınırsız', aracı düğümünün kapasitesine kadar kullanım sağlarken, 'Limited' açıkça ayarlanmadıkça kaynakları reddeder. \nÇoğu durumda, 'sınırsız' önerilir.",
+    "IdleTimeout": "Boşta Kalma Zaman Aşımı",
+    "MaxConcurrentSFTPSessions": "Maksimum eşzamanlı SFTP oturumları",
+    "MaxPendingSessionCount": "Max bekleyen oturum sayısı",
+    "MaxPendingSessionResourceSlots": "Max Bekleyen Oturum Kaynak Yuvaları",
+    "MaxSessionLifetime": "Maksimum Oturum Ömrü",
+    "Name": "isim",
+    "StorageNodes": "Depolama Düğümleri",
+    "TotalResourceSlots": "Kaynak Politikası"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Anahtar Çifti Seçin"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Aşağıdaki proje(ler) güncellenecek.",
     "ProjectResourcePolicy": "Proje Kaynak Politikası",
     "UpdateMultipleProjects": "Birden Çok Projeyi Güncelle"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Oluşturulma Tarihi",
+    "MaxNetworkCount": "Maksimum Ağ Sayısı",
+    "MaxQuotaScopeSize": "Maksimum Klasör Boyutu",
+    "MaxVFolderCount": "Maksimum Klasör Sayısı",
+    "Name": "isim"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Proje seç"

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "sau",
       "Before": "trước",
+      "Contains": "chứa",
+      "EndsWith": "kết thúc bằng",
       "Equals": "bằng",
       "GreaterThan": "lớn hơn",
       "GreaterThanOrEqual": "lớn hơn hoặc bằng",
@@ -193,8 +195,12 @@
       "In": "trong",
       "LessThan": "nhỏ hơn",
       "LessThanOrEqual": "nhỏ hơn hoặc bằng",
+      "NotContains": "không chứa",
+      "NotEndsWith": "không kết thúc bằng",
       "NotEquals": "không bằng",
-      "NotIn": "không trong"
+      "NotIn": "không trong",
+      "NotStartsWith": "không bắt đầu bằng",
+      "StartsWith": "bắt đầu bằng"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "Yêu cầu kéo thành công cho các phiên bản {{count}}.",
     "Version": "Phiên bản"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "Kích thước cụm",
+    "Concurrency": "Phiên đồng thời",
+    "CreatedAt": "Được tạo tại",
+    "DefaultForUnspecified": "Mặc định cho không xác định",
+    "DefaultForUnspecifiedTooltipDesc1": "Đặt chính sách mặc định khi không yêu cầu CPU hoặc bộ nhớ cụ thể.",
+    "DefaultForUnspecifiedTooltipDesc2": "'Unlimited' cho phép sử dụng theo công suất của nút đại lý, trong khi 'giới hạn' từ chối tài nguyên trừ khi được thiết lập rõ ràng. \nTrong hầu hết các trường hợp, 'không giới hạn' được khuyến nghị.",
+    "IdleTimeout": "Hết thời gian chờ",
+    "MaxConcurrentSFTPSessions": "Phiên SFTP đồng thời tối đa",
+    "MaxPendingSessionCount": "Số lượng phiên đang chờ xử lý tối đa",
+    "MaxPendingSessionResourceSlots": "Các khe cắm tài nguyên phiên đang chờ xử lý tối đa",
+    "MaxSessionLifetime": "Thời gian tồn tại của phiên tối đa",
+    "Name": "Tên",
+    "StorageNodes": "Nút lưu trữ",
+    "TotalResourceSlots": "Chính sách tài nguyên"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Chọn cặp khóa"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "Dự án sau sẽ được cập nhật.",
     "ProjectResourcePolicy": "Chính sách tài nguyên dự án",
     "UpdateMultipleProjects": "Cập nhật nhiều dự án"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "Được tạo tại",
+    "MaxNetworkCount": "Số lượng mạng tối đa",
+    "MaxQuotaScopeSize": "Kích thước thư mục tối đa",
+    "MaxVFolderCount": "Số lượng thư mục tối đa",
+    "Name": "Tên"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "Chọn dự án"

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "成功请求{{count}}版本的拉动。",
     "Version": "版本"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "簇的大小",
+    "Concurrency": "并发会话数",
+    "CreatedAt": "创建于",
+    "DefaultForUnspecified": "未指定的默认值",
+    "DefaultForUnspecifiedTooltipDesc1": "当不请求特定的CPU或内存时，设置默认策略。",
+    "DefaultForUnspecifiedTooltipDesc2": "“无限”允许使用代理节点的容量，而“有限”拒绝资源，除非明确设置。\n在大多数情况下，建议“无限”。",
+    "IdleTimeout": "空闲超时",
+    "MaxConcurrentSFTPSessions": "最大并发SFTP会话",
+    "MaxPendingSessionCount": "最大待定会话计数",
+    "MaxPendingSessionResourceSlots": "最大待处理会话资源插槽",
+    "MaxSessionLifetime": "最大会话寿命",
+    "Name": "名称",
+    "StorageNodes": "存储节点",
+    "TotalResourceSlots": "资源政策"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "选择密钥对"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "以下项目将被更新。",
     "ProjectResourcePolicy": "项目资源策略",
     "UpdateMultipleProjects": "批量更新项目"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "创建于",
+    "MaxNetworkCount": "最大网络数",
+    "MaxQuotaScopeSize": "文件夹最大尺寸",
+    "MaxVFolderCount": "最大文件夹数",
+    "Name": "名称"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "选择项目"

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "之后",
       "Before": "之前",
+      "Contains": "包含",
+      "EndsWith": "以...结尾",
       "Equals": "等于",
       "GreaterThan": "大于",
       "GreaterThanOrEqual": "大于或等于",
@@ -193,8 +195,12 @@
       "In": "在...中",
       "LessThan": "小于",
       "LessThanOrEqual": "小于或等于",
+      "NotContains": "不包含",
+      "NotEndsWith": "不以...结尾",
       "NotEquals": "不等于",
-      "NotIn": "不在...中"
+      "NotIn": "不在...中",
+      "NotStartsWith": "不以...开头",
+      "StartsWith": "以...开头"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -179,6 +179,8 @@
     "operator": {
       "After": "之後",
       "Before": "之前",
+      "Contains": "包含",
+      "EndsWith": "以...結尾",
       "Equals": "等於",
       "GreaterThan": "大於",
       "GreaterThanOrEqual": "大於或等於",
@@ -193,8 +195,12 @@
       "In": "在...中",
       "LessThan": "小於",
       "LessThanOrEqual": "小於或等於",
+      "NotContains": "不包含",
+      "NotEndsWith": "不以...結尾",
       "NotEquals": "不等於",
-      "NotIn": "不在...中"
+      "NotIn": "不在...中",
+      "NotStartsWith": "不以...開頭",
+      "StartsWith": "以...開頭"
     }
   },
   "comp:BAIHuggingFaceRegistrySettingModal": {

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -222,6 +222,22 @@
     "SuccessFullyPulled": "成功請求{{count}}版本的拉動。",
     "Version": "版本"
   },
+  "comp:BAIKeypairResourcePolicyV2Table": {
+    "ClusterSize": "簇的大小",
+    "Concurrency": "並發會話數",
+    "CreatedAt": "創建於",
+    "DefaultForUnspecified": "未指定的默認值",
+    "DefaultForUnspecifiedTooltipDesc1": "當不請求特定的CPU或內存時，設置默認策略。",
+    "DefaultForUnspecifiedTooltipDesc2": "“無限”允許使用代理節點的容量，而“有限”拒絕資源，除非明確設置。在大多數情況下，建議“無限”。",
+    "IdleTimeout": "空閒超時",
+    "MaxConcurrentSFTPSessions": "最大並發SFTP會話",
+    "MaxPendingSessionCount": "最大待定會話計數",
+    "MaxPendingSessionResourceSlots": "最大待處理會話資源插槽",
+    "MaxSessionLifetime": "最大会话寿命",
+    "Name": "名稱",
+    "StorageNodes": "存儲節點",
+    "TotalResourceSlots": "資源政策"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "選擇金鑰對"
   },
@@ -282,6 +298,13 @@
     "FollowingProjectsWillBeUpdated": "下列專案將會更新。",
     "ProjectResourcePolicy": "專案資源政策",
     "UpdateMultipleProjects": "更新多個專案"
+  },
+  "comp:BAIProjectResourcePolicyV2Table": {
+    "CreatedAt": "創建於",
+    "MaxNetworkCount": "最大網路數",
+    "MaxQuotaScopeSize": "文件夹最大尺寸",
+    "MaxVFolderCount": "最大資料夾數",
+    "Name": "名稱"
   },
   "comp:BAIProjectSelect": {
     "SelectProject": "選擇專案"

--- a/react/src/__generated__/KeypairResourcePolicyV2Mutation.graphql.ts
+++ b/react/src/__generated__/KeypairResourcePolicyV2Mutation.graphql.ts
@@ -1,0 +1,89 @@
+/**
+ * @generated SignedSource<<e9c7b98db4859c9c5a1af8911ae01031>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type KeypairResourcePolicyV2Mutation$variables = {
+  name: string;
+};
+export type KeypairResourcePolicyV2Mutation$data = {
+  readonly adminDeleteKeypairResourcePolicyV2: {
+    readonly name: string;
+  } | null | undefined;
+};
+export type KeypairResourcePolicyV2Mutation = {
+  response: KeypairResourcePolicyV2Mutation$data;
+  variables: KeypairResourcePolicyV2Mutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "DeleteKeypairResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminDeleteKeypairResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "KeypairResourcePolicyV2Mutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "KeypairResourcePolicyV2Mutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "a79907aee60010ce5a10601c91e6c56f",
+    "id": null,
+    "metadata": {},
+    "name": "KeypairResourcePolicyV2Mutation",
+    "operationKind": "mutation",
+    "text": "mutation KeypairResourcePolicyV2Mutation(\n  $name: String!\n) {\n  adminDeleteKeypairResourcePolicyV2(name: $name) {\n    name\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "b69cd12bcfdddcd9e5439c3d1c53b4af";
+
+export default node;

--- a/react/src/__generated__/KeypairResourcePolicyV2Query.graphql.ts
+++ b/react/src/__generated__/KeypairResourcePolicyV2Query.graphql.ts
@@ -1,0 +1,413 @@
+/**
+ * @generated SignedSource<<9afd20a4657bf7f190671138bc650d4f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type KeypairResourcePolicyV2OrderField = "CREATED_AT" | "IDLE_TIMEOUT" | "MAX_CONCURRENT_SESSIONS" | "MAX_CONCURRENT_SFTP_SESSIONS" | "MAX_CONTAINERS_PER_SESSION" | "MAX_PENDING_SESSION_COUNT" | "MAX_SESSION_LIFETIME" | "NAME" | "%future added value";
+export type OrderDirection = "ASC" | "DESC" | "%future added value";
+export type KeypairResourcePolicyV2Filter = {
+  AND?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  NOT?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  OR?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  createdAt?: DateTimeFilter | null | undefined;
+  idleTimeout?: IntFilter | null | undefined;
+  keypair?: KeypairResourcePolicyKeypairNestedFilter | null | undefined;
+  maxConcurrentSessions?: IntFilter | null | undefined;
+  maxConcurrentSftpSessions?: IntFilter | null | undefined;
+  maxContainersPerSession?: IntFilter | null | undefined;
+  maxPendingSessionCount?: IntFilter | null | undefined;
+  maxSessionLifetime?: IntFilter | null | undefined;
+  name?: StringFilter | null | undefined;
+};
+export type StringFilter = {
+  contains?: string | null | undefined;
+  endsWith?: string | null | undefined;
+  equals?: string | null | undefined;
+  iContains?: string | null | undefined;
+  iEndsWith?: string | null | undefined;
+  iEquals?: string | null | undefined;
+  iIn?: ReadonlyArray<string> | null | undefined;
+  iNotContains?: string | null | undefined;
+  iNotEndsWith?: string | null | undefined;
+  iNotEquals?: string | null | undefined;
+  iNotIn?: ReadonlyArray<string> | null | undefined;
+  iNotStartsWith?: string | null | undefined;
+  iStartsWith?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notContains?: string | null | undefined;
+  notEndsWith?: string | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+  notStartsWith?: string | null | undefined;
+  startsWith?: string | null | undefined;
+};
+export type DateTimeFilter = {
+  after?: string | null | undefined;
+  before?: string | null | undefined;
+  equals?: string | null | undefined;
+  notEquals?: string | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type KeypairResourcePolicyKeypairNestedFilter = {
+  userId?: UUIDFilter | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+};
+export type KeypairResourcePolicyV2OrderBy = {
+  direction?: OrderDirection;
+  field?: KeypairResourcePolicyV2OrderField;
+};
+export type KeypairResourcePolicyV2Query$variables = {
+  filter?: KeypairResourcePolicyV2Filter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  orderBy?: ReadonlyArray<KeypairResourcePolicyV2OrderBy> | null | undefined;
+};
+export type KeypairResourcePolicyV2Query$data = {
+  readonly adminKeypairResourcePoliciesV2: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly name: string;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIKeypairResourcePolicyV2TableFragment" | "KeypairResourcePolicyV2SettingModalFragment">;
+      };
+    }>;
+  } | null | undefined;
+};
+export type KeypairResourcePolicyV2Query = {
+  response: KeypairResourcePolicyV2Query$data;
+  variables: KeypairResourcePolicyV2Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "limit"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
+  },
+  {
+    "kind": "Variable",
+    "name": "orderBy",
+    "variableName": "orderBy"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "resourceType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "quantity",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "unlimited",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "KeypairResourcePolicyV2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "KeypairResourcePolicyV2Connection",
+        "kind": "LinkedField",
+        "name": "adminKeypairResourcePoliciesV2",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "KeypairResourcePolicyV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "KeypairResourcePolicyV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "BAIKeypairResourcePolicyV2TableFragment"
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "KeypairResourcePolicyV2SettingModalFragment"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "KeypairResourcePolicyV2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "KeypairResourcePolicyV2Connection",
+        "kind": "LinkedField",
+        "name": "adminKeypairResourcePoliciesV2",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "KeypairResourcePolicyV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "KeypairResourcePolicyV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "defaultForUnspecified",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ResourceLimitEntry",
+                    "kind": "LinkedField",
+                    "name": "totalResourceSlots",
+                    "plural": true,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxSessionLifetime",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxConcurrentSessions",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxPendingSessionCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ResourceLimitEntry",
+                    "kind": "LinkedField",
+                    "name": "maxPendingSessionResourceSlots",
+                    "plural": true,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxConcurrentSftpSessions",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxContainersPerSession",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "idleTimeout",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "VFolderHostPermissionEntry",
+                    "kind": "LinkedField",
+                    "name": "allowedVfolderHosts",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "host",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "permissions",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d95b434b6daa4ce53779845b1950d5af",
+    "id": null,
+    "metadata": {},
+    "name": "KeypairResourcePolicyV2Query",
+    "operationKind": "query",
+    "text": "query KeypairResourcePolicyV2Query(\n  $filter: KeypairResourcePolicyV2Filter\n  $orderBy: [KeypairResourcePolicyV2OrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminKeypairResourcePoliciesV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...BAIKeypairResourcePolicyV2TableFragment\n        ...KeypairResourcePolicyV2SettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIKeypairResourcePolicyV2TableFragment on KeypairResourcePolicyV2 {\n  id\n  name\n  createdAt\n  defaultForUnspecified\n  totalResourceSlots {\n    resourceType\n    quantity\n    unlimited\n  }\n  maxSessionLifetime\n  maxConcurrentSessions\n  maxPendingSessionCount\n  maxPendingSessionResourceSlots {\n    resourceType\n    quantity\n    unlimited\n  }\n  maxConcurrentSftpSessions\n  maxContainersPerSession\n  idleTimeout\n  allowedVfolderHosts {\n    host\n    permissions\n  }\n}\n\nfragment KeypairResourcePolicyV2SettingModalFragment on KeypairResourcePolicyV2 {\n  id\n  name\n  defaultForUnspecified\n  totalResourceSlots {\n    resourceType\n    quantity\n    unlimited\n  }\n  maxSessionLifetime\n  maxConcurrentSessions\n  maxContainersPerSession\n  idleTimeout\n  maxPendingSessionCount\n  maxConcurrentSftpSessions\n  allowedVfolderHosts {\n    host\n    permissions\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3fb91a8d04f84d0b90bec4cfc017d569";
+
+export default node;

--- a/react/src/__generated__/KeypairResourcePolicyV2SettingModalCreateMutation.graphql.ts
+++ b/react/src/__generated__/KeypairResourcePolicyV2SettingModalCreateMutation.graphql.ts
@@ -1,0 +1,123 @@
+/**
+ * @generated SignedSource<<9ed73abd057740240e8076d328d69603>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateKeypairResourcePolicyInput = {
+  allowedVfolderHosts: ReadonlyArray<VFolderHostPermissionEntryInput>;
+  defaultForUnspecified: string;
+  idleTimeout: number;
+  maxConcurrentSessions: number;
+  maxConcurrentSftpSessions?: number;
+  maxContainersPerSession: number;
+  maxPendingSessionCount?: number | null | undefined;
+  maxPendingSessionResourceSlots?: ReadonlyArray<ResourceSlotEntryInput> | null | undefined;
+  maxSessionLifetime: number;
+  name: string;
+  totalResourceSlots: ReadonlyArray<ResourceSlotEntryInput>;
+};
+export type ResourceSlotEntryInput = {
+  quantity: string;
+  resourceType: string;
+};
+export type VFolderHostPermissionEntryInput = {
+  host: string;
+  permissions: ReadonlyArray<string>;
+};
+export type KeypairResourcePolicyV2SettingModalCreateMutation$variables = {
+  input: CreateKeypairResourcePolicyInput;
+};
+export type KeypairResourcePolicyV2SettingModalCreateMutation$data = {
+  readonly adminCreateKeypairResourcePolicyV2: {
+    readonly keypairResourcePolicy: {
+      readonly id: string;
+    };
+  } | null | undefined;
+};
+export type KeypairResourcePolicyV2SettingModalCreateMutation = {
+  response: KeypairResourcePolicyV2SettingModalCreateMutation$data;
+  variables: KeypairResourcePolicyV2SettingModalCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateKeypairResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminCreateKeypairResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "KeypairResourcePolicyV2",
+        "kind": "LinkedField",
+        "name": "keypairResourcePolicy",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "KeypairResourcePolicyV2SettingModalCreateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "KeypairResourcePolicyV2SettingModalCreateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "85e11201ff5b0169769108c9d434c8d8",
+    "id": null,
+    "metadata": {},
+    "name": "KeypairResourcePolicyV2SettingModalCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation KeypairResourcePolicyV2SettingModalCreateMutation(\n  $input: CreateKeypairResourcePolicyInput!\n) {\n  adminCreateKeypairResourcePolicyV2(input: $input) {\n    keypairResourcePolicy {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "40f975fada4293f77a55b8b520443587";
+
+export default node;

--- a/react/src/__generated__/KeypairResourcePolicyV2SettingModalFragment.graphql.ts
+++ b/react/src/__generated__/KeypairResourcePolicyV2SettingModalFragment.graphql.ts
@@ -1,0 +1,173 @@
+/**
+ * @generated SignedSource<<0dc6c95f6ec12f42614f89c27501ddae>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type VFolderHostPermissionV2 = "CREATE_VFOLDER" | "DELETE_VFOLDER" | "DOWNLOAD_FILE" | "INVITE_OTHERS" | "MODIFY_VFOLDER" | "MOUNT_IN_SESSION" | "SET_USER_PERM" | "UPLOAD_FILE" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type KeypairResourcePolicyV2SettingModalFragment$data = {
+  readonly allowedVfolderHosts: ReadonlyArray<{
+    readonly host: string;
+    readonly permissions: ReadonlyArray<VFolderHostPermissionV2>;
+  }>;
+  readonly defaultForUnspecified: string;
+  readonly id: string;
+  readonly idleTimeout: number;
+  readonly maxConcurrentSessions: number;
+  readonly maxConcurrentSftpSessions: number;
+  readonly maxContainersPerSession: number;
+  readonly maxPendingSessionCount: number | null | undefined;
+  readonly maxSessionLifetime: number;
+  readonly name: string;
+  readonly totalResourceSlots: ReadonlyArray<{
+    readonly quantity: any | null | undefined;
+    readonly resourceType: string;
+    readonly unlimited: boolean;
+  }>;
+  readonly " $fragmentType": "KeypairResourcePolicyV2SettingModalFragment";
+};
+export type KeypairResourcePolicyV2SettingModalFragment$key = {
+  readonly " $data"?: KeypairResourcePolicyV2SettingModalFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"KeypairResourcePolicyV2SettingModalFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "KeypairResourcePolicyV2SettingModalFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "defaultForUnspecified",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ResourceLimitEntry",
+      "kind": "LinkedField",
+      "name": "totalResourceSlots",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "resourceType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "quantity",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "unlimited",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxSessionLifetime",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxConcurrentSessions",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxContainersPerSession",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "idleTimeout",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxPendingSessionCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxConcurrentSftpSessions",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "VFolderHostPermissionEntry",
+      "kind": "LinkedField",
+      "name": "allowedVfolderHosts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "host",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "permissions",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "KeypairResourcePolicyV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "689ae08c63690331faf350dfffd98b2c";
+
+export default node;

--- a/react/src/__generated__/KeypairResourcePolicyV2SettingModalModifyMutation.graphql.ts
+++ b/react/src/__generated__/KeypairResourcePolicyV2SettingModalModifyMutation.graphql.ts
@@ -1,0 +1,292 @@
+/**
+ * @generated SignedSource<<4897f9f5b7cd72d4e9babe7711d78579>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type VFolderHostPermissionV2 = "CREATE_VFOLDER" | "DELETE_VFOLDER" | "DOWNLOAD_FILE" | "INVITE_OTHERS" | "MODIFY_VFOLDER" | "MOUNT_IN_SESSION" | "SET_USER_PERM" | "UPLOAD_FILE" | "%future added value";
+export type UpdateKeypairResourcePolicyInput = {
+  allowedVfolderHosts?: ReadonlyArray<VFolderHostPermissionEntryInput> | null | undefined;
+  defaultForUnspecified?: string | null | undefined;
+  idleTimeout?: number | null | undefined;
+  maxConcurrentSessions?: number | null | undefined;
+  maxConcurrentSftpSessions?: number | null | undefined;
+  maxContainersPerSession?: number | null | undefined;
+  maxPendingSessionCount?: number | null | undefined;
+  maxPendingSessionResourceSlots?: ReadonlyArray<ResourceSlotEntryInput> | null | undefined;
+  maxSessionLifetime?: number | null | undefined;
+  totalResourceSlots?: ReadonlyArray<ResourceSlotEntryInput> | null | undefined;
+};
+export type ResourceSlotEntryInput = {
+  quantity: string;
+  resourceType: string;
+};
+export type VFolderHostPermissionEntryInput = {
+  host: string;
+  permissions: ReadonlyArray<string>;
+};
+export type KeypairResourcePolicyV2SettingModalModifyMutation$variables = {
+  input: UpdateKeypairResourcePolicyInput;
+  name: string;
+};
+export type KeypairResourcePolicyV2SettingModalModifyMutation$data = {
+  readonly adminUpdateKeypairResourcePolicyV2: {
+    readonly keypairResourcePolicy: {
+      readonly allowedVfolderHosts: ReadonlyArray<{
+        readonly host: string;
+        readonly permissions: ReadonlyArray<VFolderHostPermissionV2>;
+      }>;
+      readonly createdAt: string | null | undefined;
+      readonly defaultForUnspecified: string;
+      readonly id: string;
+      readonly idleTimeout: number;
+      readonly maxConcurrentSessions: number;
+      readonly maxConcurrentSftpSessions: number;
+      readonly maxContainersPerSession: number;
+      readonly maxPendingSessionCount: number | null | undefined;
+      readonly maxPendingSessionResourceSlots: ReadonlyArray<{
+        readonly quantity: any | null | undefined;
+        readonly resourceType: string;
+        readonly unlimited: boolean;
+      }> | null | undefined;
+      readonly maxSessionLifetime: number;
+      readonly name: string;
+      readonly totalResourceSlots: ReadonlyArray<{
+        readonly quantity: any | null | undefined;
+        readonly resourceType: string;
+        readonly unlimited: boolean;
+      }>;
+    };
+  } | null | undefined;
+};
+export type KeypairResourcePolicyV2SettingModalModifyMutation = {
+  response: KeypairResourcePolicyV2SettingModalModifyMutation$data;
+  variables: KeypairResourcePolicyV2SettingModalModifyMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "resourceType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "quantity",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "unlimited",
+    "storageKey": null
+  }
+],
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      },
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "UpdateKeypairResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminUpdateKeypairResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "KeypairResourcePolicyV2",
+        "kind": "LinkedField",
+        "name": "keypairResourcePolicy",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "defaultForUnspecified",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ResourceLimitEntry",
+            "kind": "LinkedField",
+            "name": "totalResourceSlots",
+            "plural": true,
+            "selections": (v2/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxSessionLifetime",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxConcurrentSessions",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxPendingSessionCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ResourceLimitEntry",
+            "kind": "LinkedField",
+            "name": "maxPendingSessionResourceSlots",
+            "plural": true,
+            "selections": (v2/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxConcurrentSftpSessions",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxContainersPerSession",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "idleTimeout",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "VFolderHostPermissionEntry",
+            "kind": "LinkedField",
+            "name": "allowedVfolderHosts",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "host",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "permissions",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "KeypairResourcePolicyV2SettingModalModifyMutation",
+    "selections": (v3/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "KeypairResourcePolicyV2SettingModalModifyMutation",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "44e36db821eafc2b3a5eb3a7c46e4b61",
+    "id": null,
+    "metadata": {},
+    "name": "KeypairResourcePolicyV2SettingModalModifyMutation",
+    "operationKind": "mutation",
+    "text": "mutation KeypairResourcePolicyV2SettingModalModifyMutation(\n  $name: String!\n  $input: UpdateKeypairResourcePolicyInput!\n) {\n  adminUpdateKeypairResourcePolicyV2(name: $name, input: $input) {\n    keypairResourcePolicy {\n      id\n      name\n      createdAt\n      defaultForUnspecified\n      totalResourceSlots {\n        resourceType\n        quantity\n        unlimited\n      }\n      maxSessionLifetime\n      maxConcurrentSessions\n      maxPendingSessionCount\n      maxPendingSessionResourceSlots {\n        resourceType\n        quantity\n        unlimited\n      }\n      maxConcurrentSftpSessions\n      maxContainersPerSession\n      idleTimeout\n      allowedVfolderHosts {\n        host\n        permissions\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "efbe7900175ab6be4af3c27a35689b9f";
+
+export default node;

--- a/react/src/__generated__/ProjectResourcePolicyV2Mutation.graphql.ts
+++ b/react/src/__generated__/ProjectResourcePolicyV2Mutation.graphql.ts
@@ -1,0 +1,89 @@
+/**
+ * @generated SignedSource<<1f798acb69d2526feef4ab0203c8da5b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ProjectResourcePolicyV2Mutation$variables = {
+  name: string;
+};
+export type ProjectResourcePolicyV2Mutation$data = {
+  readonly adminDeleteProjectResourcePolicyV2: {
+    readonly name: string;
+  } | null | undefined;
+};
+export type ProjectResourcePolicyV2Mutation = {
+  response: ProjectResourcePolicyV2Mutation$data;
+  variables: ProjectResourcePolicyV2Mutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "DeleteProjectResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminDeleteProjectResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectResourcePolicyV2Mutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectResourcePolicyV2Mutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "7e55a4620fd1c37cb82357baa9d15d13",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectResourcePolicyV2Mutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectResourcePolicyV2Mutation(\n  $name: String!\n) {\n  adminDeleteProjectResourcePolicyV2(name: $name) {\n    name\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d25eb2dc9186fd211b74ad23a0a53b90";
+
+export default node;

--- a/react/src/__generated__/ProjectResourcePolicyV2Query.graphql.ts
+++ b/react/src/__generated__/ProjectResourcePolicyV2Query.graphql.ts
@@ -1,0 +1,315 @@
+/**
+ * @generated SignedSource<<4c19088dc215867cc96d131b1c59aaa5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type OrderDirection = "ASC" | "DESC" | "%future added value";
+export type ProjectResourcePolicyV2OrderField = "CREATED_AT" | "MAX_NETWORK_COUNT" | "MAX_QUOTA_SCOPE_SIZE" | "MAX_VFOLDER_COUNT" | "NAME" | "%future added value";
+export type ProjectResourcePolicyV2Filter = {
+  AND?: ReadonlyArray<ProjectResourcePolicyV2Filter> | null | undefined;
+  NOT?: ReadonlyArray<ProjectResourcePolicyV2Filter> | null | undefined;
+  OR?: ReadonlyArray<ProjectResourcePolicyV2Filter> | null | undefined;
+  createdAt?: DateTimeFilter | null | undefined;
+  maxNetworkCount?: IntFilter | null | undefined;
+  maxQuotaScopeSize?: IntFilter | null | undefined;
+  maxVfolderCount?: IntFilter | null | undefined;
+  name?: StringFilter | null | undefined;
+};
+export type StringFilter = {
+  contains?: string | null | undefined;
+  endsWith?: string | null | undefined;
+  equals?: string | null | undefined;
+  iContains?: string | null | undefined;
+  iEndsWith?: string | null | undefined;
+  iEquals?: string | null | undefined;
+  iIn?: ReadonlyArray<string> | null | undefined;
+  iNotContains?: string | null | undefined;
+  iNotEndsWith?: string | null | undefined;
+  iNotEquals?: string | null | undefined;
+  iNotIn?: ReadonlyArray<string> | null | undefined;
+  iNotStartsWith?: string | null | undefined;
+  iStartsWith?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notContains?: string | null | undefined;
+  notEndsWith?: string | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+  notStartsWith?: string | null | undefined;
+  startsWith?: string | null | undefined;
+};
+export type DateTimeFilter = {
+  after?: string | null | undefined;
+  before?: string | null | undefined;
+  equals?: string | null | undefined;
+  notEquals?: string | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type ProjectResourcePolicyV2OrderBy = {
+  direction?: OrderDirection;
+  field?: ProjectResourcePolicyV2OrderField;
+};
+export type ProjectResourcePolicyV2Query$variables = {
+  filter?: ProjectResourcePolicyV2Filter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  orderBy?: ReadonlyArray<ProjectResourcePolicyV2OrderBy> | null | undefined;
+};
+export type ProjectResourcePolicyV2Query$data = {
+  readonly adminProjectResourcePoliciesV2: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly name: string;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIProjectResourcePolicyV2TableFragment" | "ProjectResourcePolicyV2SettingModalFragment">;
+      };
+    }>;
+  } | null | undefined;
+};
+export type ProjectResourcePolicyV2Query = {
+  response: ProjectResourcePolicyV2Query$data;
+  variables: ProjectResourcePolicyV2Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "limit"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
+  },
+  {
+    "kind": "Variable",
+    "name": "orderBy",
+    "variableName": "orderBy"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectResourcePolicyV2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "ProjectResourcePolicyV2Connection",
+        "kind": "LinkedField",
+        "name": "adminProjectResourcePoliciesV2",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ProjectResourcePolicyV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProjectResourcePolicyV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "BAIProjectResourcePolicyV2TableFragment"
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "ProjectResourcePolicyV2SettingModalFragment"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectResourcePolicyV2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "ProjectResourcePolicyV2Connection",
+        "kind": "LinkedField",
+        "name": "adminProjectResourcePoliciesV2",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ProjectResourcePolicyV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProjectResourcePolicyV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxVfolderCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "BinarySizeInfo",
+                    "kind": "LinkedField",
+                    "name": "maxQuotaScopeSize",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expr",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxNetworkCount",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6a1b1611d6d6ba8544ae5fa969a3e5c6",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectResourcePolicyV2Query",
+    "operationKind": "query",
+    "text": "query ProjectResourcePolicyV2Query(\n  $filter: ProjectResourcePolicyV2Filter\n  $orderBy: [ProjectResourcePolicyV2OrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminProjectResourcePoliciesV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...BAIProjectResourcePolicyV2TableFragment\n        ...ProjectResourcePolicyV2SettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIProjectResourcePolicyV2TableFragment on ProjectResourcePolicyV2 {\n  id\n  name\n  createdAt\n  maxVfolderCount\n  maxQuotaScopeSize {\n    expr\n  }\n  maxNetworkCount\n}\n\nfragment ProjectResourcePolicyV2SettingModalFragment on ProjectResourcePolicyV2 {\n  id\n  name\n  maxVfolderCount\n  maxQuotaScopeSize {\n    expr\n  }\n  maxNetworkCount\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "81d540291e86122855b5d84151d86a09";
+
+export default node;

--- a/react/src/__generated__/ProjectResourcePolicyV2SettingModalCreateMutation.graphql.ts
+++ b/react/src/__generated__/ProjectResourcePolicyV2SettingModalCreateMutation.graphql.ts
@@ -1,0 +1,111 @@
+/**
+ * @generated SignedSource<<022656eb899c9e241649d0769f2e036c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateProjectResourcePolicyInputV2 = {
+  maxNetworkCount: number;
+  maxQuotaScopeSize: BinarySizeInput;
+  maxVfolderCount: number;
+  name: string;
+};
+export type BinarySizeInput = {
+  expr: string;
+};
+export type ProjectResourcePolicyV2SettingModalCreateMutation$variables = {
+  input: CreateProjectResourcePolicyInputV2;
+};
+export type ProjectResourcePolicyV2SettingModalCreateMutation$data = {
+  readonly adminCreateProjectResourcePolicyV2: {
+    readonly projectResourcePolicy: {
+      readonly id: string;
+    };
+  } | null | undefined;
+};
+export type ProjectResourcePolicyV2SettingModalCreateMutation = {
+  response: ProjectResourcePolicyV2SettingModalCreateMutation$data;
+  variables: ProjectResourcePolicyV2SettingModalCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateProjectResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminCreateProjectResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ProjectResourcePolicyV2",
+        "kind": "LinkedField",
+        "name": "projectResourcePolicy",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectResourcePolicyV2SettingModalCreateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectResourcePolicyV2SettingModalCreateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "9964624e0e8d972ab858a6d5522f47f0",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectResourcePolicyV2SettingModalCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectResourcePolicyV2SettingModalCreateMutation(\n  $input: CreateProjectResourcePolicyInputV2!\n) {\n  adminCreateProjectResourcePolicyV2(input: $input) {\n    projectResourcePolicy {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "918964fe51fe05bdcf812a61a70c8353";
+
+export default node;

--- a/react/src/__generated__/ProjectResourcePolicyV2SettingModalFragment.graphql.ts
+++ b/react/src/__generated__/ProjectResourcePolicyV2SettingModalFragment.graphql.ts
@@ -1,0 +1,87 @@
+/**
+ * @generated SignedSource<<053639eb07447fb32139d799bf37e83d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ProjectResourcePolicyV2SettingModalFragment$data = {
+  readonly id: string;
+  readonly maxNetworkCount: number;
+  readonly maxQuotaScopeSize: {
+    readonly expr: string;
+  };
+  readonly maxVfolderCount: number;
+  readonly name: string;
+  readonly " $fragmentType": "ProjectResourcePolicyV2SettingModalFragment";
+};
+export type ProjectResourcePolicyV2SettingModalFragment$key = {
+  readonly " $data"?: ProjectResourcePolicyV2SettingModalFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProjectResourcePolicyV2SettingModalFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ProjectResourcePolicyV2SettingModalFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxVfolderCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "BinarySizeInfo",
+      "kind": "LinkedField",
+      "name": "maxQuotaScopeSize",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "expr",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxNetworkCount",
+      "storageKey": null
+    }
+  ],
+  "type": "ProjectResourcePolicyV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "f57497d71d1fc302d07cc30c14375371";
+
+export default node;

--- a/react/src/__generated__/ProjectResourcePolicyV2SettingModalModifyMutation.graphql.ts
+++ b/react/src/__generated__/ProjectResourcePolicyV2SettingModalModifyMutation.graphql.ts
@@ -1,0 +1,178 @@
+/**
+ * @generated SignedSource<<517a23e984bd7da635e78813ed230801>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateProjectResourcePolicyInput = {
+  maxNetworkCount?: number | null | undefined;
+  maxQuotaScopeSize?: BinarySizeInput | null | undefined;
+  maxVfolderCount?: number | null | undefined;
+};
+export type BinarySizeInput = {
+  expr: string;
+};
+export type ProjectResourcePolicyV2SettingModalModifyMutation$variables = {
+  input: UpdateProjectResourcePolicyInput;
+  name: string;
+};
+export type ProjectResourcePolicyV2SettingModalModifyMutation$data = {
+  readonly adminUpdateProjectResourcePolicyV2: {
+    readonly projectResourcePolicy: {
+      readonly createdAt: string | null | undefined;
+      readonly id: string;
+      readonly maxNetworkCount: number;
+      readonly maxQuotaScopeSize: {
+        readonly expr: string;
+      };
+      readonly maxVfolderCount: number;
+      readonly name: string;
+    };
+  } | null | undefined;
+};
+export type ProjectResourcePolicyV2SettingModalModifyMutation = {
+  response: ProjectResourcePolicyV2SettingModalModifyMutation$data;
+  variables: ProjectResourcePolicyV2SettingModalModifyMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      },
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "UpdateProjectResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminUpdateProjectResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ProjectResourcePolicyV2",
+        "kind": "LinkedField",
+        "name": "projectResourcePolicy",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxVfolderCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "BinarySizeInfo",
+            "kind": "LinkedField",
+            "name": "maxQuotaScopeSize",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "expr",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxNetworkCount",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectResourcePolicyV2SettingModalModifyMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectResourcePolicyV2SettingModalModifyMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "2c96373fbbfdfc5b9f9aebc8fbeee01e",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectResourcePolicyV2SettingModalModifyMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectResourcePolicyV2SettingModalModifyMutation(\n  $name: String!\n  $input: UpdateProjectResourcePolicyInput!\n) {\n  adminUpdateProjectResourcePolicyV2(name: $name, input: $input) {\n    projectResourcePolicy {\n      id\n      name\n      createdAt\n      maxVfolderCount\n      maxQuotaScopeSize {\n        expr\n      }\n      maxNetworkCount\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9a9c28802a896f925245b977923feb2a";
+
+export default node;

--- a/react/src/components/KeypairResourcePolicyV2.tsx
+++ b/react/src/components/KeypairResourcePolicyV2.tsx
@@ -1,0 +1,366 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { KeypairResourcePolicyV2Mutation } from '../__generated__/KeypairResourcePolicyV2Mutation.graphql';
+import type {
+  KeypairResourcePolicyV2OrderBy,
+  KeypairResourcePolicyV2Query as KeypairResourcePolicyV2QueryType,
+} from '../__generated__/KeypairResourcePolicyV2Query.graphql';
+import { App } from '../app-shim';
+import { convertToOrderBy } from '../helper';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import KeypairResourcePolicyV2SettingModal from './KeypairResourcePolicyV2SettingModal';
+import {
+  BAIButton,
+  BAIDeleteConfirmModal,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  BAIKeypairResourcePolicyV2Table,
+  type BAIKeypairResourcePolicyV2TableProps,
+  BAINameActionCell,
+  filterOutNullAndUndefined,
+  useFetchKey,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { Trash2, PlusIcon, SquarePenIcon } from 'lucide-react';
+import { Suspense, useDeferredValue, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+  useMutation,
+} from 'react-relay';
+
+export const KeypairResourcePolicyV2Query = graphql`
+  query KeypairResourcePolicyV2Query(
+    $filter: KeypairResourcePolicyV2Filter
+    $orderBy: [KeypairResourcePolicyV2OrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    adminKeypairResourcePoliciesV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          name
+          ...BAIKeypairResourcePolicyV2TableFragment
+          ...KeypairResourcePolicyV2SettingModalFragment
+        }
+      }
+    }
+  }
+`;
+
+type KeypairResourcePolicyV2Node = NonNullable<
+  NonNullable<
+    NonNullable<
+      KeypairResourcePolicyV2QueryType['response']['adminKeypairResourcePoliciesV2']
+    >['edges'][number]
+  >['node']
+>;
+
+export interface KeypairResourcePolicyV2Props extends Omit<
+  BAIKeypairResourcePolicyV2TableProps,
+  | 'keypairResourcePoliciesFrgmt'
+  | 'loading'
+  | 'order'
+  | 'onChangeOrder'
+  | 'dataSource'
+  | 'pagination'
+  | 'customizeColumns'
+> {
+  queryRef: PreloadedQuery<KeypairResourcePolicyV2QueryType>;
+  onReload: (
+    variables: KeypairResourcePolicyV2QueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+const KeypairResourcePolicyV2 = ({
+  queryRef,
+  onReload,
+  ...tableProps
+}: KeypairResourcePolicyV2Props) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
+  const [editingKeypairResourcePolicy, setEditingKeypairResourcePolicy] =
+    useState<KeypairResourcePolicyV2Node | null>(null);
+  const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
+    null,
+  );
+
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.KeypairResourcePolicyV2',
+  );
+
+  const filter = queryRef.variables.filter ?? undefined;
+  const orderBy = queryRef.variables.orderBy?.[0];
+  const order = orderBy
+    ? `${orderBy.direction === 'DESC' ? '-' : ''}${_.camelCase(orderBy.field)}`
+    : null;
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
+
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<KeypairResourcePolicyV2QueryType>(
+    KeypairResourcePolicyV2Query,
+    deferredQueryRef,
+  );
+
+  const [commitDelete] = useMutation<KeypairResourcePolicyV2Mutation>(graphql`
+    mutation KeypairResourcePolicyV2Mutation($name: String!) {
+      adminDeleteKeypairResourcePolicyV2(name: $name) {
+        name
+      }
+    }
+  `);
+
+  const keypairResourcePolicies = filterOutNullAndUndefined(
+    (data.adminKeypairResourcePoliciesV2?.edges ?? []).map(
+      (edge) => edge?.node,
+    ),
+  );
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIFlex justify={'between'} wrap="wrap" gap="sm">
+        <BAIGraphQLPropertyFilter
+          value={filter}
+          onChange={(next) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                filter: next,
+                offset: 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
+          filterProperties={[
+            {
+              key: 'name',
+              propertyLabel: t('resourcePolicy.Name'),
+              type: 'string',
+              fixedOperator: 'contains',
+            },
+            {
+              key: 'createdAt',
+              propertyLabel: t('resourcePolicy.CreatedAt'),
+              type: 'datetime',
+              defaultOperator: 'after',
+            },
+            {
+              key: 'maxSessionLifetime',
+              propertyLabel: t('session.MaxSessionLifetime'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxConcurrentSessions',
+              propertyLabel: t('resourcePolicy.Concurrency'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxContainersPerSession',
+              propertyLabel: t('resourcePolicy.ClusterSize'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'idleTimeout',
+              propertyLabel: t('resourcePolicy.IdleTimeout'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxConcurrentSftpSessions',
+              propertyLabel: t('resourcePolicy.MaxConcurrentSFTPSessions'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxPendingSessionCount',
+              propertyLabel: t('resourcePolicy.MaxPendingSessionCount'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+          ]}
+        />
+        <BAIFlex gap="xs">
+          <BAIFetchKeyButton
+            value={fetchKey}
+            onChange={(key) => {
+              updateFetchKey(key);
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+            }}
+            loading={isRefetching}
+          />
+          <BAIButton
+            type="primary"
+            icon={<PlusIcon />}
+            onClick={() => {
+              setIsCreatingPolicySetting(true);
+            }}
+          >
+            {t('button.Create')}
+          </BAIButton>
+        </BAIFlex>
+      </BAIFlex>
+      <BAIKeypairResourcePolicyV2Table
+        loading={isRefetching}
+        tableSettings={{
+          columnOverrides,
+          onColumnOverridesChange: setColumnOverrides,
+        }}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy:
+                convertToOrderBy<KeypairResourcePolicyV2OrderBy>(nextOrder),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
+        }}
+        pagination={{
+          pageSize,
+          current,
+          total: data.adminKeypairResourcePoliciesV2?.count ?? 0,
+          onChange: (nextCurrent, nextPageSize) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                limit: nextPageSize,
+                offset: nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          },
+        }}
+        customizeColumns={(columns) =>
+          _.map(columns, (column) =>
+            column.key === 'name'
+              ? {
+                  ...column,
+                  render: (name: string, record) => (
+                    <BAINameActionCell
+                      title={name}
+                      showActions="always"
+                      actions={[
+                        {
+                          key: 'edit',
+                          title: t('button.Edit'),
+                          icon: <SquarePenIcon />,
+                          onClick: () => {
+                            setEditingKeypairResourcePolicy(
+                              _.find(keypairResourcePolicies, {
+                                id: record.id,
+                              }) ?? null,
+                            );
+                          },
+                        },
+                        {
+                          key: 'delete',
+                          title: t('button.Delete'),
+                          icon: <Trash2 size="1em" />,
+                          type: 'danger',
+                          onClick: () => {
+                            setDeletingPolicyName(record.name);
+                          },
+                        },
+                      ]}
+                    />
+                  ),
+                }
+              : column,
+          )
+        }
+        keypairResourcePoliciesFrgmt={keypairResourcePolicies}
+        {...tableProps}
+      />
+      <Suspense>
+        <KeypairResourcePolicyV2SettingModal
+          open={!!editingKeypairResourcePolicy || isCreatingPolicySetting}
+          keypairResourcePolicyFrgmt={editingKeypairResourcePolicy}
+          onOk={() => {
+            // A create adds a new row the offset query can't know about, so it
+            // needs a refetch. An update returns every field, so Relay merges the
+            // record by id into the store and the list reflects it without one.
+            if (isCreatingPolicySetting) {
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+            }
+            setEditingKeypairResourcePolicy(null);
+            setIsCreatingPolicySetting(false);
+          }}
+          onCancel={() => {
+            setEditingKeypairResourcePolicy(null);
+            setIsCreatingPolicySetting(false);
+          }}
+        />
+      </Suspense>
+      <BAIDeleteConfirmModal
+        open={!!deletingPolicyName}
+        items={
+          deletingPolicyName
+            ? [{ key: deletingPolicyName, label: deletingPolicyName }]
+            : []
+        }
+        title={t('resourcePolicy.DeletePolicy')}
+        target={t('resourcePolicy.ResourcePolicy')}
+        confirmText={deletingPolicyName ?? ''}
+        requireConfirmInput
+        onOk={() => {
+          if (deletingPolicyName) {
+            return new Promise<void>((resolve) => {
+              commitDelete({
+                variables: { name: deletingPolicyName },
+                onCompleted: (_res, errors) => {
+                  if (errors && errors.length > 0) {
+                    for (const error of errors) {
+                      message.error(error.message);
+                    }
+                  } else {
+                    onReload(queryRef.variables, {
+                      fetchPolicy: 'network-only',
+                    });
+                    message.success(t('resourcePolicy.ResourcePolicyDeleted'));
+                  }
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+                onError(err) {
+                  message.error(err?.message);
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+              });
+            });
+          }
+        }}
+        onCancel={() => setDeletingPolicyName(null)}
+      />
+    </BAIFlex>
+  );
+};
+
+export default KeypairResourcePolicyV2;

--- a/react/src/components/KeypairResourcePolicyV2SettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicyV2SettingModal.tsx
@@ -1,0 +1,532 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  CreateKeypairResourcePolicyInput,
+  KeypairResourcePolicyV2SettingModalCreateMutation,
+} from '../__generated__/KeypairResourcePolicyV2SettingModalCreateMutation.graphql';
+import { KeypairResourcePolicyV2SettingModalFragment$key } from '../__generated__/KeypairResourcePolicyV2SettingModalFragment.graphql';
+import {
+  KeypairResourcePolicyV2SettingModalModifyMutation,
+  UpdateKeypairResourcePolicyInput,
+} from '../__generated__/KeypairResourcePolicyV2SettingModalModifyMutation.graphql';
+import { App } from '../app-shim';
+import { Form, FormInstance } from '../form-engine';
+import { convertToBinaryUnit } from '../helper';
+import { MAX_CPU_QUOTA, SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
+import { v2PermissionToKey } from '../helper/storageHostPermission';
+import { useResourceSlots, useResourceSlotsDetails } from '../hooks/backendai';
+import BAIFormItem from './BAIFormItem';
+import FormItemWithUnlimited from './FormItemWithUnlimited';
+import {
+  AstryxFormNumberInput,
+  AstryxFormSelector,
+  AstryxFormTextInput,
+} from './astryxFormControls';
+import { Card } from '@astryxdesign/core/Card';
+import { Grid } from '@astryxdesign/core/Grid';
+import { Icon } from '@astryxdesign/core/Icon';
+import { Tooltip } from '@astryxdesign/core/Tooltip';
+import {
+  BAIAllowedHostNamesSelect,
+  BAIDynamicUnitInputNumber,
+  BAIFlex,
+  BAIModal,
+  BAIModalProps,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { CircleHelp } from 'lucide-react';
+import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment, useMutation } from 'react-relay';
+
+/**
+ * The permission set granted to a storage host the admin newly allows. Same
+ * list the V1 modal used; the V2 mutation validates these kebab keys against
+ * the V1 `VFolderHostPermission` enum, not the `VFolderHostPermissionV2` names
+ * the read side returns.
+ */
+const DEFAULT_VFOLDER_HOST_PERMISSIONS = [
+  'create-vfolder',
+  'modify-vfolder',
+  'delete-vfolder',
+  'mount-in-session',
+  'upload-file',
+  'download-file',
+  'invite-others',
+  'set-user-specific-permission',
+];
+
+interface KeypairResourcePolicyV2SettingModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onCancel'
+> {
+  keypairResourcePolicyFrgmt: KeypairResourcePolicyV2SettingModalFragment$key | null;
+  onOk: () => void;
+  onCancel: () => void;
+}
+
+const KeypairResourcePolicyV2SettingModal: React.FC<
+  KeypairResourcePolicyV2SettingModalProps
+> = ({
+  keypairResourcePolicyFrgmt = null,
+  onOk,
+  onCancel,
+  ...baiModalProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const formRef = useRef<FormInstance>(null);
+  const [resourceSlots] = useResourceSlots();
+  const { mergedResourceSlots } = useResourceSlotsDetails();
+
+  const keypairResourcePolicy = useFragment(
+    graphql`
+      fragment KeypairResourcePolicyV2SettingModalFragment on KeypairResourcePolicyV2 {
+        id
+        name
+        defaultForUnspecified
+        totalResourceSlots {
+          resourceType
+          quantity
+          unlimited
+        }
+        maxSessionLifetime
+        maxConcurrentSessions
+        maxContainersPerSession
+        idleTimeout
+        maxPendingSessionCount
+        maxConcurrentSftpSessions
+        allowedVfolderHosts {
+          host
+          permissions
+        }
+      }
+    `,
+    keypairResourcePolicyFrgmt,
+  );
+
+  const [
+    commitCreateKeypairResourcePolicy,
+    isInFlightCommitCreateKeypairResourcePolicy,
+  ] = useMutation<KeypairResourcePolicyV2SettingModalCreateMutation>(graphql`
+    mutation KeypairResourcePolicyV2SettingModalCreateMutation(
+      $input: CreateKeypairResourcePolicyInput!
+    ) {
+      adminCreateKeypairResourcePolicyV2(input: $input) {
+        keypairResourcePolicy {
+          id
+        }
+      }
+    }
+  `);
+
+  const [
+    commitModifyKeypairResourcePolicy,
+    isInFlightCommitModifyKeypairResourcePolicy,
+  ] = useMutation<KeypairResourcePolicyV2SettingModalModifyMutation>(graphql`
+    mutation KeypairResourcePolicyV2SettingModalModifyMutation(
+      $name: String!
+      $input: UpdateKeypairResourcePolicyInput!
+    ) {
+      adminUpdateKeypairResourcePolicyV2(name: $name, input: $input) {
+        keypairResourcePolicy {
+          id
+          name
+          createdAt
+          defaultForUnspecified
+          totalResourceSlots {
+            resourceType
+            quantity
+            unlimited
+          }
+          maxSessionLifetime
+          maxConcurrentSessions
+          maxPendingSessionCount
+          maxPendingSessionResourceSlots {
+            resourceType
+            quantity
+            unlimited
+          }
+          maxConcurrentSftpSessions
+          maxContainersPerSession
+          idleTimeout
+          allowedVfolderHosts {
+            host
+            permissions
+          }
+        }
+      }
+    }
+  `);
+
+  // An unlimited slot has no numeric limit to prefill, so it is left out and
+  // the field renders as "unlimited" (empty).
+  const initialTotalResourceSlots: Record<string, string> = {};
+  _.forEach(keypairResourcePolicy?.totalResourceSlots, (entry) => {
+    if (entry.unlimited || _.isNil(entry.quantity)) return;
+    if (_.includes(entry.resourceType, 'mem')) {
+      let autoUnitResult = convertToBinaryUnit(
+        _.toString(entry.quantity),
+        'auto',
+        2,
+        true,
+      );
+      if (autoUnitResult?.unit === '' || autoUnitResult?.unit === 'k') {
+        autoUnitResult = convertToBinaryUnit(
+          _.toString(entry.quantity),
+          'm',
+          3,
+          true,
+        );
+      }
+      initialTotalResourceSlots[entry.resourceType] =
+        autoUnitResult?.value || '0g';
+    } else {
+      initialTotalResourceSlots[entry.resourceType] = _.toString(
+        entry.quantity,
+      );
+    }
+  });
+
+  const initialValues = {
+    name: keypairResourcePolicy?.name ?? '',
+    default_for_unspecified:
+      keypairResourcePolicy?.defaultForUnspecified || 'UNLIMITED',
+    total_resource_slots: initialTotalResourceSlots,
+    max_session_lifetime: keypairResourcePolicy?.maxSessionLifetime ?? 0,
+    max_concurrent_sessions: keypairResourcePolicy?.maxConcurrentSessions ?? 0,
+    max_containers_per_session:
+      keypairResourcePolicy?.maxContainersPerSession ?? 1,
+    idle_timeout: keypairResourcePolicy?.idleTimeout ?? 0,
+    max_pending_session_count:
+      keypairResourcePolicy?.maxPendingSessionCount ?? null,
+    max_concurrent_sftp_sessions:
+      keypairResourcePolicy?.maxConcurrentSftpSessions ?? 0,
+    allowed_vfolder_hosts: _.map(
+      keypairResourcePolicy?.allowedVfolderHosts,
+      (entry) => entry.host,
+    ),
+  };
+
+  const handleOk = () => {
+    return formRef?.current
+      ?.validateFields()
+      .then((values) => {
+        const totalResourceSlots = _.map(
+          _.pickBy(
+            values.total_resource_slots,
+            (value) => !_.isNil(value) && value !== '',
+          ),
+          (value, resourceType) => ({
+            resourceType,
+            quantity: _.includes(resourceType, 'mem')
+              ? _.toString(convertToBinaryUnit(value, '', 0)?.numberFixed)
+              : _.toString(value),
+          }),
+        );
+
+        // Keep the permissions an already-allowed host carries; a host the
+        // admin just added starts with the full default set.
+        const existingPermissionsByHost = _.fromPairs(
+          _.map(keypairResourcePolicy?.allowedVfolderHosts, (entry) => [
+            entry.host,
+            _.map(entry.permissions, v2PermissionToKey),
+          ]),
+        );
+        const allowedVfolderHosts = _.map(
+          values.allowed_vfolder_hosts ?? [],
+          (host: string) => ({
+            host,
+            permissions:
+              existingPermissionsByHost[host] ??
+              DEFAULT_VFOLDER_HOST_PERMISSIONS,
+          }),
+        );
+
+        const commonInput = {
+          defaultForUnspecified: values.default_for_unspecified,
+          totalResourceSlots,
+          maxSessionLifetime: values.max_session_lifetime ?? 0,
+          maxConcurrentSessions: values.max_concurrent_sessions ?? 0,
+          maxContainersPerSession: values.max_containers_per_session ?? 1,
+          idleTimeout: values.idle_timeout ?? 0,
+          maxPendingSessionCount: values.max_pending_session_count ?? null,
+          maxConcurrentSftpSessions: values.max_concurrent_sftp_sessions ?? 0,
+          allowedVfolderHosts,
+        };
+
+        if (keypairResourcePolicy === null) {
+          const input: CreateKeypairResourcePolicyInput = {
+            name: values.name,
+            ...commonInput,
+          };
+          commitCreateKeypairResourcePolicy({
+            variables: { input },
+            onCompleted(res, errors) {
+              if (!res?.adminCreateKeypairResourcePolicyV2 || errors) {
+                message.error(
+                  errors?.[0]?.message ||
+                    t('resourcePolicy.CannotCreateResourcePolicy'),
+                );
+                onCancel();
+              } else {
+                message.success(t('resourcePolicy.ResourcePolicyCreated'));
+                onOk();
+              }
+            },
+            onError(error) {
+              message.error(
+                error?.message ||
+                  t('resourcePolicy.CannotCreateResourcePolicy'),
+              );
+            },
+          });
+        } else {
+          const input: UpdateKeypairResourcePolicyInput = commonInput;
+          commitModifyKeypairResourcePolicy({
+            variables: { name: values.name, input },
+            onCompleted(res, errors) {
+              if (!res?.adminUpdateKeypairResourcePolicyV2 || errors) {
+                message.error(
+                  errors?.[0]?.message ||
+                    t('resourcePolicy.CannotUpdateResourcePolicy'),
+                );
+                onCancel();
+              } else {
+                message.success(t('resourcePolicy.ResourcePolicyUpdated'));
+                onOk();
+              }
+            },
+            onError(error) {
+              message.error(
+                error?.message ||
+                  t('resourcePolicy.CannotUpdateResourcePolicy'),
+              );
+            },
+          });
+        }
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <BAIModal
+      width={800}
+      title={
+        keypairResourcePolicy === null
+          ? t('resourcePolicy.CreateKeypairResourcePolicy')
+          : t('resourcePolicy.UpdateKeypairResourcePolicy')
+      }
+      okText={
+        keypairResourcePolicy === null ? t('button.Create') : t('button.Save')
+      }
+      onOk={handleOk}
+      onCancel={() => onCancel()}
+      destroyOnHidden
+      confirmLoading={
+        isInFlightCommitCreateKeypairResourcePolicy ||
+        isInFlightCommitModifyKeypairResourcePolicy
+      }
+      {...baiModalProps}
+    >
+      <Form
+        ref={formRef}
+        layout="vertical"
+        initialValues={initialValues}
+        preserve={false}
+      >
+        <BAIFormItem
+          label={t('resourcePolicy.Name')}
+          name="name"
+          required
+          rules={[
+            {
+              required: true,
+              message: t('data.explorer.ValueRequired'),
+            },
+            {
+              max: 64,
+            },
+          ]}
+        >
+          <AstryxFormTextInput
+            label={t('resourcePolicy.Name')}
+            disabled={!!keypairResourcePolicy}
+          />
+        </BAIFormItem>
+        <BAIFormItem
+          label={
+            <BAIFlex gap="xxs" align="center">
+              {t('resourcePolicy.DefaultForUnspecified')}
+              <Tooltip
+                content={
+                  <>
+                    {t('resourcePolicy.DefaultForUnspecifiedTooltipDesc1')}
+                    <br />
+                    <br />
+                    {t('resourcePolicy.DefaultForUnspecifiedTooltipDesc2')}
+                  </>
+                }
+                placement="end"
+              >
+                <Icon icon={CircleHelp} color="tertiary" size="sm" />
+              </Tooltip>
+            </BAIFlex>
+          }
+          name="default_for_unspecified"
+        >
+          <AstryxFormSelector
+            label={t('resourcePolicy.DefaultForUnspecified')}
+            options={[
+              { label: 'UNLIMITED', value: 'UNLIMITED' },
+              { label: 'LIMITED', value: 'LIMITED' },
+            ]}
+          />
+        </BAIFormItem>
+        <BAIFormItem label={t('resourcePolicy.ResourcePolicy')}>
+          <Card padding={4}>
+            <Grid columns={{ minWidth: 220, max: 3 }} gap={6}>
+              {_.map(_.keys(resourceSlots), (resourceSlotKey) => (
+                <FormItemWithUnlimited
+                  key={resourceSlotKey}
+                  unlimitedValue={undefined}
+                  label={
+                    _.get(mergedResourceSlots, resourceSlotKey)?.description ||
+                    resourceSlotKey
+                  }
+                  name={['total_resource_slots', resourceSlotKey]}
+                  rules={[
+                    {
+                      validator(__, value) {
+                        if (
+                          _.includes(resourceSlotKey, 'mem') &&
+                          value &&
+                          // @ts-ignore
+                          convertToBinaryUnit(value, 'p').number >
+                            // @ts-ignore
+                            convertToBinaryUnit('300p', 'p').number
+                        ) {
+                          return Promise.reject(
+                            new Error(
+                              t('resourcePolicy.MemorySizeExceedsLimit'),
+                            ),
+                          );
+                        }
+                        return Promise.resolve();
+                      },
+                    },
+                  ]}
+                >
+                  {_.includes(resourceSlotKey, 'mem') ? (
+                    <BAIDynamicUnitInputNumber defaultUnit="g" />
+                  ) : (
+                    <AstryxFormNumberInput
+                      label={
+                        _.get(mergedResourceSlots, resourceSlotKey)
+                          ?.description || resourceSlotKey
+                      }
+                      min={0}
+                      max={MAX_CPU_QUOTA}
+                      step={_.includes(resourceSlotKey, '.shares') ? 0.1 : 1}
+                      units={
+                        _.get(mergedResourceSlots, resourceSlotKey)
+                          ?.display_unit
+                      }
+                    />
+                  )}
+                </FormItemWithUnlimited>
+              ))}
+            </Grid>
+          </Card>
+        </BAIFormItem>
+        <BAIFormItem label={t('resourcePolicy.Sessions')}>
+          <Card padding={4}>
+            <Grid columns={{ minWidth: 220, max: 3 }} gap={6}>
+              <FormItemWithUnlimited
+                label={t('resourcePolicy.ClusterSize')}
+                name="max_containers_per_session"
+                disableUnlimited
+              >
+                <AstryxFormNumberInput
+                  label={t('resourcePolicy.ClusterSize')}
+                  min={0}
+                  max={SIGNED_32BIT_MAX_INT}
+                />
+              </FormItemWithUnlimited>
+              <FormItemWithUnlimited
+                name="max_session_lifetime"
+                unlimitedValue={0}
+                label={t('resourcePolicy.MaxSessionLifetime')}
+              >
+                <AstryxFormNumberInput
+                  label={t('resourcePolicy.MaxSessionLifetime')}
+                  min={0}
+                  max={SIGNED_32BIT_MAX_INT}
+                />
+              </FormItemWithUnlimited>
+              <FormItemWithUnlimited
+                name="max_pending_session_count"
+                unlimitedValue={null}
+                label={t('resourcePolicy.MaxPendingSessionCount')}
+              >
+                <AstryxFormNumberInput
+                  label={t('resourcePolicy.MaxPendingSessionCount')}
+                  min={0}
+                  max={SIGNED_32BIT_MAX_INT}
+                />
+              </FormItemWithUnlimited>
+              <FormItemWithUnlimited
+                name="max_concurrent_sessions"
+                unlimitedValue={0}
+                label={t('resourcePolicy.Concurrency')}
+              >
+                <AstryxFormNumberInput
+                  label={t('resourcePolicy.Concurrency')}
+                  min={0}
+                  max={SIGNED_32BIT_MAX_INT}
+                />
+              </FormItemWithUnlimited>
+              <FormItemWithUnlimited
+                name="idle_timeout"
+                unlimitedValue={0}
+                label={t('resourcePolicy.IdleTimeoutSec')}
+              >
+                <AstryxFormNumberInput
+                  label={t('resourcePolicy.IdleTimeoutSec')}
+                  min={0}
+                  max={SIGNED_32BIT_MAX_INT}
+                />
+              </FormItemWithUnlimited>
+              <FormItemWithUnlimited
+                name="max_concurrent_sftp_sessions"
+                unlimitedValue={0}
+                label={t('resourcePolicy.MaxConcurrentSFTPSessions')}
+              >
+                <AstryxFormNumberInput
+                  label={t('resourcePolicy.MaxConcurrentSFTPSessions')}
+                  min={0}
+                  max={SIGNED_32BIT_MAX_INT}
+                />
+              </FormItemWithUnlimited>
+            </Grid>
+          </Card>
+        </BAIFormItem>
+        <BAIFormItem label={t('resourcePolicy.Folders')}>
+          <Card padding={4}>
+            <BAIFormItem
+              label={t('resourcePolicy.AllowedHosts')}
+              name="allowed_vfolder_hosts"
+            >
+              <BAIAllowedHostNamesSelect mode="multiple" />
+            </BAIFormItem>
+          </Card>
+        </BAIFormItem>
+      </Form>
+    </BAIModal>
+  );
+};
+
+export default KeypairResourcePolicyV2SettingModal;

--- a/react/src/components/ProjectResourcePolicyV2.tsx
+++ b/react/src/components/ProjectResourcePolicyV2.tsx
@@ -173,14 +173,6 @@ const ProjectResourcePolicyV2 = ({
               defaultOperator: 'greaterThanOrEqual',
             },
             {
-              // The node field is a BinarySizeInfo, but the filter input is a
-              // plain IntFilter — the typed value is a raw byte count.
-              key: 'maxQuotaScopeSize',
-              propertyLabel: t('storageHost.MaxFolderSize'),
-              type: 'number',
-              defaultOperator: 'greaterThanOrEqual',
-            },
-            {
               key: 'maxNetworkCount',
               propertyLabel: t('resourcePolicy.MaxNetworkCount'),
               type: 'number',

--- a/react/src/components/ProjectResourcePolicyV2.tsx
+++ b/react/src/components/ProjectResourcePolicyV2.tsx
@@ -1,0 +1,348 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { ProjectResourcePolicyV2Mutation } from '../__generated__/ProjectResourcePolicyV2Mutation.graphql';
+import type {
+  ProjectResourcePolicyV2OrderBy,
+  ProjectResourcePolicyV2Query as ProjectResourcePolicyV2QueryType,
+} from '../__generated__/ProjectResourcePolicyV2Query.graphql';
+import { App } from '../app-shim';
+import { convertToOrderBy } from '../helper';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import ProjectResourcePolicyV2SettingModal from './ProjectResourcePolicyV2SettingModal';
+import {
+  BAIButton,
+  BAIDeleteConfirmModal,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  BAINameActionCell,
+  BAIProjectResourcePolicyV2Table,
+  type BAIProjectResourcePolicyV2TableProps,
+  filterOutNullAndUndefined,
+  useFetchKey,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { Trash2, PlusIcon, SquarePenIcon } from 'lucide-react';
+import { useDeferredValue, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+  useMutation,
+} from 'react-relay';
+
+export const ProjectResourcePolicyV2Query = graphql`
+  query ProjectResourcePolicyV2Query(
+    $filter: ProjectResourcePolicyV2Filter
+    $orderBy: [ProjectResourcePolicyV2OrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    adminProjectResourcePoliciesV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          name
+          ...BAIProjectResourcePolicyV2TableFragment
+          ...ProjectResourcePolicyV2SettingModalFragment
+        }
+      }
+    }
+  }
+`;
+
+type ProjectResourcePolicyV2Node = NonNullable<
+  NonNullable<
+    NonNullable<
+      ProjectResourcePolicyV2QueryType['response']['adminProjectResourcePoliciesV2']
+    >['edges'][number]
+  >['node']
+>;
+
+export interface ProjectResourcePolicyV2Props extends Omit<
+  BAIProjectResourcePolicyV2TableProps,
+  | 'projectResourcePoliciesFrgmt'
+  | 'loading'
+  | 'order'
+  | 'onChangeOrder'
+  | 'dataSource'
+  | 'pagination'
+  | 'customizeColumns'
+> {
+  queryRef: PreloadedQuery<ProjectResourcePolicyV2QueryType>;
+  onReload: (
+    variables: ProjectResourcePolicyV2QueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+const ProjectResourcePolicyV2 = ({
+  queryRef,
+  onReload,
+  ...tableProps
+}: ProjectResourcePolicyV2Props) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
+  const [editingProjectResourcePolicy, setEditingProjectResourcePolicy] =
+    useState<ProjectResourcePolicyV2Node | null>(null);
+  const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
+    null,
+  );
+
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.ProjectResourcePolicyV2',
+  );
+
+  const filter = queryRef.variables.filter ?? undefined;
+  const orderBy = queryRef.variables.orderBy?.[0];
+  const order = orderBy
+    ? `${orderBy.direction === 'DESC' ? '-' : ''}${_.camelCase(orderBy.field)}`
+    : null;
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
+
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<ProjectResourcePolicyV2QueryType>(
+    ProjectResourcePolicyV2Query,
+    deferredQueryRef,
+  );
+
+  const [commitDelete] = useMutation<ProjectResourcePolicyV2Mutation>(graphql`
+    mutation ProjectResourcePolicyV2Mutation($name: String!) {
+      adminDeleteProjectResourcePolicyV2(name: $name) {
+        name
+      }
+    }
+  `);
+
+  const projectResourcePolicies = filterOutNullAndUndefined(
+    (data.adminProjectResourcePoliciesV2?.edges ?? []).map(
+      (edge) => edge?.node,
+    ),
+  );
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIFlex justify={'between'} wrap="wrap" gap="sm">
+        <BAIGraphQLPropertyFilter
+          value={filter}
+          onChange={(next) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                filter: next,
+                offset: 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
+          filterProperties={[
+            {
+              key: 'name',
+              propertyLabel: t('resourcePolicy.Name'),
+              type: 'string',
+              fixedOperator: 'contains',
+            },
+            {
+              key: 'createdAt',
+              propertyLabel: t('resourcePolicy.CreatedAt'),
+              type: 'datetime',
+              defaultOperator: 'after',
+            },
+            {
+              key: 'maxVfolderCount',
+              propertyLabel: t('resourcePolicy.MaxVFolderCount'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              // The node field is a BinarySizeInfo, but the filter input is a
+              // plain IntFilter — the typed value is a raw byte count.
+              key: 'maxQuotaScopeSize',
+              propertyLabel: t('storageHost.MaxFolderSize'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxNetworkCount',
+              propertyLabel: t('resourcePolicy.MaxNetworkCount'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+          ]}
+        />
+        <BAIFlex gap="xs">
+          <BAIFetchKeyButton
+            value={fetchKey}
+            onChange={(key) => {
+              updateFetchKey(key);
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+            }}
+            loading={isRefetching}
+          />
+          <BAIButton
+            type="primary"
+            icon={<PlusIcon />}
+            onClick={() => {
+              setIsCreatingPolicySetting(true);
+            }}
+          >
+            {t('button.Create')}
+          </BAIButton>
+        </BAIFlex>
+      </BAIFlex>
+      <BAIProjectResourcePolicyV2Table
+        loading={isRefetching}
+        tableSettings={{
+          columnOverrides,
+          onColumnOverridesChange: setColumnOverrides,
+        }}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy:
+                convertToOrderBy<ProjectResourcePolicyV2OrderBy>(nextOrder),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
+        }}
+        pagination={{
+          pageSize,
+          current,
+          total: data.adminProjectResourcePoliciesV2?.count ?? 0,
+          onChange: (nextCurrent, nextPageSize) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                limit: nextPageSize,
+                offset: nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          },
+        }}
+        customizeColumns={(columns) =>
+          _.map(columns, (column) =>
+            column.key === 'name'
+              ? {
+                  ...column,
+                  render: (name: string, record) => (
+                    <BAINameActionCell
+                      title={name}
+                      showActions="always"
+                      actions={[
+                        {
+                          key: 'edit',
+                          title: t('button.Edit'),
+                          icon: <SquarePenIcon />,
+                          onClick: () => {
+                            setEditingProjectResourcePolicy(
+                              _.find(projectResourcePolicies, {
+                                id: record.id,
+                              }) ?? null,
+                            );
+                          },
+                        },
+                        {
+                          key: 'delete',
+                          title: t('button.Delete'),
+                          icon: <Trash2 size="1em" />,
+                          type: 'danger',
+                          onClick: () => {
+                            setDeletingPolicyName(record.name);
+                          },
+                        },
+                      ]}
+                    />
+                  ),
+                }
+              : column,
+          )
+        }
+        projectResourcePoliciesFrgmt={projectResourcePolicies}
+        {...tableProps}
+      />
+      <ProjectResourcePolicyV2SettingModal
+        open={!!editingProjectResourcePolicy || isCreatingPolicySetting}
+        projectResourcePolicyFrgmt={editingProjectResourcePolicy}
+        onOk={() => {
+          // A create adds a new row the offset query can't know about, so it
+          // needs a refetch. An update returns every field, so Relay merges the
+          // record by id into the store and the list reflects it without one.
+          if (isCreatingPolicySetting) {
+            onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+          }
+          setEditingProjectResourcePolicy(null);
+          setIsCreatingPolicySetting(false);
+        }}
+        onCancel={() => {
+          setEditingProjectResourcePolicy(null);
+          setIsCreatingPolicySetting(false);
+        }}
+      />
+      <BAIDeleteConfirmModal
+        open={!!deletingPolicyName}
+        items={
+          deletingPolicyName
+            ? [{ key: deletingPolicyName, label: deletingPolicyName }]
+            : []
+        }
+        title={t('resourcePolicy.DeletePolicy')}
+        target={t('resourcePolicy.ResourcePolicy')}
+        confirmText={deletingPolicyName ?? ''}
+        requireConfirmInput
+        onOk={() => {
+          if (deletingPolicyName) {
+            return new Promise<void>((resolve) => {
+              commitDelete({
+                variables: { name: deletingPolicyName },
+                onCompleted: (_res, errors) => {
+                  if (errors && errors.length > 0) {
+                    for (const error of errors) {
+                      message.error(error.message);
+                    }
+                  } else {
+                    onReload(queryRef.variables, {
+                      fetchPolicy: 'network-only',
+                    });
+                    message.success(t('resourcePolicy.ResourcePolicyDeleted'));
+                  }
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+                onError(err) {
+                  message.error(err?.message);
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+              });
+            });
+          }
+        }}
+        onCancel={() => setDeletingPolicyName(null)}
+      />
+    </BAIFlex>
+  );
+};
+
+export default ProjectResourcePolicyV2;

--- a/react/src/components/ProjectResourcePolicyV2SettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicyV2SettingModal.tsx
@@ -1,0 +1,288 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  CreateProjectResourcePolicyInputV2,
+  ProjectResourcePolicyV2SettingModalCreateMutation,
+} from '../__generated__/ProjectResourcePolicyV2SettingModalCreateMutation.graphql';
+import { ProjectResourcePolicyV2SettingModalFragment$key } from '../__generated__/ProjectResourcePolicyV2SettingModalFragment.graphql';
+import {
+  UpdateProjectResourcePolicyInput,
+  ProjectResourcePolicyV2SettingModalModifyMutation,
+} from '../__generated__/ProjectResourcePolicyV2SettingModalModifyMutation.graphql';
+import { App } from '../app-shim';
+import { Form, FormInstance } from '../form-engine';
+import { GBToBytes, bytesToGB } from '../helper';
+import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
+import { theme } from '../theme-shim';
+import BAIFormItem from './BAIFormItem';
+import FormItemWithUnlimited from './FormItemWithUnlimited';
+import {
+  AstryxFormNumberInput,
+  AstryxFormTextInput,
+} from './astryxFormControls';
+import { Banner } from '@astryxdesign/core/Banner';
+import { BAIModal, BAIModalProps, BAIFlex } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment, useMutation } from 'react-relay';
+
+interface ProjectResourcePolicyV2SettingModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onCancel'
+> {
+  projectResourcePolicyFrgmt: ProjectResourcePolicyV2SettingModalFragment$key | null;
+  onOk: () => void;
+  onCancel: () => void;
+}
+
+const ProjectResourcePolicyV2SettingModal: React.FC<
+  ProjectResourcePolicyV2SettingModalProps
+> = ({
+  projectResourcePolicyFrgmt = null,
+  onOk,
+  onCancel,
+  ...baiModalProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+
+  const formRef = useRef<FormInstance>(null);
+
+  const projectResourcePolicy = useFragment(
+    graphql`
+      fragment ProjectResourcePolicyV2SettingModalFragment on ProjectResourcePolicyV2 {
+        id
+        name
+        maxVfolderCount
+        maxQuotaScopeSize {
+          expr
+        }
+        maxNetworkCount
+      }
+    `,
+    projectResourcePolicyFrgmt,
+  );
+
+  const [
+    commitCreateProjectResourcePolicy,
+    isInFlightCommitCreateProjectResourcePolicy,
+  ] = useMutation<ProjectResourcePolicyV2SettingModalCreateMutation>(graphql`
+    mutation ProjectResourcePolicyV2SettingModalCreateMutation(
+      $input: CreateProjectResourcePolicyInputV2!
+    ) {
+      adminCreateProjectResourcePolicyV2(input: $input) {
+        projectResourcePolicy {
+          id
+        }
+      }
+    }
+  `);
+
+  const [
+    commitModifyProjectResourcePolicy,
+    isInFlightCommitModifyProjectResourcePolicy,
+  ] = useMutation<ProjectResourcePolicyV2SettingModalModifyMutation>(graphql`
+    mutation ProjectResourcePolicyV2SettingModalModifyMutation(
+      $name: String!
+      $input: UpdateProjectResourcePolicyInput!
+    ) {
+      adminUpdateProjectResourcePolicyV2(name: $name, input: $input) {
+        projectResourcePolicy {
+          id
+          name
+          createdAt
+          maxVfolderCount
+          maxQuotaScopeSize {
+            expr
+          }
+          maxNetworkCount
+        }
+      }
+    }
+  `);
+
+  // `expr` is the exact byte count as a decimal string ('-1' = unlimited).
+  const rawMaxQuotaScopeSize = projectResourcePolicy?.maxQuotaScopeSize.expr;
+  const initialMaxQuotaScopeSize =
+    _.isUndefined(rawMaxQuotaScopeSize) || rawMaxQuotaScopeSize === '-1'
+      ? -1
+      : Number(bytesToGB(Number(rawMaxQuotaScopeSize)));
+  const initialValues = {
+    name: projectResourcePolicy?.name,
+    max_vfolder_count: projectResourcePolicy?.maxVfolderCount ?? 0,
+    max_quota_scope_size: initialMaxQuotaScopeSize,
+    max_network_count: projectResourcePolicy?.maxNetworkCount ?? -1,
+  };
+
+  const handleOk = () => {
+    return formRef?.current
+      ?.validateFields()
+      .then((values) => {
+        const maxQuotaScopeSizeExpr =
+          values?.max_quota_scope_size === -1
+            ? '-1'
+            : String(GBToBytes(values?.max_quota_scope_size));
+        const commonInput = {
+          maxVfolderCount: values?.max_vfolder_count || 0,
+          maxQuotaScopeSize: { expr: maxQuotaScopeSizeExpr },
+          maxNetworkCount: values?.max_network_count ?? -1,
+        };
+        if (projectResourcePolicy === null) {
+          const input: CreateProjectResourcePolicyInputV2 = {
+            name: values?.name,
+            ...commonInput,
+          };
+          commitCreateProjectResourcePolicy({
+            variables: { input },
+            onCompleted(res, errors) {
+              if (!res?.adminCreateProjectResourcePolicyV2 || errors) {
+                message.error(
+                  errors?.[0]?.message ||
+                    t('resourcePolicy.CannotCreateResourcePolicy'),
+                );
+                onCancel();
+              } else {
+                message.success(t('resourcePolicy.ResourcePolicyCreated'));
+                onOk();
+              }
+            },
+            onError(error) {
+              message.error(
+                error?.message ||
+                  t('resourcePolicy.CannotCreateResourcePolicy'),
+              );
+            },
+          });
+        } else {
+          const input: UpdateProjectResourcePolicyInput = commonInput;
+          commitModifyProjectResourcePolicy({
+            variables: { name: values?.name, input },
+            onCompleted(res, errors) {
+              if (!res?.adminUpdateProjectResourcePolicyV2 || errors) {
+                message.error(
+                  errors?.[0]?.message ||
+                    t('resourcePolicy.CannotUpdateResourcePolicy'),
+                );
+                onCancel();
+              } else {
+                message.success(t('resourcePolicy.ResourcePolicyUpdated'));
+                onOk();
+              }
+            },
+            onError(error) {
+              message.error(
+                error?.message ||
+                  t('resourcePolicy.CannotUpdateResourcePolicy'),
+              );
+            },
+          });
+        }
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <BAIModal
+      title={
+        projectResourcePolicy === null
+          ? t('resourcePolicy.CreateProjectResourcePolicy')
+          : t('resourcePolicy.UpdateProjectResourcePolicy')
+      }
+      okText={
+        projectResourcePolicy === null ? t('button.Create') : t('button.Save')
+      }
+      onOk={handleOk}
+      onCancel={() => onCancel()}
+      destroyOnHidden
+      confirmLoading={
+        isInFlightCommitCreateProjectResourcePolicy ||
+        isInFlightCommitModifyProjectResourcePolicy
+      }
+      {...baiModalProps}
+    >
+      <Banner
+        title={t('storageHost.BeCarefulToSetProjectResourcePolicy')}
+        status="warning"
+        style={{ marginBottom: token.marginMD }}
+      />
+      <Form
+        ref={formRef}
+        layout="vertical"
+        initialValues={initialValues}
+        preserve={false}
+      >
+        <BAIFormItem
+          label={t('resourcePolicy.Name')}
+          name="name"
+          required
+          rules={[
+            {
+              required: true,
+              message: t('data.explorer.ValueRequired'),
+            },
+            {
+              max: 255,
+            },
+          ]}
+        >
+          <AstryxFormTextInput
+            label={t('resourcePolicy.Name')}
+            disabled={!!projectResourcePolicy}
+          />
+        </BAIFormItem>
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          gap={'md'}
+          style={{ marginBottom: token.marginMD }}
+        >
+          <FormItemWithUnlimited
+            name={'max_vfolder_count'}
+            unlimitedValue={0}
+            label={t('resourcePolicy.MaxFolderCount')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <AstryxFormNumberInput
+              label={t('resourcePolicy.MaxFolderCount')}
+              min={0}
+              max={SIGNED_32BIT_MAX_INT}
+            />
+          </FormItemWithUnlimited>
+          <FormItemWithUnlimited
+            name={'max_quota_scope_size'}
+            unlimitedValue={-1}
+            label={t('storageHost.MaxFolderSize')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <AstryxFormNumberInput
+              label={t('storageHost.MaxFolderSize')}
+              min={0}
+              // Maximum safe integer divided by 10^9 to prevent overflow when converting GB to bytes
+              max={Math.floor(Number.MAX_SAFE_INTEGER / Math.pow(10, 9))}
+              units="GB"
+            />
+          </FormItemWithUnlimited>
+          <FormItemWithUnlimited
+            name={'max_network_count'}
+            unlimitedValue={-1}
+            label={t('resourcePolicy.MaxNetworkCount')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <AstryxFormNumberInput
+              label={t('resourcePolicy.MaxNetworkCount')}
+              min={0}
+              max={SIGNED_32BIT_MAX_INT}
+            />
+          </FormItemWithUnlimited>
+        </BAIFlex>
+      </Form>
+    </BAIModal>
+  );
+};
+
+export default ProjectResourcePolicyV2SettingModal;

--- a/react/src/helper/storageHostPermission.ts
+++ b/react/src/helper/storageHostPermission.ts
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  v2PermissionToKey,
+  type V2AllowedVfolderHostEntry,
+} from 'backend.ai-ui';
 
 /**
  * Display label mapping for the canonical 8 permission keys. The actual column
@@ -102,43 +106,16 @@ export const hasMountWithoutFileOps = (
  * `[VFolderHostPermissionEntry!]!` array instead of the V1 JSONString. The
  * permission elements are `VFolderHostPermissionV2` enum values
  * (`CREATE_VFOLDER`, `MOUNT_IN_SESSION`, …) — convert them to the canonical
- * kebab keys (`create-vfolder`, `mount-in-session`, …) used by
- * `PERMISSION_DISPLAY_MAP` and the V1 mutations' JSONString payload.
+ * kebab keys used by `PERMISSION_DISPLAY_MAP` and the V1 mutations' payload.
+ *
+ * The conversion itself lives in BUI (`helper/vfolderHostPermission.ts`)
+ * because BUI components render V2 host permissions too; it is re-exported
+ * here so app-side call sites keep one import path.
  *
  * Domain still uses the V1 path because `DomainV2` does not expose
  * `allowedVfolderHosts` (only `ProjectV2` / `KeypairResourcePolicyV2` do).
  */
-
-/**
- * V2 enum → V1 kebab key. Most entries follow the lowercase-and-dash rule,
- * but `SET_USER_PERM` ↔ `set-user-specific-permission` is asymmetric, so we
- * spell out the full mapping. Without this, the V2 `SET_USER_PERM` would
- * naively convert to `set-user-perm`, which then fails to match the canonical
- * column key `set-user-specific-permission` (read from
- * `vfolder_host_permissions.vfolder_host_permission_list`) — the "권한 설정"
- * checkbox would silently appear unchecked even when the entity has it, and
- * a save would drop the asymmetric mapping for other hosts' entries too.
- */
-const V2_TO_V1_PERMISSION: Record<string, string> = {
-  CREATE_VFOLDER: 'create-vfolder',
-  MODIFY_VFOLDER: 'modify-vfolder',
-  DELETE_VFOLDER: 'delete-vfolder',
-  MOUNT_IN_SESSION: 'mount-in-session',
-  UPLOAD_FILE: 'upload-file',
-  DOWNLOAD_FILE: 'download-file',
-  INVITE_OTHERS: 'invite-others',
-  SET_USER_PERM: 'set-user-specific-permission',
-};
-
-/** Convert a V2 permission enum value to the canonical V1 kebab key. */
-export const v2PermissionToKey = (perm: string): string =>
-  V2_TO_V1_PERMISSION[perm] ?? perm.toLowerCase().replace(/_/g, '-');
-
-/** V2 `VFolderHostPermissionEntry` shape (host name + permission enum list). */
-export interface V2AllowedVfolderHostEntry {
-  readonly host: string;
-  readonly permissions: ReadonlyArray<string>;
-}
+export { v2PermissionToKey, type V2AllowedVfolderHostEntry };
 
 /**
  * Rebuild the V1 `allowed_vfolder_hosts` JSONString from V2 structured
@@ -147,9 +124,7 @@ export interface V2AllowedVfolderHostEntry {
  */
 export const buildAllowedHostsPayloadFromV2 = (
   allowedVfolderHosts:
-    | ReadonlyArray<V2AllowedVfolderHostEntry>
-    | null
-    | undefined,
+    ReadonlyArray<V2AllowedVfolderHostEntry> | null | undefined,
   storageHostId: string,
   enabledKeys: string[],
 ): string => {

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -2,10 +2,18 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import type { KeypairResourcePolicyV2Query as KeypairResourcePolicyV2QueryType } from '../__generated__/KeypairResourcePolicyV2Query.graphql';
+import type { ProjectResourcePolicyV2Query as ProjectResourcePolicyV2QueryType } from '../__generated__/ProjectResourcePolicyV2Query.graphql';
 import type { UserResourcePolicyV2Query as UserResourcePolicyV2QueryType } from '../__generated__/UserResourcePolicyV2Query.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
+import KeypairResourcePolicyV2, {
+  KeypairResourcePolicyV2Query,
+} from '../components/KeypairResourcePolicyV2';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
+import ProjectResourcePolicyV2, {
+  ProjectResourcePolicyV2Query,
+} from '../components/ProjectResourcePolicyV2';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';
 import UserResourcePolicyV2, {
   UserResourcePolicyV2Query,
@@ -59,6 +67,63 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
     [currentTab],
   );
 
+  const [keypairResourcePolicyQueryRef, loadKeypairResourcePolicyQuery] =
+    useQueryLoader<KeypairResourcePolicyV2QueryType>(
+      KeypairResourcePolicyV2Query,
+    );
+
+  const ensureKeypairResourcePolicyLoaded = useEffectEvent(() => {
+    if (
+      supportsSubFilter &&
+      currentTab === 'keypair' &&
+      !keypairResourcePolicyQueryRef
+    ) {
+      loadKeypairResourcePolicyQuery(
+        {
+          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+          limit: 10,
+          offset: 0,
+        },
+        { fetchPolicy: 'store-and-network' },
+      );
+    }
+  });
+  useEffect(
+    function loadKeypairResourcePolicyOnTabActivation() {
+      ensureKeypairResourcePolicyLoaded();
+    },
+    [currentTab],
+  );
+
+  const [projectResourcePolicyQueryRef, loadProjectResourcePolicyQuery] =
+    useQueryLoader<ProjectResourcePolicyV2QueryType>(
+      ProjectResourcePolicyV2Query,
+    );
+
+  const ensureProjectResourcePolicyLoaded = useEffectEvent(() => {
+    if (
+      supportsSubFilter &&
+      supportsBinarySizeExpr &&
+      currentTab === 'project' &&
+      !projectResourcePolicyQueryRef
+    ) {
+      loadProjectResourcePolicyQuery(
+        {
+          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+          limit: 10,
+          offset: 0,
+        },
+        { fetchPolicy: 'store-and-network' },
+      );
+    }
+  });
+  useEffect(
+    function loadProjectResourcePolicyOnTabActivation() {
+      ensureProjectResourcePolicyLoaded();
+    },
+    [currentTab],
+  );
+
   return (
     <BAICard
       activeTabKey={currentTab}
@@ -81,7 +146,18 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
       <Suspense fallback={<BAISkeleton />}>
         {currentTab === 'keypair' && (
           <BAIErrorBoundary>
-            <KeypairResourcePolicyList />
+            {supportsSubFilter ? (
+              keypairResourcePolicyQueryRef ? (
+                <KeypairResourcePolicyV2
+                  queryRef={keypairResourcePolicyQueryRef}
+                  onReload={loadKeypairResourcePolicyQuery}
+                />
+              ) : (
+                <BAISkeleton />
+              )
+            ) : (
+              <KeypairResourcePolicyList />
+            )}
           </BAIErrorBoundary>
         )}
         {currentTab === 'user' && (
@@ -102,7 +178,18 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
         )}
         {currentTab === 'project' && (
           <BAIErrorBoundary>
-            <ProjectResourcePolicyList />
+            {supportsSubFilter && supportsBinarySizeExpr ? (
+              projectResourcePolicyQueryRef ? (
+                <ProjectResourcePolicyV2
+                  queryRef={projectResourcePolicyQueryRef}
+                  onReload={loadProjectResourcePolicyQuery}
+                />
+              ) : (
+                <BAISkeleton />
+              )
+            ) : (
+              <ProjectResourcePolicyList />
+            )}
           </BAIErrorBoundary>
         )}
       </Suspense>


### PR DESCRIPTION
Resolves #9187 (FR-3730)

## Summary

- Restores PowerSearch filtering on the admin Resource Policy page's Keypair and Project tabs, which never got the Strawberry V2 PowerSearch path the User tab already has (`BAIGraphQLPropertyFilter`). The backend already exposed `adminKeypairResourcePoliciesV2` / `adminProjectResourcePoliciesV2` with full CRUD V2 mutations; the frontend just hadn't been wired up.
- Adds `BAIKeypairResourcePolicyV2Table` / `BAIProjectResourcePolicyV2Table` (backend.ai-ui) and `KeypairResourcePolicyV2` / `ProjectResourcePolicyV2` page components, mirroring the existing `UserResourcePolicyV2` pattern exactly (same query-loader wiring, filter properties, order/pagination, typed-confirm delete).
- Wires both into `ResourcePolicyPage.tsx` behind the same manager feature-flag gates as User (`sub-filter` for Keypair; `sub-filter` + `binary-size-expr` for Project, since `maxQuotaScopeSize` is a `BinarySizeInfo` field like User's), falling back to the existing non-filterable lists on older managers — no behavior change for managers below 26.7.0.
- Fixes a separate i18n gap in the same filter component: `comp:BAIGraphQLPropertyFilter.operator.{Contains,StartsWith,EndsWith,NotContains,NotStartsWith,NotEndsWith}` were present in `en.json` but missing from all 20 other locales, so PowerSearch operator labels (e.g. on the session list) fell back to raw English in every non-English UI. Backfilled from each locale's existing I-prefixed variant (identical display value).

## Judgment calls worth a second look

- **Project's `maxQuotaScopeSize` filter** is exposed as a plain number filter over raw bytes (the GraphQL filter input is `IntFilter`, not unit-aware), labeled with the existing unit-free `storageHost.MaxFolderSize` key rather than the GB-suffixed `resourcePolicy.MaxQuotaScopeSizeGB`. `UserResourcePolicyV2` sidesteps this entirely by not exposing that property as a filter at all — happy to align Project the same way if a byte-value filter is considered bad UX.
- **Project's `ID` column** shows the V2 GraphQL global Node ID (base64), not the raw UUID the legacy list shows, and isn't sortable — the User/Keypair V2 tables have no ID column at all. Hideable via column settings; flagging for consistency.
- **Project's `max_network_count` client feature flag** (`baiClient.supports('max_network_count')`, gating the legacy list's column) is dropped in the V2 path — any manager reaching V2 already satisfies `sub-filter` (26.7.0) which post-dates that flag (24.12.0), so the column and modal field are unconditional there.

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===`
- [ ] Manual: Resource Policy page → Keypair tab → PowerSearch by name/created date/session lifetime/etc., create/edit/delete a policy
- [ ] Manual: Resource Policy page → Project tab → same
- [ ] Manual: confirm legacy fallback still renders correctly against a manager below 26.7.0 (or by temporarily forcing `supports('sub-filter')` false)
- [ ] Manual: switch UI language to Korean (or any non-English locale) and confirm PowerSearch operator dropdowns show translated labels, not raw English
