### PR TITLE
fix(FR-3807): use the stored session before the checkout config.toml, and keep doctor offline without one

### DIFF
--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -43,7 +43,7 @@ WebUI release train, and `Makefile versiontag` leaves it alone. One workflow,
 
 The tag must equal the version in `package.json`, and a version already on npm
 is skipped rather than failing the run. To release: bump the version in a PR,
-merge, then `git tag agent-cli-v0.1.0 && git push origin agent-cli-v0.1.0`.
+merge, then `git tag agent-cli-v<version> && git push origin agent-cli-v<version>` (the tag must equal `package.json`'s version).
 The WebUI's `v*` tags deliberately do not publish the CLI — they would republish
 the same version on every WebUI release.
 

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -565,10 +565,11 @@ re-authenticates on its own.
 
 ### Endpoint resolution
 
-`--endpoint` wins; otherwise `[general] apiEndpoint` from the checkout's own
-`config.toml` (a per-place setting beats machine-wide state); otherwise the
-`endpoint` recorded in [`config.json`](#configjson); otherwise the single
-stored session. Two or more stored sessions is an error, not a guess.
+`--endpoint` wins; otherwise the single stored session (the one you can
+actually query); otherwise `[general] apiEndpoint` from the checkout's own
+`config.toml`; otherwise the `endpoint` recorded in
+[`config.json`](#configjson). Two or more stored sessions is an error, not a
+guess.
 
 ## Query
 

--- a/packages/backend.ai-agent-cli/package.json
+++ b/packages/backend.ai-agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend.ai-agent-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "bai-agent — agent-facing CLI over a Backend.AI WebUI checkout",
   "repository": {
     "type": "git",

--- a/packages/backend.ai-agent-cli/src/commands/doctor.ts
+++ b/packages/backend.ai-agent-cli/src/commands/doctor.ts
@@ -593,10 +593,13 @@ const alignmentGroup: CheckGroup = {
     // `/func/` is public, so the endpoint alone is enough to compare even
     // before anyone has logged in — the same endpoint `resolveEndpoint`
     // gives every other command, never a second precedence.
+    // A session-less probe only for an endpoint `init` recorded on purpose:
+    // a checkout's config.toml alone must not make `doctor` touch the network.
     let recorded: string | undefined;
     if (!session) {
       try {
-        recorded = resolveEndpoint({ cwd }).endpoint;
+        const resolved = resolveEndpoint({ cwd });
+        recorded = resolved.source === 'config' ? resolved.endpoint : undefined;
       } catch {
         recorded = undefined;
       }

--- a/packages/backend.ai-agent-cli/src/commands/login.ts
+++ b/packages/backend.ai-agent-cli/src/commands/login.ts
@@ -276,7 +276,7 @@ export const loginCommand = defineCommand<LoginData>({
     {
       flag: '--endpoint <url>',
       description:
-        'Manager URL. Defaults to the checkout config.toml apiEndpoint, then the endpoint init recorded, then the only stored session.',
+        'Manager URL. Defaults to the only stored session, then the checkout config.toml apiEndpoint, then the endpoint init recorded.',
       type: 'string',
     },
     {

--- a/packages/backend.ai-agent-cli/src/commands/whoami.ts
+++ b/packages/backend.ai-agent-cli/src/commands/whoami.ts
@@ -35,7 +35,7 @@ export interface WhoamiData extends WhoAmI {
 export const ENDPOINT_FLAG = {
   flag: '--endpoint <url>',
   description:
-    'Manager URL. Defaults to the checkout config.toml apiEndpoint, then the endpoint init recorded, then the only stored session.',
+    'Manager URL. Defaults to the only stored session, then the checkout config.toml apiEndpoint, then the endpoint init recorded.',
   type: 'string',
 } as const;
 

--- a/packages/backend.ai-agent-cli/src/session.test.ts
+++ b/packages/backend.ai-agent-cli/src/session.test.ts
@@ -154,6 +154,24 @@ describe('readApiEndpointFromToml', () => {
   });
 });
 
+/** A checkout root carrying a config.toml — what a developer machine has. */
+function fakeCheckoutWithToml(apiEndpoint: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'bai-agent-toml-'));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'backend.ai-webui', version: '0.0.0-test' }),
+  );
+  mkdirSync(join(root, 'data'), { recursive: true });
+  writeFileSync(join(root, 'data/schema.graphql'), '');
+  mkdirSync(join(root, 'resources/i18n'), { recursive: true });
+  mkdirSync(join(root, 'packages/backend.ai-webui-docs'), { recursive: true });
+  writeFileSync(
+    join(root, 'config.toml'),
+    `[general]\napiEndpoint = "${apiEndpoint}"\n`,
+  );
+  return root;
+}
+
 describe('resolveEndpoint', () => {
   it('prefers the flag', () => {
     saveSession(sample(), env);
@@ -180,40 +198,29 @@ describe('resolveEndpoint', () => {
     expect(() => resolveEndpoint({ cwd: '', env })).toThrow(/--endpoint/);
   });
 
-  it('prefers the recorded config.json endpoint over a stored session', () => {
-    saveSession(sample(), env);
-    updateConfig({ endpoint: 'https://config.example.com/' }, env);
-    expect(resolveEndpoint({ cwd: '', env })).toEqual({
-      endpoint: 'https://config.example.com',
-      source: 'config',
-    });
-  });
-
-  it("prefers the checkout's config.toml over everything but the flag", () => {
-    const root = mkdtempSync(join(tmpdir(), 'bai-agent-toml-'));
-    writeFileSync(
-      join(root, 'package.json'),
-      JSON.stringify({ name: 'backend.ai-webui', version: '0.0.0-test' }),
-    );
-    mkdirSync(join(root, 'data'), { recursive: true });
-    writeFileSync(join(root, 'data/schema.graphql'), '');
-    mkdirSync(join(root, 'resources/i18n'), { recursive: true });
-    mkdirSync(join(root, 'packages/backend.ai-webui-docs'), {
-      recursive: true,
-    });
-    writeFileSync(
-      join(root, 'config.toml'),
-      '[general]\napiEndpoint = "https://toml.example.com"\n',
-    );
-    saveSession(sample(), env);
+  it('uses the stored session before the checkout config.toml and config.json', () => {
+    const root = fakeCheckoutWithToml('https://toml.example.com');
     updateConfig({ endpoint: 'https://config.example.com' }, env);
     expect(resolveEndpoint({ cwd: root, env })).toEqual({
       endpoint: 'https://toml.example.com',
       source: 'config.toml',
     });
+    saveSession(sample(), env);
+    expect(resolveEndpoint({ cwd: root, env })).toEqual({
+      endpoint: ENDPOINT,
+      source: 'session',
+    });
     expect(
       resolveEndpoint({ flag: 'http://flag:1', cwd: root, env }).source,
     ).toBe('flag');
+  });
+
+  it('falls back to the recorded config.json endpoint outside a checkout', () => {
+    updateConfig({ endpoint: 'https://config.example.com/' }, env);
+    expect(resolveEndpoint({ cwd: '', env })).toEqual({
+      endpoint: 'https://config.example.com',
+      source: 'config',
+    });
   });
 
   it('fails with a login hint when nothing resolves', () => {

--- a/packages/backend.ai-agent-cli/src/session.ts
+++ b/packages/backend.ai-agent-cli/src/session.ts
@@ -188,10 +188,10 @@ export interface ResolvedEndpoint {
 }
 
 /**
- * `--endpoint` wins; otherwise the checkout's own `config.toml` (a per-place
- * setting beats machine-wide state); otherwise the endpoint `config.json`
- * recorded (`init`); otherwise the single stored session. Ambiguity is an
- * error, never a guess.
+ * `--endpoint` wins; otherwise the single stored session — the one you can
+ * actually query; otherwise the checkout's own `config.toml`; otherwise the
+ * endpoint `config.json` recorded (`init`). Ambiguity is an error, never a
+ * guess.
  */
 export function resolveEndpoint(options: {
   flag?: string;
@@ -201,21 +201,6 @@ export function resolveEndpoint(options: {
   const env = options.env ?? process.env;
   if (options.flag) {
     return { endpoint: normalizeEndpoint(options.flag), source: 'flag' };
-  }
-
-  const fromCheckout = options.cwd
-    ? checkoutApiEndpoint(options.cwd)
-    : undefined;
-  if (fromCheckout) {
-    return {
-      endpoint: normalizeEndpoint(fromCheckout),
-      source: 'config.toml',
-    };
-  }
-
-  const fromConfig = readConfig(env).endpoint;
-  if (fromConfig) {
-    return { endpoint: normalizeEndpoint(fromConfig), source: 'config' };
   }
 
   const stored = listSessions(env);
@@ -236,9 +221,24 @@ export function resolveEndpoint(options: {
     );
   }
 
+  const fromCheckout = options.cwd
+    ? checkoutApiEndpoint(options.cwd)
+    : undefined;
+  if (fromCheckout) {
+    return {
+      endpoint: normalizeEndpoint(fromCheckout),
+      source: 'config.toml',
+    };
+  }
+
+  const fromConfig = readConfig(env).endpoint;
+  if (fromConfig) {
+    return { endpoint: normalizeEndpoint(fromConfig), source: 'config' };
+  }
+
   throw new CliError(
     'usage',
-    'No endpoint: none given with --endpoint, no apiEndpoint in the checkout config.toml, none in config.json, and none stored.',
+    'No endpoint: none given with --endpoint, none stored, no apiEndpoint in the checkout config.toml, and none in config.json.',
     { hint: `${CLI_NAME} login --endpoint https://manager.example.com` },
   );
 }

--- a/packages/backend.ai-agent-cli/src/version-align.test.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.test.ts
@@ -1,5 +1,7 @@
+import { updateConfig } from './config.js';
 import { EXIT } from './errors.js';
 import { clearManagerVersionCache } from './manager.js';
+import { resolveRepoContext } from './repo-context.js';
 import { runCli } from './run.js';
 import type { SchemaIndex } from './search/schema-sdl.js';
 import { saveSession } from './session.js';
@@ -8,12 +10,33 @@ import {
   checkVersionAlignment,
 } from './version-align.js';
 import { compareVersions } from './version-order.js';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const repoCwd = import.meta.dirname;
+
+/**
+ * The real checkout's data behind a root that also carries a config.toml —
+ * what a developer machine looks like, and what CI never has.
+ */
+function checkoutWithToml(apiEndpoint: string): string {
+  const real = resolveRepoContext(repoCwd).repoRoot;
+  const root = mkdtempSync(join(tmpdir(), 'bai-agent-toml-checkout-'));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'backend.ai-webui', version: '0.0.0-toml' }),
+  );
+  for (const dir of ['data', 'resources', 'packages', 'react']) {
+    symlinkSync(join(real, dir), join(root, dir), 'dir');
+  }
+  writeFileSync(
+    join(root, 'config.toml'),
+    `[general]\napiEndpoint = "${apiEndpoint}"\n`,
+  );
+  return root;
+}
 const ENDPOINT = 'http://manager.test.invalid:8090';
 const SESSION_ID = 'abcdefghijklmnopqrstuvwxyz012345';
 
@@ -362,6 +385,29 @@ describe('schema show against a mocked manager', () => {
     await invoke(['search', 'storage folder', '--json']);
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('keeps doctor offline when only a checkout config.toml names an endpoint', async () => {
+    const spy = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', spy);
+    const root = checkoutWithToml('http://toml.test.invalid:8090');
+
+    const { stdout } = await invoke(['doctor', '--json'], root);
+    expect(spy).not.toHaveBeenCalled();
+    const { data } = JSON.parse(stdout);
+    const probe = data.checks.find(
+      (check: { group: string; check: string }) =>
+        check.group === 'alignment' && check.check === 'manager version',
+    );
+    expect(probe.status).toBe('warn');
+    expect(probe.detail).toContain('no endpoint recorded');
+
+    // An endpoint `init` recorded is a deliberate choice: then doctor probes.
+    updateConfig({ endpoint: 'http://recorded.test.invalid:8090' });
+    await invoke(['doctor', '--json'], root);
+    expect(spy).not.toHaveBeenCalled(); // config.toml still outranks config.json
+    await invoke(['doctor', '--json']);
+    expect(spy).toHaveBeenCalled(); // outside a config.toml checkout it does
   });
 });
 


### PR DESCRIPTION
Resolves #9326 (FR-3807)

## Why

#9321 moved the checkout's `config.toml` `apiEndpoint` ahead of the stored session in `resolveEndpoint`. On a developer machine — `config.toml` is untracked, absent in CI and in agent worktrees, which is why the suite stayed green — a session stored for any other endpoint is ignored by `whoami` / `schema show` / `query`, and `pnpm --filter backend.ai-agent-cli publish` aborts in `prepublishOnly` with 13 failures (`query.test.ts`, `version-align.test.ts`). #9322 also let `doctor` probe the public manager version from whatever endpoint resolved, so with a `config.toml` and no session it touched the network — breaking the suite's "no session, no network" contract.

Found while bootstrapping the first npm publish from a checkout with `config.toml`.

## What

- **Precedence**: `--endpoint` → the single stored session → the checkout `config.toml` → the `config.json` endpoint `init` recorded. A session you logged into is what you can query; the two config sources only fill in when there is none.
- **`doctor`** probes a session-less manager only when the endpoint came from `config.json` (an explicit `init`), never from a mere `config.toml`.
- **Test**: the session test lays a `config.toml` into a fake checkout, so the suite no longer depends on the file being absent.
- README and the `--endpoint` flag descriptions updated; **version `0.1.1`** for the npm release (tag `agent-cli-v0.1.1` after merge).

## Verification

- `pnpm --filter backend.ai-agent-cli lint` / `tsc` / `test`: 449 passed — run **with** the developer `config.toml` copied into the worktree (the reproduction), and without.
