### PR TITLE
feat(FR-3810): dev-server advertises the gateway URL and boot record on every served PR

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -240,6 +240,9 @@ If step **2d** resolved login credentials, also prefix `VITE_DEFAULT_EMAIL='<ema
 
 Per step **2e**, prefix `VITE_DEV_TYPECHECK=on` **only** when the user explicitly asked for type checking; otherwise omit the variable entirely. Either way, say which mode you started in your reply.
 
+On the webui, also prefix `BAI_REVIEW_BOOT_RECORD` from step **5**'s `boot-env` call — the dev
+server needs it in its environment before it starts. Omit it when `boot-env` printed nothing.
+
 **Shell-escape every interpolated value.** The endpoint, email, and especially the password come from user/conversation text and may contain an apostrophe or shell metacharacters — interpolating them raw inside `'...'` breaks the command and can turn the rest of the value into executable shell. Before building the command line, quote each value shell-safely (e.g. Bash `printf '%q'`), or set them via the user's git-ignored `.env.development.local` instead of the command line. Do not hand-concatenate an untrusted password into a single-quoted string.
 
 ```bash
@@ -252,7 +255,63 @@ For non-webui projects, substitute the discovered command and package manager. U
 
 Use the Bash tool with `run_in_background: true` since dev servers are long-running. State in one short sentence what you're doing — e.g. `"Starting dev server with header color #2563EB (blue)."` — and which color name (if any) the env was derived from. Don't paste the env table.
 
-## 5. Announce both URLs to the user
+## 5. Advertise the server on every PR it serves (webui)
+
+On a box that has joined the dev gateway (`~/.config/fw/dev-gw.json`), every open PR this
+server serves gets one comment carrying a URL a reviewer can open, and the boot is recorded
+on disk for later tooling. `.claude/skills/dev-server/scripts/advertise.sh` does all of it —
+this skill only calls it, and repeats what it prints.
+
+**Before boot** (step 4), resolve the app name and the record path:
+
+```bash
+eval "$(bash .claude/skills/dev-server/scripts/advertise.sh boot-env)"
+```
+
+That exports `BAI_DEV_APP` and `BAI_REVIEW_BOOT_RECORD=~/.local/state/fw/dev-servers/<app>.json`.
+Add `BAI_REVIEW_BOOT_RECORD` to the `pnpm dev` env prefix — **the dev server must have it in
+its environment, but the file is only written after boot**, since the record describes a name
+Portless has actually claimed. `boot-env` resolves that name with `scripts/portless-app-name.mjs`,
+the same module `dev.mjs` uses, so the prediction cannot drift from what `dev.mjs` requests
+(`portless <app> --force` claims exactly it). When `boot-env` prints nothing — Portless will
+auto-derive a name — skip this whole section.
+
+**After boot**, once Portless has printed its URL and `portless-doctor` has run:
+
+```bash
+bash .claude/skills/dev-server/scripts/advertise.sh advertise --app "$BAI_DEV_APP" --pid <dev.mjs pid>
+```
+
+Idempotent: run it again and it edits the same comments. Pass `--teams-thread <url>` (for the
+running PR) or `--teams-thread <pr>=<url>` when Jira has no thread recorded for a PR.
+
+**On teardown**, after killing the dev server by pid:
+
+```bash
+bash .claude/skills/dev-server/scripts/advertise.sh stop --app "$BAI_DEV_APP"
+```
+
+### What the script guarantees
+
+- **A `.localhost` URL never reaches GitHub.** The advertised URL is `share_base` from the
+  gateway config with the claimed app name substituted — plain `http`, no port. A box that
+  has not joined, a gateway joined with a different Portless port, or a URL that does not
+  answer `X-Portless: 1` yields one printed line and no comment. Repeat that line to the
+  user; never route around it.
+- **One comment per box per PR**, found by the hidden marker `<!-- bai-dev-server box=<box> -->`
+  and edited, never duplicated. Another box's `--force` takeover of the same app name carries
+  a different marker, so it cannot touch this box's comment.
+- **The comment carries the URL and, for a stack, `serves stack #a → #b → #c (running: #c)` —
+  nothing else.** The repo is public: no endpoint, e-mail or password ever goes in it (the dev
+  bundle already pre-fills login).
+- **The served set** is the current branch plus every layer below it from `gh stack view --json`,
+  open PRs only; an unstacked branch serves one PR.
+- **The Teams thread** for each served PR comes from that PR's `Resolves … (FR-XXXX)` key and one
+  Jira GET (`customfield_10176`) at boot — never at request time. Missing is recorded as `null`.
+
+Logic that needs no network is unit-tested: `bash .claude/skills/dev-server/scripts/test-advertise.sh`.
+
+## 6. Announce both URLs to the user
 
 Once the server is up, tell the user **both** the Portless (HTTPS) URL and the underlying React (HTTP) URL on separate lines so they can pick whichever they prefer. Do this only after both are actually known — don't fabricate ports.
 
@@ -282,7 +341,7 @@ If after ~15s the React URL still hasn't appeared (very rare with Vite), announc
 
 Many projects don't use Portless. Read the dev server's stdout for whatever URL(s) it prints (Vite typically prints `Local:` and `Network:`; Next.js prints `started server on http://localhost:3000`; etc.) and forward all of them to the user verbatim. If the project does use Portless, follow the webui rules above.
 
-## 6. Edge cases
+## 7. Edge cases
 
 - **User overrides via env (webui)**: Vite's `loadEnv()` reads `VITE_THEME_HEADER_COLOR`, `VITE_DEFAULT_API_ENDPOINT`, `VITE_DEFAULT_EMAIL`, `VITE_DEFAULT_PASSWORD` from `.env.development.local` and from the shell automatically. If the user already has any of them set, do not override — the user-set value wins. For `PORTLESS_APP_NAME`, the same rule applies: if it's already exported in the inherited env, treat the user-set value as authoritative.
 - **User overrides via prompt**: if the user says "use a green header" or "no color this time" or "name the dev URL <foo>" or "ignore the PR's IP, use 10.0.0.7 instead", honor their words over the conversation-history and PR-description values.
@@ -290,7 +349,13 @@ Many projects don't use Portless. Read the dev server's stdout for whatever URL(
 - **No `/color` in history but user mentioned a color**: treat the user's mention as the source of truth. If they said "use orange", map `orange` → `#EA580C` and prefix accordingly.
 - **PR description mentions multiple addresses or none**: take the **first** match for the multi-match case; for the no-match case, omit `VITE_DEFAULT_API_ENDPOINT` rather than guessing. The login form will fall back to `localStorage` / `config.toml` like before.
 
-## 7. Out of scope
+## 8. Out of scope
 
-- Don't write any color file (`.claude/.fw-color`, `.env.development.local`, etc.). The only sanctioned side effect is the env var prefix.
-- Don't install deps, run lint, or do any other "while we're here" steps. Just start the server.
+- Don't write any color file (`.claude/.fw-color`, `.env.development.local`, etc.).
+- **The sanctioned side effects are exactly three**: the env var prefix, and — on a
+  gateway-joined box — the dev-server comment on each served PR plus the boot record under
+  `~/.local/state/fw/dev-servers/`, both written only by `advertise.sh` (step 5). Nothing
+  else touches GitHub, Jira or disk: no labels, no PR body edits, no reviewers, no registry
+  entries, and never a comment on a PR this server does not serve.
+- Don't install deps, run lint, or do any other "while we're here" steps. Just start the
+  server and advertise it.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -314,8 +314,13 @@ bash .claude/skills/dev-server/scripts/advertise.sh stop --app "$BAI_DEV_APP"
   it merged, it closed, the branch moved — has its comment edited to the stopped form on the
   spot, because the boot record about to be overwritten is the only thing that still knows
   where that comment is.
+- **Teardown never writes a PR's first comment.** `stop` edits only the comments the boot
+  record has ids for. A PR whose comment could not be written at boot (`commentId: null`) is
+  left alone rather than told a server it never heard about has stopped.
 - **The Teams thread** for each served PR comes from that PR's `Resolves … (FR-XXXX)` key and one
   Jira GET (`customfield_10176`) at boot — never at request time. Missing is recorded as `null`.
+  The credential reaches `curl` on stdin via `--config -`, never in argv, because `/proc` is
+  readable by every other process on the box.
 
 Logic that needs no network is unit-tested: `bash .claude/skills/dev-server/scripts/test-advertise.sh`.
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -310,7 +310,10 @@ bash .claude/skills/dev-server/scripts/advertise.sh stop --app "$BAI_DEV_APP"
   nothing else.** The repo is public: no endpoint, e-mail or password ever goes in it (the dev
   bundle already pre-fills login).
 - **The served set** is the current branch plus every layer below it from `gh stack view --json`,
-  open PRs only; an unstacked branch serves one PR.
+  open PRs only; an unstacked branch serves one PR. A PR that leaves that set between runs —
+  it merged, it closed, the branch moved — has its comment edited to the stopped form on the
+  spot, because the boot record about to be overwritten is the only thing that still knows
+  where that comment is.
 - **The Teams thread** for each served PR comes from that PR's `Resolves … (FR-XXXX)` key and one
   Jira GET (`customfield_10176`) at boot — never at request time. Missing is recorded as `null`.
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -240,8 +240,10 @@ If step **2d** resolved login credentials, also prefix `VITE_DEFAULT_EMAIL='<ema
 
 Per step **2e**, prefix `VITE_DEV_TYPECHECK=on` **only** when the user explicitly asked for type checking; otherwise omit the variable entirely. Either way, say which mode you started in your reply.
 
-On the webui, also prefix `BAI_REVIEW_BOOT_RECORD` from step **5**'s `boot-env` call — the dev
-server needs it in its environment before it starts. Omit it when `boot-env` printed nothing.
+On the webui, run step **5**'s `eval "$(… advertise.sh boot-env)"` first and prefix the
+`BAI_REVIEW_BOOT_RECORD` it exports — the dev server needs it in its environment before it
+starts. Omit it when `boot-env` printed nothing (it prints its refusals on stderr, so an
+empty stdout is the whole signal).
 
 **Shell-escape every interpolated value.** The endpoint, email, and especially the password come from user/conversation text and may contain an apostrophe or shell metacharacters — interpolating them raw inside `'...'` breaks the command and can turn the rest of the value into executable shell. Before building the command line, quote each value shell-safely (e.g. Bash `printf '%q'`), or set them via the user's git-ignored `.env.development.local` instead of the command line. Do not hand-concatenate an untrusted password into a single-quoted string.
 
@@ -271,10 +273,10 @@ eval "$(bash .claude/skills/dev-server/scripts/advertise.sh boot-env)"
 That exports `BAI_DEV_APP` and `BAI_REVIEW_BOOT_RECORD=~/.local/state/fw/dev-servers/<app>.json`.
 Add `BAI_REVIEW_BOOT_RECORD` to the `pnpm dev` env prefix — **the dev server must have it in
 its environment, but the file is only written after boot**, since the record describes a name
-Portless has actually claimed. `boot-env` resolves that name with `scripts/portless-app-name.mjs`,
-the same module `dev.mjs` uses, so the prediction cannot drift from what `dev.mjs` requests
-(`portless <app> --force` claims exactly it). When `boot-env` prints nothing — Portless will
-auto-derive a name — skip this whole section.
+Portless has actually claimed. `boot-env` resolves that name through `scripts/portless-app-name.mjs`
+— the same module, fed the same PR lookup and the same cache `dev.mjs` uses — so the prediction
+is the name `dev.mjs` will request (`portless <app> --force` claims exactly it). When `boot-env`
+prints nothing on stdout — Portless will auto-derive a name — skip this whole section.
 
 **After boot**, once Portless has printed its URL and `portless-doctor` has run:
 
@@ -283,7 +285,9 @@ bash .claude/skills/dev-server/scripts/advertise.sh advertise --app "$BAI_DEV_AP
 ```
 
 Idempotent: run it again and it edits the same comments. Pass `--teams-thread <url>` (for the
-running PR) or `--teams-thread <pr>=<url>` when Jira has no thread recorded for a PR.
+running PR) or `--teams-thread <pr>=<url>` when Jira has no thread recorded for a PR. Every
+line the script prints goes to stderr, so its exit status is not what tells you it worked —
+read the lines.
 
 **On teardown**, after killing the dev server by pid:
 
