### PR TITLE
fix(FR-3801): lift the keypair max session lifetime cap off 100 (26.8)

### DIFF
--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -490,7 +490,11 @@ const KeypairResourcePolicySettingModal: React.FC<
                   label={t('resourcePolicy.MaxSessionLifetime')}
                   style={{ margin: 0, width: '100%' }}
                 >
-                  <InputNumber min={0} max={100} style={{ width: '100%' }} />
+                  <InputNumber
+                    min={0}
+                    max={SIGNED_32BIT_MAX_INT}
+                    style={{ width: '100%' }}
+                  />
                 </FormItemWithUnlimited>
               </Col>
               {baiClient.supports('max-pending-session-count') ? (


### PR DESCRIPTION
Resolves #9300 (FR-3801)

Backport of #9301 to the **26.8** release line.

## Why a separate PR instead of a cherry-pick

#9301 targets `main`, where this input is the post-Astryx `AstryxFormNumberInput`. The 26.8 branch predates the Ant Design → Astryx migration and still renders antd's `InputNumber`, so the commit does not apply. Same one-value change, re-applied against this branch's component.

## Problem

The **Max session lifetime (sec)** input in the keypair resource policy setting modal was bounded by a hardcoded `max={100}`. The field is expressed in seconds, so the ceiling is under two minutes — and it clamps silently: an operator who sets `3600` in Control Panel loses it the moment anyone opens that policy's modal in the WebUI and saves.

Reported by a customer (KNUT) during a training session on **WebUI 26.4.9**; reproducible on **26.8.1** and on `main` (fixed there by #9301).

## Fix

```diff
- <InputNumber min={0} max={100} style={{ width: '100%' }} />
+ <InputNumber
+   min={0}
+   max={SIGNED_32BIT_MAX_INT}
+   style={{ width: '100%' }}
+ />
```

`SIGNED_32BIT_MAX_INT` is already imported in this file and is what every sibling numeric field in the same modal uses — cluster size (`max_containers_per_session`), `max_pending_session_count`, concurrency (`max_concurrent_sessions`), and `max_concurrent_sftp_sessions`. Max session lifetime was the lone outlier.

The literal came in with the original resource policy page (#2357). No product rule is attached to it.

`unlimitedValue={0}` on the wrapping `FormItemWithUnlimited` is untouched, so the "unlimited" affordance still writes `0`.

## Verification

- `bash scripts/verify.sh` on this branch → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / terminology)
- No Relay or schema change, so no regenerated artifacts.
- Manual: a policy saved with `3600` round-trips without clamping; an existing policy created above 100 in Control Panel is no longer clamped when its modal is opened and saved.
