### PR TITLE
feat(FR-3767): add read-only WebMCP tools on admin pages

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -186,6 +186,32 @@ Notes:
   `bai_` + snake_case; unregistration happens automatically on unmount, which is
   what makes page-scoped tools appear and disappear with the route.
 
+### Page-scoped tools on the admin pages
+
+Four admin screens register the same read-only trio for their resource
+(FR-3767), built from `helper/webmcpAdminPageTools.ts` and registered by the
+component that already holds the data:
+
+| Page | Noun | Tools |
+|---|---|---|
+| `/admin/session` | `session` | `bai_list_visible_session`, `bai_get_current_session`, `bai_get_session_filter` |
+| `/admin/agent` (tab `agents`) | `agent` | `bai_list_visible_agent`, `bai_get_current_agent`, `bai_get_agent_filter` |
+| `/admin/users` (tab `users`) | `user` | `bai_list_visible_user`, `bai_get_current_user`, `bai_get_user_filter` |
+| `/admin/users` (tab `credentials`) | `keypair` | `bai_list_visible_keypair`, `bai_get_current_keypair`, `bai_get_keypair_filter` |
+| `/admin/rbac` | `role` | `bai_list_visible_role`, `bai_get_current_role`, `bai_get_role_filter` |
+
+`bai_list_visible_*` answers `{ rows, count, page, pageSize, sort }` for the
+rows the table is rendering; `bai_get_*_filter` answers the page's URL params
+(`{ filter?, status?, tab?, current?, pageSize? }`), which feed straight back
+into `bai_open_resource {"type":"list", …}`. `bai_get_current_*` answers
+`{ current, webui_path }` — `webui_path` is `null` for `agent`, `user` and
+`keypair`, which have no detail deep link yet.
+
+Only the mounted tab's tools are advertised, and all four pages sit under
+`/admin/*`, whose route handles declare `access: 'admin'` / `'superadmin'` and
+are enforced by `RouteAccessGuard` — a non-admin never mounts the components, so
+these tools never appear for them.
+
 ### CLI -> tab handoff (`bai-agent open`)
 
 `bai-agent open` (FR-3771) drives the tab above from the shell — the CLI computes

--- a/react/src/__generated__/AdminComputeSessionListPageQuery.graphql.ts
+++ b/react/src/__generated__/AdminComputeSessionListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<98722f20e323e7fdb514b43bcaeee262>>
+ * @generated SignedSource<<7b7c2657fd188d165dcc3572ef43642a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,7 +34,7 @@ export type AdminComputeSessionListPageQuery$data = {
       readonly node: {
         readonly id: string;
         readonly name: string;
-        readonly " $fragmentSpreads": FragmentRefs<"SessionNodesFragment" | "TerminateSessionModalFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"SessionNodesFragment" | "TerminateSessionModalFragment" | "WebMCPAdminSessionToolsFragment">;
       };
     } | null | undefined>;
   } | null | undefined, unknown>;
@@ -392,6 +392,11 @@ return {
                         {
                           "args": null,
                           "kind": "FragmentSpread",
+                          "name": "WebMCPAdminSessionToolsFragment"
+                        },
+                        {
+                          "args": null,
+                          "kind": "FragmentSpread",
                           "name": "SessionNodesFragment"
                         },
                         {
@@ -479,7 +484,14 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "service_ports",
+                    "name": "scaling_group",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "project_id",
                     "storageKey": null
                   },
                   {
@@ -487,6 +499,20 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "user_id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "created_at",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "service_ports",
                     "storageKey": null
                   },
                   {
@@ -510,13 +536,6 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "queue_position",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "created_at",
                     "storageKey": null
                   },
                   {
@@ -700,13 +719,6 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "project_id",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
                     "concreteType": "UserNode",
                     "kind": "LinkedField",
                     "name": "owner",
@@ -772,13 +784,6 @@ return {
                       },
                       (v12/*: any*/)
                     ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "scaling_group",
                     "storageKey": null
                   },
                   (v27/*: any*/),
@@ -856,16 +861,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d37cace9dd11a5cc8108fec4639e0307",
+    "cacheID": "fd73709eff61903ef41a02856aac6068",
     "id": null,
     "metadata": {},
     "name": "AdminComputeSessionListPageQuery",
     "operationKind": "query",
-    "text": "query AdminComputeSessionListPageQuery(\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n  $filterForAllCount: String\n  $filterForInteractiveCount: String\n  $filterForInferenceCount: String\n  $filterForBatchCount: String\n  $filterForSystemCount: String\n) {\n  computeSessionNodeResult: compute_session_nodes(first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(first: 0, offset: 0, filter: $filterForAllCount) {\n    count\n  }\n  interactive: compute_session_nodes(first: 0, offset: 0, filter: $filterForInteractiveCount) {\n    count\n  }\n  inference: compute_session_nodes(first: 0, offset: 0, filter: $filterForInferenceCount) {\n    count\n  }\n  batch: compute_session_nodes(first: 0, offset: 0, filter: $filterForBatchCount) {\n    count\n  }\n  system: compute_session_nodes(first: 0, offset: 0, filter: $filterForSystemCount) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditSessionPriorityModalFragment on ComputeSessionNode {\n  id\n  name\n  priority @since(version: \"24.09.0\")\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionAccessKeyFragment on ComputeSessionNode {\n  access_key\n  user_id\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n  ...SessionAccessKeyFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  priority @since(version: \"24.09.0\")\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  ...EditSessionPriorityModalFragment\n  ...SessionAccessKeyFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query AdminComputeSessionListPageQuery(\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n  $filterForAllCount: String\n  $filterForInteractiveCount: String\n  $filterForInferenceCount: String\n  $filterForBatchCount: String\n  $filterForSystemCount: String\n) {\n  computeSessionNodeResult: compute_session_nodes(first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...WebMCPAdminSessionToolsFragment\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(first: 0, offset: 0, filter: $filterForAllCount) {\n    count\n  }\n  interactive: compute_session_nodes(first: 0, offset: 0, filter: $filterForInteractiveCount) {\n    count\n  }\n  inference: compute_session_nodes(first: 0, offset: 0, filter: $filterForInferenceCount) {\n    count\n  }\n  batch: compute_session_nodes(first: 0, offset: 0, filter: $filterForBatchCount) {\n    count\n  }\n  system: compute_session_nodes(first: 0, offset: 0, filter: $filterForSystemCount) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditSessionPriorityModalFragment on ComputeSessionNode {\n  id\n  name\n  priority @since(version: \"24.09.0\")\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionAccessKeyFragment on ComputeSessionNode {\n  access_key\n  user_id\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n  ...SessionAccessKeyFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  priority @since(version: \"24.09.0\")\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  ...EditSessionPriorityModalFragment\n  ...SessionAccessKeyFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment WebMCPAdminSessionToolsFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  scaling_group\n  project_id\n  user_id\n  created_at\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7c8dbadc30e34da0dc4a5dd7f6c4a230";
+(node as any).hash = "6bbe6789c4bfb8503145148e18067d85";
 
 export default node;

--- a/react/src/__generated__/AdminUserManagementQuery.graphql.ts
+++ b/react/src/__generated__/AdminUserManagementQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8d7685a59786222e45321d7ca9e1e834>>
+ * @generated SignedSource<<55f6f5b6d5da0b4db1aa0c06fc5a5d9a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -126,7 +126,7 @@ export type AdminUserManagementQuery$data = {
           readonly email: string;
         };
         readonly id: string;
-        readonly " $fragmentSpreads": FragmentRefs<"BAIAdminUserV2TableFragment" | "PurgeUsersModalFragment" | "UpdateUsersModalFragment" | "UserInfoModalFragment" | "UserSettingModalFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIAdminUserV2TableFragment" | "PurgeUsersModalFragment" | "UpdateUsersModalFragment" | "UserInfoModalFragment" | "UserSettingModalFragment" | "WebMCPAdminUserToolsFragment">;
       };
     }>;
   } | null | undefined;
@@ -255,6 +255,11 @@ return {
                       (v8/*: any*/)
                     ],
                     "storageKey": null
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "WebMCPAdminUserToolsFragment"
                   },
                   {
                     "args": null,
@@ -414,6 +419,38 @@ return {
                   {
                     "alias": null,
                     "args": null,
+                    "concreteType": "UserV2StatusInfo",
+                    "kind": "LinkedField",
+                    "name": "status",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "status",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "statusInfo",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "needPasswordChange",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
                     "concreteType": "UserV2SecurityInfo",
                     "kind": "LinkedField",
                     "name": "security",
@@ -452,38 +489,6 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "allowedClientIp",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "UserV2StatusInfo",
-                    "kind": "LinkedField",
-                    "name": "status",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "status",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "statusInfo",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "needPasswordChange",
                         "storageKey": null
                       }
                     ],
@@ -610,16 +615,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "186ab3676b344fb26d52e6953250c98a",
+    "cacheID": "d0ea8f67acc778221faf51ab6a7f515e",
     "id": null,
     "metadata": {},
     "name": "AdminUserManagementQuery",
     "operationKind": "query",
-    "text": "query AdminUserManagementQuery(\n  $filter: UserV2Filter\n  $orderBy: [UserV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $isNotSupportTotp: Boolean!\n) {\n  adminUsersV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        basicInfo {\n          email\n        }\n        ...BAIAdminUserV2TableFragment\n        ...PurgeUsersModalFragment\n        ...UpdateUsersModalFragment\n        ...UserInfoModalFragment\n        ...UserSettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIAdminUserV2TableFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n    description\n    integrationName\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    totpActivatedAt @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  status {\n    status\n    statusInfo\n    needPasswordChange\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  timestamps {\n    createdAt\n    modifiedAt\n  }\n}\n\nfragment PurgeUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n\nfragment UpdateUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment UserInfoModalFragment on UserV2 {\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  projects {\n    edges {\n      node {\n        id\n        basicInfo {\n          name\n        }\n      }\n    }\n  }\n}\n\nfragment UserSettingModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  projects {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n  ...TOTPActivateModalFragment\n}\n"
+    "text": "query AdminUserManagementQuery(\n  $filter: UserV2Filter\n  $orderBy: [UserV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $isNotSupportTotp: Boolean!\n) {\n  adminUsersV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        basicInfo {\n          email\n        }\n        ...WebMCPAdminUserToolsFragment\n        ...BAIAdminUserV2TableFragment\n        ...PurgeUsersModalFragment\n        ...UpdateUsersModalFragment\n        ...UserInfoModalFragment\n        ...UserSettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIAdminUserV2TableFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n    description\n    integrationName\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    totpActivatedAt @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  status {\n    status\n    statusInfo\n    needPasswordChange\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  timestamps {\n    createdAt\n    modifiedAt\n  }\n}\n\nfragment PurgeUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n\nfragment UpdateUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment UserInfoModalFragment on UserV2 {\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  projects {\n    edges {\n      node {\n        id\n        basicInfo {\n          name\n        }\n      }\n    }\n  }\n}\n\nfragment UserSettingModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  projects {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n  ...TOTPActivateModalFragment\n}\n\nfragment WebMCPAdminUserToolsFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  status {\n    status\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2df6d61f777870dd091f4f3a6b9a8bfe";
+(node as any).hash = "14b148f95bcd462b2483a5b5aaf005e9";
 
 export default node;

--- a/react/src/__generated__/AgentListQuery.graphql.ts
+++ b/react/src/__generated__/AgentListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cc374ecfb8ce75e2375f58b9af2d9d61>>
+ * @generated SignedSource<<80795e6ebecd3a4461a016c3ac923fd7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,7 +25,7 @@ export type AgentListQuery$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id: string;
-        readonly " $fragmentSpreads": FragmentRefs<"AgentDetailDrawerFragment" | "AgentDetailModalFragment" | "BAIAgentTableFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"AgentDetailDrawerFragment" | "AgentDetailModalFragment" | "BAIAgentTableFragment" | "WebMCPAgentToolsFragment">;
       } | null | undefined;
     } | null | undefined>;
   } | null | undefined;
@@ -165,6 +165,11 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
+                    "name": "WebMCPAgentToolsFragment"
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
                     "name": "BAIAgentTableFragment"
                   },
                   {
@@ -262,6 +267,27 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "status",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scaling_group",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "schedulable",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "first_contact",
                     "storageKey": null
                   },
@@ -290,20 +316,6 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "status",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "scaling_group",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
                     "name": "compute_plugins",
                     "storageKey": null
                   },
