### PR TITLE
fix(FR-3819): make the Storybook theme toolbar switch both theme layers

### DIFF
--- a/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
+++ b/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
@@ -17,13 +17,16 @@
  * using the SAME measured parity tables — re-exported by BUI's own
  * `theme-shim` (ticket 10), so they cannot drift between the app and this
  * file — and the SAME seeds as `resources/theme.json` (mirrored locally as
- * `./theme.json`, already consumed by `themeConfig.ts` for the antd side).
+ * `./theme.json`, which `themeConfig.ts` also feeds to the theme-shim).
  *
  * KEEP IN SYNC (seed values only, not the glue code) with
  * `react/src/astryx-theme/backendAiTheme.ts` `BAI_DEFAULT_SEEDS` /
  * `buildBackendAiTheme({ role: 'brand' })`.
  */
-import { ANTD_ALIGN_TOKENS, ANTD_DARK_ALGORITHM_OUTPUT } from '../src/theme-shim';
+import {
+  ANTD_ALIGN_TOKENS,
+  ANTD_DARK_ALGORITHM_OUTPUT,
+} from '../src/theme-shim';
 import webuiThemeJson from './theme.json';
 import { defineTheme } from '@astryxdesign/core/theme';
 import { neutralTheme } from '@astryxdesign/theme-neutral';
@@ -38,9 +41,7 @@ const toTuple = (light: string, dark: string): [string, string] => [
 ];
 
 /** Astryx muted status surfaces = the status color at ~20%/25% alpha. */
-const toMutedTuple = (
-  tuple: [string, string],
-): [string, string] | undefined =>
+const toMutedTuple = (tuple: [string, string]): [string, string] | undefined =>
   /^#[0-9a-fA-F]{6}$/.test(tuple[0]) && /^#[0-9a-fA-F]{6}$/.test(tuple[1])
     ? [`${tuple[0]}33`, `${tuple[1]}3F`]
     : undefined;
