### PR TITLE
feat(FR-3766): add read-only WebMCP tools on user list pages

### DIFF
--- a/react/src/__generated__/ComputeSessionListPageQuery.graphql.ts
+++ b/react/src/__generated__/ComputeSessionListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<289828642f7eee9192bc226624352535>>
+ * @generated SignedSource<<244be380cc2e8e86f2cd9a82029d92a9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,8 +33,13 @@ export type ComputeSessionListPageQuery$data = {
     readonly count: number | null | undefined;
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly created_at: string | null | undefined;
         readonly id: string;
         readonly name: string;
+        readonly row_id: string | null | undefined;
+        readonly scaling_group: string | null | undefined;
+        readonly status: string | null | undefined;
+        readonly type: string | null | undefined;
         readonly " $fragmentSpreads": FragmentRefs<"SessionNodesFragment" | "TerminateSessionModalFragment">;
       };
     } | null | undefined>;
@@ -151,23 +156,58 @@ v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "count",
+  "name": "row_id",
   "storageKey": null
 },
 v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "type",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "created_at",
+  "storageKey": null
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "scaling_group",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v20 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v16 = {
+v21 = {
   "kind": "Literal",
   "name": "offset",
   "value": 0
 },
-v17 = [
-  (v14/*: any*/)
+v22 = [
+  (v19/*: any*/)
 ],
-v18 = {
+v23 = {
   "alias": "all",
   "args": [
     {
@@ -175,18 +215,18 @@ v18 = {
       "name": "filter",
       "variableName": "allFilter"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v19 = {
+v24 = {
   "alias": "interactive",
   "args": [
     {
@@ -194,18 +234,18 @@ v19 = {
       "name": "filter",
       "variableName": "interactiveFilter"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v20 = {
+v25 = {
   "alias": "inference",
   "args": [
     {
@@ -213,18 +253,18 @@ v20 = {
       "name": "filter",
       "variableName": "inferenceFilter"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v21 = {
+v26 = {
   "alias": "batch",
   "args": [
     {
@@ -232,18 +272,18 @@ v21 = {
       "name": "filter",
       "variableName": "batchFilter"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v22 = {
+v27 = {
   "alias": "system",
   "args": [
     {
@@ -251,53 +291,39 @@ v22 = {
       "name": "filter",
       "variableName": "systemFilter"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "row_id",
-  "storageKey": null
-},
-v24 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "status",
-  "storageKey": null
-},
-v25 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "priority",
   "storageKey": null
 },
-v26 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status_info",
   "storageKey": null
 },
-v27 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tag",
   "storageKey": null
 },
-v28 = [
+v31 = [
   {
     "alias": null,
     "args": null,
@@ -313,14 +339,14 @@ v28 = [
     "storageKey": null
   }
 ],
-v29 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "idle_checks",
   "storageKey": null
 },
-v30 = [
+v33 = [
   {
     "alias": null,
     "args": null,
@@ -338,16 +364,16 @@ v30 = [
         "plural": false,
         "selections": [
           (v12/*: any*/),
-          (v23/*: any*/),
+          (v14/*: any*/),
           (v13/*: any*/),
-          (v24/*: any*/)
+          (v15/*: any*/)
         ],
         "storageKey": null
       }
     ],
     "storageKey": null
   },
-  (v14/*: any*/)
+  (v19/*: any*/)
 ];
 return {
   "fragment": {
@@ -407,6 +433,11 @@ return {
                           "field": (v13/*: any*/),
                           "action": "THROW"
                         },
+                        (v14/*: any*/),
+                        (v15/*: any*/),
+                        (v16/*: any*/),
+                        (v17/*: any*/),
+                        (v18/*: any*/),
                         {
                           "args": null,
                           "kind": "FragmentSpread",
@@ -427,17 +458,17 @@ return {
               },
               "action": "THROW"
             },
-            (v14/*: any*/)
+            (v19/*: any*/)
           ],
           "storageKey": null
         },
         "to": "RESULT"
       },
-      (v18/*: any*/),
-      (v19/*: any*/),
-      (v20/*: any*/),
-      (v21/*: any*/),
-      (v22/*: any*/)
+      (v23/*: any*/),
+      (v24/*: any*/),
+      (v25/*: any*/),
+      (v26/*: any*/),
+      (v27/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -485,15 +516,11 @@ return {
                 "selections": [
                   (v12/*: any*/),
                   (v13/*: any*/),
-                  (v23/*: any*/),
-                  (v24/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "type",
-                    "storageKey": null
-                  },
+                  (v14/*: any*/),
+                  (v15/*: any*/),
+                  (v16/*: any*/),
+                  (v17/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -515,8 +542,8 @@ return {
                     "name": "agent_ids",
                     "storageKey": null
                   },
-                  (v25/*: any*/),
-                  (v26/*: any*/),
+                  (v28/*: any*/),
+                  (v29/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -529,13 +556,6 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "queue_position",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "created_at",
                     "storageKey": null
                   },
                   {
@@ -566,7 +586,7 @@ return {
                     "name": "requested_slots",
                     "storageKey": null
                   },
-                  (v27/*: any*/),
+                  (v30/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -643,7 +663,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "tags",
                                     "plural": true,
-                                    "selections": (v28/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -653,7 +673,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "labels",
                                     "plural": true,
-                                    "selections": (v28/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -670,12 +690,12 @@ return {
                                     "name": "namespace",
                                     "storageKey": null
                                   },
-                                  (v27/*: any*/),
+                                  (v30/*: any*/),
                                   (v12/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v23/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -690,8 +710,8 @@ return {
                                 "name": "cluster_idx",
                                 "storageKey": null
                               },
-                              (v24/*: any*/),
-                              (v26/*: any*/),
+                              (v15/*: any*/),
+                              (v29/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -715,7 +735,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v29/*: any*/),
+                  (v32/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -780,7 +800,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v23/*: any*/),
+                              (v14/*: any*/),
                               (v13/*: any*/),
                               (v12/*: any*/)
                             ],
@@ -789,18 +809,11 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v14/*: any*/)
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "scaling_group",
-                    "storageKey": null
-                  },
-                  (v29/*: any*/),
+                  (v32/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -815,7 +828,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependees",
                     "plural": false,
-                    "selections": (v30/*: any*/),
+                    "selections": (v33/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -825,7 +838,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependents",
                     "plural": false,
-                    "selections": (v30/*: any*/),
+                    "selections": (v33/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -842,7 +855,7 @@ return {
                     "name": "commit_status",
                     "storageKey": null
                   },
-                  (v25/*: any*/),
+                  (v28/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -863,28 +876,28 @@ return {
             ],
             "storageKey": null
           },
-          (v14/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
-      (v18/*: any*/),
-      (v19/*: any*/),
-      (v20/*: any*/),
-      (v21/*: any*/),
-      (v22/*: any*/)
+      (v23/*: any*/),
+      (v24/*: any*/),
+      (v25/*: any*/),
+      (v26/*: any*/),
+      (v27/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "c9156efb3ca6bc33beed620d708f094b",
+    "cacheID": "0e045f03661c4939ee506e1181066624",
     "id": null,
     "metadata": {},
     "name": "ComputeSessionListPageQuery",
     "operationKind": "query",
-    "text": "query ComputeSessionListPageQuery(\n  $scopeId: ScopeField\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n  $allFilter: String\n  $interactiveFilter: String\n  $inferenceFilter: String\n  $batchFilter: String\n  $systemFilter: String\n) {\n  computeSessionNodeResult: compute_session_nodes(scope_id: $scopeId, first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $allFilter) {\n    count\n  }\n  interactive: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $interactiveFilter) {\n    count\n  }\n  inference: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $inferenceFilter) {\n    count\n  }\n  batch: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $batchFilter) {\n    count\n  }\n  system: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $systemFilter) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditSessionPriorityModalFragment on ComputeSessionNode {\n  id\n  name\n  priority @since(version: \"24.09.0\")\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionAccessKeyFragment on ComputeSessionNode {\n  access_key\n  user_id\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n  ...SessionAccessKeyFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  priority @since(version: \"24.09.0\")\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  ...EditSessionPriorityModalFragment\n  ...SessionAccessKeyFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query ComputeSessionListPageQuery(\n  $scopeId: ScopeField\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n  $allFilter: String\n  $interactiveFilter: String\n  $inferenceFilter: String\n  $batchFilter: String\n  $systemFilter: String\n) {\n  computeSessionNodeResult: compute_session_nodes(scope_id: $scopeId, first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        row_id\n        status\n        type\n        created_at\n        scaling_group\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $allFilter) {\n    count\n  }\n  interactive: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $interactiveFilter) {\n    count\n  }\n  inference: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $inferenceFilter) {\n    count\n  }\n  batch: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $batchFilter) {\n    count\n  }\n  system: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $systemFilter) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditSessionPriorityModalFragment on ComputeSessionNode {\n  id\n  name\n  priority @since(version: \"24.09.0\")\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionAccessKeyFragment on ComputeSessionNode {\n  access_key\n  user_id\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n  ...SessionAccessKeyFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  priority @since(version: \"24.09.0\")\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  ...EditSessionPriorityModalFragment\n  ...SessionAccessKeyFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fd1971a2bd6b899a56cda390c054ddd3";
+(node as any).hash = "80c811161c0f91eda09c2fa11a9f2cbd";
 
 export default node;

--- a/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b1f8b5de41b47cef366c1651696ac34>>
+ * @generated SignedSource<<dde3142b74fe3a5194deeda94c6154ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,7 @@ export type DeploymentDetailPageQuery$data = {
     } | null | undefined;
     readonly currentRevision: {
       readonly id: string;
+      readonly revisionNumber: number;
     } | null | undefined;
     readonly deployingRevision: {
       readonly id: string;
@@ -179,9 +180,13 @@ v10 = {
   "selections": (v8/*: any*/),
   "storageKey": null
 },
-v11 = [
-  (v2/*: any*/)
-],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "revisionNumber",
+  "storageKey": null
+},
 v12 = {
   "alias": null,
   "args": null,
@@ -590,13 +595,6 @@ v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "revisionNumber",
-  "storageKey": null
-},
-v41 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 };
@@ -643,7 +641,10 @@ return {
               "kind": "LinkedField",
               "name": "currentRevision",
               "plural": false,
-              "selections": (v11/*: any*/),
+              "selections": [
+                (v2/*: any*/),
+                (v11/*: any*/)
+              ],
               "storageKey": null
             },
             {
@@ -653,7 +654,9 @@ return {
               "kind": "LinkedField",
               "name": "deployingRevision",
               "plural": false,
-              "selections": (v11/*: any*/),
+              "selections": [
+                (v2/*: any*/)
+              ],
               "storageKey": null
             },
             {
@@ -794,6 +797,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
+              (v11/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -929,7 +933,6 @@ return {
               },
               (v39/*: any*/),
               (v40/*: any*/),
-              (v41/*: any*/),
               (v22/*: any*/),
               (v39/*: any*/)
             ],
@@ -944,8 +947,8 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
+              (v11/*: any*/),
               (v40/*: any*/),
-              (v41/*: any*/),
               (v18/*: any*/),
               (v22/*: any*/),
               (v21/*: any*/),
@@ -1073,16 +1076,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7bc624ab346fbca25c424f1bcffa5751",
+    "cacheID": "edc7693fe97ae675be70f2df8255f3d2",
     "id": null,
     "metadata": {},
     "name": "DeploymentDetailPageQuery",
     "operationKind": "query",
-    "text": "query DeploymentDetailPageQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    id\n    metadata {\n      name\n      status\n      projectId\n    }\n    networkAccess {\n      openToPublic\n      endpointUrl\n    }\n    replicaState {\n      desiredReplicaCount\n    }\n    runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n      count\n    }\n    accessTokens {\n      count\n    }\n    currentRevision @since(version: \"26.4.3\") {\n      id\n    }\n    deployingRevision @since(version: \"26.4.3\") {\n      id\n    }\n    creator @since(version: \"26.4.3\") {\n      basicInfo {\n        email\n      }\n      id\n    }\n    ...DeploymentAddRevisionModal_deployment\n    ...DeploymentBasicInfoCard_deployment\n    ...DeploymentRevisionCard_deployment\n    ...DeploymentReplicasCard_deployment\n    ...DeploymentAccessTokensCard_deployment\n    ...DeploymentAutoScalingCard_deployment\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment DeploymentAccessTokensCard_deployment on ModelDeployment {\n  id\n  networkAccess {\n    endpointUrl\n  }\n}\n\nfragment DeploymentAddRevisionModal_deployment on ModelDeployment {\n  id\n  metadata {\n    resourceGroupName\n    projectId\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    modelMountConfig {\n      vfolderId\n    }\n    ...DeploymentAddRevisionModal_revisionSource\n    id\n  }\n}\n\nfragment DeploymentAddRevisionModal_revisionSource on ModelRevision {\n  revisionPresetId @since(version: \"26.4.4\")\n  clusterConfig {\n    mode\n    size\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n  }\n  modelRuntimeConfig {\n    runtimeVariantId\n    runtimeVariant {\n      name\n      readsVfolderConfigFiles @since(version: \"26.8.0\")\n      id\n    }\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    vfolder {\n      id\n      name\n    }\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        shell @since(version: \"26.7.0\")\n        startCommand\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          enable @since(version: \"26.4.4\")\n          path\n          maxRetries\n          initialDelay\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n  imageV2 {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n}\n\nfragment DeploymentAutoScalingCard_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  creator @since(version: \"26.4.3\") {\n    basicInfo {\n      email\n    }\n    id\n  }\n}\n\nfragment DeploymentBasicInfoCard_deployment on ModelDeployment {\n  id\n  ...DeploymentSettingModal_deployment\n  metadata {\n    name\n    projectId\n    domainName\n    status\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    openToPublic\n    endpointUrl\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment DeploymentCurrentRevisionTab_deployment on ModelDeployment {\n  id\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  deployingRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n}\n\nfragment DeploymentReplicasCard_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentRevisionCard_deployment on ModelDeployment {\n  id\n  ...DeploymentCurrentRevisionTab_deployment\n  ...DeploymentRevisionHistoryTab_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n      preset {\n        name\n        displayName\n        targetSpec {\n          key\n        }\n        id\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentRevisionHistoryTab_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  ...DeploymentAddRevisionModal_deployment\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
+    "text": "query DeploymentDetailPageQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    id\n    metadata {\n      name\n      status\n      projectId\n    }\n    networkAccess {\n      openToPublic\n      endpointUrl\n    }\n    replicaState {\n      desiredReplicaCount\n    }\n    runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n      count\n    }\n    accessTokens {\n      count\n    }\n    currentRevision @since(version: \"26.4.3\") {\n      id\n      revisionNumber\n    }\n    deployingRevision @since(version: \"26.4.3\") {\n      id\n    }\n    creator @since(version: \"26.4.3\") {\n      basicInfo {\n        email\n      }\n      id\n    }\n    ...DeploymentAddRevisionModal_deployment\n    ...DeploymentBasicInfoCard_deployment\n    ...DeploymentRevisionCard_deployment\n    ...DeploymentReplicasCard_deployment\n    ...DeploymentAccessTokensCard_deployment\n    ...DeploymentAutoScalingCard_deployment\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment DeploymentAccessTokensCard_deployment on ModelDeployment {\n  id\n  networkAccess {\n    endpointUrl\n  }\n}\n\nfragment DeploymentAddRevisionModal_deployment on ModelDeployment {\n  id\n  metadata {\n    resourceGroupName\n    projectId\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    modelMountConfig {\n      vfolderId\n    }\n    ...DeploymentAddRevisionModal_revisionSource\n    id\n  }\n}\n\nfragment DeploymentAddRevisionModal_revisionSource on ModelRevision {\n  revisionPresetId @since(version: \"26.4.4\")\n  clusterConfig {\n    mode\n    size\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n  }\n  modelRuntimeConfig {\n    runtimeVariantId\n    runtimeVariant {\n      name\n      readsVfolderConfigFiles @since(version: \"26.8.0\")\n      id\n    }\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    vfolder {\n      id\n      name\n    }\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        shell @since(version: \"26.7.0\")\n        startCommand\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          enable @since(version: \"26.4.4\")\n          path\n          maxRetries\n          initialDelay\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n  imageV2 {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n}\n\nfragment DeploymentAutoScalingCard_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  creator @since(version: \"26.4.3\") {\n    basicInfo {\n      email\n    }\n    id\n  }\n}\n\nfragment DeploymentBasicInfoCard_deployment on ModelDeployment {\n  id\n  ...DeploymentSettingModal_deployment\n  metadata {\n    name\n    projectId\n    domainName\n    status\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    openToPublic\n    endpointUrl\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment DeploymentCurrentRevisionTab_deployment on ModelDeployment {\n  id\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  deployingRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n}\n\nfragment DeploymentReplicasCard_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentRevisionCard_deployment on ModelDeployment {\n  id\n  ...DeploymentCurrentRevisionTab_deployment\n  ...DeploymentRevisionHistoryTab_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n      preset {\n        name\n        displayName\n        targetSpec {\n          key\n        }\n        id\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentRevisionHistoryTab_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  ...DeploymentAddRevisionModal_deployment\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9089d2f31b9601fe2fa64e840ab45300";
+(node as any).hash = "aedc1e57fb6986cee3c4fc99d8b42bbf";
 
 export default node;

--- a/react/src/__generated__/ModelStoreListPageV2Query.graphql.ts
+++ b/react/src/__generated__/ModelStoreListPageV2Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<57ca6b883b0e41987ba279ca20a9adab>>
+ * @generated SignedSource<<d261457e405ec67d6ee2affea612b5fd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,6 +68,12 @@ export type ModelStoreListPageV2Query$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id: string;
+        readonly metadata: {
+          readonly author: string | null | undefined;
+          readonly task: string | null | undefined;
+          readonly title: string | null | undefined;
+        };
+        readonly name: string;
         readonly " $fragmentSpreads": FragmentRefs<"ModelStoreListPageV2_ModelCardV2Fragment">;
       };
     }>;
@@ -144,6 +150,45 @@ v7 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ModelCardV2Metadata",
+  "kind": "LinkedField",
+  "name": "metadata",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "task",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "author",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -184,6 +229,8 @@ return {
                 "plural": false,
                 "selections": [
                   (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
                   {
                     "args": null,
                     "kind": "FragmentSpread",
@@ -240,45 +287,8 @@ return {
                 "plural": false,
                 "selections": [
                   (v7/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "name",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ModelCardV2Metadata",
-                    "kind": "LinkedField",
-                    "name": "metadata",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "task",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "author",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
+                  (v8/*: any*/),
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -328,16 +338,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dbde5904adf578002ddc9f413150947d",
+    "cacheID": "82ec9d96fdc88d3e0ef4f9bd4ae6decf",
     "id": null,
     "metadata": {},
     "name": "ModelStoreListPageV2Query",
     "operationKind": "query",
-    "text": "query ModelStoreListPageV2Query(\n  $scope: ProjectModelCardV2Scope!\n  $filter: ModelCardV2Filter\n  $orderBy: [ModelCardV2OrderBy!]\n  $limit: Int!\n  $offset: Int!\n) {\n  projectModelCardsV2(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...ModelStoreListPageV2_ModelCardV2Fragment\n      }\n    }\n  }\n}\n\nfragment ModelStoreListPageV2_ModelCardV2Fragment on ModelCardV2 {\n  name\n  metadata {\n    title\n    task\n    author\n  }\n  updatedAt\n  createdAt\n  availablePresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    count\n  }\n}\n"
+    "text": "query ModelStoreListPageV2Query(\n  $scope: ProjectModelCardV2Scope!\n  $filter: ModelCardV2Filter\n  $orderBy: [ModelCardV2OrderBy!]\n  $limit: Int!\n  $offset: Int!\n) {\n  projectModelCardsV2(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        metadata {\n          title\n          task\n          author\n        }\n        ...ModelStoreListPageV2_ModelCardV2Fragment\n      }\n    }\n  }\n}\n\nfragment ModelStoreListPageV2_ModelCardV2Fragment on ModelCardV2 {\n  name\n  metadata {\n    title\n    task\n    author\n  }\n  updatedAt\n  createdAt\n  availablePresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    count\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "deba47dc7280cb92b05271fb176f72c7";
+(node as any).hash = "2c92a929f8aa27ca39b2c1c899aaac36";
 
 export default node;

--- a/react/src/__generated__/VFolderNodeListPageQuery.graphql.ts
+++ b/react/src/__generated__/VFolderNodeListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<388640d228ab9e23a637eea3bf8fad47>>
+ * @generated SignedSource<<b6b33902b2221bb608ebd96d844e941a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,9 +31,14 @@ export type VFolderNodeListPageQuery$data = {
     readonly count: number | null | undefined;
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly created_at: string | null | undefined;
+        readonly host: string | null | undefined;
         readonly id: string;
+        readonly name: string | null | undefined;
+        readonly ownership_type: string | null | undefined;
         readonly permissions: ReadonlyArray<any | null | undefined> | null | undefined;
         readonly status: string | null | undefined;
+        readonly usage_mode: string | null | undefined;
         readonly " $fragmentSpreads": FragmentRefs<"BAIVFolderDeleteButtonFragment" | "DeleteVFolderModalFragment" | "EditableVFolderNameFragment" | "RestoreVFolderModalFragment" | "SharedFolderPermissionInfoModalFragment" | "VFolderNodeIdenticonFragment" | "VFolderNodesFragment">;
       };
     } | null | undefined>;
@@ -144,23 +149,58 @@ v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "count",
+  "name": "name",
   "storageKey": null
 },
 v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "host",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "usage_mode",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "ownership_type",
+  "storageKey": null
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "created_at",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v20 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v16 = {
+v21 = {
   "kind": "Literal",
   "name": "offset",
   "value": 0
 },
-v17 = [
-  (v14/*: any*/)
+v22 = [
+  (v19/*: any*/)
 ],
-v18 = {
+v23 = {
   "alias": "active",
   "args": [
     {
@@ -168,8 +208,8 @@ v18 = {
       "name": "filter",
       "variableName": "filterForActiveCount"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v8/*: any*/),
     (v9/*: any*/)
   ],
@@ -177,10 +217,10 @@ v18 = {
   "kind": "LinkedField",
   "name": "vfolder_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v19 = {
+v24 = {
   "alias": "deleted",
   "args": [
     {
@@ -188,8 +228,8 @@ v19 = {
       "name": "filter",
       "variableName": "filterForDeletedCount"
     },
-    (v15/*: any*/),
-    (v16/*: any*/),
+    (v20/*: any*/),
+    (v21/*: any*/),
     (v8/*: any*/),
     (v9/*: any*/)
   ],
@@ -197,24 +237,17 @@ v19 = {
   "kind": "LinkedField",
   "name": "vfolder_nodes",
   "plural": false,
-  "selections": (v17/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v20 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v21 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "row_id",
   "storageKey": null
 },
-v22 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -272,6 +305,11 @@ return {
                       },
                       (v12/*: any*/),
                       (v13/*: any*/),
+                      (v14/*: any*/),
+                      (v15/*: any*/),
+                      (v16/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
                       {
                         "args": null,
                         "kind": "FragmentSpread",
@@ -317,12 +355,12 @@ return {
             },
             "action": "THROW"
           },
-          (v14/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
-      (v18/*: any*/),
-      (v19/*: any*/)
+      (v23/*: any*/),
+      (v24/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -369,26 +407,16 @@ return {
                   (v11/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
-                  (v20/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "host",
-                    "storageKey": null
-                  },
+                  (v14/*: any*/),
+                  (v15/*: any*/),
+                  (v16/*: any*/),
+                  (v17/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "quota_scope_id",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "ownership_type",
                     "storageKey": null
                   },
                   {
@@ -423,13 +451,6 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "usage_mode",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
                     "name": "max_files",
                     "storageKey": null
                   },
@@ -438,13 +459,6 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "max_size",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "created_at",
                     "storageKey": null
                   },
                   {
@@ -476,7 +490,7 @@ return {
                     "storageKey": null
                   },
                   (v13/*: any*/),
-                  (v21/*: any*/),
+                  (v25/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -497,7 +511,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v22/*: any*/),
+                          (v26/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -600,7 +614,7 @@ return {
                                         "storageKey": null
                                       },
                                       (v11/*: any*/),
-                                      (v21/*: any*/),
+                                      (v25/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -662,7 +676,7 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v20/*: any*/),
+                                      (v14/*: any*/),
                                       (v11/*: any*/)
                                     ],
                                     "storageKey": null
@@ -687,7 +701,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v22/*: any*/),
+                          (v26/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -696,7 +710,7 @@ return {
                             "name": "metadata",
                             "plural": false,
                             "selections": [
-                              (v20/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -707,7 +721,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v22/*: any*/)
+                          (v26/*: any*/)
                         ],
                         "type": "VirtualFolderNode",
                         "abstractKey": null
@@ -722,25 +736,25 @@ return {
             ],
             "storageKey": null
           },
-          (v14/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       },
-      (v18/*: any*/),
-      (v19/*: any*/)
+      (v23/*: any*/),
+      (v24/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "9f143c58b02f6303981eb781e425060e",
+    "cacheID": "1a737f5c84c74b7e71b82109078174bd",
     "id": null,
     "metadata": {},
     "name": "VFolderNodeListPageQuery",
     "operationKind": "query",
-    "text": "query VFolderNodeListPageQuery(\n  $scopeId: ScopeField\n  $offset: Int\n  $first: Int\n  $filter: String\n  $order: String\n  $permission: VFolderPermissionValueField\n  $filterForActiveCount: String\n  $filterForDeletedCount: String\n) {\n  vfolder_nodes(scope_id: $scopeId, offset: $offset, first: $first, filter: $filter, order: $order, permission: $permission) {\n    edges {\n      node {\n        id\n        status\n        permissions\n        ...VFolderNodesFragment\n        ...DeleteVFolderModalFragment\n        ...EditableVFolderNameFragment\n        ...RestoreVFolderModalFragment\n        ...VFolderNodeIdenticonFragment\n        ...SharedFolderPermissionInfoModalFragment\n        ...BAIVFolderDeleteButtonFragment\n      }\n    }\n    count\n  }\n  active: vfolder_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $filterForActiveCount, permission: $permission) {\n    count\n  }\n  deleted: vfolder_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $filterForDeletedCount, permission: $permission) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAIComputeSessionNodeNotificationItemFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  ...SessionActionButtonsFragment\n  ...SessionStatusTagFragment\n}\n\nfragment BAINodeNotificationItemFragment on Node {\n  __isNode: __typename\n  ... on ComputeSessionNode {\n    __typename\n    status\n    name\n    row_id\n    ...BAIComputeSessionNodeNotificationItemFragment\n  }\n  ... on VFolder {\n    __typename\n    ...BAIVirtualFolderNodeNotificationItemV2Fragment\n  }\n  ... on VirtualFolderNode {\n    __typename\n    status\n    ...BAIVirtualFolderNodeNotificationItemFragment\n  }\n  id\n}\n\nfragment BAIVFolderDeleteButtonFragment on VirtualFolderNode {\n  permissions\n}\n\nfragment BAIVirtualFolderNodeNotificationItemFragment on VirtualFolderNode {\n  row_id\n  id\n  name\n  status\n}\n\nfragment BAIVirtualFolderNodeNotificationItemV2Fragment on VFolder {\n  id\n  metadata {\n    name\n  }\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment DeleteVFolderModalFragment on VirtualFolderNode {\n  id\n  name\n  permissions\n}\n\nfragment EditableVFolderNameFragment on VirtualFolderNode {\n  id\n  name\n  user\n  group\n  status\n}\n\nfragment RestoreVFolderModalFragment on VirtualFolderNode {\n  id\n  name\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SharedFolderPermissionInfoModalFragment on VirtualFolderNode {\n  id\n  name\n  row_id\n  creator\n  ownership_type\n  user_email\n  permission\n  ...VFolderPermissionCellFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment VFolderNodesFragment on VirtualFolderNode {\n  id\n  status\n  name\n  host\n  quota_scope_id\n  ownership_type\n  user\n  user_email\n  group\n  group_name\n  usage_mode\n  max_files\n  max_size\n  created_at\n  last_used\n  num_files\n  cur_size\n  cloneable\n  permissions @since(version: \"24.09.0\")\n  ...VFolderPermissionCellFragment\n  ...VFolderNodeIdenticonFragment\n  ...SharedFolderPermissionInfoModalFragment\n  ...BAINodeNotificationItemFragment\n}\n\nfragment VFolderPermissionCellFragment on VirtualFolderNode {\n  permissions\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n"
+    "text": "query VFolderNodeListPageQuery(\n  $scopeId: ScopeField\n  $offset: Int\n  $first: Int\n  $filter: String\n  $order: String\n  $permission: VFolderPermissionValueField\n  $filterForActiveCount: String\n  $filterForDeletedCount: String\n) {\n  vfolder_nodes(scope_id: $scopeId, offset: $offset, first: $first, filter: $filter, order: $order, permission: $permission) {\n    edges {\n      node {\n        id\n        status\n        permissions\n        name\n        host\n        usage_mode\n        ownership_type\n        created_at\n        ...VFolderNodesFragment\n        ...DeleteVFolderModalFragment\n        ...EditableVFolderNameFragment\n        ...RestoreVFolderModalFragment\n        ...VFolderNodeIdenticonFragment\n        ...SharedFolderPermissionInfoModalFragment\n        ...BAIVFolderDeleteButtonFragment\n      }\n    }\n    count\n  }\n  active: vfolder_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $filterForActiveCount, permission: $permission) {\n    count\n  }\n  deleted: vfolder_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $filterForDeletedCount, permission: $permission) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAIComputeSessionNodeNotificationItemFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  ...SessionActionButtonsFragment\n  ...SessionStatusTagFragment\n}\n\nfragment BAINodeNotificationItemFragment on Node {\n  __isNode: __typename\n  ... on ComputeSessionNode {\n    __typename\n    status\n    name\n    row_id\n    ...BAIComputeSessionNodeNotificationItemFragment\n  }\n  ... on VFolder {\n    __typename\n    ...BAIVirtualFolderNodeNotificationItemV2Fragment\n  }\n  ... on VirtualFolderNode {\n    __typename\n    status\n    ...BAIVirtualFolderNodeNotificationItemFragment\n  }\n  id\n}\n\nfragment BAIVFolderDeleteButtonFragment on VirtualFolderNode {\n  permissions\n}\n\nfragment BAIVirtualFolderNodeNotificationItemFragment on VirtualFolderNode {\n  row_id\n  id\n  name\n  status\n}\n\nfragment BAIVirtualFolderNodeNotificationItemV2Fragment on VFolder {\n  id\n  metadata {\n    name\n  }\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment DeleteVFolderModalFragment on VirtualFolderNode {\n  id\n  name\n  permissions\n}\n\nfragment EditableVFolderNameFragment on VirtualFolderNode {\n  id\n  name\n  user\n  group\n  status\n}\n\nfragment RestoreVFolderModalFragment on VirtualFolderNode {\n  id\n  name\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SharedFolderPermissionInfoModalFragment on VirtualFolderNode {\n  id\n  name\n  row_id\n  creator\n  ownership_type\n  user_email\n  permission\n  ...VFolderPermissionCellFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment VFolderNodesFragment on VirtualFolderNode {\n  id\n  status\n  name\n  host\n  quota_scope_id\n  ownership_type\n  user\n  user_email\n  group\n  group_name\n  usage_mode\n  max_files\n  max_size\n  created_at\n  last_used\n  num_files\n  cur_size\n  cloneable\n  permissions @since(version: \"24.09.0\")\n  ...VFolderPermissionCellFragment\n  ...VFolderNodeIdenticonFragment\n  ...SharedFolderPermissionInfoModalFragment\n  ...BAINodeNotificationItemFragment\n}\n\nfragment VFolderPermissionCellFragment on VirtualFolderNode {\n  permissions\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n"
   }
 };
 })();
 
-(node as any).hash = "12c653e8562be1e02812dda763ea7288";
+(node as any).hash = "583235e256f4d95f18cbf32b5cf24499";
 
 export default node;

--- a/react/src/helper/webmcpPageTools.test.ts
+++ b/react/src/helper/webmcpPageTools.test.ts
@@ -1,0 +1,139 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3766: the pure parts of the page-scoped tool triple — row pruning, param
+ * compaction, and what "current" answers when the opened item is not among the
+ * rendered rows.
+ */
+import {
+  compactFilterState,
+  createCurrentItemTool,
+  createListVisibleTool,
+  currentToolName,
+  filterToolName,
+  hiddenColumnKeys,
+  listVisibleToolName,
+  resolveOpenedRow,
+  visibleRow,
+  type PageReadToolsConfig,
+} from './webmcpPageTools';
+import type { CallToolResult } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+
+const ROWS = [
+  { id: 'a', name: 'alpha', status: 'RUNNING' },
+  { id: 'b', name: 'beta', status: 'STOPPED' },
+];
+
+const CONFIG: PageReadToolsConfig = {
+  noun: 'widget',
+  plural: 'widgets',
+  resource: 'session',
+  rowProperties: { id: { type: 'string' }, name: { type: 'string' } },
+  rows: ROWS,
+  pagination: { current: 3, pageSize: 2 },
+  filter: {},
+  current: null,
+};
+
+const structured = (result: CallToolResult): unknown =>
+  result.structuredContent;
+
+describe('tool names', () => {
+  it('are bai_ + snake_case, built from the noun', () => {
+    expect(listVisibleToolName('model_card')).toBe(
+      'bai_list_visible_model_card',
+    );
+    expect(filterToolName('model_card')).toBe('bai_get_model_card_filter');
+    expect(currentToolName('model_card')).toBe('bai_get_current_model_card');
+  });
+});
+
+describe('visibleRow', () => {
+  it('removes hidden columns but never the row identity', () => {
+    expect(visibleRow(ROWS[0], ['status', 'id'])).toEqual({
+      id: 'a',
+      name: 'alpha',
+    });
+  });
+});
+
+describe('hiddenColumnKeys', () => {
+  it('lists only the keys explicitly marked hidden', () => {
+    expect(
+      hiddenColumnKeys({ a: { hidden: true }, b: { hidden: false }, c: {} }),
+    ).toEqual(['a']);
+    expect(hiddenColumnKeys(undefined)).toEqual([]);
+  });
+});
+
+describe('compactFilterState', () => {
+  it('drops params the URL does not carry', () => {
+    expect(
+      compactFilterState({
+        filter: null,
+        statusCategory: 'running',
+        order: undefined,
+        current: 1,
+      }),
+    ).toEqual({ statusCategory: 'running', current: 1 });
+  });
+});
+
+describe('resolveOpenedRow', () => {
+  it('answers null when nothing is open', () => {
+    expect(resolveOpenedRow(ROWS, null, (id) => `/x/${id}`)).toBeNull();
+  });
+
+  it('returns the full row plus its deep link', () => {
+    expect(resolveOpenedRow(ROWS, 'b', (id) => `/x/${id}`)).toEqual({
+      id: 'b',
+      name: 'beta',
+      status: 'STOPPED',
+      webui_path: '/x/b',
+    });
+  });
+
+  it('still answers the id and link when the row is on another page', () => {
+    expect(resolveOpenedRow(ROWS, 'zzz', (id) => `/x/${id}`)).toEqual({
+      id: 'zzz',
+      webui_path: '/x/zzz',
+    });
+  });
+});
+
+describe('createListVisibleTool', () => {
+  it('omits total when the page does not know it', () => {
+    expect(
+      structured(
+        createListVisibleTool(CONFIG).execute(
+          {},
+          {} as never,
+        ) as CallToolResult,
+      ),
+    ).toEqual({ rows: ROWS, count: 2, page: 3, pageSize: 2 });
+  });
+
+  it('is read-only and takes no arguments', () => {
+    const tool = createListVisibleTool(CONFIG);
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(tool.inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+});
+
+describe('createCurrentItemTool', () => {
+  it('declares a nullable object output schema', () => {
+    expect(createCurrentItemTool(CONFIG).outputSchema).toMatchObject({
+      type: 'object',
+      required: ['current'],
+      properties: {
+        current: {
+          type: ['object', 'null'],
+          properties: { webui_path: { type: 'string' } },
+        },
+      },
+    });
+  });
+});

--- a/react/src/helper/webmcpPageTools.ts
+++ b/react/src/helper/webmcpPageTools.ts
@@ -1,0 +1,258 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * The read-only, page-scoped WebMCP tool triple every list page registers
+ * (FR-3766 / FR-3767): "what rows do I see", "what is selected", "how do I
+ * reproduce this view".
+ *
+ * A page owns the data, so it builds the config from state it already has —
+ * this module only turns that config into three `bai_*` tools with stable
+ * names, JSON-Schema output shapes and `readOnlyHint`. Nothing here fetches.
+ *
+ * Deliberately generic: the admin pages (FR-3767) register the same triple
+ * with their own nouns, rows and filter params.
+ */
+import { useWebMCPTool, type WebMCPTool } from '../hooks/useWebMCPTool';
+import type { ListResource } from './resourcePath';
+import type {
+  CallToolResult,
+  JsonObject,
+  JsonSchemaForInference,
+  JsonValue,
+} from '@mcp-b/webmcp-types';
+import * as _ from 'lodash-es';
+import type { DependencyList } from 'react';
+
+/** One rendered row. `id` identifies it; the rest are the visible columns. */
+export type PageToolRow = JsonObject & { id: string };
+
+/**
+ * The list page's URL state, named as the params actually appear in the URL
+ * (`LIST_PAGES` in `resourcePath.ts`). Pages may add their own params —
+ * `type` on sessions, `mode` on vfolders, `sort` on the model store — which
+ * ride along at the top level and are declared via `extraFilterProperties`.
+ */
+export interface PageFilterState {
+  filter?: string | null;
+  statusCategory?: string | null;
+  order?: string | null;
+  current?: number | null;
+  pageSize?: number | null;
+  [param: string]: string | number | null | undefined;
+}
+
+export interface PageReadToolsConfig {
+  /** snake_case noun the tool names are built from, e.g. `session`. */
+  noun: string;
+  /** Plural used in the tool descriptions, e.g. `sessions`. */
+  plural: string;
+  /** `bai_open_resource`'s `resource` value for this page's list. */
+  resource: ListResource;
+  /** JSON-Schema properties of one row (`id` is always present). */
+  rowProperties: Readonly<Record<string, JsonSchemaForInference>>;
+  /** The rows rendered on the CURRENT page, in the current sort order. */
+  rows: ReadonlyArray<PageToolRow>;
+  /** Column keys the user hid; pruned from every row (`id` never is). */
+  hiddenColumns?: ReadonlyArray<string>;
+  pagination: { current: number; pageSize: number; total?: number | null };
+  filter: PageFilterState;
+  /** Schema for the page-specific params carried in `filter`. */
+  extraFilterProperties?: Readonly<Record<string, JsonSchemaForInference>>;
+  /** The opened/selected item, already carrying `webui_path`, or `null`. */
+  current: PageToolRow | null;
+  /** Extra JSON-Schema properties `current` has beyond `rowProperties`. */
+  currentProperties?: Readonly<Record<string, JsonSchemaForInference>>;
+}
+
+/**
+ * `helper/webmcp`'s `webmcpResult` widened to any JSON value: these tools
+ * answer with arrays of objects, which its flat `WebMCPPayload` cannot hold.
+ */
+export const webmcpJsonResult = (payload: JsonValue): CallToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  structuredContent: payload,
+});
+
+/** Drops `undefined`/`null` params so the payload mirrors the URL exactly. */
+export const compactFilterState = (filter: PageFilterState): JsonObject =>
+  _.omitBy(filter, _.isNil) as JsonObject;
+
+/** A `BAITable` `tableSettings.columnOverrides` record, as pages persist it. */
+export type TableColumnOverrides =
+  Readonly<Record<string, { hidden?: boolean } | undefined>> | null | undefined;
+
+/**
+ * The row a page-scoped "current item" URL param points at.
+ *
+ * The opened item is normally one of the rendered rows, so the answer carries
+ * every column the row has. When it is not (the drawer outlived its page of
+ * the list), the id and the deep link are still answerable and more useful
+ * than `null` — only "nothing is open" answers `null`.
+ */
+export const resolveOpenedRow = (
+  rows: ReadonlyArray<PageToolRow>,
+  openedId: string | null | undefined,
+  toWebuiPath: (id: string) => string,
+  matches: (row: PageToolRow, openedId: string) => boolean = (row, id) =>
+    row.id === id,
+): PageToolRow | null => {
+  if (!openedId) {
+    return null;
+  }
+  const row = _.find(rows, (candidate) => matches(candidate, openedId));
+  const id = row?.id ?? openedId;
+  return { ...(row ?? {}), id, webui_path: toWebuiPath(id) };
+};
+
+/**
+ * The column keys a `BAITable` `columnOverrides` record currently hides. Pages
+ * translate those keys into row-field names before handing them over, because
+ * a column key and the GraphQL field it renders do not always match
+ * (`resourceGroup` renders `scaling_group`).
+ */
+export const hiddenColumnKeys = (
+  overrides:
+    | Readonly<Record<string, { hidden?: boolean } | undefined>>
+    | null
+    | undefined,
+): Array<string> =>
+  _.keys(_.pickBy(overrides ?? {}, (o) => o?.hidden === true));
+
+/** A row with the user-hidden columns removed. `id` always survives. */
+export const visibleRow = (
+  row: PageToolRow,
+  hiddenColumns: ReadonlyArray<string> = [],
+): JsonObject => _.omit(row, _.without(hiddenColumns, 'id')) as JsonObject;
+
+export const listVisibleToolName = (noun: string): string =>
+  `bai_list_visible_${noun}`;
+export const filterToolName = (noun: string): string =>
+  `bai_get_${noun}_filter`;
+export const currentToolName = (noun: string): string =>
+  `bai_get_current_${noun}`;
+
+const NO_ARGS = { type: 'object', properties: {} } as const;
+
+export const createListVisibleTool = (
+  config: PageReadToolsConfig,
+): WebMCPTool => {
+  const rows = _.map(config.rows, (row) =>
+    visibleRow(row, config.hiddenColumns),
+  );
+  return {
+    name: listVisibleToolName(config.noun),
+    description: `The ${config.plural} currently rendered in this Backend.AI WebUI tab: the rows of the page being shown, in the current sort order, with the columns the user has visible. Not the whole result set — call ${filterToolName(config.noun)} for the query that produced it.`,
+    inputSchema: NO_ARGS,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        rows: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: config.rowProperties,
+            required: ['id'],
+          },
+        },
+        count: { type: 'integer', description: 'Rows on this page.' },
+        page: { type: 'integer', description: '1-based page number.' },
+        pageSize: { type: 'integer' },
+        total: {
+          type: 'integer',
+          description: 'Rows matching the filter across all pages.',
+        },
+      },
+      required: ['rows', 'count', 'page', 'pageSize'],
+    },
+    annotations: { readOnlyHint: true },
+    execute: (): CallToolResult =>
+      webmcpJsonResult({
+        rows,
+        count: rows.length,
+        page: config.pagination.current,
+        pageSize: config.pagination.pageSize,
+        ...(_.isNil(config.pagination.total)
+          ? {}
+          : { total: config.pagination.total }),
+      }),
+  };
+};
+
+export const createPageFilterTool = (
+  config: PageReadToolsConfig,
+): WebMCPTool => {
+  const payload = {
+    resource: config.resource,
+    ...compactFilterState(config.filter),
+  };
+  return {
+    name: filterToolName(config.noun),
+    description: `The active filter, sort, pagination and status category of this ${config.plural} list, as the page's own URL params. Feed them back to bai_open_resource {"type":"list","resource":"${config.resource}", …} to reproduce this view.`,
+    inputSchema: NO_ARGS,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        resource: { type: 'string', const: config.resource },
+        filter: {
+          type: 'string',
+          description: 'Filter param, verbatim (free text or JSON per page).',
+        },
+        statusCategory: { type: 'string' },
+        order: { type: 'string' },
+        current: { type: 'integer', description: '1-based page number.' },
+        pageSize: { type: 'integer' },
+        ...(config.extraFilterProperties ?? {}),
+      },
+      required: ['resource'],
+    },
+    annotations: { readOnlyHint: true },
+    execute: (): CallToolResult => webmcpJsonResult(payload),
+  };
+};
+
+export const createCurrentItemTool = (
+  config: PageReadToolsConfig,
+): WebMCPTool => ({
+  name: currentToolName(config.noun),
+  description: `The ${config.noun} currently opened or selected in this Backend.AI WebUI tab (detail drawer, detail page, explorer or modal). Answers {"current": null} when nothing is open; otherwise the item plus webui_path, the deep link back to it.`,
+  inputSchema: NO_ARGS,
+  // The single-key envelope is not decoration: MCP's CallToolResult schema
+  // requires `structuredContent` to be an object, so a bare `null` is rejected
+  // by the relay ("Tool returned an invalid result").
+  outputSchema: {
+    type: 'object',
+    properties: {
+      current: {
+        type: ['object', 'null'],
+        description: `The open ${config.noun}, or null when nothing is open.`,
+        properties: {
+          ...config.rowProperties,
+          ...(config.currentProperties ?? {}),
+          webui_path: {
+            type: 'string',
+            description: 'WebUI route that reopens this item.',
+          },
+        },
+      },
+    },
+    required: ['current'],
+  },
+  annotations: { readOnlyHint: true },
+  execute: (): CallToolResult => webmcpJsonResult({ current: config.current }),
+});
+
+/**
+ * Registers the read-only triple for as long as the page is mounted. The tools
+ * disappear on navigation (the hook aborts each registration), which is what
+ * makes the relay's tool list follow the route.
+ */
+export const usePageReadTools = (
+  config: PageReadToolsConfig,
+  deps: DependencyList,
+): void => {
+  useWebMCPTool(createListVisibleTool(config), deps);
+  useWebMCPTool(createPageFilterTool(config), deps);
+  useWebMCPTool(createCurrentItemTool(config), deps);
+};

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -19,6 +19,7 @@ import SessionNodes, {
 } from '../components/SessionNodes';
 import SessionResourceGrid from '../components/SessionResourceGrid';
 import { handleRowSelectionChange } from '../helper';
+import { SESSION_DETAIL_PARAM } from '../helper/resourcePath';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
@@ -28,6 +29,7 @@ import { useCSVExport } from '../hooks/useCSVExport';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
 import { useBAIBreakpoint } from '../theme-shim';
+import { useSessionListWebMCPTools } from './webmcp/sessionListTools';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { Grid, GridSpan } from '@astryxdesign/core/Grid';
@@ -256,6 +258,13 @@ const ComputeSessionListPage = () => {
             node @required(action: THROW) {
               id @required(action: THROW)
               name @required(action: THROW)
+              # Scalars the WebMCP page tools report. Already fetched by
+              # SessionNodesFragment, so selecting them here costs nothing.
+              row_id
+              status
+              type
+              created_at
+              scaling_group
               ...SessionNodesFragment
               ...TerminateSessionModalFragment
             }
@@ -318,6 +327,26 @@ const ComputeSessionListPage = () => {
   const compute_session_nodes = computeSessionNodeResult.ok
     ? computeSessionNodeResult.value
     : null;
+  const sessionNodes = filterOutNullAndUndefined(
+    compute_session_nodes?.edges.map((e) => e?.node),
+  );
+
+  // FR-3766: the three read-only WebMCP tools for this page. Registered from
+  // here because this is where the rendered rows, the URL filter state and the
+  // open detail drawer all already are.
+  useSessionListWebMCPTools({
+    sessions: sessionNodes,
+    columnOverrides,
+    pagination: {
+      current: tablePaginationOption.current,
+      pageSize: tablePaginationOption.pageSize,
+      total: compute_session_nodes?.count,
+    },
+    queryParams,
+    openedSessionId: new URLSearchParams(location.search).get(
+      SESSION_DETAIL_PARAM,
+    ),
+  });
   // Responsive policy R3 (ticket 14): the render tree branches on `lg`
   // (the action card is unmounted below lg), so the JS hook stays; the antd
   // Row/Col track layout becomes an Astryx 24-column Grid whose spans are
@@ -627,17 +656,13 @@ const ComputeSessionListPage = () => {
                   // Using selectedRowKeys to retrieve selected rows since selectedRows lack nested fragment types
                   handleRowSelectionChange(
                     selectedRowKeys,
-                    filterOutNullAndUndefined(
-                      compute_session_nodes?.edges.map((e) => e?.node),
-                    ),
+                    sessionNodes,
                     setSelectedSessionList,
                   );
                 },
                 selectedRowKeys: _.map(selectedSessionList, (i) => i.id),
               }}
-              sessionsFrgmt={filterOutNullAndUndefined(
-                compute_session_nodes?.edges.map((e) => e?.node),
-              )}
+              sessionsFrgmt={sessionNodes}
               pagination={{
                 pageSize: tablePaginationOption.pageSize,
                 current: tablePaginationOption.current,

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 } from '../hooks/useWebUIMenuItems';
 import { theme } from '../theme-shim';
 import { toProjectContext } from '../types/projectContext';
+import { useDeploymentDetailWebMCPTools } from './webmcp/deploymentListTools';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
@@ -177,6 +178,8 @@ const DeploymentDetailPage: React.FC = () => {
             }
             currentRevision @since(version: "26.4.3") {
               id
+              # Reported by the WebMCP bai_get_current_deployment tool.
+              revisionNumber
             }
             deployingRevision @since(version: "26.4.3") {
               id
@@ -204,6 +207,13 @@ const DeploymentDetailPage: React.FC = () => {
           fetchKey === INITIAL_FETCH_KEY ? 'store-and-network' : 'network-only',
       },
     );
+
+  // FR-3766: `bai_get_current_deployment` — on the detail page "current" is
+  // the deployment being viewed. Registered before the early returns below so
+  // the hook order stays stable.
+  useDeploymentDetailWebMCPTools(
+    deploymentResult.ok ? deploymentResult.value : null,
+  );
 
   if (!deploymentResult.ok) {
     // The manager returns a partial-success GraphQL response for RBAC

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -22,6 +22,7 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
 import { toProjectContext } from '../types/projectContext';
+import { useDeploymentListWebMCPTools } from './webmcp/deploymentListTools';
 import { Button } from '@astryxdesign/core/Button';
 import { Link } from '@astryxdesign/core/Link';
 import { Text } from '@astryxdesign/core/Text';
@@ -194,6 +195,21 @@ const DeploymentListPageContent: React.FC<DeploymentListPageContentProps> = ({
 
   const isPending =
     deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
+
+  // FR-3766: the three read-only WebMCP tools for this page. "Current" here is
+  // the deployment open in the settings modal; `/deployments/:id` registers its
+  // own `bai_get_current_deployment` (see `webmcp/deploymentListTools`).
+  useDeploymentListWebMCPTools({
+    deployments: deploymentNodes,
+    columnOverrides,
+    pagination: {
+      current: tablePaginationOption.current,
+      pageSize: tablePaginationOption.pageSize,
+      total,
+    },
+    queryParams,
+    openedDeploymentGlobalId: editingDeploymentId,
+  });
 
   const [commitDeleteMutation, isInFlightDeleteMutation] =
     useMutation<DeploymentListPageDeleteMutation>(graphql`

--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -14,6 +14,7 @@ import TextHighlighter from '../components/TextHighlighter';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useModelStoreProject } from '../hooks/useModelStoreProject';
 import { theme } from '../theme-shim';
+import { useModelStoreListWebMCPTools } from './webmcp/modelStoreListTools';
 import { Badge } from '@astryxdesign/core/Badge';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Card } from '@astryxdesign/core/Card';
@@ -27,10 +28,12 @@ import {
   BAIGraphQLPropertyFilter,
   BAISelect,
   BAIStorageHostSelect,
+  filterOutNullAndUndefined,
   safeDecodeUuid,
   useUpdatableState,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
 import { ArrowUpDown } from 'lucide-react';
 import {
   parseAsJson,
@@ -195,6 +198,17 @@ const ModelCardV2Grid: React.FC<{
   offset: number;
   onTotalChange: (total: number) => void;
   onCardClick?: (id: string) => void;
+  /**
+   * URL state the WebMCP page tools report (FR-3766). They register here, not
+   * in the page, because this is the component that holds the rendered cards.
+   */
+  webmcpState: {
+    page: number;
+    pageSize: number;
+    filter?: ModelCardV2Filter | null;
+    sort: string;
+    openedModelCardId?: string | null;
+  };
 }> = ({
   projectId,
   filter,
@@ -206,6 +220,7 @@ const ModelCardV2Grid: React.FC<{
   offset,
   onTotalChange,
   onCardClick,
+  webmcpState,
 }) => {
   'use memo';
 
@@ -231,6 +246,15 @@ const ModelCardV2Grid: React.FC<{
           edges {
             node {
               id
+              # Scalars the WebMCP page tools report. Already fetched by
+              # ModelStoreListPageV2_ModelCardV2Fragment, so selecting them
+              # here costs nothing.
+              name
+              metadata {
+                title
+                task
+                author
+              }
               ...ModelStoreListPageV2_ModelCardV2Fragment
             }
           }
@@ -260,6 +284,20 @@ const ModelCardV2Grid: React.FC<{
   React.useEffect(() => {
     onTotalChanged();
   }, [total]);
+
+  useModelStoreListWebMCPTools({
+    modelCards: filterOutNullAndUndefined(_.map(items, 'node')),
+    pagination: {
+      current: webmcpState.page,
+      pageSize: webmcpState.pageSize,
+      total,
+    },
+    queryParams: {
+      filter: webmcpState.filter,
+      sort: webmcpState.sort,
+    },
+    openedModelCardId: webmcpState.openedModelCardId,
+  });
 
   if (items.length === 0) {
     return <EmptyState title={t('modelStore.NoModelsFound')} />;
@@ -468,6 +506,13 @@ const ModelStoreListPageV2: React.FC = () => {
           onTotalChange={setTotal}
           onCardClick={(id) => {
             setQueryParams({ modelCard: id });
+          }}
+          webmcpState={{
+            page: tablePaginationOption.current,
+            pageSize: tablePaginationOption.pageSize,
+            filter,
+            sort: queryParams.sort,
+            openedModelCardId: selectedModelCardId,
           }}
         />
       </div>

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -15,12 +15,14 @@ import FolderCreateModalV2 from '../components/FolderCreateModalV2';
 import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import { handleRowSelectionChange } from '../helper';
+import { VFOLDER_PARAM, VFOLDER_PATH_PARAM } from '../helper/resourcePath';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import { toProjectContext } from '../types/projectContext';
+import { useVFolderListWebMCPTools } from './webmcp/vfolderListTools';
 import { Button } from '@astryxdesign/core/Button';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Link } from '@astryxdesign/core/Link';
@@ -106,6 +108,10 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     'invitation',
     parseAsString.withOptions({ history: 'replace' }),
   );
+  // Read-only mirrors of `FolderExplorerOpener`'s params — what the WebMCP
+  // `bai_get_current_vfolder` tool reports as "open in the explorer".
+  const [openedFolderId] = useQueryState(VFOLDER_PARAM, parseAsString);
+  const [openedFolderPath] = useQueryState(VFOLDER_PATH_PARAM, parseAsString);
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.VFolderNodeListPage',
@@ -230,6 +236,13 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 id @required(action: THROW)
                 status
                 permissions
+                # Scalars the WebMCP page tools report. Already fetched by
+                # VFolderNodesFragment, so selecting them here costs nothing.
+                name
+                host
+                usage_mode
+                ownership_type
+                created_at
                 ...VFolderNodesFragment
                 ...DeleteVFolderModalFragment
                 ...EditableVFolderNameFragment
@@ -271,6 +284,25 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           deferredFetchKey === 'initial-fetch' ? undefined : deferredFetchKey,
       },
     );
+
+  const vfolderNodes = filterOutNullAndUndefined(
+    _.map(vfolder_nodes?.edges, 'node'),
+  );
+
+  // FR-3766: the three read-only WebMCP tools for this page. "Current" is the
+  // folder the explorer modal has open (`?folder=…&path=…`).
+  useVFolderListWebMCPTools({
+    vfolders: vfolderNodes,
+    columnOverrides,
+    pagination: {
+      current: tablePaginationOption.current,
+      pageSize: tablePaginationOption.pageSize,
+      total: vfolder_nodes?.count,
+    },
+    queryParams,
+    openedFolderId,
+    openedFolderPath,
+  });
 
   return (
     <VStack align="stretch" gap={5} {...props}>
@@ -517,9 +549,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             loading={deferredQueryVariables !== queryVariables}
             disableProjectFolderActions
             project={toProjectContext(currentProject)}
-            vfoldersFrgmt={filterOutNullAndUndefined(
-              _.map(vfolder_nodes?.edges, 'node'),
-            )}
+            vfoldersFrgmt={vfolderNodes}
             rowSelection={{
               type: 'checkbox',
               preserveSelectedRowKeys: true,
@@ -533,9 +563,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
               onChange: (selectedRowKeys) => {
                 handleRowSelectionChange(
                   selectedRowKeys,
-                  filterOutNullAndUndefined(
-                    _.map(vfolder_nodes?.edges, 'node'),
-                  ),
+                  vfolderNodes,
                   setSelectedFolderList,
                 );
               },

--- a/react/src/pages/webmcp/deploymentListTools.test.ts
+++ b/react/src/pages/webmcp/deploymentListTools.test.ts
@@ -1,0 +1,209 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3766: `/deployments` registers the read-only triple, and
+ * `/deployments/:id` registers only `bai_get_current_deployment` — the detail
+ * page is not a list.
+ */
+import { getModelContext, isWebMCPEnabled } from '../../helper/webmcp';
+import type { WebMCPTool } from '../../hooks/useWebMCPTool';
+import {
+  DEPLOYMENT_ROW_PROPERTIES,
+  toDeploymentRow,
+  useDeploymentDetailWebMCPTools,
+  useDeploymentListWebMCPTools,
+  type DeploymentListWebMCPToolsInput,
+} from './deploymentListTools';
+import type { CallToolResult, ModelContext } from '@mcp-b/webmcp-types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../helper/webmcp', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../helper/webmcp')>();
+  return {
+    ...actual,
+    isWebMCPEnabled: vi.fn(() => true),
+    getModelContext: vi.fn(),
+  };
+});
+
+const registerTool =
+  vi.fn<
+    (tool: WebMCPTool, options: { signal: AbortSignal }) => Promise<void>
+  >();
+const modelContext = { registerTool } as unknown as ModelContext;
+
+/** `btoa('ModelDeployment:dep-1')` / `…:dep-2` — real global-id shapes. */
+const GLOBAL_ID_1 = btoa('ModelDeployment:dep-1');
+const GLOBAL_ID_2 = btoa('ModelDeployment:dep-2');
+
+const DEPLOYMENTS = [
+  {
+    id: GLOBAL_ID_1,
+    metadata: { name: 'llama', status: 'READY' },
+    currentRevision: { revisionNumber: 3 },
+  },
+  {
+    id: GLOBAL_ID_2,
+    metadata: { name: 'mistral', status: 'STOPPED' },
+    currentRevision: null,
+  },
+];
+
+const INPUT: DeploymentListWebMCPToolsInput = {
+  deployments: DEPLOYMENTS,
+  pagination: { current: 1, pageSize: 10, total: 2 },
+  queryParams: {
+    filter: { name: { iContains: 'lla' } },
+    statusCategory: 'running',
+    order: 'NAME_ASC',
+  },
+  openedDeploymentGlobalId: null,
+};
+
+const registered = (): Record<string, WebMCPTool> =>
+  Object.fromEntries(
+    registerTool.mock.calls.map(([tool]) => [tool.name, tool] as const),
+  );
+
+const structured = (tool: WebMCPTool): unknown =>
+  (tool.execute({}, {} as never) as CallToolResult).structuredContent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isWebMCPEnabled).mockReturnValue(true);
+  vi.mocked(getModelContext).mockReturnValue(modelContext);
+});
+
+describe('useDeploymentListWebMCPTools', () => {
+  it('registers exactly the three read-only deployment tools', () => {
+    renderHook(() => useDeploymentListWebMCPTools(INPUT));
+
+    const tools = registered();
+    expect(Object.keys(tools).sort()).toEqual([
+      'bai_get_current_deployment',
+      'bai_get_deployment_filter',
+      'bai_list_visible_deployment',
+    ]);
+    Object.values(tools).forEach((tool) => {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+    });
+  });
+
+  it('answers with the rendered rows, keyed by the id the router uses', () => {
+    renderHook(() => useDeploymentListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_list_visible_deployment'])).toEqual({
+      rows: [
+        { id: 'dep-1', name: 'llama', status: 'READY', revision: 3 },
+        { id: 'dep-2', name: 'mistral', status: 'STOPPED', revision: null },
+      ],
+      count: 2,
+      page: 1,
+      pageSize: 10,
+      total: 2,
+    });
+  });
+
+  it('declares the row shape as a JSON-Schema literal', () => {
+    renderHook(() => useDeploymentListWebMCPTools(INPUT));
+
+    expect(
+      registered()['bai_list_visible_deployment'].outputSchema,
+    ).toMatchObject({
+      properties: {
+        rows: {
+          items: { properties: DEPLOYMENT_ROW_PROPERTIES, required: ['id'] },
+        },
+      },
+    });
+  });
+
+  it('reports the JSON filter as the string the URL carries', () => {
+    renderHook(() => useDeploymentListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_get_deployment_filter'])).toEqual({
+      resource: 'deployment',
+      filter: '{"name":{"iContains":"lla"}}',
+      statusCategory: 'running',
+      order: 'NAME_ASC',
+      current: 1,
+      pageSize: 10,
+    });
+  });
+
+  it('omits an empty filter object entirely', () => {
+    renderHook(() =>
+      useDeploymentListWebMCPTools({
+        ...INPUT,
+        queryParams: { filter: {}, statusCategory: 'finished' },
+      }),
+    );
+
+    expect(structured(registered()['bai_get_deployment_filter'])).toEqual({
+      resource: 'deployment',
+      statusCategory: 'finished',
+      current: 1,
+      pageSize: 10,
+    });
+  });
+
+  it('reports the deployment open in the settings modal', () => {
+    renderHook(() =>
+      useDeploymentListWebMCPTools({
+        ...INPUT,
+        openedDeploymentGlobalId: GLOBAL_ID_2,
+      }),
+    );
+
+    expect(structured(registered()['bai_get_current_deployment'])).toEqual({
+      current: {
+        ...toDeploymentRow(DEPLOYMENTS[1]),
+        webui_path: '/deployments/dep-2',
+      },
+    });
+  });
+
+  it('registers nothing when the WebMCP flag is off', () => {
+    vi.mocked(isWebMCPEnabled).mockReturnValue(false);
+
+    renderHook(() => useDeploymentListWebMCPTools(INPUT));
+
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDeploymentDetailWebMCPTools', () => {
+  it('registers only bai_get_current_deployment, for the viewed deployment', () => {
+    renderHook(() => useDeploymentDetailWebMCPTools(DEPLOYMENTS[0]));
+
+    expect(Object.keys(registered())).toEqual(['bai_get_current_deployment']);
+    expect(structured(registered()['bai_get_current_deployment'])).toEqual({
+      current: {
+        id: 'dep-1',
+        name: 'llama',
+        status: 'READY',
+        revision: 3,
+        webui_path: '/deployments/dep-1',
+      },
+    });
+  });
+
+  it('answers null while the deployment is inaccessible', () => {
+    renderHook(() => useDeploymentDetailWebMCPTools(null));
+
+    expect(structured(registered()['bai_get_current_deployment'])).toEqual({
+      current: null,
+    });
+  });
+
+  it('registers nothing when the WebMCP flag is off', () => {
+    vi.mocked(isWebMCPEnabled).mockReturnValue(false);
+
+    renderHook(() => useDeploymentDetailWebMCPTools(DEPLOYMENTS[0]));
+
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/react/src/pages/webmcp/deploymentListTools.ts
+++ b/react/src/pages/webmcp/deploymentListTools.ts
@@ -1,0 +1,156 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * `/deployments` (FR-3766): `bai_list_visible_deployment`,
+ * `bai_get_deployment_filter` and `bai_get_current_deployment`.
+ *
+ * The list page and `/deployments/:id` are sibling routes, so they never mount
+ * together — `bai_get_current_deployment` is registered by whichever one is on
+ * screen (`useDeploymentDetailWebMCPTools` below covers the detail page, where
+ * "current" is the deployment being viewed rather than one opened in a modal).
+ */
+import { resourcePath } from '../../helper/resourcePath';
+import {
+  createCurrentItemTool,
+  hiddenColumnKeys,
+  resolveOpenedRow,
+  usePageReadTools,
+  type PageToolRow,
+  type TableColumnOverrides,
+} from '../../helper/webmcpPageTools';
+import { useWebMCPTool } from '../../hooks/useWebMCPTool';
+import type { JsonSchemaForInference } from '@mcp-b/webmcp-types';
+import { toLocalId } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+
+/** The node fields `DeploymentListPageQuery` selects for these tools. */
+export interface DeploymentRowSource {
+  readonly id: string;
+  readonly metadata?: {
+    readonly name?: string | null;
+    readonly status?: string | null;
+  } | null;
+  readonly currentRevision?: {
+    readonly revisionNumber?: number | null;
+  } | null;
+}
+
+export const DEPLOYMENT_ROW_PROPERTIES: Readonly<
+  Record<string, JsonSchemaForInference>
+> = {
+  id: { type: 'string', description: 'Deployment (endpoint) id.' },
+  name: { type: 'string' },
+  status: { type: 'string' },
+  revision: { type: 'integer', description: 'Current revision number.' },
+};
+
+/** `BAIModelDeploymentNodes` column key -> the row field it renders. */
+const DEPLOYMENT_COLUMN_FIELDS: Readonly<Record<string, string>> = {
+  name: 'name',
+  status: 'status',
+  currentRevisionNumber: 'revision',
+};
+
+export const toDeploymentRow = (node: DeploymentRowSource): PageToolRow => ({
+  id: toLocalId(node.id) ?? node.id,
+  name: node.metadata?.name ?? null,
+  status: node.metadata?.status ?? null,
+  revision: node.currentRevision?.revisionNumber ?? null,
+});
+
+const deploymentPath = (id: string): string =>
+  resourcePath({ type: 'deployment', id });
+
+export interface DeploymentListWebMCPToolsInput {
+  deployments: ReadonlyArray<DeploymentRowSource>;
+  columnOverrides?: TableColumnOverrides;
+  pagination: { current: number; pageSize: number; total?: number | null };
+  queryParams: {
+    /** nuqs `parseAsJson` value; reported as the URL string it round-trips as. */
+    filter?: object | null;
+    statusCategory?: string | null;
+    order?: string | null;
+  };
+  /** Global id of the deployment whose settings modal is open, if any. */
+  openedDeploymentGlobalId?: string | null;
+}
+
+export const useDeploymentListWebMCPTools = ({
+  deployments,
+  columnOverrides,
+  pagination,
+  queryParams,
+  openedDeploymentGlobalId,
+}: DeploymentListWebMCPToolsInput): void => {
+  const rows = _.map(deployments, toDeploymentRow);
+  const hiddenColumns = _.compact(
+    _.map(
+      hiddenColumnKeys(columnOverrides),
+      (key) => DEPLOYMENT_COLUMN_FIELDS[key],
+    ),
+  );
+  const filterParam = _.isEmpty(queryParams.filter)
+    ? null
+    : JSON.stringify(queryParams.filter);
+  const openedId = openedDeploymentGlobalId
+    ? (toLocalId(openedDeploymentGlobalId) ?? openedDeploymentGlobalId)
+    : null;
+
+  usePageReadTools(
+    {
+      noun: 'deployment',
+      plural: 'deployments',
+      resource: 'deployment',
+      rowProperties: DEPLOYMENT_ROW_PROPERTIES,
+      rows,
+      hiddenColumns,
+      pagination,
+      filter: {
+        filter: filterParam,
+        statusCategory: queryParams.statusCategory ?? null,
+        order: queryParams.order ?? null,
+        current: pagination.current,
+        pageSize: pagination.pageSize,
+      },
+      current: resolveOpenedRow(rows, openedId, deploymentPath),
+    },
+    [
+      JSON.stringify(rows),
+      JSON.stringify(hiddenColumns),
+      pagination.current,
+      pagination.pageSize,
+      pagination.total,
+      filterParam,
+      queryParams.statusCategory,
+      queryParams.order,
+      openedId,
+    ],
+  );
+};
+
+/**
+ * `/deployments/:id` — only `bai_get_current_deployment`: the detail page is
+ * not a list, so it has no rows and no filter to report.
+ */
+export const useDeploymentDetailWebMCPTools = (
+  deployment: DeploymentRowSource | null | undefined,
+): void => {
+  const row = deployment ? toDeploymentRow(deployment) : null;
+  const current = row ? { ...row, webui_path: deploymentPath(row.id) } : null;
+
+  useWebMCPTool(
+    createCurrentItemTool({
+      noun: 'deployment',
+      plural: 'deployments',
+      resource: 'deployment',
+      rowProperties: DEPLOYMENT_ROW_PROPERTIES,
+      rows: [],
+      pagination: { current: 1, pageSize: 0 },
+      filter: {},
+      current,
+    }),
+    [JSON.stringify(current)],
+  );
+};

--- a/react/src/pages/webmcp/modelStoreListTools.test.ts
+++ b/react/src/pages/webmcp/modelStoreListTools.test.ts
@@ -1,0 +1,174 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3766: `/model-store` registers the read-only triple. The page has no
+ * status category (see `LIST_RESOURCES_WITHOUT_STATUS`) — `sort` carries the
+ * ordering instead — and no table settings, so no column can be hidden.
+ */
+import { getModelContext, isWebMCPEnabled } from '../../helper/webmcp';
+import type { WebMCPTool } from '../../hooks/useWebMCPTool';
+import {
+  MODEL_CARD_ROW_PROPERTIES,
+  toModelCardRow,
+  useModelStoreListWebMCPTools,
+  type ModelStoreListWebMCPToolsInput,
+} from './modelStoreListTools';
+import type { CallToolResult, ModelContext } from '@mcp-b/webmcp-types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../helper/webmcp', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../helper/webmcp')>();
+  return {
+    ...actual,
+    isWebMCPEnabled: vi.fn(() => true),
+    getModelContext: vi.fn(),
+  };
+});
+
+const registerTool =
+  vi.fn<
+    (tool: WebMCPTool, options: { signal: AbortSignal }) => Promise<void>
+  >();
+const modelContext = { registerTool } as unknown as ModelContext;
+
+const MODEL_CARDS = [
+  {
+    id: 'TW9kZWxDYXJkVjI6MQ==',
+    name: 'llama-3-8b',
+    metadata: { title: 'Llama 3 8B', task: 'text-generation', author: 'Meta' },
+  },
+  {
+    id: 'TW9kZWxDYXJkVjI6Mg==',
+    name: 'whisper',
+    metadata: { title: null, task: 'asr', author: null },
+  },
+];
+
+const INPUT: ModelStoreListWebMCPToolsInput = {
+  modelCards: MODEL_CARDS,
+  pagination: { current: 1, pageSize: 10, total: 2 },
+  queryParams: {
+    filter: { name: { iContains: 'lla' } },
+    sort: 'CREATED_AT_DESC',
+  },
+  openedModelCardId: null,
+};
+
+const registered = (): Record<string, WebMCPTool> =>
+  Object.fromEntries(
+    registerTool.mock.calls.map(([tool]) => [tool.name, tool] as const),
+  );
+
+const structured = (tool: WebMCPTool): unknown =>
+  (tool.execute({}, {} as never) as CallToolResult).structuredContent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isWebMCPEnabled).mockReturnValue(true);
+  vi.mocked(getModelContext).mockReturnValue(modelContext);
+});
+
+describe('useModelStoreListWebMCPTools', () => {
+  it('registers exactly the three read-only model-card tools', () => {
+    renderHook(() => useModelStoreListWebMCPTools(INPUT));
+
+    expect(Object.keys(registered()).sort()).toEqual([
+      'bai_get_current_model_card',
+      'bai_get_model_card_filter',
+      'bai_list_visible_model_card',
+    ]);
+    Object.values(registered()).forEach((tool) => {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+    });
+  });
+
+  it('answers with the rendered cards', () => {
+    renderHook(() => useModelStoreListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_list_visible_model_card'])).toEqual({
+      rows: [
+        {
+          id: MODEL_CARDS[0].id,
+          name: 'llama-3-8b',
+          title: 'Llama 3 8B',
+          task: 'text-generation',
+          author: 'Meta',
+        },
+        {
+          id: MODEL_CARDS[1].id,
+          name: 'whisper',
+          title: null,
+          task: 'asr',
+          author: null,
+        },
+      ],
+      count: 2,
+      page: 1,
+      pageSize: 10,
+      total: 2,
+    });
+  });
+
+  it('declares the row shape as a JSON-Schema literal', () => {
+    renderHook(() => useModelStoreListWebMCPTools(INPUT));
+
+    expect(
+      registered()['bai_list_visible_model_card'].outputSchema,
+    ).toMatchObject({
+      properties: {
+        rows: {
+          items: { properties: MODEL_CARD_ROW_PROPERTIES, required: ['id'] },
+        },
+      },
+    });
+  });
+
+  it('reports sort instead of a status category', () => {
+    renderHook(() => useModelStoreListWebMCPTools(INPUT));
+
+    const filter = structured(registered()['bai_get_model_card_filter']);
+    expect(filter).toEqual({
+      resource: 'model_card',
+      filter: '{"name":{"iContains":"lla"}}',
+      sort: 'CREATED_AT_DESC',
+      current: 1,
+      pageSize: 10,
+    });
+    expect(filter).not.toHaveProperty('statusCategory');
+  });
+
+  it('reports the card open in the drawer', () => {
+    renderHook(() =>
+      useModelStoreListWebMCPTools({
+        ...INPUT,
+        openedModelCardId: MODEL_CARDS[0].id,
+      }),
+    );
+
+    expect(structured(registered()['bai_get_current_model_card'])).toEqual({
+      current: {
+        ...toModelCardRow(MODEL_CARDS[0]),
+        webui_path: `/model-store?modelCard=${encodeURIComponent(MODEL_CARDS[0].id)}`,
+      },
+    });
+  });
+
+  it('answers null when the drawer is closed', () => {
+    renderHook(() => useModelStoreListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_get_current_model_card'])).toEqual({
+      current: null,
+    });
+  });
+
+  it('registers nothing when the WebMCP flag is off', () => {
+    vi.mocked(isWebMCPEnabled).mockReturnValue(false);
+
+    renderHook(() => useModelStoreListWebMCPTools(INPUT));
+
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/react/src/pages/webmcp/modelStoreListTools.ts
+++ b/react/src/pages/webmcp/modelStoreListTools.ts
@@ -1,0 +1,114 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * `/model-store` (FR-3766): `bai_list_visible_model_card`,
+ * `bai_get_model_card_filter` and `bai_get_current_model_card` — "current"
+ * being the card open in its drawer (`?modelCard=…`).
+ *
+ * Registered from the grid, which is where the cards live; the page has no
+ * table settings, so there are no hidden columns to respect.
+ */
+import { resourcePath } from '../../helper/resourcePath';
+import {
+  resolveOpenedRow,
+  usePageReadTools,
+  type PageToolRow,
+} from '../../helper/webmcpPageTools';
+import type { JsonSchemaForInference } from '@mcp-b/webmcp-types';
+import * as _ from 'lodash-es';
+
+/** The node fields `ModelStoreListPageV2Query` selects for these tools. */
+export interface ModelCardRowSource {
+  readonly id: string;
+  readonly name?: string | null;
+  readonly metadata?: {
+    readonly title?: string | null;
+    readonly task?: string | null;
+    readonly author?: string | null;
+  } | null;
+}
+
+export const MODEL_CARD_ROW_PROPERTIES: Readonly<
+  Record<string, JsonSchemaForInference>
+> = {
+  id: { type: 'string', description: 'Model card id (global id).' },
+  name: { type: 'string' },
+  title: {
+    type: 'string',
+    description: 'Card heading, when the card has one.',
+  },
+  task: { type: 'string' },
+  author: { type: 'string' },
+};
+
+export const toModelCardRow = (node: ModelCardRowSource): PageToolRow => ({
+  id: node.id,
+  name: node.name ?? null,
+  title: node.metadata?.title ?? null,
+  task: node.metadata?.task ?? null,
+  author: node.metadata?.author ?? null,
+});
+
+export interface ModelStoreListWebMCPToolsInput {
+  modelCards: ReadonlyArray<ModelCardRowSource>;
+  pagination: { current: number; pageSize: number; total?: number | null };
+  queryParams: {
+    /** nuqs `parseAsJson` value; reported as the URL string it round-trips as. */
+    filter?: object | null;
+    sort?: string | null;
+  };
+  /** `modelCard` search param — the card whose drawer is open. */
+  openedModelCardId?: string | null;
+}
+
+export const useModelStoreListWebMCPTools = ({
+  modelCards,
+  pagination,
+  queryParams,
+  openedModelCardId,
+}: ModelStoreListWebMCPToolsInput): void => {
+  const rows = _.map(modelCards, toModelCardRow);
+  const filterParam = _.isEmpty(queryParams.filter)
+    ? null
+    : JSON.stringify(queryParams.filter);
+
+  usePageReadTools(
+    {
+      noun: 'model_card',
+      plural: 'model cards',
+      resource: 'model_card',
+      rowProperties: MODEL_CARD_ROW_PROPERTIES,
+      rows,
+      pagination,
+      // The model store has no status/category param (see
+      // LIST_RESOURCES_WITHOUT_STATUS); `sort` carries the ordering instead.
+      filter: {
+        filter: filterParam,
+        sort: queryParams.sort ?? null,
+        current: pagination.current,
+        pageSize: pagination.pageSize,
+      },
+      extraFilterProperties: {
+        sort: {
+          type: 'string',
+          description:
+            'NAME_ASC | NAME_DESC | CREATED_AT_ASC | CREATED_AT_DESC.',
+        },
+      },
+      current: resolveOpenedRow(rows, openedModelCardId, (id) =>
+        resourcePath({ type: 'model_card', id }),
+      ),
+    },
+    [
+      JSON.stringify(rows),
+      pagination.current,
+      pagination.pageSize,
+      pagination.total,
+      filterParam,
+      queryParams.sort,
+      openedModelCardId,
+    ],
+  );
+};

--- a/react/src/pages/webmcp/sessionListTools.test.ts
+++ b/react/src/pages/webmcp/sessionListTools.test.ts
@@ -1,0 +1,215 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3766: `/session` registers three read-only tools whose answers are built
+ * from the page's own rows, URL params and open detail drawer — and registers
+ * nothing at all when `VITE_WEBMCP` is off.
+ */
+import { getModelContext, isWebMCPEnabled } from '../../helper/webmcp';
+import type { WebMCPTool } from '../../hooks/useWebMCPTool';
+import {
+  SESSION_ROW_PROPERTIES,
+  toSessionRow,
+  useSessionListWebMCPTools,
+  type SessionListWebMCPToolsInput,
+} from './sessionListTools';
+import type { CallToolResult, ModelContext } from '@mcp-b/webmcp-types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../helper/webmcp', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../helper/webmcp')>();
+  return {
+    ...actual,
+    isWebMCPEnabled: vi.fn(() => true),
+    getModelContext: vi.fn(),
+  };
+});
+
+const registerTool =
+  vi.fn<
+    (tool: WebMCPTool, options: { signal: AbortSignal }) => Promise<void>
+  >();
+const modelContext = { registerTool } as unknown as ModelContext;
+
+const SESSIONS = [
+  {
+    id: 'Z2lkOjE=',
+    row_id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    name: 'alpha',
+    status: 'RUNNING',
+    type: 'interactive',
+    created_at: '2026-01-01T00:00:00+00:00',
+    scaling_group: 'default',
+  },
+  {
+    id: 'Z2lkOjI=',
+    row_id: 'aaaaaaaa-0000-0000-0000-000000000002',
+    name: 'beta',
+    status: 'PREPARING',
+    type: 'batch',
+    created_at: '2026-01-02T00:00:00+00:00',
+    scaling_group: 'gpu',
+  },
+];
+
+const INPUT: SessionListWebMCPToolsInput = {
+  sessions: SESSIONS,
+  pagination: { current: 2, pageSize: 10, total: 42 },
+  queryParams: {
+    filter: 'name ilike "%a%"',
+    statusCategory: 'running',
+    order: '-created_at',
+    type: 'interactive',
+  },
+  openedSessionId: null,
+};
+
+const render = (input: SessionListWebMCPToolsInput = INPUT) =>
+  renderHook(() => useSessionListWebMCPTools(input));
+
+/** The tools registered by the last render, by name. */
+const registered = (): Record<string, WebMCPTool> =>
+  Object.fromEntries(
+    registerTool.mock.calls.map(([tool]) => [tool.name, tool] as const),
+  );
+
+const structured = (tool: WebMCPTool): unknown =>
+  (tool.execute({}, {} as never) as CallToolResult).structuredContent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isWebMCPEnabled).mockReturnValue(true);
+  vi.mocked(getModelContext).mockReturnValue(modelContext);
+});
+
+describe('useSessionListWebMCPTools', () => {
+  it('registers exactly the three read-only session tools', () => {
+    render();
+
+    const tools = registered();
+    expect(Object.keys(tools).sort()).toEqual([
+      'bai_get_current_session',
+      'bai_get_session_filter',
+      'bai_list_visible_session',
+    ]);
+    Object.values(tools).forEach((tool) => {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+      expect(tool.inputSchema).toEqual({ type: 'object', properties: {} });
+    });
+  });
+
+  it('answers bai_list_visible_session with the rendered rows and the page', () => {
+    render();
+
+    expect(structured(registered()['bai_list_visible_session'])).toEqual({
+      rows: [toSessionRow(SESSIONS[0]), toSessionRow(SESSIONS[1])],
+      count: 2,
+      page: 2,
+      pageSize: 10,
+      total: 42,
+    });
+  });
+
+  it('declares the row shape as a JSON-Schema literal', () => {
+    render();
+
+    expect(registered()['bai_list_visible_session'].outputSchema).toEqual({
+      type: 'object',
+      properties: {
+        rows: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: SESSION_ROW_PROPERTIES,
+            required: ['id'],
+          },
+        },
+        count: { type: 'integer', description: 'Rows on this page.' },
+        page: { type: 'integer', description: '1-based page number.' },
+        pageSize: { type: 'integer' },
+        total: {
+          type: 'integer',
+          description: 'Rows matching the filter across all pages.',
+        },
+      },
+      required: ['rows', 'count', 'page', 'pageSize'],
+    });
+  });
+
+  it('drops the columns the user hid, keeping the row identity', () => {
+    // `resourceGroup` is the table's column key for the `scaling_group` field.
+    render({
+      ...INPUT,
+      columnOverrides: { resourceGroup: { hidden: true }, type: {} },
+    });
+
+    const rows = (
+      structured(registered()['bai_list_visible_session']) as {
+        rows: Array<Record<string, unknown>>;
+      }
+    ).rows;
+    expect(rows[0]).not.toHaveProperty('scaling_group');
+    expect(rows[0]).toMatchObject({
+      id: SESSIONS[0].row_id,
+      type: 'interactive',
+    });
+  });
+
+  it('mirrors the URL params in bai_get_session_filter', () => {
+    render();
+
+    expect(structured(registered()['bai_get_session_filter'])).toEqual({
+      resource: 'session',
+      filter: 'name ilike "%a%"',
+      statusCategory: 'running',
+      order: '-created_at',
+      type: 'interactive',
+      current: 2,
+      pageSize: 10,
+    });
+  });
+
+  it('omits params the URL does not carry', () => {
+    render({
+      ...INPUT,
+      queryParams: { filter: '', statusCategory: 'finished' },
+    });
+
+    expect(structured(registered()['bai_get_session_filter'])).toEqual({
+      resource: 'session',
+      statusCategory: 'finished',
+      current: 2,
+      pageSize: 10,
+    });
+  });
+
+  it('reports the open detail drawer, with a deep link back to it', () => {
+    render({ ...INPUT, openedSessionId: SESSIONS[1].row_id });
+
+    expect(structured(registered()['bai_get_current_session'])).toEqual({
+      current: {
+        ...toSessionRow(SESSIONS[1]),
+        webui_path: `/session?sessionDetail=${SESSIONS[1].row_id}`,
+      },
+    });
+  });
+
+  it('answers null when no session is open', () => {
+    render();
+
+    expect(structured(registered()['bai_get_current_session'])).toEqual({
+      current: null,
+    });
+  });
+
+  it('registers nothing when the WebMCP flag is off', () => {
+    vi.mocked(isWebMCPEnabled).mockReturnValue(false);
+
+    render();
+
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/react/src/pages/webmcp/sessionListTools.ts
+++ b/react/src/pages/webmcp/sessionListTools.ts
@@ -1,0 +1,137 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * `/session` (FR-3766): `bai_list_visible_session`, `bai_get_session_filter`
+ * and `bai_get_current_session`, registered by `ComputeSessionListPage` from
+ * state it already holds — no extra query.
+ */
+import { resourcePath } from '../../helper/resourcePath';
+import {
+  hiddenColumnKeys,
+  resolveOpenedRow,
+  usePageReadTools,
+  type PageToolRow,
+  type TableColumnOverrides,
+} from '../../helper/webmcpPageTools';
+import type { JsonSchemaForInference } from '@mcp-b/webmcp-types';
+import * as _ from 'lodash-es';
+
+/** The node fields `ComputeSessionListPageQuery` selects for these tools. */
+export interface SessionRowSource {
+  readonly id?: string | null;
+  readonly row_id?: string | null;
+  readonly name?: string | null;
+  readonly status?: string | null;
+  readonly type?: string | null;
+  readonly created_at?: string | null;
+  readonly scaling_group?: string | null;
+}
+
+export const SESSION_ROW_PROPERTIES: Readonly<
+  Record<string, JsonSchemaForInference>
+> = {
+  id: { type: 'string', description: 'Session UUID (row_id).' },
+  name: { type: 'string' },
+  status: { type: 'string' },
+  type: {
+    type: 'string',
+    description: 'interactive | batch | inference | system.',
+  },
+  created_at: { type: 'string' },
+  scaling_group: { type: 'string', description: 'Resource group.' },
+};
+
+/**
+ * `SessionNodes` column key -> the row field it renders. Only the fields these
+ * tools expose need an entry; anything else the user hides is not in the
+ * payload to begin with.
+ */
+const SESSION_COLUMN_FIELDS: Readonly<Record<string, string>> = {
+  name: 'name',
+  status: 'status',
+  type: 'type',
+  created_at: 'created_at',
+  resourceGroup: 'scaling_group',
+};
+
+export const toSessionRow = (node: SessionRowSource): PageToolRow => ({
+  id: node.row_id ?? node.id ?? '',
+  name: node.name ?? null,
+  status: node.status ?? null,
+  type: node.type ?? null,
+  created_at: node.created_at ?? null,
+  scaling_group: node.scaling_group ?? null,
+});
+
+export interface SessionListWebMCPToolsInput {
+  sessions: ReadonlyArray<SessionRowSource>;
+  columnOverrides?: TableColumnOverrides;
+  pagination: { current: number; pageSize: number; total?: number | null };
+  queryParams: {
+    filter?: string | null;
+    statusCategory?: string | null;
+    order?: string | null;
+    type?: string | null;
+  };
+  /** `sessionDetail` search param — the session whose drawer is open. */
+  openedSessionId?: string | null;
+}
+
+export const useSessionListWebMCPTools = ({
+  sessions,
+  columnOverrides,
+  pagination,
+  queryParams,
+  openedSessionId,
+}: SessionListWebMCPToolsInput): void => {
+  const rows = _.map(sessions, toSessionRow);
+  const hiddenColumns = _.compact(
+    _.map(
+      hiddenColumnKeys(columnOverrides),
+      (key) => SESSION_COLUMN_FIELDS[key],
+    ),
+  );
+
+  usePageReadTools(
+    {
+      noun: 'session',
+      plural: 'sessions',
+      resource: 'session',
+      rowProperties: SESSION_ROW_PROPERTIES,
+      rows,
+      hiddenColumns,
+      pagination,
+      filter: {
+        filter: queryParams.filter || null,
+        statusCategory: queryParams.statusCategory ?? null,
+        order: queryParams.order ?? null,
+        type: queryParams.type ?? null,
+        current: pagination.current,
+        pageSize: pagination.pageSize,
+      },
+      extraFilterProperties: {
+        type: {
+          type: 'string',
+          description: 'Session-type tab: all | interactive | batch | …',
+        },
+      },
+      current: resolveOpenedRow(rows, openedSessionId, (id) =>
+        resourcePath({ type: 'session', id }),
+      ),
+    },
+    [
+      JSON.stringify(rows),
+      JSON.stringify(hiddenColumns),
+      pagination.current,
+      pagination.pageSize,
+      pagination.total,
+      queryParams.filter,
+      queryParams.statusCategory,
+      queryParams.order,
+      queryParams.type,
+      openedSessionId,
+    ],
+  );
+};

--- a/react/src/pages/webmcp/vfolderListTools.test.ts
+++ b/react/src/pages/webmcp/vfolderListTools.test.ts
@@ -1,0 +1,189 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3766: `/data` registers the read-only triple; "current" is the folder the
+ * explorer modal has open, whose URL id has its dashes stripped.
+ */
+import { getModelContext, isWebMCPEnabled } from '../../helper/webmcp';
+import type { WebMCPTool } from '../../hooks/useWebMCPTool';
+import {
+  VFOLDER_ROW_PROPERTIES,
+  toVFolderRow,
+  useVFolderListWebMCPTools,
+  type VFolderListWebMCPToolsInput,
+} from './vfolderListTools';
+import type { CallToolResult, ModelContext } from '@mcp-b/webmcp-types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../helper/webmcp', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../helper/webmcp')>();
+  return {
+    ...actual,
+    isWebMCPEnabled: vi.fn(() => true),
+    getModelContext: vi.fn(),
+  };
+});
+
+const registerTool =
+  vi.fn<
+    (tool: WebMCPTool, options: { signal: AbortSignal }) => Promise<void>
+  >();
+const modelContext = { registerTool } as unknown as ModelContext;
+
+const FOLDER_UUID = 'bbbbbbbb-1111-2222-3333-444444444444';
+const VFOLDERS = [
+  {
+    id: btoa(`VirtualFolderNode:${FOLDER_UUID}`),
+    name: 'datasets',
+    status: 'READY',
+    host: 'local:volume1',
+    usage_mode: 'general',
+    ownership_type: 'user',
+    created_at: '2026-01-01T00:00:00+00:00',
+  },
+];
+
+const INPUT: VFolderListWebMCPToolsInput = {
+  vfolders: VFOLDERS,
+  pagination: { current: 1, pageSize: 10, total: 1 },
+  queryParams: {
+    filter: 'name ilike "%data%"',
+    statusCategory: 'active',
+    order: '-created_at',
+    mode: 'general',
+  },
+  openedFolderId: null,
+};
+
+const registered = (): Record<string, WebMCPTool> =>
+  Object.fromEntries(
+    registerTool.mock.calls.map(([tool]) => [tool.name, tool] as const),
+  );
+
+const structured = (tool: WebMCPTool): unknown =>
+  (tool.execute({}, {} as never) as CallToolResult).structuredContent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isWebMCPEnabled).mockReturnValue(true);
+  vi.mocked(getModelContext).mockReturnValue(modelContext);
+});
+
+describe('useVFolderListWebMCPTools', () => {
+  it('registers exactly the three read-only vfolder tools', () => {
+    renderHook(() => useVFolderListWebMCPTools(INPUT));
+
+    expect(Object.keys(registered()).sort()).toEqual([
+      'bai_get_current_vfolder',
+      'bai_get_vfolder_filter',
+      'bai_list_visible_vfolder',
+    ]);
+    Object.values(registered()).forEach((tool) => {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+    });
+  });
+
+  it('answers with the rendered rows, keyed by the folder UUID', () => {
+    renderHook(() => useVFolderListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_list_visible_vfolder'])).toEqual({
+      rows: [
+        {
+          id: FOLDER_UUID,
+          name: 'datasets',
+          status: 'READY',
+          host: 'local:volume1',
+          usage_mode: 'general',
+          ownership_type: 'user',
+          created_at: '2026-01-01T00:00:00+00:00',
+        },
+      ],
+      count: 1,
+      page: 1,
+      pageSize: 10,
+      total: 1,
+    });
+  });
+
+  it('declares the row shape as a JSON-Schema literal', () => {
+    renderHook(() => useVFolderListWebMCPTools(INPUT));
+
+    expect(registered()['bai_list_visible_vfolder'].outputSchema).toMatchObject(
+      {
+        properties: {
+          rows: {
+            items: { properties: VFOLDER_ROW_PROPERTIES, required: ['id'] },
+          },
+        },
+      },
+    );
+  });
+
+  it('drops the columns the user hid', () => {
+    renderHook(() =>
+      useVFolderListWebMCPTools({
+        ...INPUT,
+        columnOverrides: { host: { hidden: true }, name: { hidden: false } },
+      }),
+    );
+
+    const rows = (
+      structured(registered()['bai_list_visible_vfolder']) as {
+        rows: Array<Record<string, unknown>>;
+      }
+    ).rows;
+    expect(rows[0]).not.toHaveProperty('host');
+    expect(rows[0]).toMatchObject({ id: FOLDER_UUID, name: 'datasets' });
+  });
+
+  it('mirrors the URL params, usage-mode tab included', () => {
+    renderHook(() => useVFolderListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_get_vfolder_filter'])).toEqual({
+      resource: 'vfolder',
+      filter: 'name ilike "%data%"',
+      statusCategory: 'active',
+      order: '-created_at',
+      mode: 'general',
+      current: 1,
+      pageSize: 10,
+    });
+  });
+
+  it('matches the explorer folder id even with its dashes stripped', () => {
+    renderHook(() =>
+      useVFolderListWebMCPTools({
+        ...INPUT,
+        openedFolderId: FOLDER_UUID.replaceAll('-', ''),
+        openedFolderPath: 'sub/dir',
+      }),
+    );
+
+    expect(structured(registered()['bai_get_current_vfolder'])).toEqual({
+      current: {
+        ...toVFolderRow(VFOLDERS[0]),
+        path: 'sub/dir',
+        webui_path: `/data?folder=${FOLDER_UUID}&path=sub%2Fdir`,
+      },
+    });
+  });
+
+  it('answers null when the explorer is closed', () => {
+    renderHook(() => useVFolderListWebMCPTools(INPUT));
+
+    expect(structured(registered()['bai_get_current_vfolder'])).toEqual({
+      current: null,
+    });
+  });
+
+  it('registers nothing when the WebMCP flag is off', () => {
+    vi.mocked(isWebMCPEnabled).mockReturnValue(false);
+
+    renderHook(() => useVFolderListWebMCPTools(INPUT));
+
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/react/src/pages/webmcp/vfolderListTools.ts
+++ b/react/src/pages/webmcp/vfolderListTools.ts
@@ -1,0 +1,156 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * `/data` (FR-3766): `bai_list_visible_vfolder`, `bai_get_vfolder_filter` and
+ * `bai_get_current_vfolder` — "current" being the folder open in the explorer
+ * modal (`?folder=…&path=…`, see `FolderExplorerOpener`).
+ */
+import { resourcePath } from '../../helper/resourcePath';
+import {
+  hiddenColumnKeys,
+  resolveOpenedRow,
+  usePageReadTools,
+  type PageToolRow,
+  type TableColumnOverrides,
+} from '../../helper/webmcpPageTools';
+import type { JsonSchemaForInference } from '@mcp-b/webmcp-types';
+import { toLocalId } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+
+/** The node fields `VFolderNodeListPageQuery` selects for these tools. */
+export interface VFolderRowSource {
+  readonly id: string;
+  readonly name?: string | null;
+  readonly status?: string | null;
+  readonly host?: string | null;
+  readonly usage_mode?: string | null;
+  readonly ownership_type?: string | null;
+  readonly created_at?: string | null;
+}
+
+export const VFOLDER_ROW_PROPERTIES: Readonly<
+  Record<string, JsonSchemaForInference>
+> = {
+  id: { type: 'string', description: 'VFolder UUID.' },
+  name: { type: 'string' },
+  status: { type: 'string' },
+  host: { type: 'string', description: 'Storage host.' },
+  usage_mode: { type: 'string' },
+  ownership_type: { type: 'string', description: 'user | group.' },
+  created_at: { type: 'string' },
+};
+
+/** `VFolderNodes` column keys map 1:1 onto the row fields above. */
+const VFOLDER_COLUMN_FIELDS: Readonly<Record<string, string>> = {
+  name: 'name',
+  status: 'status',
+  host: 'host',
+  usage_mode: 'usage_mode',
+  ownership_type: 'ownership_type',
+  created_at: 'created_at',
+};
+
+export const toVFolderRow = (node: VFolderRowSource): PageToolRow => ({
+  id: toLocalId(node.id) ?? node.id,
+  name: node.name ?? null,
+  status: node.status ?? null,
+  host: node.host ?? null,
+  usage_mode: node.usage_mode ?? null,
+  ownership_type: node.ownership_type ?? null,
+  created_at: node.created_at ?? null,
+});
+
+/** The explorer strips dashes from the id it puts in the URL. */
+const sameFolderId = (a: string, b: string): boolean =>
+  a.replaceAll('-', '').toLowerCase() === b.replaceAll('-', '').toLowerCase();
+
+export interface VFolderListWebMCPToolsInput {
+  vfolders: ReadonlyArray<VFolderRowSource>;
+  columnOverrides?: TableColumnOverrides;
+  pagination: { current: number; pageSize: number; total?: number | null };
+  queryParams: {
+    filter?: string | null;
+    statusCategory?: string | null;
+    order?: string | null;
+    mode?: string | null;
+  };
+  /** `folder` search param — the folder open in the explorer. */
+  openedFolderId?: string | null;
+  /** `path` search param — where inside that folder the explorer is. */
+  openedFolderPath?: string | null;
+}
+
+export const useVFolderListWebMCPTools = ({
+  vfolders,
+  columnOverrides,
+  pagination,
+  queryParams,
+  openedFolderId,
+  openedFolderPath,
+}: VFolderListWebMCPToolsInput): void => {
+  const rows = _.map(vfolders, toVFolderRow);
+  const hiddenColumns = _.compact(
+    _.map(
+      hiddenColumnKeys(columnOverrides),
+      (key) => VFOLDER_COLUMN_FIELDS[key],
+    ),
+  );
+  const opened = resolveOpenedRow(
+    rows,
+    openedFolderId,
+    (id) =>
+      resourcePath({
+        type: 'vfolder',
+        id,
+        ...(openedFolderPath ? { path: openedFolderPath } : {}),
+      }),
+    (row, id) => sameFolderId(row.id, id),
+  );
+
+  usePageReadTools(
+    {
+      noun: 'vfolder',
+      plural: 'folders',
+      resource: 'vfolder',
+      rowProperties: VFOLDER_ROW_PROPERTIES,
+      rows,
+      hiddenColumns,
+      pagination,
+      filter: {
+        filter: queryParams.filter || null,
+        statusCategory: queryParams.statusCategory ?? null,
+        order: queryParams.order ?? null,
+        mode: queryParams.mode ?? null,
+        current: pagination.current,
+        pageSize: pagination.pageSize,
+      },
+      extraFilterProperties: {
+        mode: {
+          type: 'string',
+          description:
+            'Usage-mode tab: all | general | data | automount | model.',
+        },
+      },
+      current:
+        opened === null ? null : { ...opened, path: openedFolderPath ?? null },
+      currentProperties: {
+        path: { type: 'string', description: 'Path open in the explorer.' },
+      },
+    },
+    [
+      JSON.stringify(rows),
+      JSON.stringify(hiddenColumns),
+      pagination.current,
+      pagination.pageSize,
+      pagination.total,
+      queryParams.filter,
+      queryParams.statusCategory,
+      queryParams.order,
+      queryParams.mode,
+      openedFolderId,
+      openedFolderPath,
+    ],
+  );
+};


### PR DESCRIPTION
Resolves #9236 (FR-3766)

Part of the bai-agent POC stack (epic FR-3740): a CLI over the manual, terminology, i18n and GraphQL schema, plus a WebMCP hand-off to the logged-in browser tab.

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

---
`bash scripts/verify.sh` → `=== ALL PASS ===` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161MScBrhguUVXb8nHqdD92