### PR TITLE
fix(FR-3705): keep form values when the registry modal's project select suspends

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.test.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.test.tsx
@@ -1,0 +1,118 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import ContainerRegistryEditorModal from './ContainerRegistryEditorModal';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment } from 'relay-test-utils';
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({
+      _config: { domainName: 'default' },
+      supports: () => false,
+    }),
+  };
+});
+
+/**
+ * Stand-in for the real project select, which fetches with
+ * `network-only` and therefore ALWAYS suspends on mount. The mock
+ * reproduces exactly that: suspend until the test resolves it.
+ */
+let projectsDeferred: { promise: Promise<void>; resolve: () => void } | null =
+  null;
+let projectsSettled = false;
+vi.mock('./ProjectSelectForAdminPage', async () => {
+  const React = await import('react');
+  return {
+    default: () => {
+      if (!projectsSettled) {
+        if (!projectsDeferred) {
+          let resolve!: () => void;
+          const promise = new Promise<void>((res) => {
+            resolve = () => {
+              projectsSettled = true;
+              res();
+            };
+          });
+          projectsDeferred = { promise, resolve };
+        }
+        throw projectsDeferred.promise;
+      }
+      return React.createElement('input', {
+        'data-testid': 'allowed-projects-select',
+      });
+    },
+  };
+});
+
+const renderModal = () => {
+  render(
+    <RelayEnvironmentProvider environment={createMockEnvironment()}>
+      {/* The app always has a Suspense boundary above the modal; without
+          one here React would simply delay the commit instead of hiding
+          (and thereby resetting) the form. */}
+      <React.Suspense fallback={<div data-testid="page-fallback" />}>
+        <ContainerRegistryEditorModal open onOk={vi.fn()} onCancel={vi.fn()} />
+      </React.Suspense>
+    </RelayEnvironmentProvider>,
+  );
+};
+
+const sslCheckbox = () =>
+  screen.getByLabelText('registry.SSLVerifyDescription');
+const globalCheckbox = () =>
+  screen.getByLabelText('registry.IsGlobalDescription');
+
+describe('ContainerRegistryEditorModal (FR-3705)', () => {
+  beforeEach(() => {
+    projectsDeferred = null;
+    projectsSettled = false;
+  });
+
+  it('unchecking "Set as global registry" keeps SSL verification unchecked across the project-select suspension', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    // Both default to checked in the Add flow.
+    expect(sslCheckbox()).toBeChecked();
+    expect(globalCheckbox()).toBeChecked();
+
+    await user.click(sslCheckbox());
+    expect(sslCheckbox()).not.toBeChecked();
+
+    // Unchecking is_global mounts the allowed-projects select, which
+    // suspends. The Suspense boundary must sit INSIDE the form: if the
+    // suspension bubbles above it, every preserve={false} field is
+    // unregistered by the hide/show cycle and reset to its initial value.
+    await user.click(globalCheckbox());
+    await waitFor(() => expect(projectsDeferred).not.toBeNull());
+    projectsDeferred!.resolve();
+    await screen.findByTestId('allowed-projects-select');
+
+    expect(globalCheckbox()).not.toBeChecked();
+    expect(sslCheckbox()).not.toBeChecked();
+  });
+});

--- a/react/src/components/ContainerRegistryEditorModal.test.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.test.tsx
@@ -2,28 +2,24 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import '../../__test__/matchMedia.mock.js';
 import '../../__test__/resizeObserver.mock.js';
 import ContainerRegistryEditorModal from './ContainerRegistryEditorModal';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import { Suspense } from 'react';
 import { RelayEnvironmentProvider } from 'react-relay';
 import { createMockEnvironment } from 'relay-test-utils';
 
