### PR TITLE
fix(FR-3739): drop power search input focus when the popup is dismissed by an outside click

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -11,6 +11,7 @@
  filter string for every page that mounts this component (the ticket-28
  consumer census) and asserts byte-for-byte stability.
 */
+import BAIPopconfirm from './BAIPopconfirm';
 import BAIPropertyFilter, {
   buildFieldSpecs,
   defaultContentSearchFieldKey,
@@ -20,7 +21,8 @@ import BAIPropertyFilter, {
   serializeFilters,
   type FilterProperty,
 } from './BAIPropertyFilter';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 describe('parseFilterValue', () => {
   it('should correctly parse filter with binary operators', () => {
@@ -531,5 +533,99 @@ describe('BAIPropertyFilter render', () => {
       />,
     );
     expect(screen.getByTestId('property-filter')).toBeInTheDocument();
+  });
+});
+
+/*
+ FR-3739 — guards `react/patches/@astryxdesign__core@0.5.0.patch`.
+
+ Astryx's `useFocusTrap` restored focus to whatever held it before the trap
+ activated whenever focus "would otherwise be lost". The suggestion popover
+ opens with `role: 'none'` + `hasAutoFocus: false`, so the input keeps focus
+ the whole time and the trap never holds it — the restore then re-focused the
+ input the dismissal had just blurred, and because the input was already
+ focused, clicking it again fired no `focus` event and the menu stayed shut.
+
+ The patch skips the restore when focus never entered the trap container. The
+ first test is the bug; the second is the behaviour the patch must NOT break —
+ a popup that does take focus still restores it.
+*/
+describe('BAIPropertyFilter dismissal (FR-3739)', () => {
+  const filterProperties: Array<FilterProperty> = [
+    { key: 'name', propertyLabel: 'Name', type: 'string' },
+    { key: 'status', propertyLabel: 'Status', type: 'string' },
+  ];
+
+  const renderFilter = () => {
+    render(
+      <BAIPropertyFilter
+        filterProperties={filterProperties}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    return screen.getByRole('combobox');
+  };
+
+  it('releases input focus when the suggestions are dismissed', async () => {
+    const input = renderFilter();
+
+    input.focus();
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+
+    // What an outside click does: the browser blurs the input, and the layer
+    // closes. Unpatched, the focus-trap teardown put focus straight back.
+    input.blur();
+    await waitFor(() =>
+      expect(input).toHaveAttribute('aria-expanded', 'false'),
+    );
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it('reopens the suggestions when the released input is focused again', async () => {
+    const input = renderFilter();
+
+    input.focus();
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+    input.blur();
+    await waitFor(() =>
+      expect(input).toHaveAttribute('aria-expanded', 'false'),
+    );
+
+    input.focus();
+    await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'true'));
+  });
+
+  it('still restores focus to the trigger of a popup that takes focus', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button" data-testid="outside">
+          outside
+        </button>
+        <BAIPopconfirm
+          title="Delete this?"
+          onConfirm={() => {}}
+          okText="Delete"
+          cancelText="Cancel"
+        >
+          <button type="button" data-testid="trigger">
+            trigger
+          </button>
+        </BAIPopconfirm>
+      </>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    await user.click(trigger);
+    const cancel = await screen.findByRole('button', { name: 'Cancel' });
+
+    // Focus genuinely enters this popup, so the trap owns it and must hand it
+    // back to the trigger when the popup closes.
+    cancel.focus();
+    expect(document.activeElement).toBe(cancel);
+    await user.click(cancel);
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,7 @@ overrides:
   lodash: ^4.18.0
 
 patchedDependencies:
+  '@astryxdesign/core@0.5.0': c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed
   '@astryxdesign/lab@0.3.0-canary.12db2a1': 0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08
   '@cloudscape-design/board-components@3.0.176': 06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98
   ansi_up@6.0.6: 99856fc7fa4571c6ef4716cfd2dbf1151a025690c737775e248e8b7fe08a4459
@@ -549,16 +550,16 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 'catalog:'
-        version: 0.5.0(3c1c048938d69fee32b54ae983eed166)
+        version: 0.5.0(c2a5fdd292d7565b26bd04dd572e2a14)
       '@astryxdesign/core':
         specifier: 'catalog:'
-        version: 0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/lab':
         specifier: 'catalog:'
-        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/theme-neutral':
         specifier: 'catalog:'
-        version: 0.5.0(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.5.0(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.5
@@ -732,13 +733,13 @@ importers:
         version: 2.0.230(react@19.2.8)(zod@4.4.3)
       '@astryxdesign/core':
         specifier: 'catalog:'
-        version: 0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/lab':
         specifier: 'catalog:'
-        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/theme-neutral':
         specifier: 'catalog:'
-        version: 0.5.0(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.5.0(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@cloudscape-design/board-components':
         specifier: 3.0.176
         version: 3.0.176(patch_hash=06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98)(@cloudscape-design/components@3.0.1341(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -976,7 +977,7 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 'catalog:'
-        version: 0.5.0(3c1c048938d69fee32b54ae983eed166)
+        version: 0.5.0(c2a5fdd292d7565b26bd04dd572e2a14)
       '@babel/core':
         specifier: 'catalog:'
         version: 7.29.7(supports-color@8.1.1)
@@ -11325,7 +11326,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astryxdesign/cli@0.5.0(3c1c048938d69fee32b54ae983eed166)':
+  '@astryxdesign/cli@0.5.0(c2a5fdd292d7565b26bd04dd572e2a14)':
     dependencies:
       commander: 12.1.0
       gpt-tokenizer: 3.4.0
@@ -11333,23 +11334,23 @@ snapshots:
       jscodeshift: 17.4.0(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       zod: 4.4.3
     optionalDependencies:
-      '@astryxdesign/core': 0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@astryxdesign/theme-neutral': 0.5.0(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/theme-neutral': 0.5.0(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@stylexjs/stylex': 0.19.0
       intl-messageformat: 11.2.13
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@astryxdesign/core': 0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@stylexjs/stylex': 0.19.0
       d3-array: 3.2.4
       d3-scale: 4.0.2
@@ -11369,9 +11370,9 @@ snapshots:
       '@lexical/utils': 0.46.0(typescript@6.0.3)
       lexical: 0.46.0(typescript@6.0.3)
 
-  '@astryxdesign/theme-neutral@0.5.0(@astryxdesign/core@0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/theme-neutral@0.5.0(@astryxdesign/core@0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@astryxdesign/core': 0.5.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.0(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react: 1.29.0(react@19.2.8)
       react: 19.2.8
 
@@ -14424,7 +14425,7 @@ snapshots:
     dependencies:
       serialize-javascript: 7.0.7
       smob: 1.6.2
-      terser: 5.46.0
+      terser: 5.49.2
     optionalDependencies:
       rollup: 4.62.4
 
@@ -22316,7 +22317,6 @@ snapshots:
       acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    optional: true
 
   test-exclude@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -157,6 +157,7 @@ overrides:
   lodash: ^4.18.0 # _.template RCE + _.unset prototype pollution (#321, #322 high)
 
 patchedDependencies:
+  "@astryxdesign/core@0.5.0": react/patches/@astryxdesign__core@0.5.0.patch
   "@astryxdesign/lab@0.3.0-canary.12db2a1": react/patches/@astryxdesign__lab@0.3.0-canary.12db2a1.patch
   "@cloudscape-design/board-components@3.0.176": react/patches/@cloudscape-design__board-components@3.0.176.patch
   ansi_up@6.0.6: react/patches/ansi_up@6.0.6.patch

--- a/react/patches/@astryxdesign__core@0.5.0.patch
+++ b/react/patches/@astryxdesign__core@0.5.0.patch
@@ -1,0 +1,63 @@
+diff --git a/dist/hooks/useFocusTrap.js b/dist/hooks/useFocusTrap.js
+index ead7e0af25144043c863026cfe48bcfdaf10f6cf..f3f192ad226e80cffad26e02b2e1c696cd808100 100644
+--- a/dist/hooks/useFocusTrap.js
++++ b/dist/hooks/useFocusTrap.js
+@@ -223,7 +223,25 @@ export function useFocusTrap(options) {
+     const previouslyFocused = document.activeElement;
+     // Snapshot the container now; by cleanup it may be detached or unmounted.
+     const container = containerRef.current;
++    // A popup that never takes focus (`role: 'none'` + `hasAutoFocus: false`,
++    // e.g. a Typeahead/PowerSearch listbox anchored to an input that keeps
++    // focus) has nothing to restore: the element that held focus throughout
++    // still holds it, or the user's outside click has just blurred it on
++    // purpose. Restoring there re-focuses the input the click dismissed, so the
++    // next click on it fires no focus event and the menu will not reopen.
++    let hadFocusInside = container?.contains(document.activeElement) ?? false;
++    const markFocusInside = event => {
++      const target = event.target;
++      if (target != null && containerRef.current?.contains(target)) {
++        hadFocusInside = true;
++      }
++    };
++    document.addEventListener('focusin', markFocusInside, true);
+     return () => {
++      document.removeEventListener('focusin', markFocusInside, true);
++      if (!hadFocusInside) {
++        return;
++      }
+       const active = document.activeElement;
+       const focusWasLost = active == null || active === document.body || active === document.documentElement || container != null && container.contains(active);
+       if (!focusWasLost) {
+diff --git a/src/hooks/useFocusTrap.ts b/src/hooks/useFocusTrap.ts
+index c05638a06c1e35345b33d9b13ecda5578821a82f..525c410546c39477b787f9cc787ba0341bf3c21d 100644
+--- a/src/hooks/useFocusTrap.ts
++++ b/src/hooks/useFocusTrap.ts
+@@ -253,7 +253,28 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
+     // Snapshot the container now; by cleanup it may be detached or unmounted.
+     const container = containerRef.current;
+ 
++    // A popup that never takes focus (`role: 'none'` + `hasAutoFocus: false`,
++    // e.g. a Typeahead/PowerSearch listbox anchored to an input that keeps
++    // focus) has nothing to restore: the element that held focus throughout
++    // still holds it, or the user's outside click has just blurred it on
++    // purpose. Restoring there re-focuses the input the click dismissed, so the
++    // next click on it fires no focus event and the menu will not reopen.
++    let hadFocusInside = container?.contains(document.activeElement) ?? false;
++    const markFocusInside = (event: FocusEvent) => {
++      const target = event.target as Node | null;
++      if (target != null && containerRef.current?.contains(target)) {
++        hadFocusInside = true;
++      }
++    };
++    document.addEventListener('focusin', markFocusInside, true);
++
+     return () => {
++      document.removeEventListener('focusin', markFocusInside, true);
++
++      if (!hadFocusInside) {
++        return;
++      }
++
+       const active = document.activeElement;
+       const focusWasLost =
+         active == null ||


### PR DESCRIPTION
Resolves #9207 (FR-3739)

Upstream: facebook/astryx#5651

## Summary

Clicking outside the power search closed its field-suggestion popover but left the input focused, so clicking the input again produced no `focus` event and the menu never reopened — users had to click outside twice, or type into the input, to get it back.

The cause is upstream, in Astryx rather than in this repo's components. `useFocusTrap` restores focus to the element that held it before the trap activated whenever focus "would otherwise be lost" (`activeElement` is null / `body` / `documentElement`, or still inside the container). A Typeahead / PowerSearch listbox opens with `role: 'none'` + `hasAutoFocus: false`, so the anchor input keeps focus the whole time and the trap never holds it. The outside click blurs the input natively, the native popover light dismiss hides the layer, and the restore then re-focuses the very input the click just dismissed.

Measured on the Sessions page, before:

| step | activeElement | aria-expanded |
|---|---|---|
| click the input | `INPUT[combobox]` | `true` |
| click outside | `INPUT[combobox]` | `false` |
| click the input again | `INPUT[combobox]` | `false` |

and after:

| step | activeElement | aria-expanded |
|---|---|---|
| click the input | `INPUT[combobox]` | `true` |
| click outside | `DIV[role=main]` | — |
| click the input again | `INPUT[combobox]` | `true` |

`@astryxdesign/core@0.5.0` is the latest published version, so a bump does not fix this. The change is therefore a `pnpm patch` (`react/patches/@astryxdesign__core@0.5.0.patch`, alongside the four patches already in that directory): `useFocusTrap` records whether focus ever entered the trap container while it was active, and skips the restore when it never did. Popups that do take focus — dialogs, dropdown menus, anything with `hasAutoFocus: true` — record a `focusin` and restore exactly as before. Reported upstream so the patch can be dropped once it is fixed there.

## Test plan

- [x] `bash scripts/verify.sh` — `=== ALL PASS ===`
- [x] `pnpm test` (98 passed) and `pnpm --filter backend.ai-ui test` (1922 passed)
- [x] Outside click releases focus; clicking the input again reopens the field menu
- [x] Escape still closes the dropdown with focus kept on the input
- [x] The user dropdown menu still restores focus to its trigger, on both Escape and outside click
- [x] ArrowDown / Enter field selection and the edit popover's Apply still commit (`filter=name ilike "%test-session%"`)
- [x] Confirmed on the dev server by the reporter