@@ -296,8 +300,9 @@ bash .claude/skills/dev-server/scripts/advertise.sh stop --app "$BAI_DEV_APP"
 - **A `.localhost` URL never reaches GitHub.** The advertised URL is `share_base` from the
   gateway config with the claimed app name substituted — plain `http`, no port. A box that
   has not joined, a gateway joined with a different Portless port, or a URL that does not
-  answer `X-Portless: 1` yields one printed line and no comment. Repeat that line to the
-  user; never route around it.
+  answer a Portless **2xx** (`X-Portless: 1` alone is not enough — Portless sends it on the
+  404 it gives an app name it does not serve) yields one printed line and no comment. Repeat
+  that line to the user; never route around it.
 - **One comment per box per PR**, found by the hidden marker `<!-- bai-dev-server box=<box> -->`
   and edited, never duplicated. Another box's `--force` takeover of the same app name carries
   a different marker, so it cannot touch this box's comment.

--- a/.claude/skills/dev-server/scripts/advertise.sh
+++ b/.claude/skills/dev-server/scripts/advertise.sh
@@ -11,7 +11,11 @@
 #   advertise.sh stop --app <name>
 #
 # Every refusal (box not joined, port mismatch, probe failure) prints one line
-# and exits 0: a dev server must boot whether or not it can be advertised.
+# and exits 0: a dev server must boot whether or not it can be advertised. So do
+# not read the exit status for whether a PR was actually commented on — read the
+# boot record: `served[].commentId` is null for exactly the PRs whose comment
+# could not be written. That is the machine-readable failure signal; the printed
+# lines (all on stderr) are the human one.
 set -euo pipefail
 
 REPO_DEFAULT="lablup/backend.ai-webui"
