### PR TITLE
fix(FR-3738): give lucide icons a baseline and SimpleProgressWithLabel one box

### DIFF
--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -70,8 +70,10 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
         <BAIMetadataList columns="single">
           <MetadataListItem label={t('agent.ResourceAllocation')}>
             {/* antd Row gutter={[16,16]} + Col xs={24} sm={12} (uniform 2-up
-                from 576px) → Grid columns={{minWidth:280, max:2}} gap={4}
-                (RESPONSIVE-POLICY R1, container-driven). */}
+                from 576px) → Grid columns={{minWidth:280, max:2}}
+                (RESPONSIVE-POLICY R1, container-driven). The gutter is 2, not
+                the mapped 4: a cell is now a whole progress block, so the gap
+                separates blocks rather than a label from its own bar. */}
             <Grid columns={{ minWidth: 280, max: 2 }} gap={2}>
               {_.map(
                 parsedAvailableSlots,
@@ -197,13 +199,9 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
               </Grid>
             </MetadataListItem>
           )}
-          {/* PILOT-DECISION: the antd Tooltip+icon-Button explaining
-              "Utilization" lived AFTER the label text (composed inside the
-              Descriptions.Item's ReactNode label). MetadataListItem's `label`
-              is a plain string and its only label-adjacent slot (`icon`)
-              renders BEFORE it — flipped position accepted; the control's
-              purpose (open the detail modal) is unchanged. Tooltip on the
-              never-disabled trigger becomes IconButton's own `tooltip`. */}
+          {/* The antd Tooltip+icon-Button keeps its position AFTER the label
+              text: BAIMetadataListItem widens Astryx's string-typed `label` to
+              a node, so the pair composes the same way it did under antd. */}
           <BAIMetadataListItem
             label={
               <HStack>

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -6,6 +6,7 @@ import { AgentResourcesFragment$key } from '../../__generated__/AgentResourcesFr
 import { useResourceSlotsDetails } from '../../hooks/backendai';
 import AgentDetailModal from '../AgentDetailModal';
 import SimpleProgressWithLabel from '../SimpleProgressWithLabel';
+import { HStack } from '@astryxdesign/core';
 import { Grid } from '@astryxdesign/core/Grid';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { MetadataListItem } from '@astryxdesign/core/MetadataList';
@@ -13,6 +14,7 @@ import {
   BAICard,
   BAIFlex,
   BAIMetadataList,
+  BAIMetadataListItem,
   BAIText,
   convertToBinaryUnit,
   convertToDecimalUnit,
@@ -70,7 +72,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
             {/* antd Row gutter={[16,16]} + Col xs={24} sm={12} (uniform 2-up
                 from 576px) → Grid columns={{minWidth:280, max:2}} gap={4}
                 (RESPONSIVE-POLICY R1, container-driven). */}
-            <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
+            <Grid columns={{ minWidth: 280, max: 2 }} gap={2}>
               {_.map(
                 parsedAvailableSlots,
                 (_value: string | number, key: ResourceSlotName) => {
@@ -82,32 +84,22 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                       parsedAvailableSlots.cpu ?? '0',
                     );
                     return (
-                      <BAIFlex
+                      <SimpleProgressWithLabel
                         key={key}
-                        direction="column"
-                        align="stretch"
-                        gap={3}
-                      >
-                        <SimpleProgressWithLabel
-                          key="cpu"
-                          size="default"
-                          title={
-                            <BAIFlex gap="xxs">
-                              <ResourceTypeIcon key={key} type={key} />
-                              {
-                                mergedResourceSlots?.['cpu']
-                                  ?.human_readable_name
-                              }
-                            </BAIFlex>
-                          }
-                          percent={_.toFinite(
-                            (_.toNumber(parsedOccupiedSlots.cpu ?? 0) /
-                              _.toNumber(parsedAvailableSlots.cpu ?? 1)) *
-                              100,
-                          ).toString()}
-                          description={`${cpuOccupiedSlot} / ${cpuAvailableSlot} ${mergedResourceSlots?.['cpu']?.display_unit}`}
-                        />
-                      </BAIFlex>
+                        size="default"
+                        title={
+                          <BAIFlex gap="xxs">
+                            <ResourceTypeIcon key={key} type={key} />
+                            {mergedResourceSlots?.['cpu']?.human_readable_name}
+                          </BAIFlex>
+                        }
+                        percent={_.toFinite(
+                          (_.toNumber(parsedOccupiedSlots.cpu ?? 0) /
+                            _.toNumber(parsedAvailableSlots.cpu ?? 1)) *
+                            100,
+                        ).toString()}
+                        description={`${cpuOccupiedSlot} / ${cpuAvailableSlot} ${mergedResourceSlots?.['cpu']?.display_unit}`}
+                      />
                     );
                   } else if (key === 'mem') {
                     const memOccupiedSlot = convertToBinaryUnit(
@@ -122,38 +114,28 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                     );
 
                     return (
-                      <BAIFlex
+                      <SimpleProgressWithLabel
                         key={key}
-                        direction="column"
-                        align="stretch"
-                        gap={3}
-                      >
-                        <SimpleProgressWithLabel
-                          key={'mem'}
-                          size="default"
-                          title={
-                            <BAIFlex gap="xxs">
-                              <ResourceTypeIcon key={key} type={key} />
-                              {
-                                mergedResourceSlots?.['mem']
-                                  ?.human_readable_name
-                              }
-                            </BAIFlex>
-                          }
-                          percent={_.toFinite(
-                            ((memOccupiedSlot?.number ?? 0) /
-                              (memAvailableSlot?.number ?? 1)) *
-                              100,
-                          ).toString()}
-                          description={`${toFixedFloorWithoutTrailingZeros(
-                            memOccupiedSlot?.numberFixed || 0,
-                            2,
-                          )}${memOccupiedSlot?.displayUnit} / ${toFixedFloorWithoutTrailingZeros(
-                            memAvailableSlot?.numberFixed || 0,
-                            2,
-                          )}${memAvailableSlot?.displayUnit}`}
-                        />
-                      </BAIFlex>
+                        size="default"
+                        title={
+                          <BAIFlex gap="xxs">
+                            <ResourceTypeIcon key={key} type={key} />
+                            {mergedResourceSlots?.['mem']?.human_readable_name}
+                          </BAIFlex>
+                        }
+                        percent={_.toFinite(
+                          ((memOccupiedSlot?.number ?? 0) /
+                            (memAvailableSlot?.number ?? 1)) *
+                            100,
+                        ).toString()}
+                        description={`${toFixedFloorWithoutTrailingZeros(
+                          memOccupiedSlot?.numberFixed || 0,
+                          2,
+                        )}${memOccupiedSlot?.displayUnit} / ${toFixedFloorWithoutTrailingZeros(
+                          memAvailableSlot?.numberFixed || 0,
+                          2,
+                        )}${memAvailableSlot?.displayUnit}`}
+                      />
                     );
                   } else if (parsedAvailableSlots[key]) {
                     const roundLength =
@@ -222,25 +204,28 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
               renders BEFORE it — flipped position accepted; the control's
               purpose (open the detail modal) is unchanged. Tooltip on the
               never-disabled trigger becomes IconButton's own `tooltip`. */}
-          <MetadataListItem
-            label={t('agent.Utilization')}
-            icon={
-              <IconButton
-                icon={<Info size="1em" />}
-                label={t('agent.DetailedInformation')}
-                tooltip={t('agent.DetailedInformation')}
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setOpenInfoModal(true);
-                }}
-              />
+          <BAIMetadataListItem
+            label={
+              <HStack>
+                {t('agent.Utilization')}
+                <IconButton
+                  icon={<Info size="1em" />}
+                  label={t('agent.DetailedInformation')}
+                  tooltip={t('agent.DetailedInformation')}
+                  variant="ghost"
+                  size="sm"
+                  style={{ color: 'inherit' }}
+                  onClick={() => {
+                    setOpenInfoModal(true);
+                  }}
+                />
+              </HStack>
             }
           >
             {_.isEmpty(parsedLiveStat?.node) ? (
               <BAIText type="secondary">-</BAIText>
             ) : (
-              <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
+              <Grid columns={{ minWidth: 280, max: 2 }} gap={2}>
                 <SimpleProgressWithLabel
                   key={'cpu_util'}
                   size="default"
@@ -410,7 +395,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                 })}
               </Grid>
             )}
