### PR TITLE
refactor(FR-3735): own the resource-policy tab state on the page with useKeyedSnapshot

### DIFF
--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -18,12 +18,27 @@ import UserResourcePolicyList from '../components/UserResourcePolicyList';
 import UserResourcePolicyV2, {
   UserResourcePolicyV2Query,
 } from '../components/UserResourcePolicyV2';
-import { useSuspendedBackendaiClient, useTabQuerySnapshot } from '../hooks';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
+import {
+  useBrowserPopstateEffect,
+  useKeyedSnapshot,
+  useSuspendedBackendaiClient,
+} from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { BAISkeleton, filterOutEmpty, BAICard } from 'backend.ai-ui';
-import { parseAsStringLiteral } from 'nuqs';
+import * as _ from 'lodash-es';
+import {
+  parseAsJson,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs';
 import React, { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQueryLoader } from 'react-relay';
+import {
+  useQueryLoader,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
 interface ResourcePolicyPageProps {}
 const tabParser = parseAsStringLiteral([
@@ -31,103 +46,180 @@ const tabParser = parseAsStringLiteral([
   'user',
   'project',
 ]).withDefault('keypair');
+const orderParser = parseAsString.withDefault('-createdAt');
+const filterParser = parseAsJson((value) => value);
+const DEFAULT_PAGE_SIZE = 10;
+
+type TabKey = typeof tabParser.defaultValue;
+type TabVariables =
+  | KeypairResourcePolicyV2QueryType['variables']
+  | UserResourcePolicyV2QueryType['variables']
+  | ProjectResourcePolicyV2QueryType['variables'];
+
+type TabSnapshot = {
+  queryParams: {
+    filter: string | null;
+    order: string;
+  };
+  tablePaginationOption: { current: number; pageSize: number };
+};
+
+const defaultSnapshot: TabSnapshot = {
+  queryParams: {
+    filter: null,
+    order: orderParser.defaultValue,
+  },
+  tablePaginationOption: { current: 1, pageSize: DEFAULT_PAGE_SIZE },
+};
+
+const variablesOf = <V extends TabVariables>(snapshot: TabSnapshot) => {
+  const { queryParams: params, tablePaginationOption: pagination } = snapshot;
+  return {
+    filter: params.filter
+      ? (filterParser.parse(params.filter) as V['filter'])
+      : null,
+    orderBy: convertToOrderBy<NonNullable<V['orderBy']>[number]>(params.order),
+    limit: pagination.pageSize,
+    offset: (pagination.current - 1) * pagination.pageSize,
+  };
+};
+
+// Inverse of `variablesOf`, for mirroring child-driven reloads to the URL.
+const snapshotOfVariables = (variables: TabVariables): TabSnapshot => {
+  const pageSize = variables.limit ?? DEFAULT_PAGE_SIZE;
+  return {
+    queryParams: {
+      filter: _.isEmpty(variables.filter)
+        ? null
+        : JSON.stringify(variables.filter),
+      order:
+        convertFirstOrderByToString(variables.orderBy) ??
+        orderParser.defaultValue,
+    },
+    tablePaginationOption: {
+      current: Math.floor((variables.offset ?? 0) / pageSize) + 1,
+      pageSize,
+    },
+  };
+};
 
 const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
   'use memo';
   const { t } = useTranslation();
-  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
   const baiClient = useSuspendedBackendaiClient();
   const supportsSubFilter = baiClient.supports('sub-filter');
   const supportsBinarySizeExpr = baiClient.supports('binary-size-expr');
+  const supportsV2: Record<TabKey, boolean> = {
+    keypair: supportsSubFilter,
+    user: supportsSubFilter && supportsBinarySizeExpr,
+    project: supportsSubFilter && supportsBinarySizeExpr,
+  };
 
-  const [userResourcePolicyQueryRef, loadUserResourcePolicyQuery] =
-    useQueryLoader<UserResourcePolicyV2QueryType>(UserResourcePolicyV2Query);
-
-  const ensureUserResourcePolicyLoaded = useEffectEvent(() => {
-    if (
-      supportsSubFilter &&
-      supportsBinarySizeExpr &&
-      currentTab === 'user' &&
-      !userResourcePolicyQueryRef
-    ) {
-      loadUserResourcePolicyQuery(
-        {
-          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
-          limit: 10,
-          offset: 0,
-        },
-        { fetchPolicy: 'store-and-network' },
-      );
-    }
-  });
-  useEffect(
-    function loadUserResourcePolicyOnTabActivation() {
-      ensureUserResourcePolicyLoaded();
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      tab: tabParser,
+      filter: parseAsString,
+      order: orderParser,
     },
-    [currentTab],
+    { history: 'replace' },
   );
+  const { tablePaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionStateOnSearchParam(
+      defaultSnapshot.tablePaginationOption,
+    );
 
   const [keypairResourcePolicyQueryRef, loadKeypairResourcePolicyQuery] =
     useQueryLoader<KeypairResourcePolicyV2QueryType>(
       KeypairResourcePolicyV2Query,
     );
-
-  const ensureKeypairResourcePolicyLoaded = useEffectEvent(() => {
-    if (
-      supportsSubFilter &&
-      currentTab === 'keypair' &&
-      !keypairResourcePolicyQueryRef
-    ) {
-      loadKeypairResourcePolicyQuery(
-        {
-          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
-          limit: 10,
-          offset: 0,
-        },
-        { fetchPolicy: 'store-and-network' },
-      );
-    }
-  });
-  useEffect(
-    function loadKeypairResourcePolicyOnTabActivation() {
-      ensureKeypairResourcePolicyLoaded();
-    },
-    [currentTab],
-  );
-
+  const [userResourcePolicyQueryRef, loadUserResourcePolicyQuery] =
+    useQueryLoader<UserResourcePolicyV2QueryType>(UserResourcePolicyV2Query);
   const [projectResourcePolicyQueryRef, loadProjectResourcePolicyQuery] =
     useQueryLoader<ProjectResourcePolicyV2QueryType>(
       ProjectResourcePolicyV2Query,
     );
 
-  const ensureProjectResourcePolicyLoaded = useEffectEvent(() => {
-    if (
-      supportsSubFilter &&
-      supportsBinarySizeExpr &&
-      currentTab === 'project' &&
-      !projectResourcePolicyQueryRef
-    ) {
+  // What the URL currently describes — both the snapshot `useKeyedSnapshot`
+  // stores for the active tab and what a browser navigation reloads from.
+  const currentSnapshot: TabSnapshot = {
+    queryParams: { filter: queryParams.filter, order: queryParams.order },
+    tablePaginationOption,
+  };
+
+  const [currentTab, setCurrentTab, peekTabSnapshot] = useKeyedSnapshot<
+    TabKey,
+    TabSnapshot
+  >(queryParams.tab, currentSnapshot);
+
+  const loadTabQuery = (tab: TabKey, snapshot: TabSnapshot) => {
+    // The legacy lists fetch on their own; only the V2 tables are preloaded.
+    if (!supportsV2[tab]) return;
+    const options = { fetchPolicy: 'store-and-network' } as const;
+    if (tab === 'keypair') {
+      loadKeypairResourcePolicyQuery(
+        variablesOf<KeypairResourcePolicyV2QueryType['variables']>(snapshot),
+        options,
+      );
+    } else if (tab === 'user') {
+      loadUserResourcePolicyQuery(
+        variablesOf<UserResourcePolicyV2QueryType['variables']>(snapshot),
+        options,
+      );
+    } else {
       loadProjectResourcePolicyQuery(
-        {
-          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
-          limit: 10,
-          offset: 0,
-        },
-        { fetchPolicy: 'store-and-network' },
+        variablesOf<ProjectResourcePolicyV2QueryType['variables']>(snapshot),
+        options,
       );
     }
-  });
-  useEffect(
-    function loadProjectResourcePolicyOnTabActivation() {
-      ensureProjectResourcePolicyLoaded();
-    },
-    [currentTab],
-  );
+  };
+
+  const mirrorSnapshot = (
+    tab: TabKey,
+    snapshot: TabSnapshot,
+    history: 'push' | 'replace',
+  ) => {
+    setQueryParams({ tab, ...snapshot.queryParams }, { history });
+    setTablePaginationOption(snapshot.tablePaginationOption);
+  };
+
+  // Child-driven reloads: load, then mirror the new variables to the URL.
+  const reloadHandlerOf =
+    <V extends TabVariables>(
+      tab: TabKey,
+      load: (variables: V, options?: UseQueryLoaderLoadQueryOptions) => void,
+    ) =>
+    (variables: V, options?: UseQueryLoaderLoadQueryOptions) => {
+      load(variables, { fetchPolicy: 'store-and-network', ...options });
+      mirrorSnapshot(tab, snapshotOfVariables(variables), 'replace');
+    };
+
+  // Queries the tab the URL currently describes. Every tab change afterwards
+  // restores its snapshot and queries inside onTabChange.
+  const loadTabFromQueryParams = () => {
+    loadTabQuery(queryParams.tab, currentSnapshot);
+  };
+
+  // First visit: mount, direct URL entry, reload.
+  const loadTabOnMount = useEffectEvent(loadTabFromQueryParams);
+  useEffect(() => {
+    loadTabOnMount();
+  }, []);
+
+  // Back/forward: the hook holds the callback until `queryParams` and
+  // `tablePaginationOption` describe the URL the user navigated to.
+  useBrowserPopstateEffect(loadTabFromQueryParams);
 
   return (
     <BAICard
       activeTabKey={currentTab}
-      onTabChange={onTabChange}
+      onTabChange={(key) => {
+        const tab = tabParser.parse(key) ?? tabParser.defaultValue;
+        if (tab === currentTab) return;
+        const snapshot = peekTabSnapshot(tab) ?? defaultSnapshot;
+        setCurrentTab(tab);
+        loadTabQuery(tab, snapshot);
+        mirrorSnapshot(tab, snapshot, 'push');
+      }}
       tabList={filterOutEmpty([
         {
           key: 'keypair',
@@ -146,11 +238,14 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
       <Suspense fallback={<BAISkeleton />}>
         {currentTab === 'keypair' && (
           <BAIErrorBoundary>
-            {supportsSubFilter ? (
+            {supportsV2.keypair ? (
               keypairResourcePolicyQueryRef ? (
                 <KeypairResourcePolicyV2
                   queryRef={keypairResourcePolicyQueryRef}
-                  onReload={loadKeypairResourcePolicyQuery}
+                  onReload={reloadHandlerOf(
+                    'keypair',
+                    loadKeypairResourcePolicyQuery,
+                  )}
                 />
               ) : (
                 <BAISkeleton />
@@ -162,11 +257,14 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
         )}
         {currentTab === 'user' && (
           <BAIErrorBoundary>
-            {supportsSubFilter && supportsBinarySizeExpr ? (
+            {supportsV2.user ? (
               userResourcePolicyQueryRef ? (
                 <UserResourcePolicyV2
                   queryRef={userResourcePolicyQueryRef}
-                  onReload={loadUserResourcePolicyQuery}
+                  onReload={reloadHandlerOf(
+                    'user',
+                    loadUserResourcePolicyQuery,
+                  )}
                 />
               ) : (
                 <BAISkeleton />
@@ -178,11 +276,14 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
         )}
         {currentTab === 'project' && (
           <BAIErrorBoundary>
-            {supportsSubFilter && supportsBinarySizeExpr ? (
+            {supportsV2.project ? (
               projectResourcePolicyQueryRef ? (
                 <ProjectResourcePolicyV2
                   queryRef={projectResourcePolicyQueryRef}
-                  onReload={loadProjectResourcePolicyQuery}
+                  onReload={reloadHandlerOf(
+                    'project',
+                    loadProjectResourcePolicyQuery,
+                  )}
                 />
               ) : (
                 <BAISkeleton />

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -95,17 +95,13 @@ const variablesOf = <V extends TabVariables>(
   const order = _.includes(sorterValuesOf[tab], params.order)
     ? params.order
     : orderParser.defaultValue;
-  // The URL parsers accept any integer; keep a hand-edited link from
-  // requesting a negative limit / offset.
-  const pageSize = Math.max(1, pagination.pageSize);
-  const current = Math.max(1, pagination.current);
   return {
     filter: params.filter
       ? (filterParser.parse(params.filter) as V['filter'])
       : null,
     orderBy: convertToOrderBy<NonNullable<V['orderBy']>[number]>(order),
-    limit: pageSize,
-    offset: (current - 1) * pageSize,
+    limit: pagination.pageSize,
+    offset: (pagination.current - 1) * pagination.pageSize,
   };
 };
 

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -95,13 +95,17 @@ const variablesOf = <V extends TabVariables>(
   const order = _.includes(sorterValuesOf[tab], params.order)
     ? params.order
     : orderParser.defaultValue;
+  // The URL parsers accept any integer; keep a hand-edited link from
+  // requesting a negative limit / offset.
+  const pageSize = Math.max(1, pagination.pageSize);
+  const current = Math.max(1, pagination.current);
   return {
     filter: params.filter
       ? (filterParser.parse(params.filter) as V['filter'])
       : null,
     orderBy: convertToOrderBy<NonNullable<V['orderBy']>[number]>(order),
-    limit: pagination.pageSize,
-    offset: (pagination.current - 1) * pagination.pageSize,
+    limit: pageSize,
+    offset: (current - 1) * pageSize,
   };
 };
 

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -25,7 +25,14 @@ import {
   useSuspendedBackendaiClient,
 } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
-import { BAISkeleton, filterOutEmpty, BAICard } from 'backend.ai-ui';
+import {
+  BAISkeleton,
+  filterOutEmpty,
+  BAICard,
+  availableKeypairResourcePolicySorterValues,
+  availableProjectResourcePolicySorterValues,
+  availableUserResourcePolicySorterValues,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import {
   parseAsJson,
@@ -56,6 +63,14 @@ type TabVariables =
   | UserResourcePolicyV2QueryType['variables']
   | ProjectResourcePolicyV2QueryType['variables'];
 
+// Which `order` strings each tab's query accepts; anything else falls back
+// to the default so a hand-edited URL cannot fail GraphQL variable validation.
+const sorterValuesOf: Record<TabKey, readonly string[]> = {
+  keypair: availableKeypairResourcePolicySorterValues,
+  user: availableUserResourcePolicySorterValues,
+  project: availableProjectResourcePolicySorterValues,
+};
+
 type TabSnapshot = {
   queryParams: {
     filter: string | null;
@@ -72,13 +87,19 @@ const defaultSnapshot: TabSnapshot = {
   tablePaginationOption: { current: 1, pageSize: DEFAULT_PAGE_SIZE },
 };
 
-const variablesOf = <V extends TabVariables>(snapshot: TabSnapshot) => {
+const variablesOf = <V extends TabVariables>(
+  tab: TabKey,
+  snapshot: TabSnapshot,
+) => {
   const { queryParams: params, tablePaginationOption: pagination } = snapshot;
+  const order = _.includes(sorterValuesOf[tab], params.order)
+    ? params.order
+    : orderParser.defaultValue;
   return {
     filter: params.filter
       ? (filterParser.parse(params.filter) as V['filter'])
       : null,
-    orderBy: convertToOrderBy<NonNullable<V['orderBy']>[number]>(params.order),
+    orderBy: convertToOrderBy<NonNullable<V['orderBy']>[number]>(order),
     limit: pagination.pageSize,
     offset: (pagination.current - 1) * pagination.pageSize,
   };
@@ -157,17 +178,23 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
     const options = { fetchPolicy: 'store-and-network' } as const;
     if (tab === 'keypair') {
       loadKeypairResourcePolicyQuery(
-        variablesOf<KeypairResourcePolicyV2QueryType['variables']>(snapshot),
+        variablesOf<KeypairResourcePolicyV2QueryType['variables']>(
+          tab,
+          snapshot,
+        ),
         options,
       );
     } else if (tab === 'user') {
       loadUserResourcePolicyQuery(
-        variablesOf<UserResourcePolicyV2QueryType['variables']>(snapshot),
+        variablesOf<UserResourcePolicyV2QueryType['variables']>(tab, snapshot),
         options,
       );
     } else {
       loadProjectResourcePolicyQuery(
-        variablesOf<ProjectResourcePolicyV2QueryType['variables']>(snapshot),
+        variablesOf<ProjectResourcePolicyV2QueryType['variables']>(
+          tab,
+          snapshot,
+        ),
         options,
       );
     }


### PR DESCRIPTION
Resolves #9197 (FR-3735)

applied test server: https://fr-3735.seungwon.10-82-0-159.sslip.io/

## Summary

Moves `ResourcePolicyPage` from `useTabQuerySnapshot` (a raw query-string snapshot per tab) to the `useKeyedSnapshot` page-owned tab state pattern piloted on `AdminUsersPage` (FR-3387, #8588). Stacked on #9189 (FR-3730), which introduced the V2 tables this page preloads.

### `ResourcePolicyPage`

- **The page owns the URL state** — one `useQueryStates` group (`tab`, `filter`, `order`) plus `useBAIPaginationOptionStateOnSearchParam` (`current`, `pageSize`) — and the three V2 `useQueryLoader` refs. The per-tab snapshot is `{ queryParams, tablePaginationOption }`, exactly as on `AdminUsersPage`.
- **One mount-time load.** The three `useEffect(..., [currentTab])` loaders (one per tab, each gated on `!queryRef`) collapse into a single `useEffectEvent` + empty-deps effect for mount / direct URL entry / reload, with `useBrowserPopstateEffect` reloading on back/forward.
- **Tab change restores and preloads in the click handler** — `peekTabSnapshot(tab) ?? defaultSnapshot` → `setCurrentTab` → `loadTabQuery` → mirror to the URL with `history: 'push'` (render-as-you-fetch, no effect round-trip).
- **Child-driven reloads are mirrored back to the URL.** `reloadHandlerOf(tab, load)` wraps each V2 table's `onReload`: load with `store-and-network`, then write `filter` / `order` / `current` / `pageSize` with `history: 'replace'`. Filter, sort and page now survive reload and deep links — before, only `?tab=` did.
- The three V2 queries share one variable shape, so `variablesOf` / `snapshotOfVariables` are single generic converters rather than per-tab copies. The V2-vs-legacy gate (`supports('sub-filter')` / `supports('binary-size-expr')`) and the legacy `*List` fallbacks are unchanged; the gate is a `Record<TabKey, boolean>` so a fourth tab cannot silently inherit the wrong rule.

### Behaviour notes

- Default sort stays `CREATED_AT DESC` (`orderParser` defaults to `'-createdAt'`). Because nuqs drops default-valued keys, clearing the sorter is mirrored to the URL as the default — the live query is unsorted until the next reload / back-forward, which re-applies the default. Same trade-off `AdminUsersPage` makes for its defaulted keys.
- A hand-edited `?current=0` / `?pageSize=-1` is left to fail: the manager rejects negative pagination (`InvalidGraphQLParameters`) and `BAIErrorBoundary` shows that error. Only `?order=` is validated (against the tab's `available*SorterValues`, falling back to the default sort), matching the `AdminUsersPage` precedent.
- Revisiting a tab re-issues its query with `store-and-network`: it paints from the Relay store immediately and revalidates in the background (the FR-3387 contract), instead of the previous "load once per page life" behaviour.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Astryx theme build / Terminology)
- `e2e/resource-policy/resource-policy.spec.ts` does not assert on the URL shape; a tab switch still lands on `?tab=<key>` (all other keys are at their defaults and elided by nuqs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
