### PR TITLE
fix(FR-3800): gate Folder Explorer write/delete on the legacy per-user permission set

### DIFF
--- a/react/src/__generated__/FolderExplorerModalV2Query.graphql.ts
+++ b/react/src/__generated__/FolderExplorerModalV2Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4cdc1fafd49e59bd654336f967435926>>
+ * @generated SignedSource<<dbdd474fca2d7d71fa5e39d501e265f9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,9 +11,14 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type FolderExplorerModalV2Query$variables = {
+  vfolderGlobalId: string;
   vfolderId: string;
 };
 export type FolderExplorerModalV2Query$data = {
+  readonly legacyVFolderNode: {
+    readonly id: string;
+    readonly permissions: ReadonlyArray<any | null | undefined> | null | undefined;
+  } | null | undefined;
   readonly vfolderNode: {
     readonly host: string;
     readonly id: string;
@@ -38,86 +43,118 @@ export type FolderExplorerModalV2Query = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "vfolderId"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
-    "name": "vfolderId",
-    "variableName": "vfolderId"
-  }
-],
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "vfolderGlobalId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "vfolderId"
+},
 v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "unmanagedPath",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "host",
-  "storageKey": null
-},
-v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
+v3 = {
+  "alias": "legacyVFolderNode",
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "id",
+      "variableName": "vfolderGlobalId"
+    }
+  ],
+  "concreteType": "VirtualFolderNode",
+  "kind": "LinkedField",
+  "name": "vfolder_node",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "permissions",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "vfolderId",
+    "variableName": "vfolderId"
+  }
+],
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "unmanagedPath",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "host",
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = [
-  (v5/*: any*/)
+v8 = [
+  (v7/*: any*/)
 ],
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "projectId",
   "storageKey": null
 },
-v8 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "ProjectBasicInfo",
   "kind": "LinkedField",
   "name": "basicInfo",
   "plural": false,