@@ -312,13 +324,6 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "version",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "schedulable",
                     "storageKey": null
                   },
                   {
@@ -362,16 +367,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "270315af555a2a571b3752e262844b0f",
+    "cacheID": "41390490c54f495c79323998b95b65a1",
     "id": null,
     "metadata": {},
     "name": "AgentListQuery",
     "operationKind": "query",
-    "text": "query AgentListQuery(\n  $filter: String\n  $order: String\n  $offset: Int\n  $first: Int\n  $before: String\n  $after: String\n  $last: Int\n) {\n  agent_nodes(filter: $filter, order: $order, offset: $offset, first: $first, after: $after, before: $before, last: $last) {\n    edges {\n      node {\n        id\n        ...BAIAgentTableFragment\n        ...AgentDetailModalFragment\n        ...AgentDetailDrawerFragment\n      }\n    }\n    count\n  }\n}\n\nfragment AgentActionButtonsFragment on AgentNode {\n  status\n  ...AgentSettingModalFragment\n  ...AgentLifeCycleControlModalFragment\n}\n\nfragment AgentComputePluginsFragment on AgentNode {\n  compute_plugins\n  available_slots\n}\n\nfragment AgentDetailDrawerContentFragment on AgentNode {\n  id\n  row_id\n  addr\n  status\n  status_changed\n  schedulable\n  first_contact\n  region\n  scaling_group\n  ...AgentStatusTagFragment\n  ...AgentComputePluginsFragment\n  ...AgentResourcesFragment\n  ...AgentActionButtonsFragment\n}\n\nfragment AgentDetailDrawerFragment on Node {\n  __isNode: __typename\n  ... on AgentNode {\n    id\n    ...AgentDetailDrawerContentFragment\n  }\n  id\n}\n\nfragment AgentDetailModalFragment on AgentNode {\n  id\n  live_stat\n  available_slots\n  occupied_slots\n}\n\nfragment AgentLifeCycleControlModalFragment on AgentNode {\n  id\n  status\n  status_changed\n}\n\nfragment AgentResourcesFragment on AgentNode {\n  occupied_slots\n  available_slots\n  live_stat\n  gpu_alloc_map\n  ...AgentDetailModalFragment\n}\n\nfragment AgentSettingModalFragment on AgentNode {\n  id\n  scaling_group\n  schedulable\n}\n\nfragment AgentStatusTagFragment on AgentNode {\n  status\n  status_changed\n  version\n}\n\nfragment BAIAgentTableFragment on AgentNode {\n  id\n  row_id\n  addr\n  region\n  architecture\n  first_contact\n  occupied_slots\n  available_slots\n  live_stat\n  status\n  scaling_group\n  compute_plugins\n  version\n  schedulable\n}\n"
+    "text": "query AgentListQuery(\n  $filter: String\n  $order: String\n  $offset: Int\n  $first: Int\n  $before: String\n  $after: String\n  $last: Int\n) {\n  agent_nodes(filter: $filter, order: $order, offset: $offset, first: $first, after: $after, before: $before, last: $last) {\n    edges {\n      node {\n        id\n        ...WebMCPAgentToolsFragment\n        ...BAIAgentTableFragment\n        ...AgentDetailModalFragment\n        ...AgentDetailDrawerFragment\n      }\n    }\n    count\n  }\n}\n\nfragment AgentActionButtonsFragment on AgentNode {\n  status\n  ...AgentSettingModalFragment\n  ...AgentLifeCycleControlModalFragment\n}\n\nfragment AgentComputePluginsFragment on AgentNode {\n  compute_plugins\n  available_slots\n}\n\nfragment AgentDetailDrawerContentFragment on AgentNode {\n  id\n  row_id\n  addr\n  status\n  status_changed\n  schedulable\n  first_contact\n  region\n  scaling_group\n  ...AgentStatusTagFragment\n  ...AgentComputePluginsFragment\n  ...AgentResourcesFragment\n  ...AgentActionButtonsFragment\n}\n\nfragment AgentDetailDrawerFragment on Node {\n  __isNode: __typename\n  ... on AgentNode {\n    id\n    ...AgentDetailDrawerContentFragment\n  }\n  id\n}\n\nfragment AgentDetailModalFragment on AgentNode {\n  id\n  live_stat\n  available_slots\n  occupied_slots\n}\n\nfragment AgentLifeCycleControlModalFragment on AgentNode {\n  id\n  status\n  status_changed\n}\n\nfragment AgentResourcesFragment on AgentNode {\n  occupied_slots\n  available_slots\n  live_stat\n  gpu_alloc_map\n  ...AgentDetailModalFragment\n}\n\nfragment AgentSettingModalFragment on AgentNode {\n  id\n  scaling_group\n  schedulable\n}\n\nfragment AgentStatusTagFragment on AgentNode {\n  status\n  status_changed\n  version\n}\n\nfragment BAIAgentTableFragment on AgentNode {\n  id\n  row_id\n  addr\n  region\n  architecture\n  first_contact\n  occupied_slots\n  available_slots\n  live_stat\n  status\n  scaling_group\n  compute_plugins\n  version\n  schedulable\n}\n\nfragment WebMCPAgentToolsFragment on AgentNode {\n  id\n  row_id\n  addr\n  region\n  architecture\n  status\n  scaling_group\n  schedulable\n  first_contact\n  occupied_slots\n  available_slots\n}\n"
   }
 };
 })();
 
-(node as any).hash = "704a2d36c0fc813bd9e20af19b2e57ae";
+(node as any).hash = "2c2e282383574aac3e52becaa5c11b7a";
 
 export default node;

--- a/react/src/__generated__/RBACManagementPageQuery.graphql.ts
+++ b/react/src/__generated__/RBACManagementPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7da94bf4581beb31bd43013768aa475c>>
+ * @generated SignedSource<<7e6f8480e24fce89a711c9fefcdd79f3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -100,7 +100,7 @@ export type RBACManagementPageQuery$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id: string;
-        readonly " $fragmentSpreads": FragmentRefs<"RoleDetailDrawerFragment" | "RoleNodesFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"RoleDetailDrawerFragment" | "RoleNodesFragment" | "WebMCPRoleToolsFragment">;
       };
     }>;
   } | null | undefined;
@@ -232,6 +232,11 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
+                    "name": "WebMCPRoleToolsFragment"
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
                     "name": "RoleNodesFragment"
                   },
                   {
@@ -321,13 +326,6 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "autoAssign",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
                     "name": "createdAt",
                     "storageKey": null
                   },
@@ -371,6 +369,7 @@ return {
                             "selections": [
                               (v7/*: any*/),
                               (v8/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -475,8 +474,7 @@ return {
                                   }
                                 ],
                                 "storageKey": null
-                              },
-                              (v6/*: any*/)
+                              }
                             ],
                             "storageKey": null
                           }
@@ -485,6 +483,13 @@ return {
                       }
                     ],
                     "storageKey": "scopes(first:3)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "autoAssign",