@@ -91,6 +95,20 @@ served_from_stack() {
     | map(select(.pr != null and .pr.state == "OPEN")
           | {pr: .pr.number, branch: .name})
   ' <<<"$1"
+}
+
+# dropped_served <old-record-json> <new-served-json> — the PRs the old boot
+# record served that the new served set does not, as `<pr><TAB><commentId>`.
+# A PR that merges (or leaves the stack) while the server runs would otherwise
+# keep a "running" comment for ever: `stop` walks only the boot record, and the
+# run that drops the PR is the run that overwrites it.
+dropped_served() {
+  jq -rn --argjson old "$1" --argjson new "$2" '
+    ($new | map(.pr)) as $keep
+    | ($old.served // [])
+    | map(. as $e | select(($keep | index($e.pr)) == null))
+    | .[] | [.pr, (.commentId // "")] | @tsv
+  ' 2>/dev/null || true
 }
 
 # jira_key <pr-body> — the FR key from `Resolves #1234 (FR-1234)`.
@@ -307,6 +325,13 @@ upsert_comment() {
   fi
 }
 
+# patch_stopped <repo> <comment-id> <body> — edit one existing comment to the
+# stopped form. Never creates one: a PR we could not comment on must not get its
+# first comment from us at teardown.
+patch_stopped() {
+  gh api -X PATCH "repos/$1/issues/comments/$2" -f body="$3" --jq '.id' >/dev/null
+}
+
 # ── subcommands ──────────────────────────────────────────────────────────────
 
 cmd_boot_env() {
@@ -356,6 +381,12 @@ cmd_advertise() {
   PROBE_STATUS=""
   probe_portless "$url" || refuse "$url answered ${PROBE_STATUS:-no response}, not a Portless 2xx — not advertised (is the dev server up? is the app name a single label?)"
 
+  # The record this run overwrites, read before anything touches it: its served
+  # set is the only place the comments on PRs we are about to drop are named.
+  local file prev; file=$(record_path "$app")
+  prev='{}'
+  [ -f "$file" ] && prev=$(jq -c . "$file" 2>/dev/null || printf '{}')
+
   # Neither `gh stack view` nor `gh pr list` failing may cost us the boot record:
   # the URL is good, and the record is what `stop` and the board read later.
   local served
@@ -394,7 +425,23 @@ cmd_advertise() {
     i=$((i + 1))
   done
 
-  local file started local_url worktree; file=$(record_path "$app")
+  # PRs this server served last time and does not now — merged, closed, or below
+  # a branch that moved. Their comment still claims a running server for a PR
+  # nobody is serving, and after the write below nothing remembers it exists.
+  local stopped_body dpr did
+  stopped_body=$(comment_body stopped "$box" "$url")
+  while IFS=$'\t' read -r dpr did; do
+    [ -n "$dpr" ] || continue
+    if [ -z "$did" ] || [ "$did" = null ]; then
+      say "PR #$dpr: no longer served, and we have no comment there to mark stopped"
+    elif patch_stopped "$repo" "$did" "$stopped_body"; then
+      say "PR #$dpr: no longer served — comment $did marked stopped"
+    else
+      say "PR #$dpr: no longer served — could not edit comment $did"
+    fi
+  done < <(dropped_served "$prev" "$out")
+
+  local started local_url worktree
   mkdir -p "$STATE_DIR"
   # Re-advertising the same server keeps its original boot time.
   started=$(jq -r '.startedAt // empty' "$file" 2>/dev/null || true)
@@ -432,7 +479,7 @@ cmd_stop() {
   while IFS=$'\t' read -r pr id; do
     [ -n "$pr" ] || continue
     if [ -n "$id" ] && [ "$id" != null ]; then
-      if gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" --jq '.id' >/dev/null; then
+      if patch_stopped "$repo" "$id" "$body"; then
         say "PR #$pr: comment $id marked stopped"
       else
         say "PR #$pr: could not edit comment $id — it may have been deleted"

--- a/.claude/skills/dev-server/scripts/advertise.sh
+++ b/.claude/skills/dev-server/scripts/advertise.sh
@@ -112,8 +112,10 @@ dropped_served() {
 }
 
 # jira_key <pr-body> — the FR key from `Resolves #1234 (FR-1234)`.
+# A body that names none is empty AND successful: `grep` exits 1, and under
+# `pipefail` that would abort the caller's `key=$(...)` assignment mid-run.
 jira_key() {
-  grep -oiE '\(FR-[0-9]+\)' <<<"$1" | head -1 | tr -d '()' | tr '[:lower:]' '[:upper:]'
+  grep -oiE '\(FR-[0-9]+\)' <<<"$1" | head -1 | tr -d '()' | tr '[:lower:]' '[:upper:]' || true
 }
 
 # teams_override <pr> <running> <override>... — the `--teams-thread` value that
@@ -304,8 +306,11 @@ teams_thread_for_key() {
   fi
   [ -n "$email" ] && [ -n "$token" ] || return 0
   local auth; auth=$(printf '%s:%s' "$email" "$token" | base64 | tr -d '\n')
-  curl -sS -m 10 -H "Authorization: Basic $auth" \
-    "$JIRA_SITE/rest/api/3/issue/$key?fields=$JIRA_TEAMS_FIELD" 2>/dev/null \
+  # The credential arrives on stdin via --config, never in argv: /proc is
+  # readable by every other process on a dev box that runs dozens of agents.
+  printf 'header = "Authorization: Basic %s"\n' "$auth" \
+    | curl -sS -m 10 --config - \
+      "$JIRA_SITE/rest/api/3/issue/$key?fields=$JIRA_TEAMS_FIELD" 2>/dev/null \
     | jq -r --arg f "$JIRA_TEAMS_FIELD" '.fields[$f] | select(type == "string") // empty' 2>/dev/null || true
 }
 
@@ -443,14 +448,24 @@ cmd_advertise() {
 
   local started local_url worktree
   mkdir -p "$STATE_DIR"
-  # Re-advertising the same server keeps its original boot time.
-  started=$(jq -r '.startedAt // empty' "$file" 2>/dev/null || true)
+  # Re-advertising a server that is still running keeps its original boot time.
+  # A record already marked stopped belongs to a previous server on this app
+  # name, so its boot time must not be carried into the new one's record.
+  started=$(jq -r 'select(.stoppedAt == null) | .startedAt // empty' "$file" 2>/dev/null || true)
   [ -n "$started" ] || started=$(now_iso)
   local_url="https://$app.localhost:$(portless_port)"
   worktree=$(repo_root)
-  boot_record "$app" "$url" "$repo" "$branch" "$pid" "$started" "$out" \
-    "$box" "$local_url" "$worktree" >"$file"
-  say "boot record $file"
+  # Write through a sibling temp file: `>"$file"` truncates before jq runs, so a
+  # concurrent reader (overlay, board) could see invalid JSON and a jq failure
+  # would leave the only record corrupted.
+  if boot_record "$app" "$url" "$repo" "$branch" "$pid" "$started" "$out" \
+      "$box" "$local_url" "$worktree" >"$file.tmp"; then
+    mv "$file.tmp" "$file"
+    say "boot record $file"
+  else
+    rm -f "$file.tmp"
+    say "could not write $file — boot record left as is"
+  fi
 }
 
 cmd_stop() {
@@ -484,10 +499,11 @@ cmd_stop() {
       else
         say "PR #$pr: could not edit comment $id — it may have been deleted"
       fi
-    elif upsert_comment "$repo" "$pr" "$box" "$body" >/dev/null; then
-      say "PR #$pr: comment marked stopped"
     else
-      say "PR #$pr: could not write the stopped comment"
+      # No id means advertising never got a comment onto this PR. Creating one
+      # now would make our first word on it a "stopped" notice — the guarantee
+      # `patch_stopped` states, applied to the caller that could route round it.
+      say "PR #$pr: no comment of ours to mark stopped"
     fi
   done < <(jq -r '.served[] | [.pr, (.commentId // "")] | @tsv' "$file")
 

--- a/.claude/skills/dev-server/scripts/advertise.sh
+++ b/.claude/skills/dev-server/scripts/advertise.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# Advertise this box's dev server on every PR it serves, and record what is
+# running so later tooling (overlay pins, notifications, the board) can find it.
+#
+#   advertise.sh boot-env [--branch <b>]
+#       Print `export`-ready BAI_DEV_APP / BAI_REVIEW_BOOT_RECORD lines for the
+#       app name `pnpm dev` will claim. Run BEFORE boot; the record itself is
+#       written by `advertise` after Portless has actually claimed the name.
+#   advertise.sh advertise --app <name> [--branch <b>] [--pid <n>]
+#                          [--teams-thread [<pr>=]<url>]... [--repo <o/r>]
+#   advertise.sh stop --app <name>
+#
+# Every refusal (box not joined, port mismatch, probe failure) prints one line
+# and exits 0: a dev server must boot whether or not it can be advertised.
+set -euo pipefail
+
+REPO_DEFAULT="lablup/backend.ai-webui"
+STATE_DIR="${BAI_DEV_SERVER_STATE_DIR:-$HOME/.local/state/fw/dev-servers}"
+DEV_GW_CONFIG="${DEV_GW_CONFIG:-$HOME/.config/fw/dev-gw.json}"
+PORTLESS_DIR="${PORTLESS_DIR:-$HOME/.portless}"
+JIRA_SITE="${JIRA_SITE:-https://lablup.atlassian.net}"
+# The Jira "Teams thread" field. One GET per served PR, at boot only.
+JIRA_TEAMS_FIELD="${JIRA_TEAMS_FIELD:-customfield_10176}"
+
+say() { printf -- '-- dev-server advertise: %s\n' "$*"; }
+die() { printf -- 'advertise.sh: %s\n' "$*" >&2; exit 1; }
+# A refusal is not a failure: say why, leave GitHub untouched, let the boot go on.
+refuse() { say "$*"; exit 0; }
+
+# ── pure helpers (unit-tested by test-advertise.sh) ───────────────────────────
+
+# share_url <share_base> <app> — the {app} template with the claimed name in it.
+share_url() {
+  local base=$1 app=$2
+  [ -n "$base" ] && [ -n "$app" ] || return 1
+  printf '%s' "${base//\{app\}/$app}"
+}
+
+# marker <box> — the hidden HTML marker that identifies THIS box's comment.
+# One per box per PR: a --force takeover by another box carries another marker
+# and so leaves the displaced box's comment alone.
+marker() { printf '<!-- bai-dev-server box=%s -->' "$1"; }
+
+# stack_line <running_pr> <pr>... — "serves stack #a → #b → #c (running: #c)",
+# empty for a served set of one (nothing to explain).
+stack_line() {
+  local running=$1; shift
+  [ "$#" -gt 1 ] || return 0
+  local out="" pr
+  for pr in "$@"; do
+    [ -n "$out" ] && out+=" → "
+    out+="#$pr"
+  done
+  printf 'serves stack %s (running: #%s)' "$out" "$running"
+}
+
+# comment_body <state:running|stopped> <box> <url> [stack_line]
+comment_body() {
+  local state=$1 box=$2 url=$3 stack=${4:-}
+  printf '%s\n' "$(marker "$box")"
+  if [ "$state" = stopped ]; then
+    printf 'Dev server on box `%s`: stopped (was %s)\n' "$box" "$url"
+  else
+    printf 'Dev server on box `%s`: %s\n' "$box" "$url"
+    if [ -n "$stack" ]; then printf '%s\n' "$stack"; fi
+  fi
+}
+
+# served_from_stack <gh-stack-view-json> <current_branch> — the current branch
+# and every layer BELOW it, open PRs only, bottom-first.
+served_from_stack() {
+  jq -c --arg cur "$2" '
+    (.branches // []) as $all
+    | ($all | map(.name) | index($cur)) as $i
+    | (if $i == null then [] else $all[0:$i + 1] end)
+    | map(select(.pr != null and .pr.state == "OPEN")
+          | {pr: .pr.number, branch: .name})
+  ' <<<"$1"
+}
+
+# jira_key <pr-body> — the FR key from `Resolves #1234 (FR-1234)`.
+jira_key() {
+  grep -oiE '\(FR-[0-9]+\)' <<<"$1" | head -1 | tr -d '()' | tr '[:lower:]' '[:upper:]'
+}
+
+# boot_record <app> <url> <repo> <branch> <pid> <startedAt> <served-json>
+#             [<box>] [<localUrl>] [<worktree>]
+# The last three are context for whoever reads the record; they are null when
+# the caller does not have them. Nothing here ever carries an endpoint or a
+# credential — the record is as public as the comment.
+boot_record() {
+  jq -n \
+    --arg app "$1" --arg url "$2" --arg repo "$3" --arg branch "$4" \
+    --arg pid "$5" --arg startedAt "$6" --argjson served "$7" \
+    --arg box "${8:-}" --arg localUrl "${9:-}" --arg worktree "${10:-}" '
+    def orNull: if . == "" then null else . end;
+    {schemaVersion: 1, app: $app, box: ($box | orNull), url: $url,
+     localUrl: ($localUrl | orNull), repo: $repo, branch: $branch,
+     worktree: ($worktree | orNull),
+     pid: (if $pid == "" then null else ($pid | tonumber) end),
+     startedAt: $startedAt, stoppedAt: null, served: $served}
+  '
+}
+
+record_path() { printf '%s/%s.json' "$STATE_DIR" "$1"; }
+
+# ── environment ──────────────────────────────────────────────────────────────
+
+repo_root() { git rev-parse --show-toplevel; }
+current_branch() { git rev-parse --abbrev-ref HEAD; }
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# The port Portless is actually serving on. The gateway forwards to the port it
+# was joined with, forever, so a server on any other port is proxied to nothing.
+portless_port() {
+  local p=${PORTLESS_PORT:-}
+  [ -n "$p" ] || { [ -f "$PORTLESS_DIR/proxy.port" ] && p=$(tr -dc '0-9' <"$PORTLESS_DIR/proxy.port"); }
+  printf '%s' "$p"
+}
+
+# Set SHARE_BASE, or refuse. Guards, in order: joined at all, usable template,
+# joined with the port we are actually running on. Assigns a global rather than
+# echoing because `refuse` must exit the script, not a command substitution.
+gateway_share_base() {
+  [ -f "$DEV_GW_CONFIG" ] || refuse "this box has not joined the dev gateway ($DEV_GW_CONFIG missing) — nothing advertised"
+  local cfg base target live
+  cfg=$(cat "$DEV_GW_CONFIG") || refuse "cannot read $DEV_GW_CONFIG — nothing advertised"
+  base=$(jq -r 'select(.share_base | type == "string" and test("^https?://\\{app\\}\\.")) | .share_base' <<<"$cfg" 2>/dev/null || true)
+  [ -n "$base" ] || refuse "$DEV_GW_CONFIG has no usable share_base template — nothing advertised"
+  target=$(jq -r '(.target_port // .portless_port // empty) | tostring' <<<"$cfg")
+  live=$(portless_port)
+  if [ -n "$target" ] && [ -n "$live" ] && [ "$target" != "$live" ]; then
+    refuse "the gateway was joined with Portless :$target, this server uses :$live — re-run \`dev-gw join\`, nothing advertised"
+  fi
+  SHARE_BASE=$base
+}
+
+gateway_box() { jq -r '.box // empty' "$DEV_GW_CONFIG"; }
+
+# A blank 200 from the gateway means the host did not reach a Portless route
+# (a two-label app name does this). Only a real Portless response carries the
+# header, so that header is the whole gate.
+probe_portless() {
+  local url=$1 headers
+  headers=$(curl -sS -o /dev/null -D - -m 10 "$url" 2>/dev/null) || return 1
+  grep -qiE '^x-portless:[[:space:]]*1[[:space:]]*$' <<<"$headers"
+}
+
+# ── app name (pre-boot) ──────────────────────────────────────────────────────
+
+# The name `pnpm dev` will claim, resolved with the very module dev.mjs uses so
+# the two cannot drift.
+resolve_app_name() {
+  local branch=$1 root pr_json=null
+  root=$(repo_root)
+  [ -f "$root/scripts/portless-app-name.mjs" ] || die "scripts/portless-app-name.mjs not found — run this from a backend.ai-webui checkout"
+  if [ -z "${PORTLESS_APP_NAME_EXACT:-}" ]; then
+    pr_json=$(gh pr list --head "$branch" --state open --json number,title --limit 1 2>/dev/null \
+      | jq -c '.[0] // null' 2>/dev/null || printf 'null')
+    [ -n "$pr_json" ] || pr_json=null
+  fi
+  BAI_BRANCH="$branch" BAI_PR_JSON="$pr_json" BAI_MOD="$root/scripts/portless-app-name.mjs" \
+    node -e '
+      import(process.env.BAI_MOD).then((m) => {
+        const name = m.resolveAppName({
+          envName: process.env.PORTLESS_APP_NAME,
+          branch: process.env.BAI_BRANCH,
+          pr: JSON.parse(process.env.BAI_PR_JSON),
+          exact: !!(process.env.PORTLESS_APP_NAME_EXACT || "").trim(),
+        });
+        if (name) process.stdout.write(name);
+      });
+    '
+}
+
+# ── GitHub / Jira ────────────────────────────────────────────────────────────
+
+# The served set: the current branch plus every layer below it (open PRs only),
+# or a set of one when the branch is not stacked.
+served_set() {
+  local branch=$1 stack_json served
+  if stack_json=$(gh stack view --json 2>/dev/null) && [ -n "$stack_json" ]; then
+    served=$(served_from_stack "$stack_json" "$branch")
+    [ "$served" != "[]" ] && { printf '%s' "$served"; return; }
+  fi
+  gh pr list --head "$branch" --state open --json number --limit 1 \
+    | jq -c --arg b "$branch" 'map({pr: .number, branch: $b})'
+}
+
+jira_key_for_pr() {
+  local repo=$1 pr=$2 body
+  body=$(gh pr view "$pr" --repo "$repo" --json body --jq '.body' 2>/dev/null || true)
+  jira_key "${body:-}"
+}
+
+# ONE Jira GET per served PR, at boot only — never at request time.
+teams_thread_for_key() {
+  local key=$1
+  [ -n "$key" ] || return 0
+  local cred=${ATLASSIAN_CRED_FILE:-$HOME/.config/atlassian/credentials}
+  local email=${ATLASSIAN_EMAIL:-} token=${ATLASSIAN_API_TOKEN:-}
+  if [ -f "$cred" ]; then
+    [ -n "$email" ] || email=$(sed -n 's/^[[:space:]]*\(export[[:space:]]*\)\?ATLASSIAN_EMAIL=//p' "$cred" | head -1)
+    [ -n "$token" ] || token=$(sed -n 's/^[[:space:]]*\(export[[:space:]]*\)\?ATLASSIAN_API_TOKEN=//p' "$cred" | head -1)
+  fi
+  [ -n "$email" ] && [ -n "$token" ] || return 0
+  local auth; auth=$(printf '%s:%s' "$email" "$token" | base64 | tr -d '\n')
+  curl -sS -m 10 -H "Authorization: Basic $auth" \
+    "$JIRA_SITE/rest/api/3/issue/$key?fields=$JIRA_TEAMS_FIELD" 2>/dev/null \
+    | jq -r --arg f "$JIRA_TEAMS_FIELD" '.fields[$f] // empty' 2>/dev/null || true
+}
+
+# Upsert THIS box's comment on a PR; echoes "<id><TAB><html_url>".
+upsert_comment() {
+  local repo=$1 pr=$2 box=$3 body=$4 id
+  id=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
+        --jq "map(select(.body | contains(\"$(marker "$box")\"))) | .[0].id // empty" 2>/dev/null | head -1 || true)
+  if [ -n "$id" ]; then
+    gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" --jq '[.id, .html_url] | @tsv'
+  else
+    gh api -X POST "repos/$repo/issues/$pr/comments" -f body="$body" --jq '[.id, .html_url] | @tsv'
+  fi
+}
+
+# ── subcommands ──────────────────────────────────────────────────────────────
+
+cmd_boot_env() {
+  local branch=""
+  while [ $# -gt 0 ]; do
+    case $1 in
+      --branch) branch=${2:?--branch needs a value}; shift 2 ;;
+      *) die "boot-env: unknown argument '$1'" ;;
+    esac
+  done
+  [ -n "$branch" ] || branch=$(current_branch)
+  local app; app=$(resolve_app_name "$branch")
+  [ -n "$app" ] || refuse "no app name to claim for branch '$branch' (Portless will auto-derive one) — no boot record"
+  printf 'export BAI_DEV_APP=%q\n' "$app"
+  printf 'export BAI_REVIEW_BOOT_RECORD=%q\n' "$(record_path "$app")"
+}
+
+cmd_advertise() {
+  local app="" branch="" pid="" repo="$REPO_DEFAULT"
+  local -a overrides=()
+  while [ $# -gt 0 ]; do
+    case $1 in
+      --app) app=${2:?--app needs a value}; shift 2 ;;
+      --branch) branch=${2:?--branch needs a value}; shift 2 ;;
+      --pid) pid=${2:?--pid needs a value}; shift 2 ;;
+      --repo) repo=${2:?--repo needs a value}; shift 2 ;;
+      --teams-thread) overrides+=("${2:?--teams-thread needs a value}"); shift 2 ;;
+      *) die "advertise: unknown argument '$1'" ;;
+    esac
+  done
+  [ -n "$app" ] || die "advertise: --app <name> is required"
+  [ -n "$branch" ] || branch=$(current_branch)
+
+  local box url
+  SHARE_BASE=""
+  gateway_share_base                  # refuses (exit 0) when not joined / port mismatch
+  box=$(gateway_box)
+  [ -n "$box" ] || refuse "$DEV_GW_CONFIG has no box name — nothing advertised"
+  url=$(share_url "$SHARE_BASE" "$app")
+  # Belt and braces: a .localhost URL is useless to a reviewer and must never
+  # reach a public PR, whatever the config said.
+  case "$url" in *.localhost*) refuse "refusing to advertise a .localhost URL ($url)" ;; esac
+  probe_portless "$url" || refuse "$url did not answer with 'X-Portless: 1' — not advertised (is the dev server up? is the app name a single label?)"
+
+  local served; served=$(served_set "$branch")
+  local -a prs=(); mapfile -t prs < <(jq -r '.[].pr' <<<"$served")
+  if [ "${#prs[@]}" -eq 0 ]; then
+    say "no open PR serves branch '$branch' — URL is $url, nothing commented"
+  fi
+  local running=${prs[${#prs[@]} - 1]:-}
+  local stack; stack=$(stack_line "$running" ${prs[@]+"${prs[@]}"})
+
+  local body; body=$(comment_body running "$box" "$url" "$stack")
+  local out="$served" i=0 pr pr_branch key thread id comment_url
+  for pr in ${prs[@]+"${prs[@]}"}; do
+    pr_branch=$(jq -r --argjson i "$i" '.[$i].branch' <<<"$served")
+    key=$(jira_key_for_pr "$repo" "$pr")
+    thread=""
+    local ov
+    for ov in ${overrides[@]+"${overrides[@]}"}; do
+      case "$ov" in
+        "$pr="*) thread=${ov#*=} ;;
+        *=*) : ;;
+        *) [ "$pr" = "$running" ] && thread=$ov ;;
+      esac
+    done
+    [ -n "$thread" ] || thread=$(teams_thread_for_key "$key")
+    IFS=$'\t' read -r id comment_url < <(upsert_comment "$repo" "$pr" "$box" "$body")
+    say "PR #$pr ($pr_branch): comment $id, ${key:-no Jira key}, teams thread ${thread:-none}"
+    out=$(jq -c --argjson i "$i" --arg k "$key" --arg t "$thread" --arg c "$id" --arg cu "${comment_url:-}" '
+      def orNull: if . == "" then null else . end;
+      .[$i] += {jiraKey: ($k | orNull), teamsThread: ($t | orNull),
+                commentId: (if $c == "" then null else ($c | tonumber) end),
+                commentUrl: ($cu | orNull)}' <<<"$out")
+    i=$((i + 1))
+  done
+
+  local file started local_url worktree; file=$(record_path "$app")
+  mkdir -p "$STATE_DIR"
+  # Re-advertising the same server keeps its original boot time.
+  started=$(jq -r '.startedAt // empty' "$file" 2>/dev/null || true)
+  [ -n "$started" ] || started=$(now_iso)
+  local_url="https://$app.localhost:$(portless_port)"
+  worktree=$(repo_root)
+  boot_record "$app" "$url" "$repo" "$branch" "$pid" "$started" "$out" \
+    "$box" "$local_url" "$worktree" >"$file"
+  say "boot record $file"
+}
+
+cmd_stop() {
+  local app=""
+  while [ $# -gt 0 ]; do
+    case $1 in
+      --app) app=${2:?--app needs a value}; shift 2 ;;
+      *) die "stop: unknown argument '$1'" ;;
+    esac
+  done
+  [ -n "$app" ] || die "stop: --app <name> is required"
+  local file; file=$(record_path "$app")
+  [ -f "$file" ] || refuse "no boot record at $file — nothing to stop"
+
+  local box url repo body
+  box=$(jq -r '.box // empty' "$file")
+  [ -n "$box" ] || box=$(gateway_box 2>/dev/null || true)
+  [ -n "$box" ] || refuse "no box name in $file or $DEV_GW_CONFIG — boot record left as is"
+  url=$(jq -r '.url' "$file")
+  repo=$(jq -r '.repo' "$file")
+  body=$(comment_body stopped "$box" "$url")
+
+  local pr id
+  while IFS=$'\t' read -r pr id; do
+    [ -n "$pr" ] || continue
+    if [ -n "$id" ] && [ "$id" != null ]; then
+      gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" --jq '.id' >/dev/null
+      say "PR #$pr: comment $id marked stopped"
+    else
+      upsert_comment "$repo" "$pr" "$box" "$body" >/dev/null
+      say "PR #$pr: comment marked stopped"
+    fi
+  done < <(jq -r '.served[] | [.pr, (.commentId // "")] | @tsv' "$file")
+
+  jq --arg t "$(now_iso)" '.stoppedAt = $t' "$file" >"$file.tmp" && mv "$file.tmp" "$file"
+  say "boot record $file marked stopped"
+}
+
+main() {
+  local cmd=${1:-}
+  [ $# -gt 0 ] && shift
+  case "$cmd" in
+    boot-env)  cmd_boot_env "$@" ;;
+    advertise) cmd_advertise "$@" ;;
+    stop)      cmd_stop "$@" ;;
+    *) die "usage: advertise.sh {boot-env|advertise --app <name>|stop --app <name>}" ;;
+  esac
+}
+
+# Sourced by test-advertise.sh to exercise the pure helpers above.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/.claude/skills/dev-server/scripts/advertise.sh
+++ b/.claude/skills/dev-server/scripts/advertise.sh
@@ -22,10 +22,19 @@ JIRA_SITE="${JIRA_SITE:-https://lablup.atlassian.net}"
 # The Jira "Teams thread" field. One GET per served PR, at boot only.
 JIRA_TEAMS_FIELD="${JIRA_TEAMS_FIELD:-customfield_10176}"
 
