### PR TITLE
style(FR-3667): top-align revision detail labels with their values

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIMetadataList.css
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.css
@@ -65,6 +65,12 @@
   color: var(--bai-metadata-list-label-color);
 }
 
+/* A side-label dt stretches to its grid row and Astryx centers it, so it
+   drifts off a multi-line value's first line — pin it to the top (FR-3667). */
+.bai-metadata-list > dl > dt {
+  align-items: flex-start;
+}
+
 .bai-metadata-list--bordered {
   --bai-metadata-list-cell-bg: var(--color-background-card);
   --bai-metadata-list-cell-padding-block: var(--spacing-4);

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.css
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.css
@@ -2,9 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- `BAIMetadataList` paint: a lightened item label (always), plus the `bordered`
- variant — outer frame + a 1px rule between items, on the list's own layout
- (no forced side labels, no label-column fill).
+ `BAIMetadataList` paint: a lightened item label and top-aligned side labels
+ (always), plus the `bordered` variant — outer frame + a 1px rule between
+ items, on the list's own layout (no forced side labels, no label-column
+ fill).
 
  ## Why CSS, not a theme variant
 

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.doc.ts
@@ -19,7 +19,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'The label/value list used on detail panels, info modals and drawers. It renders Astryx MetadataList and adds one thing: an opt-in `bordered` variant that restores the framed, ruled label/value table antd `Descriptions bordered` used to draw. Without `bordered` it is a pass-through — no class is added and no CSS is reached, so the output is exactly Astryx’s. With it, one class from `BAIMetadataList.css` frames the list, rules it into cells drawn as the grid gap, and puts the label column on a muted fill, entirely in design tokens. Everything else — `columns`, `title`, `orientation`, `maxNumOfItems` — is MetadataList’s own surface and passes straight through.',
+      'The label/value list used on detail panels, info modals and drawers. It renders Astryx MetadataList and adds one thing: an opt-in `bordered` variant that restores the framed, ruled label/value table antd `Descriptions bordered` used to draw. Without `bordered` the list keeps Astryx’s own layout with two always-on adjustments: the label is lightened to read quieter than its value, and side labels are top-aligned with their value’s first line (FR-3667). With it, one class from `BAIMetadataList.css` frames the list, rules it into cells drawn as the grid gap, and puts the label column on a muted fill, entirely in design tokens. Everything else — `columns`, `title`, `orientation`, `maxNumOfItems` — is MetadataList’s own surface and passes straight through.',
     bestPractices: [
       {
         guidance: true,

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
@@ -24,7 +24,9 @@ Independently of \`bordered\`, the wrapper lightens the item label so it reads
 quieter than its value — the base class is always applied, so this is the
 default for every list, \`bordered\` or not. The tone is the lightest mix off
 \`--color-text-secondary\` that still clears WCAG AA in both themes; override
-\`--bai-metadata-list-label-color\` to retune it.
+\`--bai-metadata-list-label-color\` to retune it. Side labels are also
+top-aligned with their value's first line, so a multi-line value doesn't
+leave the label floating mid-row (FR-3667).
 
 The paint is two classes, declarations in \`BAIMetadataList.css\`, entirely in
 design tokens.

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.stories.tsx
@@ -28,8 +28,7 @@ default for every list, \`bordered\` or not. The tone is the lightest mix off
 top-aligned with their value's first line, so a multi-line value doesn't
 leave the label floating mid-row (FR-3667).
 
-The paint is two classes, declarations in \`BAIMetadataList.css\`, entirely in
-design tokens.
+The paint lives in \`BAIMetadataList.css\`, entirely in design tokens.
 
 ## Props
 

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
@@ -14,9 +14,9 @@
  Astryx's `--color-text-secondary` so it reads quieter than its value, and
  top-aligns side labels with their value's first line (FR-3667).
 
- The paint is one class; declarations live in `BAIMetadataList.css`, entirely
- in design tokens. See that file's header for why it is CSS and how the rules
- are drawn as the grid gap.
+ The paint lives in `BAIMetadataList.css`, entirely in design tokens. See
+ that file's header for why it is CSS and how the rules are drawn as the
+ grid gap.
 */
 import './BAIMetadataList.css';
 import {

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
@@ -11,8 +11,8 @@
  already has.
 
  Independently of `bordered`, the wrapper lightens the item label one step off
- Astryx's `--color-text-secondary` so it reads quieter than its value; nothing
- about the layout changes.
+ Astryx's `--color-text-secondary` so it reads quieter than its value, and
+ top-aligns side labels with their value's first line (FR-3667).
 
  The paint is one class; declarations live in `BAIMetadataList.css`, entirely
  in design tokens. See that file's header for why it is CSS and how the rules


### PR DESCRIPTION
Resolves FR-3667 — the Jira→GitHub webhook has not cloned this issue yet (no GitHub issue exists for FR-3667 at PR creation time); the `Resolves #N (FR-3667)` line will be added once the clone appears.

## What

On the Model Deployment revision detail (both the "Current revision" tab and the "Revision detail" drawer), labels drifted to the vertical middle of their row whenever the paired value — or the neighbouring column's value in the same grid row — wrapped to multiple lines, while values stayed top-aligned. The issue's screenshot shows exactly this on the drawer (추가 마운트 / 이미지 / 런타임 / 클러스터 모드 rows).

## Mechanism

`BAIMetadataList` side labels (`label.position: 'start'`) render as `dt` cells that are **direct grid children** of the `<dl>`, so each `dt` stretches to its grid row's height. Astryx's `astryx-metadata-list-item` styles the `dt` as `display: flex; align-items: center` — correct for the 24px single-line cell, but in a stretched multi-line row it centers the label while the `dd` value flows from the top. Astryx `MetadataList` exposes no prop for this (checked via `astryx component MetadataList`), and a theme `metadata-list-item.base` override cannot scope to side-label `dt`s only, so the fix lives in `BAIMetadataList.css` next to the existing label-tone override:

```css
.bai-metadata-list > dl > dt {
  align-items: flex-start;
}
```

Scoped to direct grid children — stacked labels (`position: 'top'`) sit inside an item wrapper, don't stretch, and are unaffected. Because the fix is in the shared BUI wrapper, every side-label `BAIMetadataList` in the app (30+ call sites: session detail, user/keypair modals, role drawer, …) gets the same correction, not just the revision detail.

## Measured before/after

Measured on the deployment detail page, `생성일` row (row height 48px, paired with the two-line `자원 할당` value), label text top vs value first-line top:

| Mode | Before | After |
|---|---|---|
| Light (`data-theme="light"` asserted) | label +13px below value first line (centered in 48px row) | Δ 0px (189 / 189) |
| Dark (`data-theme="dark"` asserted) | label +13px below value first line | Δ 0px (789 / 789) |

All 20+ rows of the revision detail re-measured after the fix: every label/value pair Δ 0px on text tops (component-box rows like resource chips read −3px box-vs-text, visually on-line). The revision detail **drawer** (the surface in the issue's screenshot) verified live as well — 이미지 (3-line value) and 실행 명령어 (code block) rows top-aligned in both modes.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → ✓ built (BUI source changed)
- `pnpm --prefix ./react exec vitest run` → 103 files, 1634 tests passed
- `pnpm --filter backend.ai-ui exec vitest run` → 72 files passed / 1 skipped, 1928 tests passed / 1 skipped
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exit 1 with 3 undeclared-var findings (`BAIDialog.css`, `BAIDrawerPortal.css`, `BAIText.css`) — **pre-existing on `main`**, confirmed by stashing this change and re-running (same exit/findings); this PR adds no `var()` usage.
- Live probe: zero new page errors in light and dark passes. The console shows pre-existing `RelayResponseNormalizer` warnings (server returns the same id for `Group`/`UserGroup`) and a pre-existing nested-`<button>` warning in the revision history table header — both reproduce on `main`, unrelated to this CSS change.

## Residue

- Labels top-align against a value whose first line is a taller component (24px chips/badges) with the component's internal centering — a ≤2px optical offset, same convention as antd Descriptions; not worth per-row compensation.
- The token-gate and console findings above are pre-existing and untouched.
- Arguably an Astryx `MetadataList` defect (centered side label in a stretched grid row); the BUI override closes it app-wide, but it could be reported upstream separately.

## Screenshots

Deployment detail → 현재 리비전 tab (the drawer shares the same component and was verified live as well). Note the 생성일 / 모델 폴더 / 모델 경로 / 실행 명령어 labels floating mid-row in the before shots.

### Light

| Before | After |
|--------|-------|
| ![before-light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9314/20260831-144149-fr3667-before-light.jpg) | ![after-light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9314/20260831-144149-fr3667-after-light.jpg) |

### Dark

| Before | After |
|--------|-------|
| ![before-dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9314/20260831-144149-fr3667-before-dark.jpg) | ![after-dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9314/20260831-144149-fr3667-after-dark.jpg) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
