### PR TITLE
fix(FR-3106): neutralize CSV formula injection in exported cells

### DIFF
--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -13,7 +13,7 @@ import { MyKeypairManagementModalRevokeMyKeypairMutation } from '../__generated_
 import { MyKeypairManagementModalSwitchMainKeyMutation } from '../__generated__/MyKeypairManagementModalSwitchMainKeyMutation.graphql';
 import { App } from '../app-shim';
 import { convertToOrderBy } from '../helper';
-import { downloadCSV } from '../helper/csv-util';
+import { downloadCSV, escapeCsvValue } from '../helper/csv-util';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { theme } from '../theme-shim';
@@ -90,7 +90,7 @@ const downloadCredentialCSV = (credential: KeypairCredential) => {
     credential.secretKey,
     credential.sshPublicKey,
   ]
-    .map((v) => `"${v.replace(/"/g, '""')}"`)
+    .map((value) => escapeCsvValue(value))
     .join(',');
 
   const csvContent = `${header}\n${row}\n`;

--- a/react/src/helper/csv-util.test.ts
+++ b/react/src/helper/csv-util.test.ts
@@ -3,7 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 // csv-util.test.ts
-import { downloadCSV, JSONToCSVBody, parseCSV, UTF8_BOM } from './csv-util';
+import {
+  downloadCSV,
+  escapeCsvValue,
+  JSONToCSVBody,
+  parseCSV,
+  UTF8_BOM,
+} from './csv-util';
 
 describe('JSONToCSVBody', () => {
   it('should convert JSON data to CSV format without formatting rules', () => {
@@ -73,6 +79,66 @@ describe('JSONToCSVBody', () => {
     const expected = '"name","age"\n"John ""Doe""",30\n"Jane, the Great",25';
 
     expect(result).toBe(expected);
+  });
+
+  it('should neutralize a data cell that a spreadsheet would run as a formula', () => {
+    const data = [{ email: 'user@example.com', name: '=1+2' }];
+
+    const result = JSONToCSVBody(data);
+
+    expect(result).toBe('"email","name"\n"user@example.com","\'=1+2"');
+  });
+
+  it('should leave the "-" placeholder and negative numbers alone', () => {
+    const data = [{ idle_timeout: '-', max_sessions: '-30' }];
+
+    const result = JSONToCSVBody(data);
+
+    expect(result).toBe('"idle_timeout","max_sessions"\n"-","-30"');
+  });
+});
+
+describe('escapeCsvValue', () => {
+  it.each([
+    ['=1+2', '"\'=1+2"'],
+    ['+1+2', '"\'+1+2"'],
+    ['-1+2', '"\'-1+2"'],
+    ['@SUM(1)', '"\'@SUM(1)"'],
+    ['\t=1+2', '"\'\t=1+2"'],
+    ['\r=1+2', '"\'\r=1+2"'],
+  ])('should neutralize the formula trigger in %j', (input, expected) => {
+    expect(escapeCsvValue(input)).toBe(expected);
+  });
+
+  it.each([
+    ['-', '"-"'],
+    ['-30', '"-30"'],
+    ['+30', '"+30"'],
+    ['-1.5', '"-1.5"'],
+    ['user@example.com', '"user@example.com"'],
+    ['John', '"John"'],
+    ['', '""'],
+  ])('should leave %j unchanged', (input, expected) => {
+    expect(escapeCsvValue(input)).toBe(expected);
+  });
+
+  it('should keep neutralizing a value that also needs quote escaping', () => {
+    expect(escapeCsvValue('="quoted"')).toBe('"\'=""quoted"""');
+  });
+
+  it('should not touch numbers and booleans, which cannot carry a formula', () => {
+    expect(escapeCsvValue(-30)).toBe('-30');
+    expect(escapeCsvValue(0)).toBe('0');
+    expect(escapeCsvValue(false)).toBe('false');
+  });
+
+  it('should render null and undefined as an empty cell', () => {
+    expect(escapeCsvValue(null)).toBe('');
+    expect(escapeCsvValue(undefined)).toBe('');
+  });
+
+  it('should serialize objects without neutralizing the JSON', () => {
+    expect(escapeCsvValue({ cpu: 1 })).toBe('"{""cpu"":1}"');
   });
 });
 

--- a/react/src/helper/csv-util.ts
+++ b/react/src/helper/csv-util.ts
@@ -4,13 +4,45 @@
  */
 import * as _ from 'lodash-es';
 
+// Excel keeps Lotus compatibility, so `+`, `-` and `@` open a formula just as
+// `=` does, and a leading tab or CR hides one of them behind whitespace that
+// the importer strips before parsing the cell.
+const CSV_FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
+
+const PLAIN_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+
+/**
+ * Prefixes a cell a spreadsheet would evaluate as a formula with a single
+ * quote, so it is shown as the text the export meant to carry.
+ *
+ * Quoting the field does not help: Excel and LibreOffice evaluate a formula
+ * inside a quoted CSV field too. A signed number is a value rather than an
+ * expression, and `-` alone is the "no value" placeholder the resource policy
+ * exports emit, so both are left as they are.
+ *
+ * @param value - The already-stringified cell value.
+ * @returns The value, prefixed with `'` when it would otherwise execute.
+ */
+const neutralizeCsvFormula = (value: string) => {
+  if (!value || !CSV_FORMULA_TRIGGERS.includes(value[0])) {
+    return value;
+  }
+  if (value === '-' || PLAIN_NUMBER_PATTERN.test(value)) {
+    return value;
+  }
+  return `'${value}`;
+};
+
 /**
  * Escapes a value for CSV formatting.
+ *
+ * Every CSV cell this app writes should go through this helper rather than a
+ * local escaper, so formula neutralization stays in one place.
  *
  * @param value - The value to escape.
  * @returns The escaped value.
  */
-function escapeCsvValue(value: any) {
+export function escapeCsvValue(value: any) {
   if (value === null || value === undefined) {
     return '';
   }
@@ -22,7 +54,7 @@ function escapeCsvValue(value: any) {
   value = _.isString(value) ? value : JSON.stringify(value);
 
   // Replace double quotes within the value with two double quotes
-  return `"${value.replace(/"/g, '""')}"`;
+  return `"${neutralizeCsvFormula(value).replace(/"/g, '""')}"`;
 }
 
 /**

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -8,7 +8,7 @@ import EndpointDiagnosticsSection from '../components/EndpointDiagnosticsSection
 import ErrorBoundaryWithNullFallback from '../components/ErrorBoundaryWithNullFallback';
 import StorageProxyDiagnosticsSection from '../components/StorageProxyDiagnosticsSection';
 import WebServerConfigDiagnosticsSection from '../components/WebServerConfigDiagnosticsSection';
-import { downloadCSV } from '../helper/csv-util';
+import { downloadCSV, escapeCsvValue } from '../helper/csv-util';
 import { DiagnosticResult } from '../types/diagnostics';
 import { Collapsible, CollapsibleGroup } from '@astryxdesign/core/Collapsible';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
@@ -108,11 +108,6 @@ const DiagnosticsPage = () => {
       return;
     }
 
-    const escCsv = (val: string) =>
-      val.includes(',') || val.includes('"') || val.includes('\n')
-        ? `"${val.replace(/"/g, '""')}"`
-        : val;
-
     const header = [
       'ID',
       'Severity',
@@ -133,7 +128,7 @@ const DiagnosticsPage = () => {
     ]);
 
     const csvContent = [header, ...rows]
-      .map((row) => row.map(escCsv).join(','))
+      .map((row) => row.map((cell) => escapeCsvValue(cell)).join(','))
       .join('\n');
 
     const today = new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
This PR proposes neutralizing CSV formula injection in the cells written by `escapeCsvValue`, so an exported value that begins with `=`, `+`, `-`, `@`, tab or CR is no longer evaluated as a formula when the download is opened in a spreadsheet (fixes #7842). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/470. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

`escapeCsvValue` in `react/src/helper/csv-util.ts` wraps a cell in quotes and doubles the quotes inside it, but the leading character reaches the file untouched. Excel, LibreOffice and Sheets treat a leading `=` as the start of a formula, and Excel keeps Lotus compatibility so `+`, `-` and `@` open one too; a leading tab or CR hides one of those behind whitespace the importer strips. Wrapping the field in quotes does not prevent any of it. `react/src/pages/DiagnosticsPage.tsx` and `react/src/components/MyKeypairManagementModal.tsx` each carry their own local escaper with exactly the same gap, which is the set of three sites #7842 lists.

Reproduced on `main` at `f376cc1`, with no changes applied:

```
cd react
node --experimental-strip-types --input-type=module \
  -e "import { JSONToCSVBody } from './src/helper/csv-util.ts'; console.log(JSONToCSVBody([{ name: '=1+2' }]));"
```

```
"name"
"=1+2"
```

The value is written through verbatim, so a spreadsheet evaluates it on open. Emails, user and project names, and resource-policy rows all reach these exports, and the four `exportCSVWithFormattingRules` callers (`GeneratedKeypairListModal`, `KeypairResourcePolicyList`, `UserResourcePolicyList`, `ProjectResourcePolicyList`) plus the two local builders are the download buttons users press.

## The change

`neutralizeCsvFormula` is added to `csv-util.ts` and applied inside `escapeCsvValue`, prefixing an affected cell with a single quote. `escapeCsvValue` is now exported, and the local escaper in `DiagnosticsPage` and the row builder in `MyKeypairManagementModal` are routed through it, so the rule lives in one place as #7842 suggests.

Two behavioural details worth your attention, since both are choices rather than mechanics:

- A blanket prefix would also rewrite the `-` placeholder your `format_rules` emit for empty values in the three resource-policy exports, and every negative number. Neither can carry an expression, so a value that is exactly `-` or a plain signed number is left alone. Both cases are covered by tests, so the behaviour is pinned rather than incidental.
- `DiagnosticsPage` used to quote a cell only when it contained a comma, quote or newline. Going through the shared helper means every cell is quoted. That is still RFC 4180 and parses identically, but it does change the shape of that one file, so it should be a deliberate call rather than a surprise.

## Verification

Everything below was run in `react/`, before and after the change, on this branch.

- `pnpm exec vitest run`: 102 files / 1631 tests passing on the untouched tree, 102 files / 1650 passing after. The 19 extra are the new cases; no previously passing test changed state.
- `pnpm exec eslint ./src --max-warnings=0 --no-warn-ignored` and `pnpm exec tsc --noEmit`: clean both before and after. `prettier --check` passes on all four files.
- The new tests genuinely fail without the fix. Reverting only the `neutralizeCsvFormula(...)` call inside `escapeCsvValue` and re-running `pnpm exec vitest run src/helper/csv-util.test.ts` gives `8 failed | 32 passed` — the 8 are exactly the neutralization assertions, while the `-` placeholder and negative-number controls stay green.
- Neither `DiagnosticsPage` nor `MyKeypairManagementModal` has a test file, so the suite does not actually cover those two edits. We ran their exact row-building expressions against the real helper instead:

```
DiagnosticsPage:
"ID","Severity","Category","Title","Description","Remediation"
"csp-1","warning","CSP","Header missing","'=1+2",""
"ep-2","info","Endpoint","Reachable, fast","Latency 20ms","-"

MyKeypairManagementModal:
"AKIAEXAMPLE","'=1+2","ssh-rsa AAAAB3"
```

One merge note: #7941 is open against `react/src/helper/csv-util.test.ts` for `parseCSV` / `exportCSVWithFormattingRules` coverage. It adds cases in a different part of that file and does not touch the helper itself, so the two changes are compatible, but whichever lands second will want a rebase.

## How this was managed

We imported this repository's issues and pull requests into a board — 6,889 stories, with your milestones as epics — and ran this change on it as the story [Neutralize CSV formula injection in CSV export helpers](https://eastagiletracker.com/projects/470/stories/427396), which is the imported copy of #7842. The board is live at https://eastagiletracker.com/projects/470

![board](https://raw.githubusercontent.com/eastagiletracker/backend%2Eai-webui/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