@@ -61,9 +62,9 @@ const warningMuted = toMutedTuple(warning);
 
 /**
  * Backend.AI brand Astryx theme — Storybook's build of `backendAiBrandTheme`
- * (ticket 02). Mounted unconditionally in `decorators.tsx` so every story
- * (legacy and Astryx-native alike) renders against the real brand palette in
- * both light and dark, independent of the "Theme Style" (antd-only) toolbar.
+ * (ticket 02), and the `webui` half of the "Theme" toolbar (themeConfig.ts).
+ * The `astryx` half mounts `neutralTheme` instead, so a story can be checked
+ * against a brand-less baseline.
  */
 export const astryxBrandTheme = defineTheme({
   name: 'storybook-bai-brand',
@@ -89,19 +90,19 @@ export const astryxBrandTheme = defineTheme({
     // from the accent and stories render on a warm pink-beige canvas the app
     // never shows (FR-3500 review, 2026-08-12).
     '--color-text-primary': ['#141414', '#FFFFFF'] as [string, string],
-    '--color-text-secondary': ['rgba(0,0,0,0.65)', 'rgba(255,255,255,0.65)'] as [
-      string,
-      string,
-    ],
+    '--color-text-secondary': [
+      'rgba(0,0,0,0.65)',
+      'rgba(255,255,255,0.65)',
+    ] as [string, string],
     '--color-text-disabled': ['rgba(0,0,0,0.25)', 'rgba(255,255,255,0.25)'] as [
       string,
       string,
     ],
     '--color-icon-primary': ['#141414', '#FFFFFF'] as [string, string],
-    '--color-icon-secondary': ['rgba(0,0,0,0.45)', 'rgba(255,255,255,0.45)'] as [
-      string,
-      string,
-    ],
+    '--color-icon-secondary': [
+      'rgba(0,0,0,0.45)',
+      'rgba(255,255,255,0.45)',
+    ] as [string, string],
     '--color-icon-disabled': ['rgba(0,0,0,0.25)', 'rgba(255,255,255,0.25)'] as [
       string,
       string,

--- a/packages/backend.ai-ui/.storybook/decorators.tsx
+++ b/packages/backend.ai-ui/.storybook/decorators.tsx
@@ -4,12 +4,11 @@ import BAIConfigProvider from '../src/components/provider/BAIConfigProvider/BAIC
 import { FormConfigProvider } from '../src/form-engine/FormConfigProvider';
 import { i18n } from '../src/locale';
 import { ThemeShimProvider, theme } from '../src/theme-shim';
-import { astryxBrandTheme } from './astryxBrandTheme';
-import { themeConfigs, type ThemeStyle } from './themeConfig';
+import { themePresets, type ThemeStyle } from './themeConfig';
+import { Skeleton } from '@astryxdesign/core/Skeleton';
 import { Theme as AstryxThemeProvider } from '@astryxdesign/core/theme';
 import type { Decorator } from '@storybook/react-vite';
 import { useDarkMode } from '@vueless/storybook-dark-mode';
-import { Skeleton } from '@astryxdesign/core/Skeleton';
 import dayjs from 'dayjs';
 import 'dayjs/locale/de';
 import 'dayjs/locale/el';
@@ -78,21 +77,15 @@ const GlobalConfigProvider: React.FC<StorybookProviderProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const currentThemeConfig = themeConfigs[themeStyle];
+  const preset = themePresets[themeStyle];
   const isWebUIStyle = themeStyle === 'webui';
-  const seedToken =
-    (isDarkMode ? currentThemeConfig.dark : currentThemeConfig.light).token ??
-    {};
 
   return (
-    // Astryx brand theme (ticket 32, mirrors the app's always-on
-    // `AstryxBrandTheme` — see DefaultProviders.tsx). Mounted unconditionally
-    // (not gated by the antd-only "Theme Style" toolbar below) so
-    // Astryx-native components (BAITable, BAIComplexSelect,
-    // PowerSearch, …) render the real Backend.AI palette instead of Astryx's
-    // theme-neutral default, in both light and dark.
+    // Both theme layers follow the "Theme" toolbar together: the Astryx
+    // `<Theme>` drives Astryx-native components, the shim's seeds drive the
+    // legacy antd-era ones. See themeConfig.ts for why one alone is inert.
     <AstryxThemeProvider
-      theme={astryxBrandTheme}
+      theme={preset.theme}
       mode={isDarkMode ? 'dark' : 'light'}
     >
       {/* Astryx theme shim (ticket 10): BUI's legacy antd-consuming
@@ -101,37 +94,18 @@ const GlobalConfigProvider: React.FC<StorybookProviderProps> = ({
           light-mode default seeds. */}
       <ThemeShimProvider
         mode={isDarkMode ? 'dark' : 'light'}
-        seeds={{
-          colorPrimary: seedToken.colorPrimary,
-          colorLink: seedToken.colorLink ?? seedToken.colorPrimary,
-          colorInfo: seedToken.colorInfo,
-          colorSuccess: seedToken.colorSuccess,
-          colorError: seedToken.colorError,
-          colorWarning: seedToken.colorWarning,
-          fontFamily: seedToken.fontFamily,
-        }}
+        seeds={isDarkMode ? preset.dark : preset.light}
       >
-        {/* BAIConfigProvider (ticket 30): the real production wrapper. It
-            used to be antd's ConfigProvider + Astryx's
-            InternationalizationProvider; the final switch removed the antd
-            leg, so it now carries only the locale — which still drives BUI's
-            i18next, dayjs and Astryx's resolver from one `lang`, keeping
-            Astryx chrome strings and plurals on the story's locale instead of
-            the 'en' context default (P13).
-
-            The `theme` / `modal` / `drawer` / `tag` props that used to be
-            passed through here are gone with that leg: each configured an
-            antd component. The mode and seeds the toolbar picks reach the
-            tree through `AstryxThemeProvider` + `ThemeShimProvider` above,
-            which is where they already were. */}
+        {/* The real production wrapper, carrying only the locale — which
+            drives BUI's i18next, dayjs and Astryx's resolver from one `lang`,
+            keeping Astryx chrome strings and plurals on the story's locale
+            instead of the 'en' context default (P13). */}
         <BAIConfigProvider locale={{ lang: locale }}>
           {/* The `form.requiredMark` inversion — no asterisk on required
-              fields, "(Optional)" appended to the rest — moved off
-              `ConfigProvider form={{…}}` onto the self-hosted engine's own
-              provider (tickets 34 + 35), mirroring what
+              fields, "(Optional)" appended to the rest — mirrors what
               `react/src/components/DefaultProviders.tsx` does in the app.
-              Still gated on the WebUI theme style, since it is Backend.AI
-              product behaviour rather than an engine default. */}
+              Gated on the WebUI preset: it is Backend.AI product behaviour,
+              so the Astryx baseline keeps the engine default's asterisk. */}
           <FormConfigProvider
             {...(isWebUIStyle && {
               requiredMark: (label, { required }) => (

--- a/packages/backend.ai-ui/.storybook/preview.tsx
+++ b/packages/backend.ai-ui/.storybook/preview.tsx
@@ -34,13 +34,14 @@ const preview: Preview = {
       },
     },
     themeStyle: {
-      name: 'Theme Style',
-      description: 'Theme style preset',
+      name: 'Theme',
+      description:
+        'Astryx theme-neutral baseline vs. the Backend.AI brand theme',
       toolbar: {
         icon: 'paintbrush',
         items: [
-          { value: 'default', title: 'Default (Ant Design)' },
-          { value: 'webui', title: 'WebUI (Backend.AI)' },
+          { value: 'webui', title: 'Backend.AI (WebUI)' },
+          { value: 'astryx', title: 'Astryx (neutral)' },
         ],
         dynamicTitle: true,
       },
@@ -48,7 +49,9 @@ const preview: Preview = {
   },
   initialGlobals: {
     locale: 'en',
-    themeStyle: 'default',
+    // The app's theme is the default — the neutral baseline is the
+    // "does this component assume the brand?" check, not the norm.
+    themeStyle: 'webui',
   },
 };
 

--- a/packages/backend.ai-ui/.storybook/themeConfig.ts
+++ b/packages/backend.ai-ui/.storybook/themeConfig.ts
@@ -1,44 +1,79 @@
+import type { BrandSeeds } from '../src/theme-shim';
+import { astryxBrandTheme } from './astryxBrandTheme';
 import webuiThemeJson from './theme.json';
+import type { DefinedTheme } from '@astryxdesign/core/theme';
+import { neutralTheme } from '@astryxdesign/theme-neutral';
 
-export type ThemeMode = 'light' | 'dark';
-export type ThemeStyle = 'default' | 'webui';
+export type ThemeStyle = 'astryx' | 'webui';
+
+type Seeds = Partial<BrandSeeds>;
 
 /**
- * The seed bag the "Theme Style" toolbar feeds `ThemeShimProvider`.
- *
- * Was `import type { ThemeConfig } from 'antd'`, the shape antd's
- * `ConfigProvider theme` prop took. `.storybook/theme.json` is a copy of the
- * app's `resources/theme.json`, which is still authored in antd token names
- * (that vocabulary is what the theme-shim reads — see
- * `src/theme-shim/tokenType.ts`), so the SHAPE is unchanged; only the type's
- * provenance is. Declared here rather than imported from the shim because
- * only the two keys below are ever read.
+ * A "Theme" toolbar preset. Both layers must move together: Astryx-native
+ * components read the `<Theme>`, while the legacy antd-era ones read the
+ * shim's seed bag — and the shim's `colorPrimary`/`colorSuccess`/… are
+ * `verdict: 'brand'`, i.e. seed-only, never probed from the CSS cascade.
+ * Setting just one layer is what made the pre-FR-3819 toolbar look inert.
  */
-export interface ThemeConfig {
-  token?: Record<string, string | number>;
-  components?: Record<string, Record<string, string | number>>;
+export interface ThemePreset {
+  theme: DefinedTheme;
+  light: Seeds;
+  dark: Seeds;
 }
 
-// Theme seed configs, in antd token vocabulary (see above).
-export const themeConfigs: Record<
-  ThemeStyle,
-  { light: ThemeConfig; dark: ThemeConfig }
-> = {
-  default: {
-    light: {},
-    dark: {
-      token: {
-        colorBgContainer: '#1f2229',
-        colorBgElevated: '#262931',
-        colorBgLayout: '#181b1f',
-        colorBgSpotlight: '#2c2f36',
-        colorBorder: '#3d424d',
-        colorBorderSecondary: '#2c2f36',
-      },
-    },
+/**
+ * Astryx theme-neutral's own palette, read off `@astryxdesign/theme-neutral`'s
+ * `theme.css` (0.5.2) — a monochrome accent, deliberately not a brand hue.
+ * The shim re-runs antd's dark ramp over these seeds, so the dark shades land
+ * near, not exactly on, Astryx's own; the point is the absent brand hue.
+ */
+const ASTRYX_NEUTRAL_SEEDS: { light: Seeds; dark: Seeds } = {
+  light: {
+    colorPrimary: '#262626',
+    colorLink: '#262626',
+    colorInfo: '#00458c',
+    colorError: '#a50c25',
+    colorSuccess: '#007004',
+    colorWarning: '#745b00',
+    fontFamily:
+      'Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  },
+  dark: {
+    colorPrimary: '#ebebeb',
+    colorLink: '#ebebeb',
+    colorInfo: '#c7d3ff',
+    colorError: '#ffc6c1',
+    colorSuccess: '#9fe59b',
+    colorWarning: '#fdcf4f',
+    fontFamily:
+      'Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  },
+};
+
+/** The seeds the app feeds `ThemeShimProvider` in `DefaultProviders.tsx`. */
+const webuiSeeds = (mode: 'light' | 'dark'): Seeds => {
+  const t = webuiThemeJson[mode].token;
+  return {
+    colorPrimary: t.colorPrimary,
+    colorLink: t.colorLink ?? t.colorPrimary,
+    colorInfo: t.colorInfo,
+    colorError: t.colorError,
+    colorSuccess: t.colorSuccess,
+    // theme.json declares no colorWarning — the shim falls back to antd's seed.
+    colorWarning: undefined,
+    fontFamily: t.fontFamily,
+  };
+};
+
+export const themePresets: Record<ThemeStyle, ThemePreset> = {
+  astryx: {
+    theme: neutralTheme,
+    light: ASTRYX_NEUTRAL_SEEDS.light,
+    dark: ASTRYX_NEUTRAL_SEEDS.dark,
   },
   webui: {
-    light: webuiThemeJson.light,
-    dark: webuiThemeJson.dark,
+    theme: astryxBrandTheme,
+    light: webuiSeeds('light'),
+    dark: webuiSeeds('dark'),
   },
 };


### PR DESCRIPTION
Resolves #9338 (FR-3819)

The BUI Storybook's theme toolbar booted on a preset labelled **"Default (Ant Design)"**. antd is not a dependency of this project any more — the component system is Astryx — so the label named a library that cannot be imported. Measuring the control to fix the label turned up the bigger problem: **whichever option you picked, the canvas looked the same.**

> **Scope change.** An earlier revision of this PR deleted the toolbar as vestigial. Review pushed back: an Astryx-neutral baseline and the Backend.AI brand are genuinely different themes, and being able to flip between them is exactly what a component library's Storybook wants. The control was not useless — it was wired to the wrong layer. This PR rewires it instead.

## Why the toolbar had no effect

There are **two theme layers** in the preview, and the toolbar moved only one.

| Layer | Who reads it | What the old toolbar did |
|---|---|---|
| Astryx `<Theme>` | Astryx-native components (`BAITable`, `BAIComplexSelect`, PowerSearch, …) | nothing — `astryxBrandTheme` was mounted **unconditionally** |
| theme-shim seed bag | the legacy antd-era components | swapped, but the swap could not carry a theme |

The seed bag alone cannot carry a theme. Most tokens the shim maps are `verdict: 'astryx'` and resolve from the Astryx CSS cascade regardless of seeds; the seed-only ones (`colorPrimary`, `colorSuccess`, `colorInfo`, …, all `verdict: 'brand'` in `theme-shim/mapping.ts`) fall back to `FALLBACK_SEEDS`, which already hold the Backend.AI values — `colorPrimary: '#ff7a00'`, `colorSuccess: '#00bd9b'`, `fontFamily: 'Ubuntu'`. Both presets therefore converged on the brand palette.

`astryxBrandTheme.ts`'s own header said so out loud: *"Mounted unconditionally in `decorators.tsx` … independent of the 'Theme Style' (antd-only) toolbar."*

The old `default` preset's dark seed bag was dead twice over: `decorators.tsx` forwarded only seven seed keys and none of its six greys was among them, and five of the six are `verdict: 'astryx'` (the sixth, `colorBgSpotlight`, is `verdict: 'self'`) — so none of them ever came from the bag.

**Measured by this PR's earlier revision**, before any rewiring: all 497 stories rendered under both presets and compared by screenshot hash — 30 differed. A same-preset control run over a 20-story sample separated flake from signal: 15 real differences, all form surfaces, all traceable to the one thing `decorators.tsx` actually gated on the style (the `requiredMark` inversion), plus 5 animation flake. That measurement is what established the control was inert; the disagreement was only over the remedy.

## What this PR does

A preset now carries **both** layers, so they move together:

| Toolbar option | Astryx `<Theme>` | shim seed bag |
|---|---|---|
| **Backend.AI (WebUI)** — default | `astryxBrandTheme` | `resources/theme.json` seeds |
| **Astryx (neutral)** | `neutralTheme` | theme-neutral's own palette |

`themeConfig.ts` returns, reframed: it no longer holds "antd-shaped seed bags" but the two presets, each pairing a `DefinedTheme` with its seeds. The toolbar is renamed **"Theme"**, and the app's own theme is the default — the neutral baseline is the "does this component assume the brand?" check, not the norm.

`requiredMark` is gated back onto the WebUI preset: the "(Optional)" inversion is Backend.AI product behaviour, so the Astryx baseline shows the engine default's asterisk. That is the axis the toolbar is for.

## Verification

Probed against the running Storybook (`iframe.html?…&globals=themeStyle:…`), same story, toggle only:

| | `--color-accent` | body font |
|---|---|---|
| `webui` | `light-dark(#FF7A00, #be5e06)` | Ubuntu |
| `astryx` | `light-dark(#262626, #ebebeb)` | Figtree |

Both layers confirmed to move, not just the visible one: the `<Theme>` layer via `--color-accent` above, and the **shim seed layer** via `document.body.style.fontFamily` — written inline by `ThemedContainer` from `theme.useToken()`, and `fontFamily` is a pure seed value (`out.fontFamily = seeds.fontFamily`). It switches `Ubuntu, Roboto, sans-serif` ↔ `Figtree, -apple-system, …`.

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `.storybook/**` is covered by neither `tsconfig.json` (`include` is `src/**`) nor `pnpm lint` (eslint ignores it), so `verify.sh` does not reach these files — typechecked separately via an ad-hoc tsconfig adding `.storybook/**`, confirmed all 10 storybook files entered the program, exit 0.

## Notes

- Astryx neutral's dark seeds are an approximation: the shim re-runs antd's dark ramp over whatever seed it is given, so the dark shades land near, not exactly on, theme-neutral's own. The point of the preset is the *absent brand hue*, which survives that. Recorded in `themeConfig.ts`.
- Left alone to keep the diff tight: `FALLBACK_SEEDS`' comment calls them "antd's default seeds"; they are the Backend.AI ones.

Related: FR-3734 covers the broader Storybook Ant Design → Astryx copy sweep (intro/docs prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqx4mQ8ttcv5iYvkvoWumk