-  "selections": (v6/*: any*/),
+  "selections": (v8/*: any*/),
   "storageKey": null
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "FolderExplorerModalV2Query",
     "selections": [
+      (v3/*: any*/),
       {
         "alias": "vfolderNode",
-        "args": (v1/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "VFolder",
         "kind": "LinkedField",
         "name": "vfolderV2",
         "plural": false,
         "selections": [
+          (v5/*: any*/),
+          (v6/*: any*/),
           (v2/*: any*/),
-          (v3/*: any*/),
-          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -125,7 +162,7 @@ return {
             "kind": "LinkedField",
             "name": "metadata",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v8/*: any*/),
             "storageKey": null
           },
           {
@@ -136,7 +173,7 @@ return {
             "name": "ownership",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -145,7 +182,7 @@ return {
                 "name": "project",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/)
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -171,21 +208,25 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "FolderExplorerModalV2Query",
     "selections": [
+      (v3/*: any*/),
       {
         "alias": "vfolderNode",
-        "args": (v1/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "VFolder",
         "kind": "LinkedField",
         "name": "vfolderV2",
         "plural": false,
         "selections": [
+          (v5/*: any*/),
+          (v6/*: any*/),
           (v2/*: any*/),
-          (v3/*: any*/),
-          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -194,7 +235,7 @@ return {
             "name": "metadata",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -234,7 +275,7 @@ return {
             "name": "ownership",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -243,8 +284,8 @@ return {
                 "name": "project",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/),
-                  (v4/*: any*/)
+                  (v10/*: any*/),
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -288,7 +329,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v4/*: any*/)
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -333,16 +374,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1262a01b36f437256e32ded119856058",
+    "cacheID": "e7134f4471e1cdd49d215c89f9807dae",
     "id": null,
     "metadata": {},
     "name": "FolderExplorerModalV2Query",
     "operationKind": "query",
-    "text": "query FolderExplorerModalV2Query(\n  $vfolderId: UUID!\n) {\n  vfolderNode: vfolderV2(vfolderId: $vfolderId) {\n    unmanagedPath\n    host\n    id\n    metadata {\n      name\n    }\n    ownership {\n      projectId\n      project {\n        basicInfo {\n          name\n        }\n        id\n      }\n    }\n    ...FolderExplorerHeaderV2Fragment\n    ...VFolderNodeDescriptionV2Fragment\n  }\n}\n\nfragment EditableVFolderNameV2Fragment on VFolder {\n  id\n  status\n  metadata {\n    name\n  }\n  ownership {\n    userId\n    projectId\n  }\n}\n\nfragment FileBrowserButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment FolderExplorerHeaderV2Fragment on VFolder {\n  id\n  unmanagedPath\n  ...VFolderNodeIdenticonV2Fragment\n  ...EditableVFolderNameV2Fragment\n  ...FileBrowserButtonV2Fragment\n  ...SFTPServerButtonV2Fragment\n}\n\nfragment SFTPServerButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment VFolderNodeDescriptionV2Fragment on VFolder {\n  id\n  host\n  status\n  unmanagedPath\n  metadata {\n    name\n    usageMode\n    cloneable\n    createdAt\n  }\n  accessControl {\n    permission\n    ownershipType\n  }\n  ownership {\n    userId\n    projectId\n    creatorId\n    user {\n      basicInfo {\n        email\n      }\n      id\n    }\n    project {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  ...VFolderPermissionCellV2Fragment\n  ...useVirtualFolderNodePathV2Fragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n\nfragment VFolderPermissionCellV2Fragment on VFolder {\n  accessControl {\n    permission\n  }\n}\n\nfragment useVirtualFolderNodePathV2Fragment on VFolder {\n  id\n  metadata {\n    quotaScopeId\n  }\n}\n"
+    "text": "query FolderExplorerModalV2Query(\n  $vfolderId: UUID!\n  $vfolderGlobalId: String!\n) {\n  legacyVFolderNode: vfolder_node(id: $vfolderGlobalId) {\n    id\n    permissions\n  }\n  vfolderNode: vfolderV2(vfolderId: $vfolderId) {\n    unmanagedPath\n    host\n    id\n    metadata {\n      name\n    }\n    ownership {\n      projectId\n      project {\n        basicInfo {\n          name\n        }\n        id\n      }\n    }\n    ...FolderExplorerHeaderV2Fragment\n    ...VFolderNodeDescriptionV2Fragment\n  }\n}\n\nfragment EditableVFolderNameV2Fragment on VFolder {\n  id\n  status\n  metadata {\n    name\n  }\n  ownership {\n    userId\n    projectId\n  }\n}\n\nfragment FileBrowserButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment FolderExplorerHeaderV2Fragment on VFolder {\n  id\n  unmanagedPath\n  ...VFolderNodeIdenticonV2Fragment\n  ...EditableVFolderNameV2Fragment\n  ...FileBrowserButtonV2Fragment\n  ...SFTPServerButtonV2Fragment\n}\n\nfragment SFTPServerButtonV2Fragment on VFolder {\n  id\n  host\n}\n\nfragment VFolderNodeDescriptionV2Fragment on VFolder {\n  id\n  host\n  status\n  unmanagedPath\n  metadata {\n    name\n    usageMode\n    cloneable\n    createdAt\n  }\n  accessControl {\n    permission\n    ownershipType\n  }\n  ownership {\n    userId\n    projectId\n    creatorId\n    user {\n      basicInfo {\n        email\n      }\n      id\n    }\n    project {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  ...VFolderPermissionCellV2Fragment\n  ...useVirtualFolderNodePathV2Fragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n\nfragment VFolderPermissionCellV2Fragment on VFolder {\n  accessControl {\n    permission\n  }\n}\n\nfragment useVirtualFolderNodePathV2Fragment on VFolder {\n  id\n  metadata {\n    quotaScopeId\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "61e4efe56e6e90cc4772aab3c2c781b2";
+(node as any).hash = "3adbf5633fb4b71397777ccec0472a04";
 
 export default node;

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -49,6 +49,7 @@ import {
   BAIModal,
   type BAIModalProps,
   BAIUnmountAfterClose,
+  toGlobalId,
   useFetchKey,
   useInterval,
   VFolderFile,
@@ -186,36 +187,52 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
   // dashed form via the shared `formatToUUID` helper.
   const vfolderUuid =
     vfolderID.length === 32 ? formatToUUID(vfolderID) : vfolderID;
-  const { vfolderNode } = useLazyLoadQuery<FolderExplorerModalV2Query>(
-    graphql`
-      query FolderExplorerModalV2Query($vfolderId: UUID!) {
-        vfolderNode: vfolderV2(vfolderId: $vfolderId) {
-          unmanagedPath
-          host
-          id
-          metadata {
-            name
+  const { vfolderNode, legacyVFolderNode } =
+    useLazyLoadQuery<FolderExplorerModalV2Query>(
+      graphql`
+        query FolderExplorerModalV2Query(
+          $vfolderId: UUID!
+          $vfolderGlobalId: String!
+        ) {
+          # TODO(needs-backend): stopgap for FR-3800 — vfolderV2 exposes only
+          # the mount permission (accessControl.permission), not the caller's
+          # effective permission set, so write/delete gating reads the legacy
+          # per-user RBAC list here. Replace with the V2 field once the
+          # backend adds it (FR-2619 follow-up).
+          legacyVFolderNode: vfolder_node(id: $vfolderGlobalId) {
+            id
+            permissions
           }
-          ownership {
-            projectId
-            project {
-              basicInfo {
-                name
+          vfolderNode: vfolderV2(vfolderId: $vfolderId) {
+            unmanagedPath
+            host
+            id
+            metadata {
+              name
+            }
+            ownership {
+              projectId
+              project {
+                basicInfo {
+                  name
+                }
               }
             }
+            ...FolderExplorerHeaderV2Fragment
+            ...VFolderNodeDescriptionV2Fragment
           }
-          ...FolderExplorerHeaderV2Fragment
-          ...VFolderNodeDescriptionV2Fragment
         }
-      }
-    `,
-    { vfolderId: vfolderUuid },
-    {
-      // Only fetch when both deferredOpen and modalProps.open are true to prevent unnecessary requests during React transitions
-      fetchPolicy:
-        deferredOpen && modalProps.open ? 'store-and-network' : 'store-only',
-    },
-  );
+      `,
+      {
+        vfolderId: vfolderUuid,
+        vfolderGlobalId: toGlobalId('VirtualFolderNode', vfolderID),
+      },
+      {
+        // Only fetch when both deferredOpen and modalProps.open are true to prevent unnecessary requests during React transitions
+        fetchPolicy:
+          deferredOpen && modalProps.open ? 'store-and-network' : 'store-only',
+      },
+    );
 
   // Permission calculation follows the folder's own ownership project when
   // the folder is project-owned (what the user can do must not depend on the
@@ -300,25 +317,25 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
   );
   // `upload-file` on the storage host gates the actual upload pipeline:
   // upload buttons (file/folder), drag-drop, and the in-app text editor save
-  // (which overwrites the file via the upload API). mkdir / create-file /
-  // rename are kept enabled — there is no corresponding host-level
-  // capability for them today, and FR-2619 will revisit the effective
-  // permission set.
-  const hasUploadContentPermission = _.includes(
+  // (which overwrites the file via the upload API).
+  const hasUploadHostPermission = _.includes(
     unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
     'upload-file',
   );
-  // TODO(needs-backend): write/delete capability should be derived from the
-  // caller's *effective* permission set on this entity (e.g.,
-  // `delete_content`, `write_content`), not from the folder's mount
-  // permission. The V2 schema currently exposes only the mount permission via
-  // `accessControl.permission` (`READ_ONLY` / `READ_WRITE` / `RW_DELETE`),
-  // which is what the folder is mounted *as* into a session — not what the
-  // caller is allowed to do on the folder itself. Until the backend exposes a
-  // proper effective permission set, allow all callers and let the server
-  // enforce authorization. See FR-2619 follow-up.
-  const hasDeleteContentPermission = true;
-  const hasWriteContentPermission = true;
+  // Share-permission gating (FR-3800) reads the legacy per-user RBAC list —
+  // see the TODO(needs-backend) on the query above.
+  const hasDeleteContentPermission = _.includes(
+    legacyVFolderNode?.permissions,
+    'delete_content',
+  );
+  const hasWriteContentPermission = _.includes(
+    legacyVFolderNode?.permissions,
+    'write_content',
+  );
+  // Upload/editor write through the upload API: both the host capability and
+  // the folder-level write permission are required.
+  const hasUploadContentPermission =
+    hasUploadHostPermission && hasWriteContentPermission;
   // TODO: Skip permission check due to inaccurate API response. Update when API is fixed.
   const hasNoPermissions = false;
 


### PR DESCRIPTION
Resolves #9299 (FR-3800)

## Problem

A folder shared **read-only** still let the recipient rename, create, delete, upload and edit files from the Folder Explorer. `FolderExplorerModalV2` hardcoded:

```ts
const hasDeleteContentPermission = true;
const hasWriteContentPermission = true;
```

## Fix

Keep the V2 modal, but fetch the **legacy `vfolder_node.permissions`** (the per-user RBAC evaluation the pre-FR-2619 modal used) in the same lazy-load query, and derive the gates from it:

```graphql
# TODO(needs-backend): stopgap for FR-3800 — vfolderV2 exposes only
# the mount permission (accessControl.permission), not the caller's
# effective permission set, so write/delete gating reads the legacy
# per-user RBAC list here. Replace with the V2 field once the
# backend adds it (FR-2619 follow-up).
legacyVFolderNode: vfolder_node(id: $vfolderGlobalId) {
  id
  permissions
}
```

```ts
const hasDeleteContentPermission = _.includes(legacyVFolderNode?.permissions, 'delete_content');
const hasWriteContentPermission = _.includes(legacyVFolderNode?.permissions, 'write_content');
const hasUploadContentPermission = hasUploadHostPermission && hasWriteContentPermission;
```

Upload / editor save now require the storage-host `upload-file` capability **and** folder-level write — both write through the upload API. All V2-only features (audit-log tab, ADR-0001 project-context handling, layout fixes) are untouched.

## How to review

A read-only share is already prepared on the team test backend (`http://10.82.0.130:8090`): the folder **`backend.ai-webui`**, owned by `admin@lablup.com`, is shared **read-only (R)** with the standard e2e **user** account (`user@lablup.com` — see `e2e/utils/test-util.ts` seed accounts).

1. Run this branch (`pnpm run dev`) and log in as the **user** account against `http://10.82.0.130:8090`.
2. Data page → the `backend.ai-webui` folder shows **Read only (R)** in the mount-permission column. Open it in the Folder Explorer.
3. **Expected with this PR:** upload (file/folder), create folder/file, per-file rename and delete, bulk delete, drag-and-drop upload, and editor save are all **disabled**.
   **On `main`:** the same actions are enabled and actually succeed — the customer-reported bug.
4. Positive cross-check: open one of the user's **own** folders — every action stays enabled (owner permission).

Note on `rw` shares: the manager's RBAC map (`models/vfolder/row.py`, `LEGACY_PERMISSION_TO_RBAC_PERMISSION_MAP`) grants `delete_content` at `rw` as well — `rw` vs `wd` differ in *mount* capability, not content actions. So an `rw`-shared folder correctly shows both write **and** delete enabled; only `ro` locks the explorer. The UI mirrors exactly what the manager enforces.

## Why the legacy field, not `vfolderV2.accessControl.permission`

Verified against the manager source (`lablup/backend.ai` @ `46de869e57`):

- **`vfolderV2.accessControl.permission` is not a per-viewer value.** The resolver path (`api/gql/vfolder_v2/resolver/query.py:78` → `repositories/vfolder/repository.py:221-231`, `:1175-1202`) copies the **`vfolders.permission` column verbatim** — the owner's default mount permission, marked `# legacy` in the model and defaulting to `'rw'`. The recipient's `vfolder_permissions` share row is used **only as a visibility filter** (`models/vfolder/scopes.py:69-87`), never as a value. Two different users querying the same folder get the identical enum.
- Consequence: for a folder shared **read-only**, the recipient sees `READ_WRITE` (or `RW_DELETE`) — so gating on `accessControl.permission` (the approach in #9304) **cannot fix the customer scenario**. It also *over*-blocks: an owner whose folder column is `'rw'` (the default) would lose the delete affordance on their own folder.
- **Legacy `vfolder_node.permissions` is a genuine per-user RBAC evaluation** (`api/gql_legacy/vfolder.py:281-315` → `get_permission_ctx` → `VFolderPermissionContextBuilder`, `models/vfolder/row.py:1363-1388`). For a non-admin recipient the share row **overrides** the scope-derived set (`row.py:1210-1249`), so a read-only share yields exactly `["read_attribute", "read_content", "mount_ro"]` — no `write_content` / `delete_content`. (Admin recipients get a superset by design.)

The V2 schema exposes no per-viewer permission set at all today, so the extra legacy fetch is the only correct source; the `TODO(needs-backend)` on the query records the switch-over plan.

## Relation to #9304

#9304 gates the V2 modal on `accessControl.permission`. Per the manager-source findings above, that field cannot distinguish a read-only share from the owner's own view, so the read-only-share scenario in the customer report would remain broken (and owners of `'rw'` folders would lose delete). Happy to consolidate however the team prefers.

## Scope note — server-side enforcement is not in this PR

The customer observed the file actually being modified, so the manager accepted the write too. This PR restores the correct UI affordances; manager-side enforcement of the read-only share permission needs separate verification (called out in FR-3800).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / theme / terminology)
- `vitest run src/components/FolderExplorerModalV2.test.tsx` → 3 passed
- Relay artifact regenerated and committed (`FolderExplorerModalV2Query.graphql.ts`)
- Manual matrix: `ro` share → write/delete/upload/edit disabled; `rw` / `wd` share → write and delete enabled (matches the manager's RBAC map — see "How to review"); owner → all enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkB2dJUVmnSiaHb2vQw95F