-vi.mock('react-i18next', async () => {
-  const React = await import('react');
-  return {
-    useTranslation: () => ({
-      t: (key: string) => key,
-      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
-      ready: true,
-    }),
-    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
-    initReactI18next: { type: '3rdParty', init: () => {} },
-  };
-});
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+    ready: true,
+  }),
+  // BUI's locale module runs `i18n.use(initReactI18next).init()` on import.
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
 
 vi.mock('../hooks', async (importOriginal) => {
   const originalModule = await importOriginal<typeof import('../hooks')>();
@@ -36,31 +32,16 @@ vi.mock('../hooks', async (importOriginal) => {
   };
 });
 
-/**
- * Stand-in for the real project select, which fetches with
- * `network-only` and therefore ALWAYS suspends on mount. The mock
- * reproduces exactly that: suspend until the test resolves it.
- */
-let projectsDeferred: { promise: Promise<void>; resolve: () => void } | null =
-  null;
+// The real select fetches with network-only, so it always suspends on mount;
+// this stand-in does the same until the test resolves it.
+let resolveProjects: () => void;
+let projectsPromise: Promise<void>;
 let projectsSettled = false;
 vi.mock('./ProjectSelectForAdminPage', async () => {
   const React = await import('react');
   return {
     default: () => {
-      if (!projectsSettled) {
-        if (!projectsDeferred) {
-          let resolve!: () => void;
-          const promise = new Promise<void>((res) => {
-            resolve = () => {
-              projectsSettled = true;
-              res();
-            };
-          });
-          projectsDeferred = { promise, resolve };
-        }
-        throw projectsDeferred.promise;
-      }
+      if (!projectsSettled) throw projectsPromise;
       return React.createElement('input', {
         'data-testid': 'allowed-projects-select',
       });
@@ -74,9 +55,9 @@ const renderModal = () => {
       {/* The app always has a Suspense boundary above the modal; without
           one here React would simply delay the commit instead of hiding
           (and thereby resetting) the form. */}
-      <React.Suspense fallback={<div data-testid="page-fallback" />}>
+      <Suspense fallback={null}>
         <ContainerRegistryEditorModal open onOk={vi.fn()} onCancel={vi.fn()} />
-      </React.Suspense>
+      </Suspense>
     </RelayEnvironmentProvider>,
   );
 };
@@ -88,28 +69,29 @@ const globalCheckbox = () =>
 
 describe('ContainerRegistryEditorModal (FR-3705)', () => {
   beforeEach(() => {
-    projectsDeferred = null;
     projectsSettled = false;
+    projectsPromise = new Promise<void>((res) => {
+      resolveProjects = () => {
+        projectsSettled = true;
+        res();
+      };
+    });
   });
 
   it('unchecking "Set as global registry" keeps SSL verification unchecked across the project-select suspension', async () => {
     const user = userEvent.setup();
     renderModal();
 
-    // Both default to checked in the Add flow.
     expect(sslCheckbox()).toBeChecked();
     expect(globalCheckbox()).toBeChecked();
 
     await user.click(sslCheckbox());
     expect(sslCheckbox()).not.toBeChecked();
 
-    // Unchecking is_global mounts the allowed-projects select, which
-    // suspends. The Suspense boundary must sit INSIDE the form: if the
-    // suspension bubbles above it, every preserve={false} field is
-    // unregistered by the hide/show cycle and reset to its initial value.
+    // The boundary must be inside the form — see the FR-3705 comment in
+    // ContainerRegistryEditorModal.tsx and engine contract 30.
     await user.click(globalCheckbox());
-    await waitFor(() => expect(projectsDeferred).not.toBeNull());
-    projectsDeferred!.resolve();
+    resolveProjects();
     await screen.findByTestId('allowed-projects-select');
 
     expect(globalCheckbox()).not.toBeChecked();

--- a/react/src/components/ContainerRegistryEditorModal.test.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.test.tsx
@@ -52,9 +52,8 @@ vi.mock('./ProjectSelectForAdminPage', async () => {
 const renderModal = () => {
   render(
     <RelayEnvironmentProvider environment={createMockEnvironment()}>
-      {/* The app always has a Suspense boundary above the modal; without
-          one here React would simply delay the commit instead of hiding
-          (and thereby resetting) the form. */}
+      {/* Without an outer boundary (the app always has one) React would delay
+          the commit instead of hiding — and thereby resetting — the form. */}
       <Suspense fallback={null}>
         <ContainerRegistryEditorModal open onOk={vi.fn()} onCancel={vi.fn()} />
       </Suspense>
@@ -88,8 +87,7 @@ describe('ContainerRegistryEditorModal (FR-3705)', () => {
     await user.click(sslCheckbox());
     expect(sslCheckbox()).not.toBeChecked();
 
-    // The boundary must be inside the form — see the FR-3705 comment in
-    // ContainerRegistryEditorModal.tsx and engine contract 30.
+    // The Suspense boundary must sit inside the form — engine contract 30.
     await user.click(globalCheckbox());
     resolveProjects();
     await screen.findByTestId('allowed-projects-select');

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -376,10 +376,6 @@ const ContainerRegistryEditorModal: React.FC<
           >
             {(form) => (
               <BAIFormItem noStyle name={'password'}>
-                {/* antd Input.Password -> Astryx TextInput type="password"
-                    (MAPPING.md §3.6). PILOT-DECISION: the visibility-toggle
-                    eye affordance is antd sugar with no TextInput
-                    counterpart; dropped (simplicity policy). */}
                 <AstryxFormTextInput
                   label={t('registry.Password')}
                   type="password"
@@ -489,9 +485,6 @@ const ContainerRegistryEditorModal: React.FC<
             !(form as FormInstance<RegistryFormInput>).getFieldValue(
               'is_global',
             ) && (
-              // Suspense must sit INSIDE the form: hiding the form resets
-              // every preserve={false} field (FR-3705; engine contract 30 in
-              // formEngineAcceptance.test.tsx).
               <Suspense
                 fallback={
                   <BAIFormItem label={t('registry.AllowedProjects')}>

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -18,8 +18,7 @@ import {
   AstryxFormSelector,
   AstryxFormTextInput,
 } from './astryxFormControls';
-import { Selector } from '@astryxdesign/core/Selector';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { BAIFlex, BAIModal, BAIModalProps, BAISkeleton } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -490,20 +489,13 @@ const ContainerRegistryEditorModal: React.FC<
             !(form as FormInstance<RegistryFormInput>).getFieldValue(
               'is_global',
             ) && (
-              // Suspense must sit INSIDE the form: if the project select
-              // suspends above it, the hide/show cycle unregisters every
-              // preserve={false} field and resets it to initial (FR-3705).
+              // Suspense must sit INSIDE the form: hiding the form resets
+              // every preserve={false} field (FR-3705; engine contract 30 in
+              // formEngineAcceptance.test.tsx).
               <Suspense
                 fallback={
                   <BAIFormItem label={t('registry.AllowedProjects')}>
-                    {/* Suspense placeholder only — an inert, loading Selector. */}
-                    <Selector
-                      label={t('registry.AllowedProjects')}
-                      isLabelHidden
-                      isLoading
-                      options={[]}
-                      width="100%"
-                    />
+                    <BAISkeleton variant="input" />
                   </BAIFormItem>
                 }
               >

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -18,7 +18,7 @@ import {
   AstryxFormSelector,
   AstryxFormTextInput,
 } from './astryxFormControls';
-import { BAIFlex, BAIModal, BAIModalProps, BAISkeleton } from 'backend.ai-ui';
+import { BAIFlex, BAIModal, BAIModalProps, BAISelect } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -495,7 +495,7 @@ const ContainerRegistryEditorModal: React.FC<
               <Suspense
                 fallback={
                   <BAIFormItem label={t('registry.AllowedProjects')}>
-                    <BAISkeleton variant="input" />
+                    <BAISelect mode="multiple" loading disabled />
                   </BAIFormItem>
                 }
               >

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -18,9 +18,10 @@ import {
   AstryxFormSelector,
   AstryxFormTextInput,
 } from './astryxFormControls';
+import { Selector } from '@astryxdesign/core/Selector';
 import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, { useRef } from 'react';
+import React, { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
@@ -489,16 +490,34 @@ const ContainerRegistryEditorModal: React.FC<
             !(form as FormInstance<RegistryFormInput>).getFieldValue(
               'is_global',
             ) && (
-              <BAIFormItem
-                name="allowed_group_ids"
-                label={t('registry.AllowedProjects')}
+              // Suspense must sit INSIDE the form: if the project select
+              // suspends above it, the hide/show cycle unregisters every
+              // preserve={false} field and resets it to initial (FR-3705).
+              <Suspense
+                fallback={
+                  <BAIFormItem label={t('registry.AllowedProjects')}>
+                    {/* Suspense placeholder only — an inert, loading Selector. */}
+                    <Selector
+                      label={t('registry.AllowedProjects')}
+                      isLabelHidden
+                      isLoading
+                      options={[]}
+                      width="100%"
+                    />
+                  </BAIFormItem>
+                }
               >
-                <ProjectSelectForAdminPage
-                  domain={baiClient._config.domainName}
-                  mode="multiple"
-                  allowClear
-                />
-              </BAIFormItem>
+                <BAIFormItem
+                  name="allowed_group_ids"
+                  label={t('registry.AllowedProjects')}
+                >
+                  <ProjectSelectForAdminPage
+                    domain={baiClient._config.domainName}
+                    mode="multiple"
+                    allowClear
+                  />
+                </BAIFormItem>
+              </Suspense>
             )
           }
         </BAIFormItem>

--- a/react/src/form-engine/formEngineAcceptance.test.tsx
+++ b/react/src/form-engine/formEngineAcceptance.test.tsx
@@ -4,7 +4,8 @@
 
  THE acceptance suite for the self-hosted form engine (to-astryx ticket 34).
 
- 29 tests distilled from `answers/08 §5` — the semantics this repository
+ 29 tests distilled from `answers/08 §5` (plus contract 30, added for
+ FR-3705) — the semantics this repository
  actually depends on, each traced to a real call site.
 
  STATUS (final switch): antd is UNINSTALLED. This suite used to run TWICE —
@@ -1539,5 +1540,85 @@ describe.each(IMPLEMENTATIONS)('form engine acceptance [%s]', (_name, Form) => {
       { name: ['max'], errors: ['Max is required'], warnings: [] },
       { name: ['tags', 0, 'key'], errors: ['Key is required'], warnings: [] },
     ]);
+  });
+
+  // 30. ContainerRegistryEditorModal.tsx (FR-3705) — a trap that cost real
+  //     debugging time: when a child suspends and the nearest boundary sits
+  //     ABOVE the form, React's hide/show cycle runs every Field's cleanup,
+  //     and with `preserve={false}` each unregistration resets that field to
+  //     its initial value. So a Suspense hide counts as an unmount; call
+  //     sites must keep suspending children behind a boundary INSIDE the
+  //     form. If `Field` ever becomes offscreen-aware, revisit this and the
+  //     FR-3705 call-site comment together.
+  it('30. a Suspense hide/show cycle above a `preserve={false}` form resets its fields', async () => {
+    let settled = false;
+    let resolveChild!: () => void;
+    const childPromise = new Promise<void>((res) => {
+      resolveChild = () => {
+        settled = true;
+        res();
+      };
+    });
+    const SuspendingChild: React.FC<any> = (props) => {
+      if (!settled) throw childPromise;
+      return <Input data-testid="lazy-child" {...props} />;
+    };
+    let form!: FormInstance;
+    const captureForm = (instance: FormInstance) => {
+      form = instance;
+    };
+    const Demo = () => {
+      const instance = useTestForm(captureForm);
+      const show = Form.useWatch('show', instance);
+      return (
+        <Form
+          form={instance}
+          preserve={false}
+          initialValues={{ show: false, keep: 'initial' }}
+        >
+          <Form.Item name="show" valuePropName="checked">
+            <Check />
+          </Form.Item>
+          <Form.Item name="keep">
+            <Input />
+          </Form.Item>
+          {show ? (
+            <Form.Item name="lazy">
+              <SuspendingChild />
+            </Form.Item>
+          ) : null}
+        </Form>
+      );
+    };
+    render(
+      <React.Suspense fallback={null}>
+        <Demo />
+      </React.Suspense>,
+    );
+    await settle();
+
+    await act(async () => {
+      form.setFieldValue('keep', 'typed');
+    });
+    await settle();
+    expect(form.getFieldValue('keep')).toBe('typed');
+
+    // Mounting the suspending child hides the whole form behind the outer
+    // boundary until the promise resolves.
+    await act(async () => {
+      form.setFieldValue('show', true);
+    });
+    await settle();
+    await act(async () => {
+      resolveChild();
+      await childPromise;
+    });
+    await settle();
+
+    // EVERY field reset to initial — including `show`, so the lazy item is
+    // gone again and the child never re-renders.
+    expect(form.getFieldValue('keep')).toBe('initial');
+    expect(form.getFieldValue('show')).toBe(false);
+    expect(screen.queryByTestId('lazy-child')).not.toBeInTheDocument();
   });
 });

--- a/react/src/form-engine/formEngineAcceptance.test.tsx
+++ b/react/src/form-engine/formEngineAcceptance.test.tsx
@@ -1543,13 +1543,10 @@ describe.each(IMPLEMENTATIONS)('form engine acceptance [%s]', (_name, Form) => {
   });
 
   // 30. ContainerRegistryEditorModal.tsx (FR-3705) — a trap that cost real
-  //     debugging time: when a child suspends and the nearest boundary sits
-  //     ABOVE the form, React's hide/show cycle runs every Field's cleanup,
-  //     and with `preserve={false}` each unregistration resets that field to
-  //     its initial value. So a Suspense hide counts as an unmount; call
-  //     sites must keep suspending children behind a boundary INSIDE the
-  //     form. If `Field` ever becomes offscreen-aware, revisit this and the
-  //     FR-3705 call-site comment together.
+  //     debugging time: a Suspense hide counts as an unmount, so a boundary
+  //     ABOVE the form resets every `preserve={false}` field to its initial
+  //     value on the hide/show cycle. Keep suspending children behind a
+  //     boundary INSIDE the form.
   it('30. a Suspense hide/show cycle above a `preserve={false}` form resets its fields', async () => {
     let settled = false;
     let resolveChild!: () => void;


### PR DESCRIPTION
Resolves #9123 (FR-3705)

applied server: https://fr-3735.seungwon.10-82-0-159.sslip.io/

## Bug

In the **Add/Modify container registry** modal, uncheck **SSL verification**, then uncheck **Set as global registry** — SSL verification flips back to checked.

## Root cause

Unchecking `is_global` mounts `ProjectSelectForAdminPage`, whose `network-only` `useLazyLoadQuery` always suspends on mount. The nearest `Suspense` boundary sat **above the form**, so React hid the whole form subtree while the query loaded. A Suspense hide/show cycle runs every effect cleanup, which unregisters every form field — and with the form's `preserve={false}`, each unregistration resets the field to its initial value. On reveal, the fields re-register with initial values: `ssl_verify` (and `is_global` itself) revert to checked.

## Fix

Move the `Suspense` boundary **inside** the form, wrapping only the conditional allowed-projects item, with a loading `BAISelect` fallback that keeps the real control's chrome. The suspension no longer reaches the form, so sibling fields keep their values.

## Regression test

`ContainerRegistryEditorModal.test.tsx` renders the real modal under an outer Suspense boundary (as the app does) with a suspending stand-in for the project select:

- unchecks SSL verification, then unchecks Set-as-global,
- resolves the suspension,
- asserts both checkboxes stay unchecked.

Verified to **fail against the previous code** and pass with the fix.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm vitest run src/components/ContainerRegistryEditorModal.test.tsx src/form-engine/formEngineAcceptance.test.tsx` → 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

