### PR TITLE
chore(FR-3803): publish backend.ai-agent-cli to npm at 0.1.0 with its own release tag

### DIFF
--- a/.github/workflows/publish-backend.ai-agent-cli.yml
+++ b/.github/workflows/publish-backend.ai-agent-cli.yml
@@ -1,0 +1,68 @@
+name: Publish backend.ai-agent-cli to npm registry
+
+# The CLI is versioned on its own (0.x in packages/backend.ai-agent-cli), not on
+# the WebUI's `v*` release tags: a WebUI release must not republish the same
+# CLI version (npm would refuse it and the run would go red). A push to main
+# that touches the package publishes a canary; a tag `agent-cli-v<version>`
+# publishes that version, which must equal package.json's.
+
+on:
+  push:
+    paths:
+      - packages/backend.ai-agent-cli/**
+    branches:
+      - main
+    tags:
+      - agent-cli-v*
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          registry-url: "https://registry.npmjs.org"
+      - name: Update npm
+        # Pinned. pnpm publish delegates to the npm CLI; OIDC trusted
+        # publishing needs npm >= 11.5.1.
+        run: npm install -g npm@11.16.0
+
+      - name: Update to canary version
+        if: github.ref_type == 'branch'
+        run: |
+          cd packages/backend.ai-agent-cli
+          ./scripts/update-canary-version.sh
+
+      # `prepublishOnly` runs lint, test and build; the tests read the checkout
+      # data (SDL, i18n, manual), which is why this runs from the full checkout.
+      - name: Publish to npm (canary)
+        if: github.ref_type == 'branch'
+        run: |
+          cd packages/backend.ai-agent-cli
+          pnpm publish --tag canary --access public --no-git-checks
+
+      - name: Determine npm tag and publish strategy
+        if: github.ref_type == 'tag'
+        id: determine-tag
+        run: |
+          cd packages/backend.ai-agent-cli
+          # refs/tags/agent-cli-v0.1.0 -> 0.1.0
+          VERSION="${GITHUB_REF#refs/tags/agent-cli-v}"
+          # Captured first so a non-zero exit (tag ≠ package.json) fails the step.
+          SCRIPT_OUTPUT=$(./scripts/determine-publish-strategy.sh "$VERSION")
+          echo "$SCRIPT_OUTPUT" | while IFS='=' read -r key value; do
+            if [ -n "$key" ]; then
+              echo "${key}=${value}" >> "$GITHUB_OUTPUT"
+            fi
+          done
+
+      - name: Publish to npm
+        if: github.ref_type == 'tag' && steps.determine-tag.outputs.should_publish == 'true'
+        run: |
+          cd packages/backend.ai-agent-cli
+          pnpm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -44,6 +44,17 @@ merge, then `git tag agent-cli-v0.1.0 && git push origin agent-cli-v0.1.0`.
 The WebUI's `v*` tags deliberately do not publish the CLI — they would republish
 the same version on every WebUI release.
 
+**First publish is a one-time bootstrap.** The workflow authenticates with npm
+trusted publishing (OIDC, `id-token: write`, no token secret), which is
+configured on the package's settings page on npmjs.com — a page that does not
+exist until the package has been published once. Until then both triggers fail
+with `ENEEDAUTH`. Before the first tag: publish `0.1.0` by hand from a checkout
+with a granular npm token (`pnpm --filter backend.ai-agent-cli publish --access
+public`), then add this repository's `publish-backend.ai-agent-cli.yml` as a
+trusted publisher on the package page. The `backend.ai-docs-toolkit` workflow
+went red on every push to `main` until its package was bootstrapped the same
+way.
+
 ## Repo mode
 
 `bai-agent` reads the checkout live — it copies nothing and takes no workspace

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -8,6 +8,42 @@ This package is the skeleton every later command plugs into: one file per
 command under `src/commands/`, a shared output layer, and a shared repo-context
 locator. Node ≥ 22, ESM, built with tsup.
 
+## Install
+
+Inside a `backend.ai-webui` checkout the CLI runs from the workspace:
+
+```bash
+pnpm --filter backend.ai-agent-cli build   # once; the proxy runs the bundle
+pnpm run bai-agent <cmd>                   # from the repository root
+```
+
+Anywhere else, from npm:
+
+```bash
+npm install -g backend.ai-agent-cli        # or: npx backend.ai-agent-cli <cmd>
+bai-agent --help
+```
+
+The package bundles its dependencies and ships `mappings/` next to `dist/`, so
+the install has no runtime dependency beyond Node ≥ 22.
+
+### Versioning and releases
+
+The CLI is versioned on its own — `0.x` in this `package.json` — not on the
+WebUI release train, and `Makefile versiontag` leaves it alone. One workflow,
+`.github/workflows/publish-backend.ai-agent-cli.yml`, with two triggers:
+
+| Event                                       | Publishes                                       |
+| ------------------------------------------- | ----------------------------------------------- |
+| push to `main` touching this package        | `<version>-canary-<sha>-<date>` under `canary`  |
+| tag `agent-cli-v<version>`                  | `<version>` under `latest` (`-rc.N` → `rc`)     |
+
+The tag must equal the version in `package.json`, and a version already on npm
+is skipped rather than failing the run. To release: bump the version in a PR,
+merge, then `git tag agent-cli-v0.1.0 && git push origin agent-cli-v0.1.0`.
+The WebUI's `v*` tags deliberately do not publish the CLI — they would republish
+the same version on every WebUI release.
+
 ## Repo mode
 
 `bai-agent` reads the checkout live — it copies nothing and takes no workspace

--- a/packages/backend.ai-agent-cli/package.json
+++ b/packages/backend.ai-agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend.ai-agent-cli",
-  "version": "26.9.0-alpha.0",
+  "version": "0.1.0",
   "description": "bai-agent — agent-facing CLI over a Backend.AI WebUI checkout",
   "repository": {
     "type": "git",

--- a/packages/backend.ai-agent-cli/scripts/determine-publish-strategy.sh
+++ b/packages/backend.ai-agent-cli/scripts/determine-publish-strategy.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Given the version from an `agent-cli-v<version>` tag, decides whether and
+# under which npm dist-tag to publish. Prints `should_publish=` / `npm_tag=`
+# lines for GITHUB_OUTPUT; everything else goes to stderr.
+#
+# The tag must equal package.json's version: the CLI is versioned by hand in
+# the package (0.x), and a tag that disagrees with it is a mistake, not a
+# request to publish something else.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_JSON="${PACKAGE_DIR}/package.json"
+
+TAG_VERSION="$1"
+if [ -z "$TAG_VERSION" ]; then
+  echo "Usage: $0 <version>   (e.g. 0.1.0 or 0.2.0-rc.1)" >&2
+  exit 1
+fi
+
+PACKAGE_NAME=$(node -p "require('${PACKAGE_JSON}').name")
+PACKAGE_VERSION=$(node -p "require('${PACKAGE_JSON}').version")
+
+if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+  echo "Error: tag version ${TAG_VERSION} does not match ${PACKAGE_JSON} (${PACKAGE_VERSION})." >&2
+  echo "Bump the package version in a PR first, then tag agent-cli-v${PACKAGE_VERSION}." >&2
+  exit 1
+fi
+
+case "$TAG_VERSION" in
+  *-rc*)    NPM_TAG="rc" ;;
+  *-beta*)  NPM_TAG="beta" ;;
+  *-alpha*)
+    echo "Alpha version detected; skipping npm publish." >&2
+    echo "should_publish=false"
+    echo "npm_tag="
+    exit 0
+    ;;
+  *)        NPM_TAG="latest" ;;
+esac
+
+# npm refuses to republish a version; make that a skip, not a red workflow.
+if npm view "${PACKAGE_NAME}@${TAG_VERSION}" version >/dev/null 2>&1; then
+  echo "Skipping publish: ${PACKAGE_NAME}@${TAG_VERSION} is already on npm." >&2
+  echo "should_publish=false"
+  echo "npm_tag="
+  exit 0
+fi
+
+echo "Publishing ${PACKAGE_NAME}@${TAG_VERSION} under dist-tag ${NPM_TAG}." >&2
+echo "should_publish=true"
+echo "npm_tag=${NPM_TAG}"

--- a/packages/backend.ai-agent-cli/scripts/update-canary-version.sh
+++ b/packages/backend.ai-agent-cli/scripts/update-canary-version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Rewrites this package's version to a canary (`<base>-canary-<sha>-<date>`).
+# Unlike backend.ai-ui's script, the base comes from THIS package.json: the CLI
+# is versioned on its own (0.x), not on the WebUI release train.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_JSON="${PACKAGE_DIR}/package.json"
+
+COMMIT_HASH=$(git rev-parse --short=9 HEAD)
+BUILD_DATE=$(date +%Y%m%d)
+
+BASE_VERSION_FULL=$(node -p "require('${PACKAGE_JSON}').version")
+# Only the release part (0.1.0-rc.1 -> 0.1.0); the canary carries its own suffix.
+BASE_VERSION="${BASE_VERSION_FULL%%-*}"
+
+CANARY_VERSION="${BASE_VERSION}-canary-${COMMIT_HASH}-${BUILD_DATE}"
+
+echo "Updating version to ${CANARY_VERSION}"
+echo "  Base version: ${BASE_VERSION}"
+echo "  Commit hash: ${COMMIT_HASH}"
+echo "  Build date: ${BUILD_DATE}"
+
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('${PACKAGE_JSON}', 'utf8'));
+  pkg.version = '${CANARY_VERSION}';
+  fs.writeFileSync('${PACKAGE_JSON}', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+echo "Updated package.json version to ${CANARY_VERSION}"


### PR DESCRIPTION
Resolves #9317 (FR-3803)

## Why

`bai-agent` only existed inside a `backend.ai-webui` checkout: not on npm (`npm view backend.ai-agent-cli` → 404) and versioned on the WebUI's `26.9.0-alpha.0`. Installing the CLI and its Claude skill on another machine needs a published artifact with a version of its own. First of three: this PR → #9321 (`sync`) → #9322 (`init` wizard).

## What

- `packages/backend.ai-agent-cli/package.json` version → **`0.1.0`**, decoupled from the WebUI train. `Makefile versiontag` and the `bump-alpha-version` skill do not touch this package, so it stays independent.
- `.github/workflows/publish-backend.ai-agent-cli.yml`, modelled on `publish-backend.ai-ui.yml`:
  - push to `main` touching the package → `0.1.0-canary-<sha>-<date>` under the `canary` dist-tag
  - tag **`agent-cli-v<version>`** → that version under `latest` (`-rc.N` → `rc`, `-beta` → `beta`, `-alpha` skipped)
  - The WebUI's `v*` tags deliberately do **not** trigger it — they would republish the same CLI version on every WebUI release, which npm refuses and which would turn the run red.
- `scripts/update-canary-version.sh` reads the package's own version (backend.ai-ui's reads the root's).
- `scripts/determine-publish-strategy.sh` refuses a tag that disagrees with `package.json` (exit 1, so the step fails) and skips a version already on npm instead of failing.
- README: install from npm + the versioning/release procedure.

`pnpm pack --dry-run` confirms the tarball is `dist/`, `mappings/`, `README.md`, `package.json`; `node dist/cli.js version` reports `0.1.0`.

## Verification

- `pnpm --filter backend.ai-agent-cli lint` / `test`: 409 passed
- `scripts/verify.sh`: see the stack's top PR (#9322) — run once on the full stack

## Review follow-up (self `/code-review`, before Copilot)

- **First publish needs a bootstrap.** The workflow uses npm trusted publishing (OIDC), which is configured on a package page that only exists after a first publish — until then both triggers fail with `ENEEDAUTH` (the `backend.ai-docs-toolkit` workflow was red for months for this reason). Documented in the README: publish `0.1.0` by hand once with a granular token, then register this workflow as the trusted publisher. **This is a human step before/around merging** — merging this PR alone will produce one red canary run on `main` until the package exists.
- Not applied (out of scope, noted for a follow-up): the three publish workflows + canary/strategy scripts are copy-paste siblings; a `workflow_call` reusable workflow parameterised by package dir / tag prefix / version source would collapse them.
