### PR TITLE
fix(FR-3801): lift the keypair max session lifetime cap off 100

### DIFF
--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -488,7 +488,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                   <AstryxFormNumberInput
                     label={t('resourcePolicy.MaxSessionLifetime')}
                     min={0}
-                    max={100}
+                    max={SIGNED_32BIT_MAX_INT}
                   />
                 </FormItemWithUnlimited>
               </div>


### PR DESCRIPTION
Resolves #9300 (FR-3801)

## Problem

The **Max session lifetime (sec)** input in the keypair resource policy setting modal was bounded by a hardcoded `max={100}`. The field is expressed in seconds, so the ceiling is under two minutes — and it clamps silently: an operator who sets `3600` in Control Panel loses it the moment anyone opens that policy's modal in the WebUI and saves.

Reported by a customer (KNUT) during a training session on **WebUI 26.4.9**; still reproducible on **v26.4.10** and `main`.

## Fix

```diff
  <AstryxFormNumberInput
    label={t('resourcePolicy.MaxSessionLifetime')}
    min={0}
-   max={100}
+   max={SIGNED_32BIT_MAX_INT}
  />
```

`SIGNED_32BIT_MAX_INT` is already imported in this file and is what every sibling numeric field in the same modal uses:

| Field | Line | Bound |
|---|---|---|
| Cluster size (`max_containers_per_session`) | `:477` | `SIGNED_32BIT_MAX_INT` |
| `max_pending_session_count` | `:506` | `SIGNED_32BIT_MAX_INT` |
| Concurrency (`max_concurrent_sessions`) | `:521` | `SIGNED_32BIT_MAX_INT` |
| `max_concurrent_sftp_sessions` | `:549` | `SIGNED_32BIT_MAX_INT` |
| **Max session lifetime** | `:491` | **`100`** ← the outlier |

The literal came in with the original resource policy page (#2357) and passed through the Ant Design → Astryx migration (#8626) unchanged. No product rule is attached to it.

`unlimitedValue={0}` on the wrapping `FormItemWithUnlimited` is untouched, so the "unlimited" affordance still writes `0`.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / theme / terminology)
- Manual: a policy saved with `3600` round-trips without clamping; an existing policy created above 100 in Control Panel is no longer clamped when its modal is opened and saved.