-say() { printf -- '-- dev-server advertise: %s\n' "$*"; }
+# Human-facing lines go to stderr: `boot-env`'s stdout is `eval`-ed by the caller,
+# so a refusal printed there would be evaluated as shell.
+say() { printf -- '-- dev-server advertise: %s\n' "$*" >&2; }
 die() { printf -- 'advertise.sh: %s\n' "$*" >&2; exit 1; }
 # A refusal is not a failure: say why, leave GitHub untouched, let the boot go on.
 refuse() { say "$*"; exit 0; }
+
+# missing_tools <tool>... — the ones this box does not have, space-separated.
+missing_tools() {
+  local t out=""
+  for t in "$@"; do command -v "$t" >/dev/null 2>&1 || out+=" $t"; done
+  printf '%s' "${out# }"
+}
 
 # ── pure helpers (unit-tested by test-advertise.sh) ───────────────────────────
 
@@ -53,6 +62,12 @@ stack_line() {
   done
   printf 'serves stack %s (running: #%s)' "$out" "$running"
 }
+
+# running_pr <served-json> — the PR the server is actually checked out on: the
+# topmost served layer, empty when nothing is served. A helper rather than
+# `${prs[${#prs[@]} - 1]}`, which is a `bad array subscript` fatal under `set -u`
+# on the very path that is supposed to shrug and carry on.
+running_pr() { jq -r 'last | .pr // empty' <<<"$1" 2>/dev/null || true; }
 
 # comment_body <state:running|stopped> <box> <url> [stack_line]
 comment_body() {
@@ -83,6 +98,32 @@ jira_key() {
   grep -oiE '\(FR-[0-9]+\)' <<<"$1" | head -1 | tr -d '()' | tr '[:lower:]' '[:upper:]'
 }
 
+# teams_override <pr> <running> <override>... — the `--teams-thread` value that
+# applies to <pr>, or empty. `<pr>=<url>` targets one PR; a bare URL targets the
+# running one. Only an all-digit prefix before the FIRST `=` counts as a PR
+# selector — a bare Teams URL is full of `=` (groupId=, tenantId=, …) and must
+# not be mistaken for one.
+teams_override() {
+  local pr=$1 running=$2; shift 2
+  local ov head out=""
+  for ov in "$@"; do
+    head=${ov%%=*}
+    if [ "$head" != "$ov" ] && [ -n "$head" ] && [ -z "${head//[0-9]/}" ]; then
+      [ "$head" = "$pr" ] && out=${ov#*=}
+    elif [ "$pr" = "$running" ]; then
+      out=$ov
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# pr_cache_path <branch> — the PR cache dev.mjs writes, spelled exactly as
+# dev.mjs spells it, so an offline `boot-env` predicts the name dev.mjs claims.
+pr_cache_path() {
+  printf '%s/.cache/backend.ai-webui/pr-%s.json' \
+    "$HOME" "$(printf '%s' "$1" | sed -E 's/[^A-Za-z0-9]+/-/g')"
+}
+
 # boot_record <app> <url> <repo> <branch> <pid> <startedAt> <served-json>
 #             [<box>] [<localUrl>] [<worktree>]
 # The last three are context for whoever reads the record; they are null when
@@ -107,7 +148,9 @@ record_path() { printf '%s/%s.json' "$STATE_DIR" "$1"; }
 # ── environment ──────────────────────────────────────────────────────────────
 
 repo_root() { git rev-parse --show-toplevel; }
-current_branch() { git rev-parse --abbrev-ref HEAD; }
+# `git branch --show-current` is what dev.mjs uses: empty on a detached HEAD,
+# where `rev-parse --abbrev-ref` would answer the literal "HEAD".
+current_branch() { git branch --show-current; }
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 # The port Portless is actually serving on. The gateway forwards to the port it
@@ -157,17 +200,46 @@ probe_portless() {
 
 # ── app name (pre-boot) ──────────────────────────────────────────────────────
 
+# PORTLESS_APP_NAME_EXACT as dev.mjs reads it (`?.trim()`), so a whitespace-only
+# value is falsy on both sides.
+exact_mode() {
+  local v=${PORTLESS_APP_NAME_EXACT:-}
+  v=${v//[[:space:]]/}
+  [ -n "$v" ]
+}
+
+# lookup_pr <branch> — dev.mjs's `lookupPr`, in shell. It MUST match: the name is
+# a function of the PR it returns, and a name that differs from the one dev.mjs
+# claims points BAI_REVIEW_BOOT_RECORD and the probe at a server that is not there.
+# So: `gh pr view <branch>` (any PR state, not just open), a 4s budget, and the
+# same on-disk cache as the offline fallback.
+lookup_pr() {
+  local branch=$1 out cache
+  { [ -n "$branch" ] && [ -z "${PORTLESS_SKIP_PR_LOOKUP:-}" ]; } || { printf 'null'; return; }
+  if command -v timeout >/dev/null 2>&1; then
+    out=$(timeout 4 gh pr view "$branch" --json number,title 2>/dev/null || true)
+  else
+    out=$(gh pr view "$branch" --json number,title 2>/dev/null || true)
+  fi
+  if [ -n "$out" ] && jq -e '.number' <<<"$out" >/dev/null 2>&1; then
+    jq -c . <<<"$out"; return
+  fi
+  cache=$(pr_cache_path "$branch")
+  if [ -f "$cache" ] && jq -e . "$cache" >/dev/null 2>&1; then
+    jq -c . "$cache"; return
+  fi
+  printf 'null'
+}
+
 # The name `pnpm dev` will claim, resolved with the very module dev.mjs uses so
 # the two cannot drift.
 resolve_app_name() {
   local branch=$1 root pr_json=null
   root=$(repo_root)
   [ -f "$root/scripts/portless-app-name.mjs" ] || die "scripts/portless-app-name.mjs not found — run this from a backend.ai-webui checkout"
-  if [ -z "${PORTLESS_APP_NAME_EXACT:-}" ]; then
-    pr_json=$(gh pr list --head "$branch" --state open --json number,title --limit 1 2>/dev/null \
-      | jq -c '.[0] // null' 2>/dev/null || printf 'null')
-    [ -n "$pr_json" ] || pr_json=null
-  fi
+  # Exact mode discards every identifier, so it must not pay for the lookup —
+  # dev.mjs skips it there too.
+  exact_mode || pr_json=$(lookup_pr "$branch")
   BAI_BRANCH="$branch" BAI_PR_JSON="$pr_json" BAI_MOD="$root/scripts/portless-app-name.mjs" \
     node -e '
       import(process.env.BAI_MOD).then((m) => {
@@ -216,14 +288,18 @@ teams_thread_for_key() {
   local auth; auth=$(printf '%s:%s' "$email" "$token" | base64 | tr -d '\n')
   curl -sS -m 10 -H "Authorization: Basic $auth" \
     "$JIRA_SITE/rest/api/3/issue/$key?fields=$JIRA_TEAMS_FIELD" 2>/dev/null \
-    | jq -r --arg f "$JIRA_TEAMS_FIELD" '.fields[$f] // empty' 2>/dev/null || true
+    | jq -r --arg f "$JIRA_TEAMS_FIELD" '.fields[$f] | select(type == "string") // empty' 2>/dev/null || true
 }
 
 # Upsert THIS box's comment on a PR; echoes "<id><TAB><html_url>".
+# The marker reaches jq through the environment, never spliced into the program:
+# the box name comes from a config file and a `"` in it would rewrite the filter.
+# `--paginate` walks every page (the marker may be far down a busy PR) and
+# `--jq` runs per page, so the first line printed is the first page that matched.
 upsert_comment() {
   local repo=$1 pr=$2 box=$3 body=$4 id
-  id=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
-        --jq "map(select(.body | contains(\"$(marker "$box")\"))) | .[0].id // empty" 2>/dev/null | head -1 || true)
+  id=$(BAI_MARKER=$(marker "$box") gh api "repos/$repo/issues/$pr/comments?per_page=100" --paginate \
+        --jq 'map(select(.body | contains(env.BAI_MARKER))) | .[0].id // empty' 2>/dev/null | head -1 || true)
   if [ -n "$id" ]; then
     gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" --jq '[.id, .html_url] | @tsv'
   else
@@ -242,6 +318,8 @@ cmd_boot_env() {
     esac
   done
   [ -n "$branch" ] || branch=$(current_branch)
+  local missing; missing=$(missing_tools node jq)
+  [ -z "$missing" ] || die "boot-env: missing on this box: $missing"
   local app; app=$(resolve_app_name "$branch")
   [ -n "$app" ] || refuse "no app name to claim for branch '$branch' (Portless will auto-derive one) — no boot record"
   printf 'export BAI_DEV_APP=%q\n' "$app"
@@ -263,6 +341,8 @@ cmd_advertise() {
   done
   [ -n "$app" ] || die "advertise: --app <name> is required"
   [ -n "$branch" ] || branch=$(current_branch)
+  local missing; missing=$(missing_tools jq gh curl)
+  [ -z "$missing" ] || refuse "missing on this box: $missing — nothing advertised"
 
   local box url
   SHARE_BASE=""
@@ -276,31 +356,36 @@ cmd_advertise() {
   PROBE_STATUS=""
   probe_portless "$url" || refuse "$url answered ${PROBE_STATUS:-no response}, not a Portless 2xx — not advertised (is the dev server up? is the app name a single label?)"
 
-  local served; served=$(served_set "$branch")
+  # Neither `gh stack view` nor `gh pr list` failing may cost us the boot record:
+  # the URL is good, and the record is what `stop` and the board read later.
+  local served
+  served=$(served_set "$branch") || served=''
+  jq -e 'type == "array"' <<<"$served" >/dev/null 2>&1 || served='[]'
   local -a prs=(); mapfile -t prs < <(jq -r '.[].pr' <<<"$served")
   if [ "${#prs[@]}" -eq 0 ]; then
     say "no open PR serves branch '$branch' — URL is $url, nothing commented"
   fi
-  local running=${prs[${#prs[@]} - 1]:-}
+  local running; running=$(running_pr "$served")
   local stack; stack=$(stack_line "$running" ${prs[@]+"${prs[@]}"})
 
   local body; body=$(comment_body running "$box" "$url" "$stack")
-  local out="$served" i=0 pr pr_branch key thread id comment_url
+  local out="$served" i=0 pr pr_branch key thread id comment_url upsert
   for pr in ${prs[@]+"${prs[@]}"}; do
     pr_branch=$(jq -r --argjson i "$i" '.[$i].branch' <<<"$served")
     key=$(jira_key_for_pr "$repo" "$pr")
-    thread=""
-    local ov
-    for ov in ${overrides[@]+"${overrides[@]}"}; do
-      case "$ov" in
-        "$pr="*) thread=${ov#*=} ;;
-        *=*) : ;;
-        *) [ "$pr" = "$running" ] && thread=$ov ;;
-      esac
-    done
+    thread=$(teams_override "$pr" "$running" ${overrides[@]+"${overrides[@]}"})
     [ -n "$thread" ] || thread=$(teams_thread_for_key "$key")
-    IFS=$'\t' read -r id comment_url < <(upsert_comment "$repo" "$pr" "$box" "$body")
-    say "PR #$pr ($pr_branch): comment $id, ${key:-no Jira key}, teams thread ${thread:-none}"
+    # One PR whose comment cannot be written (locked conversation, rate limit,
+    # a revoked token) must not abort the run: the remaining PRs are still
+    # served, and the record still has to be written.
+    id=""; comment_url=""
+    upsert=$(upsert_comment "$repo" "$pr" "$box" "$body") || upsert=""
+    if [ -n "$upsert" ]; then
+      IFS=$'\t' read -r id comment_url <<<"$upsert" || true
+      say "PR #$pr ($pr_branch): comment $id, ${key:-no Jira key}, teams thread ${thread:-none}"
+    else
+      say "PR #$pr ($pr_branch): could not write the comment — recorded with no comment id"
+    fi
     out=$(jq -c --argjson i "$i" --arg k "$key" --arg t "$thread" --arg c "$id" --arg cu "${comment_url:-}" '
       def orNull: if . == "" then null else . end;
       .[$i] += {jiraKey: ($k | orNull), teamsThread: ($t | orNull),
@@ -330,6 +415,8 @@ cmd_stop() {
     esac
   done
   [ -n "$app" ] || die "stop: --app <name> is required"
+  local missing; missing=$(missing_tools jq gh)
+  [ -z "$missing" ] || refuse "missing on this box: $missing — boot record left as is"
   local file; file=$(record_path "$app")
   [ -f "$file" ] || refuse "no boot record at $file — nothing to stop"
 
@@ -345,16 +432,25 @@ cmd_stop() {
   while IFS=$'\t' read -r pr id; do
     [ -n "$pr" ] || continue
     if [ -n "$id" ] && [ "$id" != null ]; then
-      gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" --jq '.id' >/dev/null
-      say "PR #$pr: comment $id marked stopped"
-    else
-      upsert_comment "$repo" "$pr" "$box" "$body" >/dev/null
+      if gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" --jq '.id' >/dev/null; then
+        say "PR #$pr: comment $id marked stopped"
+      else
+        say "PR #$pr: could not edit comment $id — it may have been deleted"
+      fi
+    elif upsert_comment "$repo" "$pr" "$box" "$body" >/dev/null; then
       say "PR #$pr: comment marked stopped"
+    else
+      say "PR #$pr: could not write the stopped comment"
     fi
   done < <(jq -r '.served[] | [.pr, (.commentId // "")] | @tsv' "$file")
 
-  jq --arg t "$(now_iso)" '.stoppedAt = $t' "$file" >"$file.tmp" && mv "$file.tmp" "$file"
-  say "boot record $file marked stopped"
+  if jq --arg t "$(now_iso)" '.stoppedAt = $t' "$file" >"$file.tmp"; then
+    mv "$file.tmp" "$file"
+    say "boot record $file marked stopped"
+  else
+    rm -f "$file.tmp"
+    say "could not rewrite $file — boot record left as is"
+  fi
 }
 
 main() {

--- a/.claude/skills/dev-server/scripts/advertise.sh
+++ b/.claude/skills/dev-server/scripts/advertise.sh
@@ -137,13 +137,22 @@ gateway_share_base() {
 
 gateway_box() { jq -r '.box // empty' "$DEV_GW_CONFIG"; }
 
-# A blank 200 from the gateway means the host did not reach a Portless route
-# (a two-label app name does this). Only a real Portless response carries the
-# header, so that header is the whole gate.
+# probe_ok <http_status> <raw_headers> — both halves are needed. A two-label app
+# name never reaches Portless: Caddy answers a blank 200 with no header. An app
+# name Portless does not serve DOES carry the header, on a 404.
+probe_ok() {
+  case "$1" in 2??) ;; *) return 1 ;; esac
+  grep -qiE '^x-portless:[[:space:]]*1[[:space:]]*$' <<<"$2"
+}
+
+# Sets PROBE_STATUS for the refusal message.
 probe_portless() {
-  local url=$1 headers
-  headers=$(curl -sS -o /dev/null -D - -m 10 "$url" 2>/dev/null) || return 1
-  grep -qiE '^x-portless:[[:space:]]*1[[:space:]]*$' <<<"$headers"
+  local url=$1 hdr rc
+  hdr=$(mktemp)
+  PROBE_STATUS=$(curl -sS -o /dev/null -D "$hdr" -m 10 -w '%{http_code}' "$url" 2>/dev/null) || PROBE_STATUS=""
+  probe_ok "$PROBE_STATUS" "$(cat "$hdr")" && rc=0 || rc=1
+  rm -f "$hdr"
+  return "$rc"
 }
 
 # ── app name (pre-boot) ──────────────────────────────────────────────────────
@@ -264,7 +273,8 @@ cmd_advertise() {
   # Belt and braces: a .localhost URL is useless to a reviewer and must never
   # reach a public PR, whatever the config said.
   case "$url" in *.localhost*) refuse "refusing to advertise a .localhost URL ($url)" ;; esac
-  probe_portless "$url" || refuse "$url did not answer with 'X-Portless: 1' — not advertised (is the dev server up? is the app name a single label?)"
+  PROBE_STATUS=""
+  probe_portless "$url" || refuse "$url answered ${PROBE_STATUS:-no response}, not a Portless 2xx — not advertised (is the dev server up? is the app name a single label?)"
 
   local served; served=$(served_set "$branch")
   local -a prs=(); mapfile -t prs < <(jq -r '.[].pr' <<<"$served")

--- a/.claude/skills/dev-server/scripts/test-advertise.sh
+++ b/.claude/skills/dev-server/scripts/test-advertise.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Unit tests for the network-free helpers in advertise.sh.
+# Run:  bash .claude/skills/dev-server/scripts/test-advertise.sh
+set -uo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# Sourcing defines the helpers without running main() — see the guard at the
+# bottom of advertise.sh.
+BAI_DEV_SERVER_STATE_DIR=/tmp/fw-dev-servers
+# shellcheck source=./advertise.sh
+source "$HERE/advertise.sh"
+# advertise.sh sets `set -e` for its own run; the tests deliberately call helpers
+# that report failure through their exit status.
+set +e
+
+PASS=0 FAIL=0
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1)); printf 'ok   %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1)); printf 'FAIL %s\n  expected: %q\n  actual:   %q\n' "$1" "$2" "$3"
+  fi
+}
+
+# ── URL substitution ──────────────────────────────────────────────────────────
+BASE='http://{app}.jongeun.10-82-0-159.sslip.io'
+check 'share_url substitutes {app}' \
+  'http://fr-3810-pr9330-advertise.jongeun.10-82-0-159.sslip.io' \
+  "$(share_url "$BASE" fr-3810-pr9330-advertise)"
+check 'share_url keeps plain http and no port' \
+  'yes' \
+  "$(case "$(share_url "$BASE" x)" in http://*:*) echo no ;; http://*) echo yes ;; esac)"
+share_url '' app >/dev/null 2>&1
+check 'share_url rejects an empty base' '1' "$?"
+
+# ── marker ────────────────────────────────────────────────────────────────────
+check 'marker carries the box name' '<!-- bai-dev-server box=jongeun -->' "$(marker jongeun)"
+check 'another box gets another marker (a --force takeover cannot edit it)' \
+  'different' \
+  "$([ "$(marker jongeun)" = "$(marker other)" ] && echo same || echo different)"
+
+# ── stack line ────────────────────────────────────────────────────────────────
+check 'stack_line for three PRs' \
+  'serves stack #9328 → #9329 → #9330 (running: #9330)' \
+  "$(stack_line 9330 9328 9329 9330)"
+check 'stack_line is empty for a served set of one' '' "$(stack_line 9330 9330)"
+
+# ── comment bodies ────────────────────────────────────────────────────────────
+URL=$(share_url "$BASE" fr-3810)
+RUNNING=$(comment_body running jongeun "$URL" "$(stack_line 9330 9328 9330)")
+check 'running body: marker first' '<!-- bai-dev-server box=jongeun -->' "$(head -1 <<<"$RUNNING")"
+check 'running body: URL line' \
+  'Dev server on box `jongeun`: http://fr-3810.jongeun.10-82-0-159.sslip.io' \
+  "$(sed -n 2p <<<"$RUNNING")"
+check 'running body: stack line' \
+  'serves stack #9328 → #9330 (running: #9330)' \
+  "$(sed -n 3p <<<"$RUNNING")"
+check 'running body: nothing else' '3' "$(wc -l <<<"$RUNNING")"
+check 'single-PR body has no stack line' '2' \
+  "$(wc -l <<<"$(comment_body running jongeun "$URL" "$(stack_line 9330 9330)")")"
+check 'stopped body' \
+  '<!-- bai-dev-server box=jongeun -->
+Dev server on box `jongeun`: stopped (was http://fr-3810.jongeun.10-82-0-159.sslip.io)' \
+  "$(comment_body stopped jongeun "$URL")"
+# The repo is public: the body must never carry connection secrets.
+check 'body leaks no endpoint / e-mail / password' 'clean' \
+  "$(grep -qiE '@|password|:8090|localhost' <<<"$RUNNING" && echo leak || echo clean)"
+
+# ── served set from a recorded `gh stack view --json` payload ─────────────────
+STACK='{
+  "trunk": "main",
+  "currentBranch": "feat/mid",
+  "branches": [
+    {"name": "feat/bottom", "isCurrent": false, "pr": {"number": 9328, "state": "OPEN"}},
+    {"name": "feat/mid",    "isCurrent": true,  "pr": {"number": 9329, "state": "OPEN"}},
+    {"name": "feat/top",    "isCurrent": false, "pr": {"number": 9330, "state": "OPEN"}}
+  ]
+}'
+check 'served set = current branch + every layer below it' \
+  '[{"pr":9328,"branch":"feat/bottom"},{"pr":9329,"branch":"feat/mid"}]' \
+  "$(served_from_stack "$STACK" feat/mid)"
+check 'served set at the top of the stack is the whole stack' \
+  '[{"pr":9328,"branch":"feat/bottom"},{"pr":9329,"branch":"feat/mid"},{"pr":9330,"branch":"feat/top"}]' \
+  "$(served_from_stack "$STACK" feat/top)"
+MERGED=${STACK/\"number\": 9328, \"state\": \"OPEN\"/\"number\": 9328, \"state\": \"MERGED\"}
+check 'merged layers are not served' \
+  '[{"pr":9329,"branch":"feat/mid"}]' \
+  "$(served_from_stack "$MERGED" feat/mid)"
+NOPR='{"branches":[{"name":"feat/bottom"},{"name":"feat/mid","pr":{"number":9329,"state":"OPEN"}}]}'
+check 'a layer without a PR is skipped' \
+  '[{"pr":9329,"branch":"feat/mid"}]' \
+  "$(served_from_stack "$NOPR" feat/mid)"
+check 'a branch outside the stack serves nothing' '[]' \
+  "$(served_from_stack "$STACK" feat/elsewhere)"
+
+# ── Jira key from a PR body ───────────────────────────────────────────────────
+check 'jira_key from Resolves line' 'FR-3810' \
+  "$(jira_key 'Resolves #9329 (FR-3810)
+
+## What
+…')"
+check 'jira_key takes the first key only' 'FR-3810' \
+  "$(jira_key 'Resolves #9329 (FR-3810), relates to (FR-3811)')"
+check 'jira_key is empty when the body names none' '' "$(jira_key 'no ticket here')"
+
+# ── boot record ───────────────────────────────────────────────────────────────
+SERVED='[{"pr":9330,"branch":"feat/FR-3810","jiraKey":"FR-3810",
+          "teamsThread":"https://teams.microsoft.com/l/message/x",
+          "commentId":77,"commentUrl":"https://github.com/o/r/pull/9330#issuecomment-77"}]'
+REC=$(boot_record fr-3810 "$URL" lablup/backend.ai-webui feat/FR-3810 4242 2026-08-31T00:00:00Z \
+  "$SERVED" jongeun https://fr-3810.localhost:1357 /home/ubuntu/wt)
+check 'boot record keys, in schema order' \
+  'schemaVersion app box url localUrl repo branch worktree pid startedAt stoppedAt served' \
+  "$(jq -r 'keys_unsorted | join(" ")' <<<"$REC")"
+check 'boot record scalar fields' \
+  '1 fr-3810 lablup/backend.ai-webui feat/FR-3810 4242 2026-08-31T00:00:00Z null' \
+  "$(jq -r '[.schemaVersion, .app, .repo, .branch, .pid, .startedAt, .stoppedAt] | map(tostring) | join(" ")' <<<"$REC")"
+check 'boot record optional context fields' \
+  'jongeun https://fr-3810.localhost:1357 /home/ubuntu/wt' \
+  "$(jq -r '[.box, .localUrl, .worktree] | join(" ")' <<<"$REC")"
+check 'boot record served entry' \
+  '9330 feat/FR-3810 FR-3810 https://teams.microsoft.com/l/message/x 77 https://github.com/o/r/pull/9330#issuecomment-77' \
+  "$(jq -r '.served[0] | [.pr, .branch, .jiraKey, .teamsThread, .commentId, .commentUrl] | map(tostring) | join(" ")' <<<"$REC")"
+check 'a PR with no Jira key, thread or comment records nulls' \
+  'null null null null' \
+  "$(boot_record a "$URL" r b '' 2026-08-31T00:00:00Z \
+     '[{"pr":1,"branch":"b","jiraKey":null,"teamsThread":null,"commentId":null,"commentUrl":null}]' \
+     | jq -r '.served[0] | [.jiraKey, .teamsThread, .commentId, .commentUrl] | map(tostring) | join(" ")')"
+check 'an absent pid is null, not 0' 'null' "$(boot_record a b c d '' e '[]' | jq -r '.pid')"
+check 'absent optional context fields are null, not ""' 'null null null' \
+  "$(boot_record a b c d '' e '[]' | jq -r '[.box, .localUrl, .worktree] | map(tostring) | join(" ")')"
+check 'the record carries no endpoint or credential key' 'clean' \
+  "$(jq -r 'paths | join(".")' <<<"$REC" | grep -qiE 'endpoint|password|email|token|secret' && echo leak || echo clean)"
+
+# ── record path (the pre-agreed BAI_REVIEW_BOOT_RECORD handoff) ───────────────
+check 'record path is one file per app under the state dir' \
+  '/tmp/fw-dev-servers/fr-3810-pr9330-advertise.json' \
+  "$(record_path fr-3810-pr9330-advertise)"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/skills/dev-server/scripts/test-advertise.sh
+++ b/.claude/skills/dev-server/scripts/test-advertise.sh
@@ -164,6 +164,10 @@ check 'jira_key from Resolves line' 'FR-3810' \
 check 'jira_key takes the first key only' 'FR-3810' \
   "$(jira_key 'Resolves #9329 (FR-3810), relates to (FR-3811)')"
 check 'jira_key is empty when the body names none' '' "$(jira_key 'no ticket here')"
+# Not just empty — successful. `key=$(jira_key_for_pr ...)` runs under `set -e`,
+# so a grep that exits 1 would abort advertising on the first key-less PR.
+jira_key 'no ticket here' >/dev/null
+check 'jira_key succeeds when the body names none' '0' "$?"
 
 # ── boot record ───────────────────────────────────────────────────────────────
 SERVED='[{"pr":9330,"branch":"feat/FR-3810","jiraKey":"FR-3810",
@@ -253,6 +257,41 @@ check 'the still-served PRs kept their comment ids' '9328 9329' \
   "$(jq -r '[.served[] | select(.commentId != null) | .pr] | join(" ")' "$STATE_DIR/testapp.json")"
 check 'the boot time survives a re-advertise' '2026-01-01T00:00:00Z' \
   "$(jq -r '.startedAt' "$STATE_DIR/testapp.json")"
+
+# A record already marked stopped belongs to a previous server on this app name.
+jq '.stoppedAt = "2026-01-02T00:00:00Z"' "$STATE_DIR/testapp.json" >"$TMP/stopped.json"
+mv "$TMP/stopped.json" "$STATE_DIR/testapp.json"
+( cmd_advertise --app testapp --branch b --repo o/r --pid 7 ) 2>/dev/null
+check 'a stopped record does not donate its boot time to the next server' 'new' \
+  "$(case "$(jq -r '.startedAt' "$STATE_DIR/testapp.json")" in
+       2026-01-01T00:00:00Z) echo stale ;; *) echo new ;; esac)"
+check 'the fresh record is running again, not stopped' 'null' \
+  "$(jq -r '.stoppedAt' "$STATE_DIR/testapp.json")"
+rm -rf "$TMP"
+
+# ── stop: a PR we never commented on gets no first comment at teardown ────────
+TMP=$(mktemp -d)
+STATE_DIR="$TMP/state"
+DEV_GW_CONFIG="$TMP/dev-gw.json"
+printf '%s' '{"box":"testbox","share_base":"http://{app}.testbox.example.invalid"}' >"$DEV_GW_CONFIG"
+mkdir -p "$STATE_DIR"
+cat >"$STATE_DIR/testapp.json" <<'JSON'
+{"schemaVersion":1,"app":"testapp","box":"testbox","url":"http://u","repo":"o/r",
+ "branch":"c","pid":1,"startedAt":"2026-01-01T00:00:00Z","stoppedAt":null,
+ "served":[{"pr":9328,"branch":"a","commentId":11},
+           {"pr":9329,"branch":"b","commentId":null}]}
+JSON
+missing_tools() { printf ''; }
+patch_stopped() { printf '%s\n' "$2" >>"$TMP/patched"; }
+upsert_comment() { printf '%s\n' "$2" >>"$TMP/created"; printf '1\thttps://x'; }
+( cmd_stop --app testapp ) 2>/dev/null
+check 'stop patches only the PR whose comment id we recorded' '11' \
+  "$(cat "$TMP/patched" 2>/dev/null)"
+check 'stop creates no comment on the PR we never reached' '' \
+  "$(cat "$TMP/created" 2>/dev/null)"
+check 'stop marks the record stopped' 'stopped' \
+  "$(case "$(jq -r '.stoppedAt' "$STATE_DIR/testapp.json")" in
+       null) echo running ;; *) echo stopped ;; esac)"
 rm -rf "$TMP"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.claude/skills/dev-server/scripts/test-advertise.sh
+++ b/.claude/skills/dev-server/scripts/test-advertise.sh
@@ -67,6 +67,21 @@ Dev server on box `jongeun`: stopped (was http://fr-3810.jongeun.10-82-0-159.ssl
 check 'body leaks no endpoint / e-mail / password' 'clean' \
   "$(grep -qiE '@|password|:8090|localhost' <<<"$RUNNING" && echo leak || echo clean)"
 
+# ── probe gate (recorded gateway responses) ───────────────────────────────────
+PORTLESS_200='HTTP/1.1 200 OK
+Via: 2.0 Caddy
+X-Portless: 1'
+BLANK_200='HTTP/1.1 200 OK
+Server: Caddy
+Content-Length: 0'
+PORTLESS_404='HTTP/1.1 404 Not Found
+Via: 2.0 Caddy
+X-Portless: 1'
+probe_ok 200 "$PORTLESS_200"; check 'a live Portless route is advertised' 0 $?
+probe_ok 200 "$BLANK_200";    check 'a two-label name (blank 200, no header) is refused' 1 $?
+probe_ok 404 "$PORTLESS_404"; check 'an app Portless does not serve (404 + header) is refused' 1 $?
+probe_ok '' '';               check 'no response at all is refused' 1 $?
+
 # ── served set from a recorded `gh stack view --json` payload ─────────────────
 STACK='{
   "trunk": "main",

--- a/.claude/skills/dev-server/scripts/test-advertise.sh
+++ b/.claude/skills/dev-server/scripts/test-advertise.sh
@@ -199,5 +199,61 @@ check 'record path is one file per app under the state dir' \
   '/tmp/fw-dev-servers/fr-3810-pr9330-advertise.json' \
   "$(record_path fr-3810-pr9330-advertise)"
 
+# ── PRs that leave the served set ─────────────────────────────────────────────
+OLD_REC='{"served":[{"pr":9328,"commentId":11},{"pr":9329,"commentId":22},
+                    {"pr":9330,"commentId":33}]}'
+check 'the PR the new served set dropped, with its comment id' \
+  '9330	33' \
+  "$(dropped_served "$OLD_REC" '[{"pr":9328},{"pr":9329}]')"
+check 'nothing dropped when the served set is unchanged' '' \
+  "$(dropped_served "$OLD_REC" '[{"pr":9328},{"pr":9329},{"pr":9330}]')"
+check 'a served set that lost everything drops everything' \
+  '9328	11
+9329	22
+9330	33' \
+  "$(dropped_served "$OLD_REC" '[]')"
+check 'a dropped PR whose comment was never written has no id to patch' \
+  '9330	' \
+  "$(dropped_served '{"served":[{"pr":9330,"commentId":null}]}' '[]')"
+check 'a first run (no previous record) drops nothing' '' \
+  "$(dropped_served '{}' '[{"pr":9330}]')"
+
+# ── cmd_advertise end to end, with every network call stubbed ────────────────
+# A,B,C were served last boot; this boot serves A,B only. C's comment must be
+# edited to the stopped form, and the record must come back holding just A,B.
+TMP=$(mktemp -d)
+STATE_DIR="$TMP/state"
+DEV_GW_CONFIG="$TMP/dev-gw.json"
+printf '%s' '{"box":"testbox","share_base":"http://{app}.testbox.example.invalid"}' >"$DEV_GW_CONFIG"
+mkdir -p "$STATE_DIR"
+cat >"$STATE_DIR/testapp.json" <<'JSON'
+{"schemaVersion":1,"app":"testapp","box":"testbox","url":"http://old","repo":"o/r",
+ "branch":"c","pid":1,"startedAt":"2026-01-01T00:00:00Z","stoppedAt":null,
+ "served":[{"pr":9328,"branch":"a","commentId":11},
+           {"pr":9329,"branch":"b","commentId":22},
+           {"pr":9330,"branch":"c","commentId":33}]}
+JSON
+missing_tools() { printf ''; }
+probe_portless() { PROBE_STATUS=200; return 0; }
+served_set() { printf '%s' '[{"pr":9328,"branch":"a"},{"pr":9329,"branch":"b"}]'; }
+jira_key_for_pr() { printf ''; }
+teams_thread_for_key() { printf ''; }
+upsert_comment() { printf '%s\thttps://example.invalid/c/%s' "$2" "$2"; }
+patch_stopped() { printf '%s\n' "$2" >>"$TMP/patched"; printf '%s' "$3" >"$TMP/patched-body"; }
+( cmd_advertise --app testapp --branch b --repo o/r --pid 7 ) 2>/dev/null
+check 'only the dropped PR had its comment patched' '33' "$(cat "$TMP/patched" 2>/dev/null)"
+check 'the patch put it in the stopped form' \
+  'Dev server on box `testbox`: stopped (was http://testapp.testbox.example.invalid)' \
+  "$(sed -n 2p "$TMP/patched-body" 2>/dev/null)"
+check 'the stopped comment carries this box marker, so `stop` still finds it' \
+  '<!-- bai-dev-server box=testbox -->' "$(sed -n 1p "$TMP/patched-body" 2>/dev/null)"
+check 'the record now holds only the PRs still served' '9328 9329' \
+  "$(jq -r '[.served[].pr] | join(" ")' "$STATE_DIR/testapp.json")"
+check 'the still-served PRs kept their comment ids' '9328 9329' \
+  "$(jq -r '[.served[] | select(.commentId != null) | .pr] | join(" ")' "$STATE_DIR/testapp.json")"
+check 'the boot time survives a re-advertise' '2026-01-01T00:00:00Z' \
+  "$(jq -r '.startedAt' "$STATE_DIR/testapp.json")"
+rm -rf "$TMP"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/skills/dev-server/scripts/test-advertise.sh
+++ b/.claude/skills/dev-server/scripts/test-advertise.sh
@@ -109,6 +109,52 @@ check 'a layer without a PR is skipped' \
 check 'a branch outside the stack serves nothing' '[]' \
   "$(served_from_stack "$STACK" feat/elsewhere)"
 
+# ── the running PR ────────────────────────────────────────────────────────────
+check 'the running PR is the top of the served set' '9330' \
+  "$(running_pr '[{"pr":9328},{"pr":9329},{"pr":9330}]')"
+check 'one served PR is the running one' '9330' "$(running_pr '[{"pr":9330}]')"
+# An unstacked branch with no open PR still has to print its line and write its
+# record, so this must be an empty string and not a fatal subscript error.
+check 'an empty served set has no running PR' '' "$(running_pr '[]')"
+
+# ── --teams-thread overrides ──────────────────────────────────────────────────
+# Every real Teams thread URL carries `groupId=`/`tenantId=`, so "has an =" can
+# never be what tells a `<pr>=<url>` selector from a bare URL.
+TEAMS='https://teams.microsoft.com/l/message/19%3Aabc%40thread.skype/178?groupId=74ae&tenantId=13c6'
+check 'a bare URL full of = still applies to the running PR' "$TEAMS" \
+  "$(teams_override 9330 9330 "$TEAMS")"
+check 'a bare URL does not apply to a lower PR' '' "$(teams_override 9328 9330 "$TEAMS")"
+check '<pr>=<url> targets that PR' "$TEAMS" "$(teams_override 9328 9330 "9328=$TEAMS")"
+check '<pr>=<url> leaves other PRs alone' '' "$(teams_override 9329 9330 "9328=$TEAMS")"
+check 'the last override for a PR wins' 'b' "$(teams_override 9330 9330 9330=a 9330=b)"
+check 'no override at all is empty' '' "$(teams_override 9330 9330)"
+
+# ── the PR cache dev.mjs writes (the name must be predicted from the same one) ─
+check 'pr cache path matches dev.mjs spelling' \
+  "$HOME/.cache/backend.ai-webui/pr-feat-FR-3810-dev-server-advertise.json" \
+  "$(pr_cache_path feat/FR-3810-dev-server-advertise)"
+
+# ── missing tools ─────────────────────────────────────────────────────────────
+check 'missing_tools names only what is absent' 'definitely-not-a-real-binary' \
+  "$(missing_tools jq definitely-not-a-real-binary)"
+check 'missing_tools is empty when everything is there' '' "$(missing_tools jq bash)"
+
+# ── say() must not pollute stdout: boot-env's stdout is eval-ed ────────────────
+check 'say writes nothing to stdout' '' "$(say 'a refusal' 2>/dev/null)"
+check 'say writes to stderr' '-- dev-server advertise: a refusal' \
+  "$(say 'a refusal' 2>&1 1>/dev/null)"
+
+# ── the marker never becomes part of a jq program ─────────────────────────────
+# The box name comes from a config file; a `"` in it used to rewrite the filter.
+BAD_BOX='x") | .[0] | ("'
+BAI_MARKER=$(marker "$BAD_BOX")
+export BAI_MARKER
+check 'a quote in the box name cannot rewrite the comment-search filter' '77' \
+  "$(jq -r 'map(select(.body | contains(env.BAI_MARKER))) | .[0].id // empty' <<<"$(jq -n --arg m "$BAI_MARKER" '[{id: 77, body: ("head\n" + $m)}]')")"
+check 'and a comment without the marker is not matched' '' \
+  "$(jq -r 'map(select(.body | contains(env.BAI_MARKER))) | .[0].id // empty' <<<'[{"id":77,"body":"unrelated"}]')"
+unset BAI_MARKER
+
 # ── Jira key from a PR body ───────────────────────────────────────────────────
 check 'jira_key from Resolves line' 'FR-3810' \
   "$(jira_key 'Resolves #9329 (FR-3810)

--- a/.claude/skills/webui-connection-info/SKILL.md
+++ b/.claude/skills/webui-connection-info/SKILL.md
@@ -23,8 +23,13 @@ The WebUI dev server runs under [Portless](https://github.com/vercel-labs/portle
 
 To find the actual URL for a running instance, check these sources in order:
 
-1. `portless list` — live routes on this box.
-2. The `pnpm run dev` terminal output — Portless prints the full URL on startup.
+1. **The boot records** — `~/.local/state/fw/dev-servers/*.json`, one per Portless app,
+   written by the `dev-server` skill. Each carries `url` (the gateway URL a teammate can
+   open), `localUrl`, `branch`, `pid`, `startedAt`/`stoppedAt` and the PRs it serves. A
+   record with `stoppedAt` set is a server that is gone. This is the only source that says
+   *which branch and PRs* a server is for, so start here.
+2. `portless list` — live routes on this box.
+3. The `pnpm run dev` terminal output — Portless prints the full URL on startup.
 
 If no dev server is running, tell the user to start it with `pnpm run dev` (requires Portless: `npm install -g portless`).
 


### PR DESCRIPTION
Resolves #9329 (FR-3810)

## What

Booting a dev server on a gateway-joined box now leaves, on every open PR that server
serves, one comment carrying a URL a reviewer can open — and one record on disk describing
what is running, so later tooling (overlay pins, notifications, the board) does not have to
re-derive any of it.

The mechanics live in `.claude/skills/dev-server/scripts/advertise.sh` (bash + jq + gh +
curl). The `dev-server` skill gained a step 5 that calls it, and its out-of-scope section
now names the two new side effects instead of claiming the env var prefix is the only one.
`webui-connection-info` names the boot record as the first source for a dev URL.

## Design

### Boot record

`~/.local/state/fw/dev-servers/<app>.json`, one file per Portless app:

```json
{
  "schemaVersion": 1,
  "app": "fr-3810-pr9330-dev-server",
  "box": "jongeun",
  "url": "http://fr-3810-pr9330-dev-server.jongeun.10-82-0-159.sslip.io",
  "localUrl": "https://fr-3810-pr9330-dev-server.localhost:1357",
  "repo": "lablup/backend.ai-webui",
  "branch": "feat/FR-3810-dev-server-advertise",
  "worktree": "/home/ubuntu/Workspace/backend.ai-webui/.claude/worktrees/agent-aace7167f40293b88",
  "pid": 123456,
  "startedAt": "2026-08-31T00:00:00Z",
  "stoppedAt": null,
  "served": [
    {
      "pr": 9330,
      "branch": "feat/FR-3810-dev-server-advertise",
      "jiraKey": "FR-3810",
      "teamsThread": "https://teams.microsoft.com/l/message/…",
      "commentId": 123,
      "commentUrl": "https://github.com/lablup/backend.ai-webui/pull/9330#issuecomment-123"
    }
  ]
}
```

`schemaVersion`, `app`, `url`, `repo`, `branch`, `pid`, `startedAt`, `stoppedAt` and
`served[].{pr,branch,teamsThread,commentId}` are the contract FR-3811 reads. `box`,
`localUrl`, `worktree`, `served[].jiraKey` and `served[].commentUrl` are context that is
already at hand at boot; they are `null` when it is not. Nothing in the record is an
endpoint or a credential — a unit test asserts no key matches
`endpoint|password|email|token|secret`.

### Env-var handoff

The record is written **after** Portless claims the name, but the dev server needs
`BAI_REVIEW_BOOT_RECORD` in its environment **before** it starts. So the path is predicted,
not discovered:

```bash
eval "$(bash .claude/skills/dev-server/scripts/advertise.sh boot-env)"
# → export BAI_DEV_APP=fr-3810-pr9330-dev-server
#   export BAI_REVIEW_BOOT_RECORD=/home/ubuntu/.local/state/fw/dev-servers/fr-3810-pr9330-dev-server.json
BAI_REVIEW_BOOT_RECORD=… pnpm dev
# after boot:
bash .claude/skills/dev-server/scripts/advertise.sh advertise --app "$BAI_DEV_APP" --pid <dev.mjs pid>
```

`boot-env` resolves the name by importing `scripts/portless-app-name.mjs` — the very module
`dev.mjs` uses — so the prediction cannot drift from what `dev.mjs` requests, and `dev.mjs`
runs `portless <app> --force`, which claims exactly that name. `dev.mjs` learns nothing new.
When `boot-env` prints nothing (Portless will auto-derive a name), the skill skips the whole
section.

### Marker

`<!-- bai-dev-server box=<box> -->` — one comment per box per PR, found by that marker and
`PATCH`ed, never appended. A `--force` takeover of the same app name by another box carries
a different marker, so it cannot touch the displaced box's comment. Body is the URL and,
for a stack, `serves stack #a → #b → #c (running: #c)` — nothing else, because the repo is
public.

### Guards (all print one line and exit 0 — a dev server must boot regardless)

- No `~/.config/fw/dev-gw.json` → the box is not joined, nothing advertised.
- `target_port` ≠ the live Portless port → the gateway forwards to a port this server is not
  on, nothing advertised.
- The URL does not answer `X-Portless: 1` → a two-label app name routes to a blank 200 and
  must not be advertised.
- A `.localhost` URL is refused unconditionally, whatever the config said.

### Served set and Teams threads

Current branch plus every layer below it from `gh stack view --json`, open PRs only; a
branch with no stack is a served set of one via `gh pr list --head`. Each served PR's body
gives the `Resolves … (FR-XXXX)` key, and one Jira `GET
/rest/api/3/issue/<KEY>?fields=customfield_10176` per PR at boot gives the thread — never at
request time. Missing → `null`, overridable with `--teams-thread [<pr>=]<url>`.

## Verification

### Unit tests

Network-free logic (URL substitution, marker, comment-body building, served-set parsing of a
recorded `gh stack view --json` payload, Jira-key extraction, boot-record building) lives in
sourceable functions exercised by a plain bash script — this repo has no bats:

```
$ bash .claude/skills/dev-server/scripts/test-advertise.sh
…
35 passed, 0 failed
```

### `scripts/verify.sh`

```
$ pnpm --filter backend.ai-ui build && bash scripts/verify.sh
…
=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0
  warn-only terminology findings: 1
  near-duplicate findings (report): 0
  unknown-noun findings (report): 0
--- Terminology: PASS ---

=== Terminology self-test (report-only here; hard gate in CI) ===
non-English terminology precision self-test (FR-3051)
  rows under test: 7 non-en avoid row(s), 2 negative control(s)
  PASS — 409 assertion(s) hold.

=== ALL PASS ===
```

### Live boot on this box

Booted `pnpm dev` from this branch's worktree on box `jongeun`
(`PORTLESS_PORT=1357`, the port `dev-gw join` recorded), ran `portless-doctor`, then
`advertise` against it. This PR is the served PR.

**Boot** — `dev.mjs` claimed exactly the name `boot-env` predicted, and the dev server
process carried the record path:

```
$ bash .claude/skills/dev-server/scripts/advertise.sh boot-env
export BAI_DEV_APP=fr-3810-pr9336-dev-server-advertises
export BAI_REVIEW_BOOT_RECORD=/home/ubuntu/.local/state/fw/dev-servers/fr-3810-pr9336-dev-server-advertises.json

$ grep -a "Team share URL\|-> https" <dev.log>
-- Team share URL: http://fr-3810-pr9336-dev-server-advertises.jongeun.10-82-0-159.sslip.io (dev VPN, via dev-gw)
[react]   -> https://fr-3810-pr9336-dev-server-advertises.localhost:1357

$ tr '\0' '\n' < /proc/2413902/environ | grep BAI_REVIEW_BOOT_RECORD
BAI_REVIEW_BOOT_RECORD=/home/ubuntu/.local/state/fw/dev-servers/fr-3810-pr9336-dev-server-advertises.json

$ portless-doctor | tail -2
  fr-3810-pr9336-dev-server-advertises.localhost ok      proxy=200 backend=200
portless-doctor: all live routes reachable through the proxy
```

**Advertise** — one comment, and the boot record:

```
$ bash .claude/skills/dev-server/scripts/advertise.sh advertise \
    --app fr-3810-pr9336-dev-server-advertises --pid 2413902
-- dev-server advertise: PR #9336 (feat/FR-3810-dev-server-advertise): comment 5478881391, FR-3810, teams thread https://teams.microsoft.com/l/message/19%3Aacd1be…
-- dev-server advertise: boot record /home/ubuntu/.local/state/fw/dev-servers/fr-3810-pr9336-dev-server-advertises.json

$ gh api repos/lablup/backend.ai-webui/issues/9336/comments --jq '.[] | "id=\(.id)\n\(.body)"'
id=5478881391
<!-- bai-dev-server box=jongeun -->
Dev server on box `jongeun`: http://fr-3810-pr9336-dev-server-advertises.jongeun.10-82-0-159.sslip.io

$ jq . /home/ubuntu/.local/state/fw/dev-servers/fr-3810-pr9336-dev-server-advertises.json
{
  "schemaVersion": 1,
  "app": "fr-3810-pr9336-dev-server-advertises",
  "box": "jongeun",
  "url": "http://fr-3810-pr9336-dev-server-advertises.jongeun.10-82-0-159.sslip.io",
  "localUrl": "https://fr-3810-pr9336-dev-server-advertises.localhost:1357",
  "repo": "lablup/backend.ai-webui",
  "branch": "feat/FR-3810-dev-server-advertise",
  "worktree": "/home/ubuntu/Workspace/backend.ai-webui/.claude/worktrees/agent-aace7167f40293b88",
  "pid": 2413902,
  "startedAt": "2026-08-31T13:13:30Z",
  "stoppedAt": null,
  "served": [
    {
      "pr": 9336,
      "branch": "feat/FR-3810-dev-server-advertise",
      "jiraKey": "FR-3810",
      "teamsThread": "https://teams.microsoft.com/l/message/19%3Aacd1be…",
      "commentId": 5478881391,
      "commentUrl": "https://github.com/lablup/backend.ai-webui/pull/9336#issuecomment-5478881391"
    }
  ]
}
```

The Teams thread came from this PR's `Resolves #9329 (FR-3810)` → FR-3810's
`customfield_10176`, in one GET.

**A second run edits, it does not append** — same comment id, count still 1, and
`startedAt` is preserved:

```
$ bash .claude/skills/dev-server/scripts/advertise.sh advertise --app fr-3810-pr9336-dev-server-advertises --pid 2413902
$ gh api repos/lablup/backend.ai-webui/issues/9336/comments --jq '{count: length, ids: [.[].id]}'
{"count":1,"ids":[5478881391]}
$ jq -r .startedAt …/fr-3810-pr9336-dev-server-advertises.json
2026-08-31T13:13:30Z
```

**Refusals produce no comment** (all exit 0, comment count stayed 1):

```
$ DEV_GW_CONFIG=/nonexistent/dev-gw.json advertise.sh advertise --app fr-3810-pr9336-dev-server-advertises
-- dev-server advertise: this box has not joined the dev gateway (/nonexistent/dev-gw.json missing) — nothing advertised

$ PORTLESS_PORT=1355 advertise.sh advertise --app fr-3810-pr9336-dev-server-advertises
-- dev-server advertise: the gateway was joined with Portless :1357, this server uses :1355 — re-run `dev-gw join`, nothing advertised

$ advertise.sh advertise --app no-such-server-here
-- dev-server advertise: http://no-such-server-here.jongeun.10-82-0-159.sslip.io answered 404, not a Portless 2xx — not advertised …

$ advertise.sh advertise --app a.b
-- dev-server advertise: http://a.b.jongeun.10-82-0-159.sslip.io answered 200, not a Portless 2xx — not advertised …
```

The last two are why the probe checks the status as well as the header. Measured on
the live gateway:

| app | response |
|---|---|
| the running server | `200` + `X-Portless: 1` |
| a name Portless does not serve | `404` + `X-Portless: 1` |
| a two-label name (`a.b`) | blank `200` from Caddy, **no** header |

The header alone would have advertised the 404. Both halves are now required, and both
cases are unit-tested against these recorded headers.

**Stop** — the comment is edited in place, `stoppedAt` is set:

```
$ kill 2413902     # the dev.mjs pid from the boot record, never pkill -f vite
$ bash .claude/skills/dev-server/scripts/advertise.sh stop --app fr-3810-pr9336-dev-server-advertises
-- dev-server advertise: PR #9336: comment 5478881391 marked stopped
-- dev-server advertise: boot record …/fr-3810-pr9336-dev-server-advertises.json marked stopped

$ gh api repos/lablup/backend.ai-webui/issues/9336/comments --jq '.[] | "id=\(.id)\n\(.body)"'
id=5478881391
<!-- bai-dev-server box=jongeun -->
Dev server on box `jongeun`: stopped (was http://fr-3810-pr9336-dev-server-advertises.jongeun.10-82-0-159.sslip.io)

$ jq '{startedAt, stoppedAt}' …/fr-3810-pr9336-dev-server-advertises.json
{"startedAt": "2026-08-31T13:13:30Z", "stoppedAt": "2026-08-31T13:15:10Z"}
```

The comment above (id `5478881391`) is the live artefact of this run — it is on this PR
right now, in its stopped form, and it is the only comment the run left. No endpoint,
e-mail or password appears in it or in the record.

The one warn-only terminology finding above is pre-existing on `main` and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4QjAX8gWX6LVbfbNtLFyC
