### PR TITLE
fix(FR-3800): gate Folder Explorer write and delete on the folder permission

### DIFF
--- a/react/src/__generated__/FolderExplorerModalV2Query.graphql.ts
+++ b/react/src/__generated__/FolderExplorerModalV2Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4cdc1fafd49e59bd654336f967435926>>
+ * @generated SignedSource<<1f4374b44a312b5064c4884e8a815025>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,11 +10,15 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type VFolderMountPermission = "READ_ONLY" | "READ_WRITE" | "RW_DELETE" | "%future added value";
 export type FolderExplorerModalV2Query$variables = {
   vfolderId: string;
 };
 export type FolderExplorerModalV2Query$data = {
   readonly vfolderNode: {
+    readonly accessControl: {
+      readonly permission: VFolderMountPermission;
+    };
     readonly host: string;
     readonly id: string;
     readonly metadata: {
@@ -77,27 +81,34 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "permission",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = [
-  (v5/*: any*/)
+v7 = [
+  (v6/*: any*/)
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "projectId",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "ProjectBasicInfo",
   "kind": "LinkedField",
   "name": "basicInfo",
   "plural": false,
-  "selections": (v6/*: any*/),
+  "selections": (v7/*: any*/),
   "storageKey": null
 };
 return {
@@ -121,11 +132,23 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "VFolderAccessControlInfo",
+            "kind": "LinkedField",
+            "name": "accessControl",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "VFolderMetadataInfo",
             "kind": "LinkedField",
             "name": "metadata",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": null
           },
           {
@@ -136,7 +159,7 @@ return {
             "name": "ownership",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -145,7 +168,7 @@ return {
                 "name": "project",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -189,12 +212,31 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "VFolderAccessControlInfo",
+            "kind": "LinkedField",
+            "name": "accessControl",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "ownershipType",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "VFolderMetadataInfo",
             "kind": "LinkedField",
             "name": "metadata",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -234,7 +276,7 @@ return {
             "name": "ownership",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -243,7 +285,7 @@ return {
                 "name": "project",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/),
+                  (v9/*: any*/),
                   (v4/*: any*/)
                 ],
                 "storageKey": null
@@ -301,31 +343,6 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "VFolderAccessControlInfo",
-            "kind": "LinkedField",
-            "name": "accessControl",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "permission",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "ownershipType",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
           }
         ],
         "storageKey": null
@@ -333,16 +350,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1262a01b36f437256e32ded119856058",
+    "cacheID": "cdf48bf6c0d11f012c3466951944fe80",
     "id": null,
     "metadata": {},
     "name": "FolderExplorerModalV2Query",
     "operationKind": "query",
-    "text": "query FolderExplorerModalV2Query(\n  $vfolderId: UUID!\n) {\n  vfolderNode: vfolderV2(vfolderId: $vfolderId) {\n    unmanagedPath\n    host\n    id\n    metadata {\n      name\n    }\n    ownership {\n      projectId\n      project {\n        basicInfo {\n          name\n        }\n        id\n      }\n    }\n    ...FolderExplorerHeaderV2Fragment\n    ...VFolderNodeDescriptionV2Fragment\n  }\n}\n\nfragment EditableVFolderNameV2Fragment on VFolder {\n  id\n  status\n  metadata {\n    name\n  }\n  ownership {\n    userId\n    projectId\n  }\n}\n\nfragment FileBrowserButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment FolderExplorerHeaderV2Fragment on VFolder {\n  id\n  unmanagedPath\n  ...VFolderNodeIdenticonV2Fragment\n  ...EditableVFolderNameV2Fragment\n  ...FileBrowserButtonV2Fragment\n  ...SFTPServerButtonV2Fragment\n}\n\nfragment SFTPServerButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment VFolderNodeDescriptionV2Fragment on VFolder {\n  id\n  host\n  status\n  unmanagedPath\n  metadata {\n    name\n    usageMode\n    cloneable\n    createdAt\n  }\n  accessControl {\n    permission\n    ownershipType\n  }\n  ownership {\n    userId\n    projectId\n    creatorId\n    user {\n      basicInfo {\n        email\n      }\n      id\n    }\n    project {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  ...VFolderPermissionCellV2Fragment\n  ...useVirtualFolderNodePathV2Fragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n\nfragment VFolderPermissionCellV2Fragment on VFolder {\n  accessControl {\n    permission\n  }\n}\n\nfragment useVirtualFolderNodePathV2Fragment on VFolder {\n  id\n  metadata {\n    quotaScopeId\n  }\n}\n"
+    "text": "query FolderExplorerModalV2Query(\n  $vfolderId: UUID!\n) {\n  vfolderNode: vfolderV2(vfolderId: $vfolderId) {\n    unmanagedPath\n    host\n    id\n    accessControl {\n      permission\n    }\n    metadata {\n      name\n    }\n    ownership {\n      projectId\n      project {\n        basicInfo {\n          name\n        }\n        id\n      }\n    }\n    ...FolderExplorerHeaderV2Fragment\n    ...VFolderNodeDescriptionV2Fragment\n  }\n}\n\nfragment EditableVFolderNameV2Fragment on VFolder {\n  id\n  status\n  metadata {\n    name\n  }\n  ownership {\n    userId\n    projectId\n  }\n}\n\nfragment FileBrowserButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment FolderExplorerHeaderV2Fragment on VFolder {\n  id\n  unmanagedPath\n  ...VFolderNodeIdenticonV2Fragment\n  ...EditableVFolderNameV2Fragment\n  ...FileBrowserButtonV2Fragment\n  ...SFTPServerButtonV2Fragment\n}\n\nfragment SFTPServerButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment VFolderNodeDescriptionV2Fragment on VFolder {\n  id\n  host\n  status\n  unmanagedPath\n  metadata {\n    name\n    usageMode\n    cloneable\n    createdAt\n  }\n  accessControl {\n    permission\n    ownershipType\n  }\n  ownership {\n    userId\n    projectId\n    creatorId\n    user {\n      basicInfo {\n        email\n      }\n      id\n    }\n    project {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  ...VFolderPermissionCellV2Fragment\n  ...useVirtualFolderNodePathV2Fragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n\nfragment VFolderPermissionCellV2Fragment on VFolder {\n  accessControl {\n    permission\n  }\n}\n\nfragment useVirtualFolderNodePathV2Fragment on VFolder {\n  id\n  metadata {\n    quotaScopeId\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "61e4efe56e6e90cc4772aab3c2c781b2";
+(node as any).hash = "8253d461f04ed9f3f47e26f5753e89fa";
 
 export default node;

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -193,6 +193,9 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
           unmanagedPath
           host
           id
+          accessControl {
+            permission
+          }
           metadata {
             name
           }
@@ -298,27 +301,24 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
     unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
     'download-file',
   );
-  // `upload-file` on the storage host gates the actual upload pipeline:
-  // upload buttons (file/folder), drag-drop, and the in-app text editor save
-  // (which overwrites the file via the upload API). mkdir / create-file /
-  // rename are kept enabled — there is no corresponding host-level
-  // capability for them today, and FR-2619 will revisit the effective
-  // permission set.
-  const hasUploadContentPermission = _.includes(
+  const hasUploadHostPermission = _.includes(
     unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
     'upload-file',
   );
-  // TODO(needs-backend): write/delete capability should be derived from the
-  // caller's *effective* permission set on this entity (e.g.,
-  // `delete_content`, `write_content`), not from the folder's mount
-  // permission. The V2 schema currently exposes only the mount permission via
-  // `accessControl.permission` (`READ_ONLY` / `READ_WRITE` / `RW_DELETE`),
-  // which is what the folder is mounted *as* into a session — not what the
-  // caller is allowed to do on the folder itself. Until the backend exposes a
-  // proper effective permission set, allow all callers and let the server
-  // enforce authorization. See FR-2619 follow-up.
-  const hasDeleteContentPermission = true;
-  const hasWriteContentPermission = true;
+  // TODO(needs-backend): `accessControl.permission` is the folder's *mount*
+  // permission, the closest thing V2 exposes to an effective permission set
+  // (legacy `vfolder_node.permissions` had `write_content` / `delete_content`).
+  // Swap this for the real set once the backend ships it — FR-2619 follow-up.
+  // Allow-list rather than `!== 'READ_ONLY'` so an unknown future enum value
+  // fails closed instead of granting write.
+  const folderPermission = vfolderNode?.accessControl?.permission;
+  const hasWriteContentPermission =
+    folderPermission === 'READ_WRITE' || folderPermission === 'RW_DELETE';
+  const hasDeleteContentPermission = folderPermission === 'RW_DELETE';
+  // Upload and the in-app editor save both go through the upload API, so they
+  // need the storage host capability *and* write on the folder itself.
+  const hasUploadContentPermission =
+    hasUploadHostPermission && hasWriteContentPermission;
   // TODO: Skip permission check due to inaccurate API response. Update when API is fixed.
   const hasNoPermissions = false;
 


### PR DESCRIPTION
Resolves #9299 (FR-3800)

## Problem

A folder shared **read-only** still let the recipient rename, create, delete, upload and edit files from the Folder Explorer.

`FolderExplorerModalV2` hardcoded both capabilities:

```ts
const hasDeleteContentPermission = true;
const hasWriteContentPermission = true;
```

Upload and the in-app editor *were* gated — but on the storage **host** capability `upload-file` from `allowed_vfolder_hosts`, which is a different permission axis and says nothing about how the folder was shared. Three axes exist; the explorer consulted only the first:

| Axis | Source | Before |
|---|---|---|
| Storage host capability | `allowed_vfolder_hosts` in the resource policy | upload/edit only |
| Folder share permission (`ro`/`rw`/`wd`) | `vfolderV2.accessControl.permission` | **not queried** |
| Effective content permission | legacy `vfolder_node.permissions` | **absent from V2 schema** |

This is a regression from the V2 migration (FR-2619). The pre-migration `FolderExplorerModal.tsx` — now dead code, no longer imported — derived both flags from `vfolder_node.permissions` (`write_content` / `delete_content`). V2 dropped that field with nothing equivalent, so the code allowed everything and deferred to server-side authorization. The customer report shows the write actually landing, so that deferral was not holding.

Reported by a customer (KNUT) on **WebUI 26.4.9**; still reproducible on **v26.4.10** and `main`.

## Fix

Query `accessControl { permission }` and derive the gates from it:

```ts
const folderPermission = vfolderNode?.accessControl?.permission;
const hasWriteContentPermission =
  folderPermission === 'READ_WRITE' || folderPermission === 'RW_DELETE';
const hasDeleteContentPermission = folderPermission === 'RW_DELETE';
const hasUploadContentPermission =
  hasUploadHostPermission && hasWriteContentPermission;
```

Resulting matrix:

| Share permission | write (rename/mkdir/create) | delete | upload / editor save |
|---|---|---|---|
| `READ_ONLY` | ✗ | ✗ | ✗ |
| `READ_WRITE` | ✓ | ✗ | ✓ (with host `upload-file`) |
| `RW_DELETE` | ✓ | ✓ | ✓ (with host `upload-file`) |

Two deliberate choices:

- **Allow-list, not `!== 'READ_ONLY'`** — an unknown future enum value (`%future added value`) fails closed rather than silently granting write.
- **Upload/editor require host capability AND folder write** — both write through the upload API, so either axis alone is insufficient.

`accessControl.permission` is the folder's *mount* permission, not a true effective permission set, so the `TODO(needs-backend)` stays — narrowed to that one point and still pointing at the FR-2619 follow-up. It is nonetheless exactly the `ro`/`rw`/`wd` the sharer picked, so gating on it restores the pre-migration behaviour.

## Scope note — server-side enforcement is not in this PR

The customer observed the file actually being modified, so the manager accepted the write too. This PR removes the affordance; it does not close the API path. Manager-side enforcement of the read-only share permission needs to be verified separately and is called out in FR-3800.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / theme / terminology)
- `vitest run src/components/FolderExplorerModalV2.test.tsx` → 3 passed
- Relay artifact regenerated and committed (`FolderExplorerModalV2Query.graphql.ts`)