-          </MetadataListItem>
+          </BAIMetadataListItem>
         </BAIMetadataList>
       </BAICard>
       <AgentDetailModal

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -211,11 +211,7 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
   // span via GridSpan 'full'.
   return size === 'default' ? (
     <Grid columns={{ minWidth: 280, max: 2 }} gap={4}>
-      {_.map(utilItems, (item, index) => (
-        <BAIFlex key={index} direction="column" align="stretch">
-          {item}
-        </BAIFlex>
-      ))}
+      {utilItems}
       <GridSpan columns="full">
         <BAIFlex justify="end">
           <Text>

--- a/react/src/components/SimpleProgressWithLabel.tsx
+++ b/react/src/components/SimpleProgressWithLabel.tsx
@@ -36,7 +36,9 @@ const SimpleProgressWithLabel: React.FC<SimpleProgressWithLabelProps> = ({
 
   if (size === 'default') {
     return (
-      <>
+      // One box, not a fragment: as siblings the label row and the bar become
+      // two separate cells wherever this is dropped into a Grid.
+      <BAIFlex direction="column" align="stretch" gap={3}>
         <BAIFlex justify="between">
           <Text>{title}</Text>
           {/* antd `type="secondary" fontSize={fontSizeSM}` is exactly Astryx's
@@ -62,7 +64,7 @@ const SimpleProgressWithLabel: React.FC<SimpleProgressWithLabelProps> = ({
             height: token.sizeXS,
           }}
         />
-      </>
+      </BAIFlex>
     );
   }
 

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -14,7 +14,6 @@ import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useVirtualFolderPath } from '../hooks/useVirtualFolderNodePath';
 import VirtualFolderPath from './VirtualFolderNodeItems/VirtualFolderPath';
 import { Badge } from '@astryxdesign/core/Badge';
-import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Selector } from '@astryxdesign/core/Selector';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
@@ -24,6 +23,7 @@ import {
   toLocalId,
   BAIFlex,
   BAIMetadataList,
+  BAIMetadataListItem,
   useErrorMessageResolver,
   badgeVariantForStatus,
   BAIText,
@@ -107,8 +107,8 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
   const items = filterOutEmpty([
     !vfolderNode?.unmanaged_path && {
       key: 'path',
-      // PILOT-DECISION (V2 precedent): the copy affordance moves from the
-      // LABEL to the VALUE — `MetadataListItem.label` is a plain string (P2).
+      // PILOT-DECISION (V2 precedent): the copy affordance sits on the VALUE,
+      // next to the path it copies, not on the label.
       label: t('data.folders.Path'),
       children: (
         <HStack gap={1} align="start" wrap="wrap">
@@ -273,9 +273,9 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
   return (
     <BAIMetadataList columns="single">
       {items.map((item) => (
-        <MetadataListItem key={item.key} label={item.label as string}>
+        <BAIMetadataListItem key={item.key} label={item.label}>
           {item.children}
-        </MetadataListItem>
+        </BAIMetadataListItem>
       ))}
     </BAIMetadataList>
   );

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -88,8 +88,13 @@
   ) !important;
 }
 
-/* fix: match the icon size between Lucide and Ant.d icons */
+/* A lucide glyph is text-sized and sits on the text baseline. `display` is
+   load-bearing: Astryx's reset blockifies every `svg` (reset.css "Media"), and
+   a block box ignores `vertical-align` — without this the icon is inert-aligned
+   and a bare-icon line box measures 14px against a text line's 22px.
+   Inert where the icon is a flex/grid item, which is nearly every call site. */
 .lucide {
+  display: inline-block !important;
   width: 1em !important;
   height: 1em !important;
   vertical-align: -0.125em !important;


### PR DESCRIPTION
Resolves #9205 (FR-3738)

## Summary

Two layout defects left over from the Astryx migration, both visible in the agent detail drawer.

**1. A lucide icon never aligned to the text baseline.** `react/src/index.css` already carried `.lucide { vertical-align: -0.125em !important }`, but it had never applied: Astryx's reset blockifies every replaced element (`@astryxdesign/core/src/reset.css`, "Media" — `:where(img, svg, …) { display: block }`), and a block box does not participate in baseline alignment. Adding `display: inline-block` activates the rule that was already there.

**2. `SimpleProgressWithLabel` (`size="default"`) returned a fragment.** Its title row and its bar were bare siblings, so a `<Grid>` placed them in two separate cells — Utilization showed `CPU 5.23%` in the left column and its bar in the right. Wrapping them in one `BAIFlex` fixes every call site, including the four that never carried the hand-rolled workaround (the accelerator branch of Resource Allocation; the CPU / RAM / per-device rows of Utilization), and lets the two that did drop it.

**Riding along:** `VFolderNodeDescription` was casting `item.label as string` for the Astryx `MetadataListItem`, although `BAIMetadataListItem` (FR-3517) exists to widen that prop and its V2 twin already uses it. No `as string` cast on a `MetadataListItem` label remains in the app.

## Measurements

Agent detail drawer, `/admin/agent` → agent row, light theme, 1456px viewport:

| | before | after |
|---|---|---|
| icon-only `<dd>` height | 14px | **21.99px** |
| text `<dd>` height (reference) | 21.99px | 21.99px |
| icon centre within its `<dd>` | 7.0px | 10.75px (text x-height centre) |
| `svg.lucide` computed `display` | `block` (so `vertical-align` inert) | `inline-block` |

Blast radius of the CSS rule on that page: **57 of 59** lucide icons are flex/grid items, where `display` is blockified by the container anyway and the rule is inert. Only the 2 icons in inline contexts change — which is the intent.

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===`
- [x] Agent detail drawer at 1456px: Utilization now matches Resource Allocation — CPU left / RAM right, each bar directly under its own label. Net Rx / Net Tx unchanged.
- [x] `스케줄링 가능` check icon sits on the same line position as neighbouring text values.
- [ ] **Not verified live:** `SessionUsageMonitor` (`size="default"`) — the test cluster had no running sessions, so that code path did not render. Note it gains a 3px label-to-bar gap: its wrapper used `gap` 0 while Resource Allocation used `gap={3}`, and the component now owns `gap={3}` for both. Reviewer with a live session, please eyeball the session usage panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4LvxxY56whvXEQ1sadgqr