+                    "storageKey": null
                   },
                   {
                     "alias": null,
@@ -657,16 +662,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "20f3f5cebe85a6e0c1f345dc1f7c07a3",
+    "cacheID": "5b5fd32b3c64b55d592ab101079eabf2",
     "id": null,
     "metadata": {},
     "name": "RBACManagementPageQuery",
     "operationKind": "query",
-    "text": "query RBACManagementPageQuery(\n  $filter: RoleFilter\n  $orderBy: [RoleOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminRoles(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...RoleNodesFragment\n        ...RoleDetailDrawerFragment\n      }\n    }\n  }\n}\n\nfragment RoleAssignmentTabFragment on Role {\n  id\n  name\n  source\n  firstScope: scopes(first: 1) {\n    edges {\n      node {\n        scopeType\n        scopeId\n        id\n      }\n    }\n  }\n  users(limit: 10, offset: 0) {\n    count\n    edges {\n      node {\n        id\n        userId\n        grantedBy\n        grantedAt\n        user {\n          id\n          basicInfo {\n            email\n            fullName\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment RoleDetailDrawerContentFragment on Role {\n  id\n  name\n  description\n  source\n  status\n  autoAssign @since(version: \"26.4.4\")\n  createdAt\n  updatedAt\n  deletedAt\n  ...RoleAssignmentTabFragment\n  ...RolePermissionDetailTab_roleScopeFragment\n}\n\nfragment RoleDetailDrawerFragment on Role {\n  name\n  source\n  ...RoleDetailDrawerContentFragment\n  ...RoleFormModalFragment\n  id\n}\n\nfragment RoleFormModalFragment on Role {\n  id\n  name\n  description\n  autoAssign @since(version: \"26.4.4\")\n}\n\nfragment RoleNodesFragment on Role {\n  id\n  name\n  description\n  source\n  status\n  autoAssign @since(version: \"26.4.4\")\n  createdAt\n  updatedAt\n  scopes(first: 3) {\n    count\n    edges {\n      node {\n        scopeType\n        scopeId\n        scope {\n          __typename\n          ... on ProjectV2 {\n            basicInfo {\n              projectName: name\n            }\n          }\n          ... on DomainV2 {\n            basicInfo {\n              domainName: name\n            }\n          }\n          ... on UserV2 {\n            basicInfo {\n              userEmail: email\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on ArtifactRegistry {\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment RolePermissionDetailTab_roleScopeFragment on Role {\n  totalScopes: scopes(first: 1) {\n    count\n  }\n  ...ScopedRolePermissionCardFragment\n}\n\nfragment RoleScopePermissionEditModalFragment on Role {\n  id\n}\n\nfragment ScopedRolePermissionCardFragment on Role {\n  id\n  ...RoleScopePermissionEditModalFragment\n}\n"
+    "text": "query RBACManagementPageQuery(\n  $filter: RoleFilter\n  $orderBy: [RoleOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminRoles(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...WebMCPRoleToolsFragment\n        ...RoleNodesFragment\n        ...RoleDetailDrawerFragment\n      }\n    }\n  }\n}\n\nfragment RoleAssignmentTabFragment on Role {\n  id\n  name\n  source\n  firstScope: scopes(first: 1) {\n    edges {\n      node {\n        scopeType\n        scopeId\n        id\n      }\n    }\n  }\n  users(limit: 10, offset: 0) {\n    count\n    edges {\n      node {\n        id\n        userId\n        grantedBy\n        grantedAt\n        user {\n          id\n          basicInfo {\n            email\n            fullName\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment RoleDetailDrawerContentFragment on Role {\n  id\n  name\n  description\n  source\n  status\n  autoAssign @since(version: \"26.4.4\")\n  createdAt\n  updatedAt\n  deletedAt\n  ...RoleAssignmentTabFragment\n  ...RolePermissionDetailTab_roleScopeFragment\n}\n\nfragment RoleDetailDrawerFragment on Role {\n  name\n  source\n  ...RoleDetailDrawerContentFragment\n  ...RoleFormModalFragment\n  id\n}\n\nfragment RoleFormModalFragment on Role {\n  id\n  name\n  description\n  autoAssign @since(version: \"26.4.4\")\n}\n\nfragment RoleNodesFragment on Role {\n  id\n  name\n  description\n  source\n  status\n  autoAssign @since(version: \"26.4.4\")\n  createdAt\n  updatedAt\n  scopes(first: 3) {\n    count\n    edges {\n      node {\n        scopeType\n        scopeId\n        scope {\n          __typename\n          ... on ProjectV2 {\n            basicInfo {\n              projectName: name\n            }\n          }\n          ... on DomainV2 {\n            basicInfo {\n              domainName: name\n            }\n          }\n          ... on UserV2 {\n            basicInfo {\n              userEmail: email\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on ArtifactRegistry {\n            id\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment RolePermissionDetailTab_roleScopeFragment on Role {\n  totalScopes: scopes(first: 1) {\n    count\n  }\n  ...ScopedRolePermissionCardFragment\n}\n\nfragment RoleScopePermissionEditModalFragment on Role {\n  id\n}\n\nfragment ScopedRolePermissionCardFragment on Role {\n  id\n  ...RoleScopePermissionEditModalFragment\n}\n\nfragment WebMCPRoleToolsFragment on Role {\n  id\n  name\n  description\n  source\n  status\n  createdAt\n  updatedAt\n  scopes(first: 3) {\n    count\n    edges {\n      node {\n        scopeType\n        scopeId\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0f6cab3b3c35f29ed0bcaddc6f17a156";
+(node as any).hash = "d26faf113cac8236a790e1211643b287";
 
 export default node;

--- a/react/src/__generated__/WebMCPAdminSessionToolsFragment.graphql.ts
+++ b/react/src/__generated__/WebMCPAdminSessionToolsFragment.graphql.ts
@@ -1,0 +1,108 @@
+/**
+ * @generated SignedSource<<29639903f3e15833175937306f618119>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type WebMCPAdminSessionToolsFragment$data = ReadonlyArray<{
+  readonly created_at: string | null | undefined;
+  readonly id: string;
+  readonly name: string | null | undefined;
+  readonly project_id: string | null | undefined;
+  readonly row_id: string | null | undefined;
+  readonly scaling_group: string | null | undefined;
+  readonly status: string | null | undefined;
+  readonly type: string | null | undefined;
+  readonly user_id: string | null | undefined;
+  readonly " $fragmentType": "WebMCPAdminSessionToolsFragment";
+}>;
+export type WebMCPAdminSessionToolsFragment$key = ReadonlyArray<{
+  readonly " $data"?: WebMCPAdminSessionToolsFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"WebMCPAdminSessionToolsFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "WebMCPAdminSessionToolsFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "row_id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "type",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "scaling_group",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "project_id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "user_id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "created_at",
+      "storageKey": null
+    }
+  ],
+  "type": "ComputeSessionNode",
+  "abstractKey": null
+};
+
+(node as any).hash = "f146799f4b376512cd5717734755a37a";
+
+export default node;

--- a/react/src/__generated__/WebMCPAdminUserToolsFragment.graphql.ts
+++ b/react/src/__generated__/WebMCPAdminUserToolsFragment.graphql.ts
@@ -1,0 +1,149 @@
+/**
+ * @generated SignedSource<<19b7c3b46845528363f9eed05521e432>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type UserRoleV2 = "ADMIN" | "MONITOR" | "SUPERADMIN" | "USER" | "%future added value";
+export type UserStatusV2 = "ACTIVE" | "BEFORE_VERIFICATION" | "DELETED" | "INACTIVE" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type WebMCPAdminUserToolsFragment$data = ReadonlyArray<{
+  readonly basicInfo: {
+    readonly email: string;
+    readonly fullName: string | null | undefined;
+    readonly username: string | null | undefined;
+  };
+  readonly id: string;
+  readonly organization: {
+    readonly domainName: string | null | undefined;
+    readonly mainAccessKey: string | null | undefined;
+    readonly resourcePolicy: string;
+    readonly role: UserRoleV2 | null | undefined;
+  };
+  readonly status: {
+    readonly status: UserStatusV2;
+  };
+  readonly " $fragmentType": "WebMCPAdminUserToolsFragment";
+}>;
+export type WebMCPAdminUserToolsFragment$key = ReadonlyArray<{
+  readonly " $data"?: WebMCPAdminUserToolsFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"WebMCPAdminUserToolsFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "WebMCPAdminUserToolsFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserV2BasicInfo",
+      "kind": "LinkedField",
+      "name": "basicInfo",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "email",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fullName",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "username",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserV2OrganizationInfo",
+      "kind": "LinkedField",
+      "name": "organization",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "domainName",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "role",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "resourcePolicy",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "mainAccessKey",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserV2StatusInfo",
+      "kind": "LinkedField",
+      "name": "status",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "status",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "UserV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "48b934d7607c71ce19c347c2ccb062bf";
+
+export default node;

--- a/react/src/__generated__/WebMCPAgentToolsFragment.graphql.ts
+++ b/react/src/__generated__/WebMCPAgentToolsFragment.graphql.ts
@@ -1,0 +1,124 @@
+/**
+ * @generated SignedSource<<abfeb1120aa138f27274746e7083af55>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type WebMCPAgentToolsFragment$data = ReadonlyArray<{
+  readonly addr: string | null | undefined;
+  readonly architecture: string | null | undefined;
+  readonly available_slots: string | null | undefined;
+  readonly first_contact: string | null | undefined;
+  readonly id: string;
+  readonly occupied_slots: string | null | undefined;
+  readonly region: string | null | undefined;
+  readonly row_id: string | null | undefined;
+  readonly scaling_group: string | null | undefined;
+  readonly schedulable: boolean | null | undefined;
+  readonly status: string | null | undefined;
+  readonly " $fragmentType": "WebMCPAgentToolsFragment";
+}>;
+export type WebMCPAgentToolsFragment$key = ReadonlyArray<{
+  readonly " $data"?: WebMCPAgentToolsFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"WebMCPAgentToolsFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "WebMCPAgentToolsFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "row_id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "addr",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "region",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "architecture",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "scaling_group",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "schedulable",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "first_contact",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "occupied_slots",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "available_slots",
+      "storageKey": null
+    }
+  ],
+  "type": "AgentNode",
+  "abstractKey": null
+};
+
+(node as any).hash = "bd0c6b0c0a275c1ec3c32cd862c6de3f";
+
+export default node;

--- a/react/src/__generated__/WebMCPRoleToolsFragment.graphql.ts
+++ b/react/src/__generated__/WebMCPRoleToolsFragment.graphql.ts
@@ -1,0 +1,164 @@
+/**
+ * @generated SignedSource<<2b3f5195e431c575617c4904146daf85>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type RBACElementType = "AGENT" | "APP_CONFIG" | "APP_CONFIG_ALLOW_LIST" | "APP_CONFIG_DEFINITION" | "APP_CONFIG_FRAGMENT" | "ARTIFACT" | "ARTIFACT_REGISTRY" | "ARTIFACT_REVISION" | "AUDIT_LOG" | "CONTAINER_REGISTRY" | "DEPLOYMENT_POLICY" | "DEPLOYMENT_REVISION" | "DEPLOYMENT_TOKEN" | "DOMAIN" | "DOMAIN_ADMIN_PAGE" | "EVENT_LOG" | "IMAGE" | "IMAGE_ALIAS" | "KERNEL" | "KERNEL_HISTORY" | "KEYPAIR" | "KEYPAIR_RESOURCE_POLICY" | "MODEL_CARD" | "MODEL_DEPLOYMENT" | "NETWORK" | "NOTIFICATION_CHANNEL" | "NOTIFICATION_RULE" | "PROJECT" | "PROJECT_ADMIN_PAGE" | "PROJECT_RESOURCE_POLICY" | "RESOURCE_GROUP" | "RESOURCE_PRESET" | "ROLE" | "ROLE_ASSIGNMENT" | "ROUTING" | "SESSION" | "SESSION_APP_SERVICE" | "SESSION_TEMPLATE" | "STORAGE_HOST" | "USER" | "USER_EMAIL" | "USER_RESOURCE_POLICY" | "VFOLDER" | "VFOLDER_DATA" | "%future added value";
+export type RoleSource = "CUSTOM" | "SYSTEM" | "%future added value";
+export type RoleStatus = "ACTIVE" | "DELETED" | "INACTIVE" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type WebMCPRoleToolsFragment$data = ReadonlyArray<{
+  readonly createdAt: string;
+  readonly description: string | null | undefined;
+  readonly id: string;
+  readonly name: string;
+  readonly scopes: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly scopeId: string;
+        readonly scopeType: RBACElementType;
+      };
+    }>;
+  } | null | undefined;
+  readonly source: RoleSource;
+  readonly status: RoleStatus;
+  readonly updatedAt: string;
+  readonly " $fragmentType": "WebMCPRoleToolsFragment";
+}>;
+export type WebMCPRoleToolsFragment$key = ReadonlyArray<{
+  readonly " $data"?: WebMCPRoleToolsFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"WebMCPRoleToolsFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "WebMCPRoleToolsFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "source",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3
+        }
+      ],
+      "concreteType": "EntityConnection",
+      "kind": "LinkedField",
+      "name": "scopes",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "EntityRefEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "EntityRef",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "scopeType",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "scopeId",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "scopes(first:3)"
+    }
+  ],
+  "type": "Role",
+  "abstractKey": null
+};
+
+(node as any).hash = "1dca56a712796893041068b12682884c";
+
+export default node;

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -14,6 +14,7 @@ import { theme } from '../theme-shim';
 import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
 import KeypairSettingModal from './KeypairSettingModal';
+import { WebMCPAdminKeypairTools } from './WebMCPAdminUserTools';
 import { Badge } from '@astryxdesign/core/Badge';
 import { Text } from '@astryxdesign/core/Text';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
@@ -361,6 +362,16 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
+      <WebMCPAdminKeypairTools
+        keypairs={filterOutNullAndUndefined(keypair_list?.items)}
+        count={keypair_list?.total_count ?? 0}
+        page={current}
+        pageSize={pageSize}
+        sort={variables.order ?? null}
+        filter={variables.filter ?? null}
+        activeType={activeType}
+        currentKeypairId={(keypairInfoModalFrgmt as Keypair | null)?.id ?? null}
+      />
       <BAITable<Keypair>
         rowKey={'id'}
         loading={isPending}

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -21,6 +21,7 @@ import PurgeUsersModal from './PurgeUsersModal';
 import UpdateUsersModal from './UpdateUsersModal';
 import UserInfoModal from './UserInfoModal';
 import UserSettingModal from './UserSettingModal';
+import { WebMCPAdminUserTools } from './WebMCPAdminUserTools';
 import { Button } from '@astryxdesign/core/Button';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
@@ -82,6 +83,7 @@ export const AdminUserManagementQuery = graphql`
           basicInfo {
             email
           }
+          ...WebMCPAdminUserToolsFragment
           ...BAIAdminUserV2TableFragment
           ...PurgeUsersModalFragment
           ...UpdateUsersModalFragment
@@ -537,6 +539,26 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = ({
           </ButtonGroup>
         </BAIFlex>
       </BAIFlex>
+      <WebMCPAdminUserTools
+        usersFrgmt={filterOutNullAndUndefined(
+          _.map(adminUsersV2?.edges, 'node'),
+        )}
+        count={adminUsersV2?.count ?? 0}
+        page={current}
+        pageSize={pageSize}
+        sort={orderValue ?? null}
+        filter={
+          _.isEmpty(propertyFilterValue)
+            ? null
+            : JSON.stringify(propertyFilterValue)
+        }
+        status={statusValue}
+        currentUserId={
+          selectedUserForInfoModal?.id ??
+          selectedUserForSettingModal?.id ??
+          null
+        }
+      />
       <BAIAdminUserV2Table
         usersFrgmt={filterOutNullAndUndefined(
           _.map(adminUsersV2?.edges, 'node'),

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -13,6 +13,7 @@ import { useThemeMode } from '../hooks/useThemeMode';
 import AgentDetailDrawer from './AgentDetailDrawer';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import BAIRadioGroup from './BAIRadioGroup';
+import WebMCPAgentTools from './WebMCPAgentTools';
 import { Badge } from '@astryxdesign/core/Badge';
 import {
   AgentNodeInList,
@@ -123,6 +124,7 @@ const AgentList: React.FC<AgentListProps> = ({
           edges {
             node {
               id
+              ...WebMCPAgentToolsFragment
               ...BAIAgentTableFragment
               ...AgentDetailModalFragment
               ...AgentDetailDrawerFragment
@@ -334,6 +336,18 @@ const AgentList: React.FC<AgentListProps> = ({
           onColumnOverridesChange: setColumnOverrides,
         }}
         {...tableProps}
+      />
+      <WebMCPAgentTools
+        agentsFrgmt={filterOutEmpty(
+          agent_nodes?.edges.map((e) => e?.node) ?? [],
+        )}
+        count={agent_nodes?.count ?? 0}
+        page={tablePaginationOption.current}
+        pageSize={tablePaginationOption.pageSize}
+        sort={queryVariables.order ?? null}
+        filter={queryParams.filter}
+        status={queryParams.status}
+        currentAgentId={currentAgentInfo?.id ?? null}
       />
       <BAIUnmountAfterClose>
         <AgentDetailDrawer

--- a/react/src/components/WebMCPAdminPageTools.test.tsx
+++ b/react/src/components/WebMCPAdminPageTools.test.tsx
@@ -1,0 +1,123 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3767: the admin pages' tool catalog, and the dev-only gate in front of it.
+ *
+ * Role gating is NOT in this code: all four pages sit under the `/admin/*`
+ * subtree, whose route handles declare `access: 'admin'` (`/admin/session`,
+ * `/admin/users`) or `access: 'superadmin'` (`/admin/agent`, `/admin/rbac`) and
+ * are enforced by `RouteAccessGuard`. `routeMatching.test.tsx`
+ * ("route-handle access declarations") is the test that pins those four
+ * declarations; a non-admin never mounts the components, so the tools are never
+ * registered for them.
+ */
+import { getModelContext, isWebMCPEnabled } from '../helper/webmcp';
+import { useWebMCPTool, type WebMCPTool } from '../hooks/useWebMCPTool';
+import { createAdminSessionTools } from './WebMCPAdminSessionTools';
+import {
+  createAdminKeypairTools,
+  createAdminUserTools,
+} from './WebMCPAdminUserTools';
+import { createAgentTools } from './WebMCPAgentTools';
+import { createRoleTools } from './WebMCPRoleTools';
+import type { ModelContext } from '@mcp-b/webmcp-types';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../helper/webmcp', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../helper/webmcp')>();
+  return {
+    ...actual,
+    isWebMCPEnabled: vi.fn(() => true),
+    getModelContext: vi.fn(),
+  };
+});
+
+const mockIsWebMCPEnabled = vi.mocked(isWebMCPEnabled);
+const mockGetModelContext = vi.mocked(getModelContext);
+
+const registerTool = vi.fn();
+const modelContext = { registerTool } as unknown as ModelContext;
+
+const emptyList = { rows: [], count: 0, page: 1, pageSize: 10, sort: null };
+const nothingOpen = { current: null, webui_path: null };
+const noFilter = { filter: null, status: null };
+
+/** Every tool the four admin pages register, as if all of them were mounted. */
+const allAdminPageTools = (): Array<WebMCPTool> => [
+  ...createAdminSessionTools(emptyList, nothingOpen, noFilter),
+  ...createAgentTools(emptyList, nothingOpen, noFilter),
+  ...createAdminUserTools(emptyList, nothingOpen, noFilter),
+  ...createAdminKeypairTools(emptyList, nothingOpen, noFilter),
+  ...createRoleTools(emptyList, nothingOpen, noFilter),
+];
+
+/**
+ * Stands in for all four pages being mounted at once. The tool list has a fixed
+ * length, so the loop calls the hook in a stable order.
+ */
+const MountAllAdminPageTools: React.FC = () => {
+  allAdminPageTools().forEach((tool) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useWebMCPTool(tool, []);
+  });
+  return null;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsWebMCPEnabled.mockReturnValue(true);
+  mockGetModelContext.mockReturnValue(modelContext);
+});
+
+describe('admin page tool catalog', () => {
+  it('is the read-only vocabulary, three tools per noun', () => {
+    expect(allAdminPageTools().map((tool) => tool.name)).toEqual([
+      'bai_list_visible_session',
+      'bai_get_current_session',
+      'bai_get_session_filter',
+      'bai_list_visible_agent',
+      'bai_get_current_agent',
+      'bai_get_agent_filter',
+      'bai_list_visible_user',
+      'bai_get_current_user',
+      'bai_get_user_filter',
+      'bai_list_visible_keypair',
+      'bai_get_current_keypair',
+      'bai_get_keypair_filter',
+      'bai_list_visible_role',
+      'bai_get_current_role',
+      'bai_get_role_filter',
+    ]);
+  });
+
+  it('marks every tool read-only and argument-free', () => {
+    allAdminPageTools().forEach((tool) => {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+      expect(tool.inputSchema).toEqual({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      });
+      expect(tool.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('registers all of them while the pages are mounted', () => {
+    render(<MountAllAdminPageTools />);
+
+    expect(registerTool).toHaveBeenCalledTimes(15);
+  });
+
+  it('registers nothing when the dev server was started without VITE_WEBMCP=on', () => {
+    mockIsWebMCPEnabled.mockReturnValue(false);
+
+    render(<MountAllAdminPageTools />);
+
+    expect(mockGetModelContext).not.toHaveBeenCalled();
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/react/src/components/WebMCPAdminSessionTools.test.ts
+++ b/react/src/components/WebMCPAdminSessionTools.test.ts
@@ -1,0 +1,147 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3767: the `/admin/session` tools. The page has no session detail route —
+ * the drawer is the `sessionDetail` search param (FR-3759) — so
+ * `bai_get_current_session` resolves its deep link through `resourcePath`.
+ */
+import type { WebMCPAdminSessionToolsFragment$data } from '../__generated__/WebMCPAdminSessionToolsFragment.graphql';
+import type { WebMCPTool } from '../hooks/useWebMCPTool';
+import {
+  createAdminSessionTools,
+  currentSessionItem,
+  sessionRows,
+} from './WebMCPAdminSessionTools';
+import type { CallToolResult } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+
+const sessions = [
+  {
+    id: 'Q29tcHV0ZVNlc3Npb25Ob2RlOmFiYw==',
+    row_id: 'abc',
+    name: 'training-1',
+    status: 'RUNNING',
+    type: 'batch',
+    scaling_group: 'default',
+    project_id: 'p-1',
+    user_id: 'u-1',
+    created_at: '2026-08-20T10:00:00+00:00',
+  },
+  {
+    id: 'Q29tcHV0ZVNlc3Npb25Ob2RlOmRlZg==',
+    row_id: 'def',
+    name: 'notebook-1',
+    status: 'TERMINATED',
+    type: 'interactive',
+    scaling_group: 'default',
+    project_id: 'p-2',
+    user_id: 'u-2',
+    created_at: '2026-08-21T10:00:00+00:00',
+  },
+] as unknown as WebMCPAdminSessionToolsFragment$data;
+
+const run = (tool: WebMCPTool): CallToolResult =>
+  tool.execute({}, {} as never) as CallToolResult;
+
+describe('sessionRows', () => {
+  it('flattens the fragment onto the columns the admin table shows', () => {
+    expect(sessionRows(sessions)[0]).toEqual({
+      id: 'Q29tcHV0ZVNlc3Npb25Ob2RlOmFiYw==',
+      session_id: 'abc',
+      name: 'training-1',
+      status: 'RUNNING',
+      type: 'batch',
+      resource_group: 'default',
+      project_id: 'p-1',
+      user_id: 'u-1',
+      created_at: '2026-08-20T10:00:00+00:00',
+    });
+  });
+});
+
+describe('currentSessionItem', () => {
+  const rows = sessionRows(sessions);
+
+  it('resolves the sessionDetail param to its row and deep link', () => {
+    expect(currentSessionItem(rows, 'def')).toEqual({
+      current: rows[1],
+      webui_path: '/session?sessionDetail=def',
+    });
+  });
+
+  it('is null on both keys when the drawer is closed', () => {
+    expect(currentSessionItem(rows, null)).toEqual({
+      current: null,
+      webui_path: null,
+    });
+  });
+
+  it('still reports the deep link when the id is off the current page', () => {
+    expect(currentSessionItem(rows, 'ghi')).toEqual({
+      current: null,
+      webui_path: '/session?sessionDetail=ghi',
+    });
+  });
+});
+
+describe('admin session page tools', () => {
+  const rows = sessionRows(sessions);
+  const [listTool, currentTool, filterTool] = createAdminSessionTools(
+    { rows, count: 37, page: 2, pageSize: 10, sort: '-created_at' },
+    currentSessionItem(rows, 'abc'),
+    {
+      filter: 'name ilike "%train%"',
+      status: 'running',
+      tab: 'batch',
+      current: 2,
+      pageSize: 10,
+    },
+  );
+
+  it('registers exactly the three read-only session tools', () => {
+    expect([listTool.name, currentTool.name, filterTool.name]).toEqual([
+      'bai_list_visible_session',
+      'bai_get_current_session',
+      'bai_get_session_filter',
+    ]);
+    expect(
+      [listTool, currentTool, filterTool].every(
+        (tool) => tool.annotations?.readOnlyHint === true,
+      ),
+    ).toBe(true);
+    expect(listTool.inputSchema).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+
+  it('lists the rendered rows with the count, page and sort', () => {
+    expect(run(listTool).structuredContent).toEqual({
+      rows,
+      count: 37,
+      page: 2,
+      pageSize: 10,
+      sort: '-created_at',
+    });
+  });
+
+  it('answers the open drawer with its row and the session ref path', () => {
+    expect(run(currentTool).structuredContent).toEqual({
+      current: rows[0],
+      webui_path: '/session?sessionDetail=abc',
+    });
+  });
+
+  it('reports the status category and the session-type tab', () => {
+    expect(run(filterTool).structuredContent).toEqual({
+      filter: 'name ilike "%train%"',
+      status: 'running',
+      tab: 'batch',
+      current: 2,
+      pageSize: 10,
+    });
+  });
+});

--- a/react/src/components/WebMCPAdminSessionTools.tsx
+++ b/react/src/components/WebMCPAdminSessionTools.tsx
@@ -1,0 +1,143 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Read-only WebMCP tools for the admin (all-projects) session list (FR-3767) —
+ * `/admin/session`.
+ *
+ * Mounted by `AdminComputeSessionListPage`, which only renders under the
+ * `/admin/session` route; that subtree declares `handle.access: 'admin'`, so
+ * `RouteAccessGuard` keeps non-admins off the page and these tools with it.
+ *
+ * The page has no session detail route: the drawer is opened by the
+ * `sessionDetail` search param (FR-3759), which is what
+ * `bai_get_current_session` reads.
+ */
+import type {
+  WebMCPAdminSessionToolsFragment$data,
+  WebMCPAdminSessionToolsFragment$key,
+} from '../__generated__/WebMCPAdminSessionToolsFragment.graphql';
+import { resourcePath, SESSION_DETAIL_PARAM } from '../helper/resourcePath';
+import {
+  createGetCurrentTool,
+  createGetFilterTool,
+  createListVisibleTool,
+  findRowById,
+  webmcpRow,
+  type WebMCPCurrentItem,
+  type WebMCPPageFilter,
+  type WebMCPRow,
+  type WebMCPVisibleRows,
+} from '../helper/webmcpAdminPageTools';
+import { useWebMCPTool, type WebMCPTool } from '../hooks/useWebMCPTool';
+import * as _ from 'lodash-es';
+import { parseAsString, useQueryState } from 'nuqs';
+import React from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+const LIST_DESCRIPTION =
+  'The session rows the Backend.AI WebUI admin session list (all projects) is currently rendering, with the columns it shows (session id, name, status, type, resource group, project, owner and creation time), plus the total count, the page and the sort in effect.';
+
+const CURRENT_DESCRIPTION =
+  'The session whose detail drawer is open on the admin session list, or null. The drawer is URL state (the sessionDetail search param), so webui_path is the deep link that reopens it.';
+
+const FILTER_DESCRIPTION =
+  'The admin session list\'s current URL state: the property filter, the running/finished status category, the session-type tab and the page/pageSize. Feed the values back through bai_open_resource {"type":"list","resource":"session"}.';
+
+export interface WebMCPAdminSessionToolsProps {
+  sessionsFrgmt: WebMCPAdminSessionToolsFragment$key;
+  count: number;
+  page: number;
+  pageSize: number;
+  sort: string | null;
+  filter: string | null;
+  statusCategory: string | null;
+  /** The session-type tab (`all` / `interactive` / `batch` / …). */
+  type: string | null;
+}
+
+export const sessionRows = (
+  sessions: WebMCPAdminSessionToolsFragment$data,
+): Array<WebMCPRow> =>
+  _.map(sessions, (session) =>
+    webmcpRow({
+      id: session.id,
+      session_id: session.row_id ?? null,
+      name: session.name ?? null,
+      status: session.status ?? null,
+      type: session.type ?? null,
+      resource_group: session.scaling_group ?? null,
+      project_id: session.project_id ?? null,
+      user_id: session.user_id ?? null,
+      created_at: session.created_at ?? null,
+    }),
+  );
+
+export const createAdminSessionTools = (
+  visible: WebMCPVisibleRows,
+  current: WebMCPCurrentItem,
+  filter: WebMCPPageFilter,
+): Array<WebMCPTool> => [
+  createListVisibleTool('session', LIST_DESCRIPTION, visible),
+  createGetCurrentTool('session', CURRENT_DESCRIPTION, current),
+  createGetFilterTool('session', FILTER_DESCRIPTION, filter),
+];
+
+/** The `{ current, webui_path }` pair for the drawer the URL currently opens. */
+export const currentSessionItem = (
+  rows: Array<WebMCPRow>,
+  sessionDetailId: string | null,
+): WebMCPCurrentItem => ({
+  current: findRowById(rows, sessionDetailId, 'session_id'),
+  webui_path: sessionDetailId
+    ? resourcePath({ type: 'session', id: sessionDetailId })
+    : null,
+});
+
+/** Registers the admin session tools while the admin session list is mounted. */
+const WebMCPAdminSessionTools: React.FC<WebMCPAdminSessionToolsProps> = ({
+  sessionsFrgmt,
+  count,
+  page,
+  pageSize,
+  sort,
+  filter,
+  statusCategory,
+  type,
+}) => {
+  'use memo';
+  const sessions = useFragment(
+    graphql`
+      fragment WebMCPAdminSessionToolsFragment on ComputeSessionNode
+      @relay(plural: true) {
+        id
+        row_id
+        name
+        status
+        type
+        scaling_group
+        project_id
+        user_id
+        created_at
+      }
+    `,
+    sessionsFrgmt,
+  );
+  const [sessionDetailId] = useQueryState(SESSION_DETAIL_PARAM, parseAsString);
+
+  const rows = sessionRows(sessions);
+  const [listTool, currentTool, filterTool] = createAdminSessionTools(
+    { rows, count, page, pageSize, sort },
+    currentSessionItem(rows, sessionDetailId),
+    { filter, status: statusCategory, tab: type, current: page, pageSize },
+  );
+
+  useWebMCPTool(listTool, [sessions, count, page, pageSize, sort]);
+  useWebMCPTool(currentTool, [sessions, sessionDetailId]);
+  useWebMCPTool(filterTool, [filter, statusCategory, type, page, pageSize]);
+
+  return null;
+};
+
+export default WebMCPAdminSessionTools;

--- a/react/src/components/WebMCPAdminUserTools.test.ts
+++ b/react/src/components/WebMCPAdminUserTools.test.ts
@@ -1,0 +1,215 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3767: the two tabs of `/admin/users` — `user` and `keypair`. Neither has a
+ * detail deep link, so both `bai_get_current_*` tools answer `webui_path: null`
+ * and say so in their description.
+ */
+import type { WebMCPAdminUserToolsFragment$data } from '../__generated__/WebMCPAdminUserToolsFragment.graphql';
+import { findRowById } from '../helper/webmcpAdminPageTools';
+import type { WebMCPTool } from '../hooks/useWebMCPTool';
+import {
+  createAdminKeypairTools,
+  createAdminUserTools,
+  keypairRows,
+  userRows,
+  type WebMCPKeypairInput,
+} from './WebMCPAdminUserTools';
+import type { CallToolResult } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+
+const users = [
+  {
+    id: 'VXNlclYyOnUtMQ==',
+    basicInfo: {
+      email: 'admin@lablup.com',
+      fullName: 'Admin',
+      username: 'admin',
+    },
+    organization: {
+      domainName: 'default',
+      role: 'SUPERADMIN',
+      resourcePolicy: 'default',
+      mainAccessKey: 'AKIA-ADMIN',
+    },
+    status: { status: 'ACTIVE' },
+  },
+  {
+    id: 'VXNlclYyOnUtMg==',
+    basicInfo: { email: 'user@lablup.com', fullName: null, username: 'user' },
+    organization: null,
+    status: { status: 'INACTIVE' },
+  },
+] as unknown as WebMCPAdminUserToolsFragment$data;
+
+const keypairs: Array<WebMCPKeypairInput | null> = [
+  {
+    id: 'kp-1',
+    access_key: 'AKIA-ADMIN',
+    user_id: 'admin@lablup.com',
+    is_admin: true,
+    resource_policy: 'default',
+    rate_limit: 30000,
+    num_queries: 12,
+    concurrency_used: 1,
+    created_at: '2026-01-01T00:00:00+00:00',
+  },
+  null,
+];
+
+const run = (tool: WebMCPTool): CallToolResult =>
+  tool.execute({}, {} as never) as CallToolResult;
+
+describe('userRows', () => {
+  it('flattens the fragment onto the columns the Users tab shows', () => {
+    expect(userRows(users)[0]).toEqual({
+      id: 'VXNlclYyOnUtMQ==',
+      email: 'admin@lablup.com',
+      full_name: 'Admin',
+      username: 'admin',
+      domain: 'default',
+      role: 'SUPERADMIN',
+      resource_policy: 'default',
+      main_access_key: 'AKIA-ADMIN',
+      status: 'ACTIVE',
+    });
+  });
+
+  it('reports missing sub-objects as null columns', () => {
+    expect(userRows(users)[1]).toMatchObject({
+      full_name: null,
+      domain: null,
+      role: null,
+      status: 'INACTIVE',
+    });
+  });
+});
+
+describe('user tab tools', () => {
+  const rows = userRows(users);
+  const [listTool, currentTool, filterTool] = createAdminUserTools(
+    { rows, count: 2, page: 1, pageSize: 10, sort: 'email' },
+    { current: findRowById(rows, 'VXNlclYyOnUtMQ=='), webui_path: null },
+    {
+      filter: '{"username":{"contains":"ad"}}',
+      status: 'ACTIVE',
+      tab: 'users',
+      current: 1,
+      pageSize: 10,
+    },
+  );
+
+  it('registers exactly the three read-only user tools', () => {
+    expect([listTool.name, currentTool.name, filterTool.name]).toEqual([
+      'bai_list_visible_user',
+      'bai_get_current_user',
+      'bai_get_user_filter',
+    ]);
+    expect(
+      [listTool, currentTool, filterTool].every(
+        (tool) => tool.annotations?.readOnlyHint === true,
+      ),
+    ).toBe(true);
+  });
+
+  it('lists the rendered rows with the count, page and sort', () => {
+    expect(run(listTool).structuredContent).toEqual({
+      rows,
+      count: 2,
+      page: 1,
+      pageSize: 10,
+      sort: 'email',
+    });
+  });
+
+  it('answers the open modal with the row and a null webui_path', () => {
+    expect(run(currentTool).structuredContent).toEqual({
+      current: rows[0],
+      webui_path: null,
+    });
+    expect(currentTool.description).toContain('webui_path is always null');
+  });
+
+  it('reports the Users tab URL params', () => {
+    expect(run(filterTool).structuredContent).toEqual({
+      filter: '{"username":{"contains":"ad"}}',
+      status: 'ACTIVE',
+      tab: 'users',
+      current: 1,
+      pageSize: 10,
+    });
+  });
+});
+
+describe('keypairRows', () => {
+  it('flattens keypair_list items and skips the null ones', () => {
+    expect(keypairRows(keypairs)).toEqual([
+      {
+        id: 'kp-1',
+        access_key: 'AKIA-ADMIN',
+        user_id: 'admin@lablup.com',
+        is_admin: true,
+        resource_policy: 'default',
+        rate_limit: 30000,
+        num_queries: 12,
+        concurrency_used: 1,
+        created_at: '2026-01-01T00:00:00+00:00',
+      },
+    ]);
+  });
+});
+
+describe('credentials tab tools', () => {
+  const rows = keypairRows(keypairs);
+  const [listTool, currentTool, filterTool] = createAdminKeypairTools(
+    { rows, count: 1, page: 1, pageSize: 20, sort: null },
+    { current: findRowById(rows, 'kp-1'), webui_path: null },
+    {
+      filter: null,
+      status: 'inactive',
+      tab: 'credentials',
+      current: 1,
+      pageSize: 20,
+    },
+  );
+
+  it('registers exactly the three read-only keypair tools', () => {
+    expect([listTool.name, currentTool.name, filterTool.name]).toEqual([
+      'bai_list_visible_keypair',
+      'bai_get_current_keypair',
+      'bai_get_keypair_filter',
+    ]);
+    expect(
+      [listTool, currentTool, filterTool].every(
+        (tool) => tool.annotations?.readOnlyHint === true,
+      ),
+    ).toBe(true);
+  });
+
+  it('answers with the rendered keypair rows and the open one', () => {
+    expect(run(listTool).structuredContent).toEqual({
+      rows,
+      count: 1,
+      page: 1,
+      pageSize: 20,
+      sort: null,
+    });
+    expect(run(currentTool).structuredContent).toEqual({
+      current: rows[0],
+      webui_path: null,
+    });
+  });
+
+  it('reports the credentials segment under the URL name activeType', () => {
+    expect(run(filterTool).structuredContent).toEqual({
+      filter: null,
+      status: 'inactive',
+      tab: 'credentials',
+      current: 1,
+      pageSize: 20,
+    });
+    expect(filterTool.description).toContain('activeType');
+  });
+});

--- a/react/src/components/WebMCPAdminUserTools.tsx
+++ b/react/src/components/WebMCPAdminUserTools.tsx
@@ -1,0 +1,224 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Read-only WebMCP tools for the two tabs of `/admin/users` (FR-3767): `user`
+ * on the Users tab and `keypair` on the Credentials tab.
+ *
+ * Mounted by `AdminUserManagement` / `AdminUserCredentialList`, whose only call
+ * site is `AdminUsersPage` under the `/admin/users` route; that subtree
+ * declares `handle.access: 'admin'`, so `RouteAccessGuard` keeps non-admins off
+ * the page and these tools with it. Only the mounted tab's tools are
+ * registered, because the other tab's component is not rendered.
+ *
+ * Neither users nor keypairs have a detail deep link yet (`resourcePath`'s
+ * `ResourceRef` has no member for them), so `bai_get_current_*` reports the row
+ * with `webui_path: null`.
+ */
+import type {
+  WebMCPAdminUserToolsFragment$data,
+  WebMCPAdminUserToolsFragment$key,
+} from '../__generated__/WebMCPAdminUserToolsFragment.graphql';
+import {
+  createGetCurrentTool,
+  createGetFilterTool,
+  createListVisibleTool,
+  findRowById,
+  webmcpRow,
+  type WebMCPCurrentItem,
+  type WebMCPPageFilter,
+  type WebMCPRow,
+  type WebMCPVisibleRows,
+} from '../helper/webmcpAdminPageTools';
+import { useWebMCPTool, type WebMCPTool } from '../hooks/useWebMCPTool';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+const USER_LIST_DESCRIPTION =
+  'The user rows the Backend.AI WebUI /admin/users Users tab is currently rendering, with the columns it shows (email, full name, username, domain, role, resource policy, main access key and status), plus the total count, the page and the sort in effect.';
+
+const USER_CURRENT_DESCRIPTION =
+  'The user whose detail or edit modal is open on the /admin/users Users tab, or null. Users have no detail deep link yet, so webui_path is always null; open the list with bai_open_resource {"type":"list","resource":"user"} instead.';
+
+const USER_FILTER_DESCRIPTION =
+  'The /admin/users Users tab\'s current URL state: the property filter (JSON), the ACTIVE/INACTIVE status segment, the tab and the page/pageSize. Feed the values back through bai_open_resource {"type":"list","resource":"user"}.';
+
+const KEYPAIR_LIST_DESCRIPTION =
+  'The keypair rows the Backend.AI WebUI /admin/users Credentials tab is currently rendering, with the columns it shows (access key, user id, admin flag, resource policy, rate limit, queries, concurrency used and creation time), plus the total count, the page and the sort in effect.';
+
+const KEYPAIR_CURRENT_DESCRIPTION =
+  'The keypair whose info modal is open on the /admin/users Credentials tab, or null. Keypairs have no detail deep link yet, so webui_path is always null; open the list with bai_open_resource {"type":"list","resource":"keypair"} instead.';
+
+const KEYPAIR_FILTER_DESCRIPTION =
+  'The /admin/users Credentials tab\'s current URL state: the free-text filter, the active/inactive segment (URL param "activeType"), the tab and the page/pageSize. Feed the values back through bai_open_resource {"type":"list","resource":"keypair"}.';
+
+export const userRows = (
+  users: WebMCPAdminUserToolsFragment$data,
+): Array<WebMCPRow> =>
+  _.map(users, (user) =>
+    webmcpRow({
+      id: user.id,
+      email: user.basicInfo?.email ?? null,
+      full_name: user.basicInfo?.fullName ?? null,
+      username: user.basicInfo?.username ?? null,
+      domain: user.organization?.domainName ?? null,
+      role: user.organization?.role ?? null,
+      resource_policy: user.organization?.resourcePolicy ?? null,
+      main_access_key: user.organization?.mainAccessKey ?? null,
+      status: user.status?.status ?? null,
+    }),
+  );
+
+export const createAdminUserTools = (
+  visible: WebMCPVisibleRows,
+  current: WebMCPCurrentItem,
+  filter: WebMCPPageFilter,
+): Array<WebMCPTool> => [
+  createListVisibleTool('user', USER_LIST_DESCRIPTION, visible),
+  createGetCurrentTool('user', USER_CURRENT_DESCRIPTION, current),
+  createGetFilterTool('user', USER_FILTER_DESCRIPTION, filter),
+];
+
+export interface WebMCPAdminUserToolsProps {
+  usersFrgmt: WebMCPAdminUserToolsFragment$key;
+  count: number;
+  page: number;
+  pageSize: number;
+  sort: string | null;
+  filter: string | null;
+  status: string | null;
+  /** Relay global id of the user whose detail / edit modal is open. */
+  currentUserId: string | null;
+}
+
+/** Registers the `user` tools while the Users tab is mounted. */
+export const WebMCPAdminUserTools: React.FC<WebMCPAdminUserToolsProps> = ({
+  usersFrgmt,
+  count,
+  page,
+  pageSize,
+  sort,
+  filter,
+  status,
+  currentUserId,
+}) => {
+  'use memo';
+  const users = useFragment(
+    graphql`
+      fragment WebMCPAdminUserToolsFragment on UserV2 @relay(plural: true) {
+        id
+        basicInfo {
+          email
+          fullName
+          username
+        }
+        organization {
+          domainName
+          role
+          resourcePolicy
+          mainAccessKey
+        }
+        status {
+          status
+        }
+      }
+    `,
+    usersFrgmt,
+  );
+
+  const rows = userRows(users);
+  const [listTool, currentTool, filterTool] = createAdminUserTools(
+    { rows, count, page, pageSize, sort },
+    { current: findRowById(rows, currentUserId), webui_path: null },
+    { filter, status, tab: 'users', current: page, pageSize },
+  );
+
+  useWebMCPTool(listTool, [users, count, page, pageSize, sort]);
+  useWebMCPTool(currentTool, [users, currentUserId]);
+  useWebMCPTool(filterTool, [filter, status, page, pageSize]);
+
+  return null;
+};
+
+/** One row of `keypair_list.items`, as the Credentials tab already has it. */
+export interface WebMCPKeypairInput {
+  readonly id: string | null | undefined;
+  readonly access_key: string | null | undefined;
+  readonly user_id: string | null | undefined;
+  readonly is_admin: boolean | null | undefined;
+  readonly resource_policy: string | null | undefined;
+  readonly rate_limit: number | null | undefined;
+  readonly num_queries: number | null | undefined;
+  readonly concurrency_used?: number | null | undefined;
+  readonly created_at: string | null | undefined;
+}
+
+export const keypairRows = (
+  keypairs: ReadonlyArray<WebMCPKeypairInput | null | undefined>,
+): Array<WebMCPRow> =>
+  _.map(_.compact(keypairs), (keypair) =>
+    webmcpRow({
+      id: keypair.id ?? null,
+      access_key: keypair.access_key ?? null,
+      user_id: keypair.user_id ?? null,
+      is_admin: keypair.is_admin ?? null,
+      resource_policy: keypair.resource_policy ?? null,
+      rate_limit: keypair.rate_limit ?? null,
+      num_queries: keypair.num_queries ?? null,
+      concurrency_used: keypair.concurrency_used ?? null,
+      created_at: keypair.created_at ?? null,
+    }),
+  );
+
+export const createAdminKeypairTools = (
+  visible: WebMCPVisibleRows,
+  current: WebMCPCurrentItem,
+  filter: WebMCPPageFilter,
+): Array<WebMCPTool> => [
+  createListVisibleTool('keypair', KEYPAIR_LIST_DESCRIPTION, visible),
+  createGetCurrentTool('keypair', KEYPAIR_CURRENT_DESCRIPTION, current),
+  createGetFilterTool('keypair', KEYPAIR_FILTER_DESCRIPTION, filter),
+];
+
+export interface WebMCPAdminKeypairToolsProps {
+  keypairs: ReadonlyArray<WebMCPKeypairInput | null | undefined>;
+  count: number;
+  page: number;
+  pageSize: number;
+  sort: string | null;
+  filter: string | null;
+  /** `active` / `inactive` — the URL spells this segment `activeType`. */
+  activeType: string | null;
+  /** `id` of the keypair whose info modal is open. */
+  currentKeypairId: string | null;
+}
+
+/** Registers the `keypair` tools while the Credentials tab is mounted. */
+export const WebMCPAdminKeypairTools: React.FC<
+  WebMCPAdminKeypairToolsProps
+> = ({
+  keypairs,
+  count,
+  page,
+  pageSize,
+  sort,
+  filter,
+  activeType,
+  currentKeypairId,
+}) => {
+  'use memo';
+  const rows = keypairRows(keypairs);
+  const [listTool, currentTool, filterTool] = createAdminKeypairTools(
+    { rows, count, page, pageSize, sort },
+    { current: findRowById(rows, currentKeypairId), webui_path: null },
+    { filter, status: activeType, tab: 'credentials', current: page, pageSize },
+  );
+
+  useWebMCPTool(listTool, [keypairs, count, page, pageSize, sort]);
+  useWebMCPTool(currentTool, [keypairs, currentKeypairId]);
+  useWebMCPTool(filterTool, [filter, activeType, page, pageSize]);
+
+  return null;
+};

--- a/react/src/components/WebMCPAgentTools.test.ts
+++ b/react/src/components/WebMCPAgentTools.test.ts
@@ -1,0 +1,136 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3767: the `/admin/agent` agent-list tools — the rows they flatten out of
+ * the page's Relay fragment, and what each handler answers.
+ */
+import type { WebMCPAgentToolsFragment$data } from '../__generated__/WebMCPAgentToolsFragment.graphql';
+import { findRowById } from '../helper/webmcpAdminPageTools';
+import type { WebMCPTool } from '../hooks/useWebMCPTool';
+import { agentRows, createAgentTools } from './WebMCPAgentTools';
+import type { CallToolResult } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+
+const agents = [
+  {
+    id: 'QWdlbnROb2RlOmktMDAx',
+    row_id: 'i-001',
+    addr: 'tcp://10.0.0.1:6001',
+    region: 'local/amd64',
+    architecture: 'x86_64',
+    status: 'ALIVE',
+    scaling_group: 'default',
+    schedulable: true,
+    first_contact: '2026-08-01T00:00:00+00:00',
+    occupied_slots: '{"cpu": "4", "mem": "8589934592"}',
+    available_slots: '{"cpu": "16", "mem": "34359738368"}',
+  },
+  {
+    id: 'QWdlbnROb2RlOmktMDAy',
+    row_id: 'i-002',
+    addr: 'tcp://10.0.0.2:6001',
+    region: 'local/amd64',
+    architecture: 'x86_64',
+    status: 'TERMINATED',
+    scaling_group: 'default',
+    schedulable: false,
+    first_contact: '2026-08-02T00:00:00+00:00',
+    occupied_slots: null,
+    available_slots: 'not json',
+  },
+] as unknown as WebMCPAgentToolsFragment$data;
+
+const run = (tool: WebMCPTool): CallToolResult =>
+  tool.execute({}, {} as never) as CallToolResult;
+
+describe('agentRows', () => {
+  it('flattens the fragment onto the columns the table shows', () => {
+    expect(agentRows(agents)[0]).toEqual({
+      id: 'QWdlbnROb2RlOmktMDAx',
+      agent_id: 'i-001',
+      endpoint: 'tcp://10.0.0.1:6001',
+      region: 'local/amd64',
+      architecture: 'x86_64',
+      status: 'ALIVE',
+      resource_group: 'default',
+      schedulable: true,
+      first_contact: '2026-08-01T00:00:00+00:00',
+      occupied_slots: { cpu: '4', mem: '8589934592' },
+      available_slots: { cpu: '16', mem: '34359738368' },
+    });
+  });
+
+  it('reports unparseable / absent resource slots as null', () => {
+    expect(agentRows(agents)[1]).toMatchObject({
+      occupied_slots: null,
+      available_slots: null,
+    });
+  });
+});
+
+describe('agent page tools', () => {
+  const rows = agentRows(agents);
+  const [listTool, currentTool, filterTool] = createAgentTools(
+    { rows, count: 2, page: 1, pageSize: 10, sort: '-first_contact' },
+    {
+      current: findRowById(rows, 'QWdlbnROb2RlOmktMDAy'),
+      webui_path: null,
+    },
+    {
+      filter: 'schedulable == "true"',
+      status: 'ALIVE',
+      tab: 'agents',
+      current: 1,
+      pageSize: 10,
+    },
+  );
+
+  it('registers exactly the three read-only agent tools', () => {
+    expect([listTool.name, currentTool.name, filterTool.name]).toEqual([
+      'bai_list_visible_agent',
+      'bai_get_current_agent',
+      'bai_get_agent_filter',
+    ]);
+    expect(
+      [listTool, currentTool, filterTool].every(
+        (tool) => tool.annotations?.readOnlyHint === true,
+      ),
+    ).toBe(true);
+  });
+
+  it('lists the rendered rows with the count, page and sort', () => {
+    expect(run(listTool).structuredContent).toMatchObject({
+      count: 2,
+      page: 1,
+      pageSize: 10,
+      sort: '-first_contact',
+    });
+    expect(
+      (run(listTool).structuredContent as { rows: Array<{ agent_id: string }> })
+        .rows,
+    ).toHaveLength(2);
+  });
+
+  it('answers the open drawer with the row and a null webui_path', () => {
+    expect(run(currentTool).structuredContent).toEqual({
+      current: rows[1],
+      webui_path: null,
+    });
+  });
+
+  it('says agents have no deep link in the tool description', () => {
+    expect(currentTool.description).toContain('webui_path is always null');
+  });
+
+  it('reports the list URL params', () => {
+    expect(run(filterTool).structuredContent).toEqual({
+      filter: 'schedulable == "true"',
+      status: 'ALIVE',
+      tab: 'agents',
+      current: 1,
+      pageSize: 10,
+    });
+  });
+});

--- a/react/src/components/WebMCPAgentTools.tsx
+++ b/react/src/components/WebMCPAgentTools.tsx
@@ -1,0 +1,130 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Read-only WebMCP tools for the agent list (FR-3767) — `/admin/agent?tab=agents`.
+ *
+ * Mounted by `AgentList`, whose every call site is superadmin-only (the
+ * `/admin/agent` route declares `access: 'superadmin'`; the dashboard's
+ * `ActiveAgents` board item is rendered only for superadmins), so a non-admin
+ * tab never advertises these tools.
+ */
+import type {
+  WebMCPAgentToolsFragment$data,
+  WebMCPAgentToolsFragment$key,
+} from '../__generated__/WebMCPAgentToolsFragment.graphql';
+import {
+  createGetCurrentTool,
+  createGetFilterTool,
+  createListVisibleTool,
+  findRowById,
+  parseJsonColumn,
+  webmcpRow,
+  type WebMCPCurrentItem,
+  type WebMCPPageFilter,
+  type WebMCPRow,
+  type WebMCPVisibleRows,
+} from '../helper/webmcpAdminPageTools';
+import { useWebMCPTool, type WebMCPTool } from '../hooks/useWebMCPTool';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+const LIST_DESCRIPTION =
+  'The agent rows the Backend.AI WebUI agent list is currently rendering, with the columns it shows (id/endpoint, region, architecture, status, resource group, schedulable, first contact and the occupied/available resource slots), plus the total count, the page and the sort in effect.';
+
+const CURRENT_DESCRIPTION =
+  'The agent whose detail drawer is open in the agent list, or null. Agents have no detail deep link yet, so webui_path is always null; open the list with bai_open_resource {"type":"list","resource":"agent"} instead.';
+
+const FILTER_DESCRIPTION =
+  'The agent list\'s current URL state: the property filter, the ALIVE/TERMINATED status segment and the page/pageSize. Feed the values back through bai_open_resource {"type":"list","resource":"agent"}.';
+
+export interface WebMCPAgentToolsProps {
+  agentsFrgmt: WebMCPAgentToolsFragment$key;
+  /** Total matching the filter (the table's pagination total). */
+  count: number;
+  page: number;
+  pageSize: number;
+  sort: string | null;
+  filter: string | null;
+  status: string | null;
+  /** Relay global id of the agent whose detail drawer is open. */
+  currentAgentId: string | null;
+}
+
+export const agentRows = (
+  agents: WebMCPAgentToolsFragment$data,
+): Array<WebMCPRow> =>
+  _.map(agents, (agent) =>
+    webmcpRow({
+      id: agent.id,
+      agent_id: agent.row_id ?? null,
+      endpoint: agent.addr ?? null,
+      region: agent.region ?? null,
+      architecture: agent.architecture ?? null,
+      status: agent.status ?? null,
+      resource_group: agent.scaling_group ?? null,
+      schedulable: agent.schedulable ?? null,
+      first_contact: agent.first_contact ?? null,
+      occupied_slots: parseJsonColumn(agent.occupied_slots),
+      available_slots: parseJsonColumn(agent.available_slots),
+    }),
+  );
+
+export const createAgentTools = (
+  visible: WebMCPVisibleRows,
+  current: WebMCPCurrentItem,
+  filter: WebMCPPageFilter,
+): Array<WebMCPTool> => [
+  createListVisibleTool('agent', LIST_DESCRIPTION, visible),
+  createGetCurrentTool('agent', CURRENT_DESCRIPTION, current),
+  createGetFilterTool('agent', FILTER_DESCRIPTION, filter),
+];
+
+/** Registers the agent tools for as long as the agent list is mounted. */
+const WebMCPAgentTools: React.FC<WebMCPAgentToolsProps> = ({
+  agentsFrgmt,
+  count,
+  page,
+  pageSize,
+  sort,
+  filter,
+  status,
+  currentAgentId,
+}) => {
+  'use memo';
+  const agents = useFragment(
+    graphql`
+      fragment WebMCPAgentToolsFragment on AgentNode @relay(plural: true) {
+        id
+        row_id
+        addr
+        region
+        architecture
+        status
+        scaling_group
+        schedulable
+        first_contact
+        occupied_slots
+        available_slots
+      }
+    `,
+    agentsFrgmt,
+  );
+
+  const rows = agentRows(agents);
+  const [listTool, currentTool, filterTool] = createAgentTools(
+    { rows, count, page, pageSize, sort },
+    { current: findRowById(rows, currentAgentId), webui_path: null },
+    { filter, status, tab: 'agents', current: page, pageSize },
+  );
+
+  useWebMCPTool(listTool, [agents, count, page, pageSize, sort]);
+  useWebMCPTool(currentTool, [agents, currentAgentId]);
+  useWebMCPTool(filterTool, [filter, status, page, pageSize]);
+
+  return null;
+};
+
+export default WebMCPAgentTools;

--- a/react/src/components/WebMCPRoleTools.test.ts
+++ b/react/src/components/WebMCPRoleTools.test.ts
@@ -1,0 +1,165 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3767: the `/admin/rbac` role tools. The role drawer is URL state, so
+ * `bai_get_current_role`'s `webui_path` is the `resourcePath` role ref — the
+ * same link `bai_open_resource {"type":"role"}` navigates to.
+ */
+import type { WebMCPRoleToolsFragment$data } from '../__generated__/WebMCPRoleToolsFragment.graphql';
+import type { WebMCPTool } from '../hooks/useWebMCPTool';
+import {
+  createRoleTools,
+  currentRoleItem,
+  roleFilterText,
+  roleRows,
+} from './WebMCPRoleTools';
+import type { CallToolResult } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+
+const roles = [
+  {
+    id: 'Um9sZTpyLTE=',
+    name: 'superadmin',
+    description: 'Everything',
+    source: 'SYSTEM',
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00+00:00',
+    updatedAt: '2026-02-01T00:00:00+00:00',
+    scopes: {
+      count: 2,
+      edges: [
+        { node: { scopeType: 'domain', scopeId: 'default' } },
+        { node: null },
+      ],
+    },
+  },
+  {
+    id: 'Um9sZTpyLTI=',
+    name: 'viewer',
+    description: null,
+    source: 'CUSTOM',
+    status: 'DELETED',
+    createdAt: '2026-03-01T00:00:00+00:00',
+    updatedAt: null,
+    scopes: null,
+  },
+] as unknown as WebMCPRoleToolsFragment$data;
+
+const run = (tool: WebMCPTool): CallToolResult =>
+  tool.execute({}, {} as never) as CallToolResult;
+
+describe('roleRows', () => {
+  it('flattens the fragment onto the columns the table shows', () => {
+    expect(roleRows(roles)[0]).toEqual({
+      id: 'Um9sZTpyLTE=',
+      name: 'superadmin',
+      description: 'Everything',
+      source: 'SYSTEM',
+      status: 'ACTIVE',
+      created_at: '2026-01-01T00:00:00+00:00',
+      updated_at: '2026-02-01T00:00:00+00:00',
+      scope_count: 2,
+      scopes: [{ scope_type: 'domain', scope_id: 'default' }],
+    });
+  });
+
+  it('reports a role with no scopes as an empty scope list', () => {
+    expect(roleRows(roles)[1]).toMatchObject({
+      description: null,
+      updated_at: null,
+      scope_count: null,
+      scopes: [],
+    });
+  });
+});
+
+describe('roleFilterText', () => {
+  it("renders the page's JSON filter object as text", () => {
+    expect(roleFilterText({ name: { contains: 'admin' } })).toBe(
+      '{"name":{"contains":"admin"}}',
+    );
+    expect(roleFilterText('name == "x"')).toBe('name == "x"');
+    expect(roleFilterText(null)).toBeNull();
+    expect(roleFilterText(undefined)).toBeNull();
+  });
+});
+
+describe('currentRoleItem', () => {
+  const rows = roleRows(roles);
+
+  it('resolves the roleDetail param to its row and deep link', () => {
+    expect(currentRoleItem(rows, 'Um9sZTpyLTI=')).toEqual({
+      current: rows[1],
+      webui_path: '/admin/rbac?roleDetail=Um9sZTpyLTI%3D',
+    });
+  });
+
+  it('is null on both keys when the drawer is closed', () => {
+    expect(currentRoleItem(rows, null)).toEqual({
+      current: null,
+      webui_path: null,
+    });
+  });
+});
+
+describe('role page tools', () => {
+  const rows = roleRows(roles);
+  const [listTool, currentTool, filterTool] = createRoleTools(
+    { rows, count: 2, page: 1, pageSize: 10, sort: 'name' },
+    currentRoleItem(rows, 'Um9sZTpyLTE='),
+    {
+      filter: roleFilterText({ name: { contains: 'admin' } }),
+      status: 'ACTIVE',
+      tab: 'roles',
+      current: 1,
+      pageSize: 10,
+    },
+  );
+
+  it('registers exactly the three read-only role tools', () => {
+    expect([listTool.name, currentTool.name, filterTool.name]).toEqual([
+      'bai_list_visible_role',
+      'bai_get_current_role',
+      'bai_get_role_filter',
+    ]);
+    expect(
+      [listTool, currentTool, filterTool].every(
+        (tool) => tool.annotations?.readOnlyHint === true,
+      ),
+    ).toBe(true);
+    expect(filterTool.inputSchema).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+
+  it('lists the rendered rows with the count, page and sort', () => {
+    expect(run(listTool).structuredContent).toEqual({
+      rows,
+      count: 2,
+      page: 1,
+      pageSize: 10,
+      sort: 'name',
+    });
+  });
+
+  it('answers the open drawer with its row and the role ref path', () => {
+    expect(run(currentTool).structuredContent).toEqual({
+      current: rows[0],
+      webui_path: '/admin/rbac?roleDetail=Um9sZTpyLTE%3D',
+    });
+  });
+
+  it('reports the RBAC list URL params', () => {
+    expect(run(filterTool).structuredContent).toEqual({
+      filter: '{"name":{"contains":"admin"}}',
+      status: 'ACTIVE',
+      tab: 'roles',
+      current: 1,
+      pageSize: 10,
+    });
+  });
+});

--- a/react/src/components/WebMCPRoleTools.tsx
+++ b/react/src/components/WebMCPRoleTools.tsx
@@ -1,0 +1,155 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Read-only WebMCP tools for the RBAC role list (FR-3767) — `/admin/rbac`.
+ *
+ * Mounted by `RBACManagementPage`, whose only route declares
+ * `handle.access: 'superadmin'`, so `RouteAccessGuard` keeps everyone else off
+ * the page and these tools with it.
+ *
+ * The role detail drawer is URL state (`roleDetail`), which is exactly the ref
+ * `resourcePath({ type: 'role', id })` builds.
+ */
+import type {
+  WebMCPRoleToolsFragment$data,
+  WebMCPRoleToolsFragment$key,
+} from '../__generated__/WebMCPRoleToolsFragment.graphql';
+import { resourcePath } from '../helper/resourcePath';
+import {
+  createGetCurrentTool,
+  createGetFilterTool,
+  createListVisibleTool,
+  findRowById,
+  webmcpRow,
+  type WebMCPCurrentItem,
+  type WebMCPPageFilter,
+  type WebMCPRow,
+  type WebMCPVisibleRows,
+} from '../helper/webmcpAdminPageTools';
+import { useWebMCPTool, type WebMCPTool } from '../hooks/useWebMCPTool';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+const LIST_DESCRIPTION =
+  'The role rows the Backend.AI WebUI RBAC management page (/admin/rbac) is currently rendering, with the columns it shows (name, description, source, status and timestamps) and the first scopes each role is mapped to, plus the total count, the page and the sort in effect.';
+
+const CURRENT_DESCRIPTION =
+  'The role whose detail drawer is open on /admin/rbac, or null. The drawer is URL state (the roleDetail search param), so webui_path is the deep link that reopens it.';
+
+const FILTER_DESCRIPTION =
+  'The RBAC role list\'s current URL state: the property filter (JSON), the ACTIVE/DELETED status segment and the page/pageSize. Feed the values back through bai_open_resource {"type":"list","resource":"role"}.';
+
+export interface WebMCPRoleToolsProps {
+  rolesFrgmt: WebMCPRoleToolsFragment$key;
+  count: number;
+  page: number;
+  pageSize: number;
+  sort: string | null;
+  /** The page's filter param; an object here is reported as its JSON text. */
+  filter: unknown;
+  status: string | null;
+  /** Relay global id from the `roleDetail` search param. */
+  currentRoleId: string | null;
+}
+
+export const roleRows = (
+  roles: WebMCPRoleToolsFragment$data,
+): Array<WebMCPRow> =>
+  _.map(roles, (role) =>
+    webmcpRow({
+      id: role.id,
+      name: role.name ?? null,
+      description: role.description ?? null,
+      source: role.source ?? null,
+      status: role.status ?? null,
+      created_at: role.createdAt ?? null,
+      updated_at: role.updatedAt ?? null,
+      scope_count: role.scopes?.count ?? null,
+      scopes: _.map(
+        _.compact(_.map(role.scopes?.edges, (edge) => edge?.node)),
+        (scope) => ({
+          scope_type: scope.scopeType ?? null,
+          scope_id: scope.scopeId ?? null,
+        }),
+      ),
+    }),
+  );
+
+export const createRoleTools = (
+  visible: WebMCPVisibleRows,
+  current: WebMCPCurrentItem,
+  filter: WebMCPPageFilter,
+): Array<WebMCPTool> => [
+  createListVisibleTool('role', LIST_DESCRIPTION, visible),
+  createGetCurrentTool('role', CURRENT_DESCRIPTION, current),
+  createGetFilterTool('role', FILTER_DESCRIPTION, filter),
+];
+
+/** The `{ current, webui_path }` pair for the drawer the URL currently opens. */
+export const currentRoleItem = (
+  rows: Array<WebMCPRow>,
+  roleId: string | null,
+): WebMCPCurrentItem => ({
+  current: findRowById(rows, roleId),
+  webui_path: roleId ? resourcePath({ type: 'role', id: roleId }) : null,
+});
+
+/** The filter param as text: the page stores it as a JSON object. */
+export const roleFilterText = (filter: unknown): string | null =>
+  _.isNil(filter) ? null : _.isString(filter) ? filter : JSON.stringify(filter);
+
+/** Registers the role tools while the RBAC management page is mounted. */
+const WebMCPRoleTools: React.FC<WebMCPRoleToolsProps> = ({
+  rolesFrgmt,
+  count,
+  page,
+  pageSize,
+  sort,
+  filter,
+  status,
+  currentRoleId,
+}) => {
+  'use memo';
+  const roles = useFragment(
+    graphql`
+      fragment WebMCPRoleToolsFragment on Role @relay(plural: true) {
+        id
+        name
+        description
+        source
+        status
+        createdAt
+        updatedAt
+        scopes(first: 3) {
+          count
+          edges {
+            node {
+              scopeType
+              scopeId
+            }
+          }
+        }
+      }
+    `,
+    rolesFrgmt,
+  );
+
+  const rows = roleRows(roles);
+  const filterText = roleFilterText(filter);
+  const [listTool, currentTool, filterTool] = createRoleTools(
+    { rows, count, page, pageSize, sort },
+    currentRoleItem(rows, currentRoleId),
+    { filter: filterText, status, tab: 'roles', current: page, pageSize },
+  );
+
+  useWebMCPTool(listTool, [roles, count, page, pageSize, sort]);
+  useWebMCPTool(currentTool, [roles, currentRoleId]);
+  useWebMCPTool(filterTool, [filterText, status, page, pageSize]);
+
+  return null;
+};
+
+export default WebMCPRoleTools;

--- a/react/src/helper/webmcpAdminPageTools.test.ts
+++ b/react/src/helper/webmcpAdminPageTools.test.ts
@@ -1,0 +1,154 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3767: the three builders every admin page tool is made of — their names,
+ * their read-only annotation, their argument-free schema literal and the
+ * payloads their handlers answer with.
+ */
+import type { WebMCPTool } from '../hooks/useWebMCPTool';
+import {
+  createGetCurrentTool,
+  createGetFilterTool,
+  createListVisibleTool,
+  findRowById,
+  NO_ARGS_INPUT_SCHEMA,
+  parseJsonColumn,
+  webmcpRow,
+} from './webmcpAdminPageTools';
+import type { CallToolResult } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+
+const rows = [
+  { id: 'agent-1', agent_id: 'i-001', status: 'ALIVE' },
+  { id: 'agent-2', agent_id: 'i-002', status: 'TERMINATED' },
+];
+
+const run = (tool: WebMCPTool): CallToolResult =>
+  tool.execute({}, {} as never) as CallToolResult;
+
+describe('createListVisibleTool', () => {
+  const tool = createListVisibleTool('agent', 'the rendered agent rows', {
+    rows,
+    count: 42,
+    page: 2,
+    pageSize: 10,
+    sort: '-first_contact',
+  });
+
+  it('is a read-only bai_list_visible_<noun> taking no arguments', () => {
+    expect(tool.name).toBe('bai_list_visible_agent');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(tool.inputSchema).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+    expect(tool.inputSchema).toBe(NO_ARGS_INPUT_SCHEMA);
+  });
+
+  it('answers with { rows, count, page, pageSize, sort }', () => {
+    expect(run(tool).structuredContent).toEqual({
+      rows,
+      count: 42,
+      page: 2,
+      pageSize: 10,
+      sort: '-first_contact',
+    });
+  });
+
+  it('reports an absent sort as null rather than dropping the key', () => {
+    const unsorted = createListVisibleTool('agent', 'd', {
+      rows: [],
+      count: 0,
+      page: 1,
+      pageSize: 10,
+    });
+    expect(run(unsorted).structuredContent).toMatchObject({ sort: null });
+  });
+});
+
+describe('createGetCurrentTool', () => {
+  it('is a read-only bai_get_current_<noun> carrying the deep link', () => {
+    const tool = createGetCurrentTool('role', 'the open role', {
+      current: { id: 'role-1', name: 'admin' },
+      webui_path: '/admin/rbac?roleDetail=role-1',
+    });
+
+    expect(tool.name).toBe('bai_get_current_role');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(run(tool).structuredContent).toEqual({
+      current: { id: 'role-1', name: 'admin' },
+      webui_path: '/admin/rbac?roleDetail=role-1',
+    });
+  });
+
+  it('keeps both keys when nothing is open', () => {
+    const tool = createGetCurrentTool('user', 'the open user', {
+      current: null,
+      webui_path: null,
+    });
+    expect(run(tool).structuredContent).toEqual({
+      current: null,
+      webui_path: null,
+    });
+  });
+});
+
+describe('createGetFilterTool', () => {
+  it('is a read-only bai_get_<noun>_filter over the page URL params', () => {
+    const tool = createGetFilterTool('agent', 'the agent list URL state', {
+      filter: 'schedulable == "true"',
+      status: 'ALIVE',
+      tab: 'agents',
+      current: 3,
+      pageSize: 20,
+    });
+
+    expect(tool.name).toBe('bai_get_agent_filter');
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(run(tool).structuredContent).toEqual({
+      filter: 'schedulable == "true"',
+      status: 'ALIVE',
+      tab: 'agents',
+      current: 3,
+      pageSize: 20,
+    });
+  });
+
+  it('omits params the page does not have, but keeps explicit nulls', () => {
+    const tool = createGetFilterTool('keypair', 'd', {
+      filter: null,
+      tab: 'credentials',
+    });
+    expect(run(tool).structuredContent).toEqual({
+      filter: null,
+      tab: 'credentials',
+    });
+  });
+});
+
+describe('row helpers', () => {
+  it('webmcpRow drops undefined columns only', () => {
+    expect(webmcpRow({ a: 1, b: null, c: undefined })).toEqual({
+      a: 1,
+      b: null,
+    });
+  });
+
+  it('parseJsonColumn parses a JSON-string column, else null', () => {
+    expect(parseJsonColumn('{"cpu":"4"}')).toEqual({ cpu: '4' });
+    expect(parseJsonColumn('not json')).toBeNull();
+    expect(parseJsonColumn('[1,2]')).toBeNull();
+    expect(parseJsonColumn(null)).toBeNull();
+    expect(parseJsonColumn(undefined)).toBeNull();
+  });
+
+  it('findRowById looks up by `id`, or by the column it is told', () => {
+    expect(findRowById(rows, 'agent-2')).toEqual(rows[1]);
+    expect(findRowById(rows, 'i-001', 'agent_id')).toEqual(rows[0]);
+    expect(findRowById(rows, 'nope')).toBeNull();
+    expect(findRowById(rows, null)).toBeNull();
+  });
+});

--- a/react/src/helper/webmcpAdminPageTools.ts
+++ b/react/src/helper/webmcpAdminPageTools.ts
@@ -1,0 +1,148 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Builders for the read-only, page-scoped WebMCP tools the admin list pages
+ * register (FR-3767): `bai_list_visible_<noun>`, `bai_get_current_<noun>` and
+ * `bai_get_<noun>_filter`.
+ *
+ * Every tool here answers from what the page already rendered — the Relay
+ * fragment it drew the table from, its pagination state and its nuqs URL
+ * params. None of them fetches, and all three carry
+ * `annotations.readOnlyHint`.
+ */
+import type { WebMCPTool } from '../hooks/useWebMCPTool';
+import type {
+  CallToolResult,
+  InputSchema,
+  JsonObject,
+  JsonValue,
+} from '@mcp-b/webmcp-types';
+import * as _ from 'lodash-es';
+
+/** One rendered table row, flattened to the columns the page shows. */
+export type WebMCPRow = JsonObject;
+
+/** These tools report what the page renders, so none of them takes arguments. */
+export const NO_ARGS_INPUT_SCHEMA: InputSchema = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+};
+
+const jsonResult = (payload: JsonObject): CallToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  structuredContent: payload,
+});
+
+/** Drops `undefined` entries so a payload only carries columns that exist. */
+export const webmcpRow = (
+  row: Record<string, JsonValue | undefined>,
+): WebMCPRow => _.omitBy(row, _.isUndefined) as WebMCPRow;
+
+/**
+ * A GraphQL JSON-string column (`occupied_slots`, …) as an object, or `null`
+ * when it is absent or unparseable.
+ */
+export const parseJsonColumn = (
+  value: string | null | undefined,
+): JsonObject | null => {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return _.isPlainObject(parsed) ? (parsed as JsonObject) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** What `bai_list_visible_<noun>` answers with. */
+export interface WebMCPVisibleRows {
+  /** The rows on the page right now, in the order the table renders them. */
+  rows: Array<WebMCPRow>;
+  /** Total matching the current filter, i.e. the pagination total. */
+  count: number;
+  /** 1-based page number. */
+  page: number;
+  pageSize: number;
+  /** The table's current sort (`-created_at`), or `null` for the default. */
+  sort?: string | null;
+}
+
+/** What `bai_get_<noun>_filter` answers with — the page's URL params. */
+export interface WebMCPPageFilter {
+  filter?: string | null;
+  status?: string | null;
+  tab?: string | null;
+  /** 1-based page number, spelled as the table's `current`. */
+  current?: number;
+  pageSize?: number;
+}
+
+/** What `bai_get_current_<noun>` answers with. */
+export interface WebMCPCurrentItem {
+  /** The opened / selected row, or `null` when nothing is open. */
+  current: WebMCPRow | null;
+  /** Deep link to it, or `null` for pages that have no per-row URL yet. */
+  webui_path: string | null;
+}
+
+export const createListVisibleTool = (
+  noun: string,
+  description: string,
+  visible: WebMCPVisibleRows,
+): WebMCPTool => ({
+  name: `bai_list_visible_${noun}`,
+  description,
+  inputSchema: NO_ARGS_INPUT_SCHEMA,
+  annotations: { readOnlyHint: true },
+  execute: (): CallToolResult =>
+    jsonResult({
+      rows: visible.rows,
+      count: visible.count,
+      page: visible.page,
+      pageSize: visible.pageSize,
+      sort: visible.sort ?? null,
+    }),
+});
+
+export const createGetCurrentTool = (
+  noun: string,
+  description: string,
+  item: WebMCPCurrentItem,
+): WebMCPTool => ({
+  name: `bai_get_current_${noun}`,
+  description,
+  inputSchema: NO_ARGS_INPUT_SCHEMA,
+  annotations: { readOnlyHint: true },
+  execute: (): CallToolResult =>
+    jsonResult({ current: item.current, webui_path: item.webui_path }),
+});
+
+export const createGetFilterTool = (
+  noun: string,
+  description: string,
+  filter: WebMCPPageFilter,
+): WebMCPTool => ({
+  name: `bai_get_${noun}_filter`,
+  description,
+  inputSchema: NO_ARGS_INPUT_SCHEMA,
+  annotations: { readOnlyHint: true },
+  execute: (): CallToolResult =>
+    jsonResult(_.omitBy(filter, _.isUndefined) as JsonObject),
+});
+
+/**
+ * Finds the row a page's "currently open" id points at. `column` is the row
+ * key that id is expressed in — the Relay global `id` for most pages, the
+ * per-page readable id where the URL param carries that instead.
+ */
+export const findRowById = (
+  rows: Array<WebMCPRow>,
+  id: string | null | undefined,
+  column: string = 'id',
+): WebMCPRow | null =>
+  id ? (_.find(rows, (row) => row[column] === id) ?? null) : null;

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -16,6 +16,7 @@ import SessionNodes, {
   availableSessionSorterValues,
 } from '../components/SessionNodes';
 import SessionResourceGrid from '../components/SessionResourceGrid';
+import WebMCPAdminSessionTools from '../components/WebMCPAdminSessionTools';
 import { handleRowSelectionChange } from '../helper';
 import { liftProjectPredicate } from '../helper/adminSessionProjectLift';
 import { ExtractResultValue } from '../helper/resultTypes';
@@ -214,6 +215,7 @@ const AdminComputeSessionListPage = () => {
             node @required(action: THROW) {
               id @required(action: THROW)
               name @required(action: THROW)
+              ...WebMCPAdminSessionToolsFragment
               ...SessionNodesFragment
               ...TerminateSessionModalFragment
             }
@@ -274,6 +276,18 @@ const AdminComputeSessionListPage = () => {
 
   return (
     <BAIFlex direction="column" align="stretch" gap={'sm'}>
+      <WebMCPAdminSessionTools
+        sessionsFrgmt={filterOutNullAndUndefined(
+          compute_session_nodes?.edges.map((e) => e?.node),
+        )}
+        count={compute_session_nodes?.count ?? 0}
+        page={tablePaginationOption.current}
+        pageSize={tablePaginationOption.pageSize}
+        sort={queryVariables.order ?? null}
+        filter={queryParams.filter || null}
+        statusCategory={queryParams.statusCategory}
+        type={queryParams.type}
+      />
       <BAITabs
         activeKey={queryParams.type}
         onChange={(key) => {

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -18,6 +18,7 @@ import RoleNodes, {
   type RoleNodeInList,
   availableRoleSorterValues,
 } from '../components/RoleNodes';
+import WebMCPRoleTools from '../components/WebMCPRoleTools';
 import { convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
@@ -31,6 +32,7 @@ import {
   BAINameActionCell,
   BAIUserSelect,
   filterOutEmpty,
+  filterOutNullAndUndefined,
   INITIAL_FETCH_KEY,
   toLocalId,
   useBAILogger,
@@ -108,6 +110,7 @@ const RBACManagementPage: React.FC = () => {
           edges {
             node {
               id
+              ...WebMCPRoleToolsFragment
               ...RoleNodesFragment
               ...RoleDetailDrawerFragment
             }
@@ -338,6 +341,16 @@ const RBACManagementPage: React.FC = () => {
             </BAIButton>
           </BAIFlex>
         </BAIFlex>
+        <WebMCPRoleTools
+          rolesFrgmt={filterOutNullAndUndefined(roleNodes)}
+          count={queryRef.adminRoles?.count ?? 0}
+          page={tablePaginationOption.current}
+          pageSize={tablePaginationOption.pageSize}
+          sort={queryParams.order ?? null}
+          filter={queryParams.filter}
+          status={queryParams.status}
+          currentRoleId={selectedRoleId}
+        />
         <RoleNodes
           rolesFrgmt={roleNodes}
           loading={deferredQueryVariables !== queryVariables}

--- a/react/src/routeMatching.test.tsx
+++ b/react/src/routeMatching.test.tsx
@@ -95,6 +95,7 @@ describe('route-handle access declarations (FR-3383)', () => {
     ['/admin/deployments', 'superadmin'],
     ['/admin/dashboard', 'superadmin'],
     ['/admin/rbac', 'superadmin'],
+    ['/admin/agent', 'superadmin'],
     // Project-admin subtree.
     ['/project/foo/admin/users', 'projectAdmin'],
     ['/project/foo/admin/session', 'projectAdmin'],


### PR DESCRIPTION
Resolves #9237 (FR-3767)

Part of the bai-agent POC stack (epic FR-3740): a CLI over the manual, terminology, i18n and GraphQL schema, plus a WebMCP hand-off to the logged-in browser tab.

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

---
`bash scripts/verify.sh` → `=== ALL PASS ===` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161MScBrhguUVXb8nHqdD92