### PR TITLE
test: e2e auto-heal 2026-09-01 — Astryx tab-role contract in user/profile specs, toast announcer duplication in forgot-password

### DIFF
--- a/e2e/auth/forgot-password.spec.ts
+++ b/e2e/auth/forgot-password.spec.ts
@@ -16,6 +16,14 @@
 import { modifyConfigToml, webuiEndpoint } from '../utils/test-util';
 import { test, expect, type Page } from '@playwright/test';
 
+// Astryx's ToastViewport renders every toast twice: once in the visible
+// stack (`role="region"`, named "Notifications") and once in a singleton
+// screen-reader announcer — an unscoped getByText() strict-mode-violates.
+// See preset-crud.spec.ts / registry.spec.ts for the identical pattern.
+function toastRegion(page: Page) {
+  return page.getByRole('region', { name: 'Notifications' });
+}
+
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const TEST_EMAIL = 'test@example.com';
@@ -135,7 +143,7 @@ test.describe('Forgot password email modal', () => {
 
       // 4. Verify success notification appears and modal closes
       await expect(
-        page.getByText('A verification email has been sent.'),
+        toastRegion(page).getByText('A verification email has been sent.'),
       ).toBeVisible({ timeout: 10_000 });
       await expect(
         page.getByRole('dialog', { name: 'Send change password email' }),
@@ -169,7 +177,7 @@ test.describe('Forgot password email modal', () => {
 
       // 4. Verify error notification appears and modal stays open
       await expect(
-        page.getByText(
+        toastRegion(page).getByText(
           'This email address is not registered. Please contact your administrator.',
         ),
       ).toBeVisible({ timeout: 10_000 });

--- a/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
+++ b/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
@@ -15,6 +15,8 @@ import {
   addIpTags,
   removeAllIpTags,
   deriveDifferentIp,
+  profileModal,
+  usersTabButton,
 } from '../utils/user-profile-util';
 import test, { expect } from '@playwright/test';
 
@@ -43,11 +45,7 @@ test.describe.serial(
       // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab` elements —
       // `role="tab"` is never emitted unless `TabList` is given `role="tablist"`,
       // which this app never does (see registry.spec.ts's identical pattern).
-      await expect(
-        page
-          .getByRole('navigation', { name: 'Tabs' })
-          .getByRole('button', { name: 'Users' }),
-      ).toBeVisible();
+      await expect(usersTabButton(page)).toBeVisible();
 
       // 3. Create the test user
       await page.getByRole('button', { name: 'Create User' }).click();
@@ -83,8 +81,7 @@ test.describe.serial(
       expect(currentClientIp).toBeTruthy();
 
       // Close profile modal
-      await userPage
-        .locator('.ant-modal')
+      await profileModal(userPage)
         .getByRole('button', { name: 'Cancel' })
         .click();
 
@@ -95,7 +92,7 @@ test.describe.serial(
 
       await loginAsAdmin(adminPage, adminRequest);
       await navigateTo(adminPage, 'credential');
-      await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await expect(usersTabButton(adminPage)).toBeVisible();
 
       // Find and edit the test user
       const userRow = adminPage.getByRole('row').filter({ hasText: EMAIL });
@@ -152,7 +149,7 @@ test.describe.serial(
 
       await loginAsAdmin(adminPage, adminRequest);
       await navigateTo(adminPage, 'credential');
-      await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await expect(usersTabButton(adminPage)).toBeVisible();
 
       // Find and edit the test user
       const userRow = adminPage.getByRole('row').filter({ hasText: EMAIL });
@@ -204,7 +201,7 @@ test.describe.serial(
       // 2. Navigate directly to the Active users view and filter by this user's email
       // to reliably find the user regardless of table pagination.
       await navigateTo(page, 'credential');
-      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await expect(usersTabButton(page)).toBeVisible();
       await page.getByText('Active', { exact: true }).click();
 
       // Use the filter to search for this specific user's email.
@@ -249,7 +246,7 @@ test.describe.serial(
       // Click the Inactive radio (URL param is `activeType`, not `status`,
       // so a query-string navigate won't toggle the view).
       await page.getByText('Inactive', { exact: true }).click();
-      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await expect(usersTabButton(page)).toBeVisible();
 
       // Apply the same email filter on the Inactive tab
       const inactiveFilterInput = page

--- a/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
+++ b/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
@@ -39,7 +39,15 @@ test.describe.serial(
 
       // 2. Navigate to credential page
       await navigateTo(page, 'credential');
-      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      // `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+      // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab` elements —
+      // `role="tab"` is never emitted unless `TabList` is given `role="tablist"`,
+      // which this app never does (see registry.spec.ts's identical pattern).
+      await expect(
+        page
+          .getByRole('navigation', { name: 'Tabs' })
+          .getByRole('button', { name: 'Users' }),
+      ).toBeVisible();
 
       // 3. Create the test user
       await page.getByRole('button', { name: 'Create User' }).click();

--- a/e2e/user-profile/user-profile.spec.ts
+++ b/e2e/user-profile/user-profile.spec.ts
@@ -12,6 +12,7 @@ import {
   addIpTags,
   removeAllIpTags,
   createDisposableUser,
+  profileModal,
 } from '../utils/user-profile-util';
 import test, { expect } from '@playwright/test';
 
@@ -101,15 +102,14 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.getByRole('dialog', {
-          name: 'My Account Information',
-        });
+        const modal = profileModal(page);
 
-        // Verify Allowed Client IPs label is visible.
-        // The FormItem label ("...(optional)") and the inner field's own
-        // label both render "Allowed client IPs" text — scope to the first.
+        // The test's contract is that the field is PRESENT, so assert the
+        // control, not just its label — both the FormItem label and the inner
+        // field label render the same text, so a text-only check passes even
+        // when the combobox is missing.
         await expect(
-          modal.getByText('Allowed client IPs').first(),
+          getAllowedClientIpFormItem(modal).getByRole('combobox'),
         ).toBeVisible();
 
         // Verify hint text
@@ -130,12 +130,9 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
 
-        await addIpTags(page.locator('.ant-modal'), [
-          '192.168.1.1',
-          '10.0.0.1',
-        ]);
+        await addIpTags(profileModal(page), ['192.168.1.1', '10.0.0.1']);
 
         // Verify tags are created
         await expect(
@@ -145,8 +142,7 @@ test.describe(
           formItem.locator('.ant-tag').filter({ hasText: '10.0.0.1' }),
         ).toBeVisible();
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
@@ -158,9 +154,9 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
 
-        await addIpTags(page.locator('.ant-modal'), [
+        await addIpTags(profileModal(page), [
           '10.20.30.0/24',
           '192.168.0.0/16',
         ]);
@@ -172,8 +168,7 @@ test.describe(
           formItem.locator('.ant-tag').filter({ hasText: '192.168.0.0/16' }),
         ).toBeVisible();
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
@@ -185,9 +180,9 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
 
-        await addIpTags(page.locator('.ant-modal'), ['not-an-ip']);
+        await addIpTags(profileModal(page), ['not-an-ip']);
 
         const redTag = formItem
           .locator('.ant-tag')
@@ -195,8 +190,7 @@ test.describe(
         await expect(redTag).toBeVisible();
         await expect(redTag).toHaveClass(/ant-tag-red/);
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
@@ -208,9 +202,9 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
 
-        await addIpTags(page.locator('.ant-modal'), [
+        await addIpTags(profileModal(page), [
           '192.168.1.1',
           'invalid-ip',
           '10.0.0.0/8',
@@ -234,8 +228,7 @@ test.describe(
         await expect(cidrTag).toBeVisible();
         await expect(cidrTag).not.toHaveClass(/ant-tag-red/);
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
@@ -244,9 +237,9 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
 
-        await addIpTags(page.locator('.ant-modal'), ['192.168.1.1']);
+        await addIpTags(profileModal(page), ['192.168.1.1']);
 
         const tag = formItem
           .locator('.ant-tag')
@@ -260,15 +253,13 @@ test.describe(
         // Astryx `Tokenizer`; each token carries a real remove button whose
         // accessible name is `Remove <value>` (measured on the live profile
         // modal), so target that instead of any class.
-        // NOTE: the surrounding `.ant-modal` / `.ant-tag` selectors in this
-        // file are equally stale and belong to the separate `.ant-*` selector
-        // migration — deliberately left alone here.
+        // NOTE: the `.ant-tag` selectors still in this file are equally stale
+        // and belong to the separate `.ant-*` selector migration.
         await tag.getByRole('button', { name: /^Remove / }).click();
 
         await expect(tag).toBeHidden();
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
@@ -280,11 +271,11 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
         const currentIp = await getCurrentClientIp(page);
 
         const fakeIp = currentIp === '10.0.0.1' ? '10.0.0.2' : '10.0.0.1';
-        await addIpTags(page.locator('.ant-modal'), [fakeIp]);
+        await addIpTags(profileModal(page), [fakeIp]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -302,10 +293,10 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
         const currentIp = await getCurrentClientIp(page);
 
-        await addIpTags(page.locator('.ant-modal'), [currentIp]);
+        await addIpTags(profileModal(page), [currentIp]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -315,9 +306,8 @@ test.describe(
 
         // Cleanup: clear allowed IPs
         await openProfileModal(page);
-        await removeAllIpTags(page.locator('.ant-modal'));
-        await page
-          .locator('.ant-modal')
+        await removeAllIpTags(profileModal(page));
+        await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
@@ -332,13 +322,13 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
         const currentIp = await getCurrentClientIp(page);
 
         const ipParts = currentIp.split('.');
         const cidrRange = `${ipParts[0]}.${ipParts[1]}.${ipParts[2]}.0/24`;
 
-        await addIpTags(page.locator('.ant-modal'), [cidrRange]);
+        await addIpTags(profileModal(page), [cidrRange]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -348,9 +338,8 @@ test.describe(
 
         // Cleanup: clear allowed IPs
         await openProfileModal(page);
-        await removeAllIpTags(page.locator('.ant-modal'));
-        await page
-          .locator('.ant-modal')
+        await removeAllIpTags(profileModal(page));
+        await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
@@ -365,11 +354,11 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
         const currentIp = await getCurrentClientIp(page);
 
         // First, set an IP
-        await addIpTags(page.locator('.ant-modal'), [currentIp]);
+        await addIpTags(profileModal(page), [currentIp]);
         await modal.getByRole('button', { name: 'Update' }).click();
         await expect(
           page.getByText('Profile has been successfully updated.'),
@@ -377,9 +366,8 @@ test.describe(
 
         // Reopen and remove all IPs
         await openProfileModal(page);
-        await removeAllIpTags(page.locator('.ant-modal'));
-        await page
-          .locator('.ant-modal')
+        await removeAllIpTags(profileModal(page));
+        await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
@@ -388,11 +376,10 @@ test.describe(
 
         // Verify IPs are cleared
         await openProfileModal(page);
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
         await expect(formItem.locator('.ant-tag')).toHaveCount(0);
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
@@ -409,7 +396,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         const fullNameInput = modal.locator('input#full_name');
         const originalName = await fullNameInput.inputValue();
@@ -426,20 +413,15 @@ test.describe(
 
         // Reopen and verify the name was saved
         await openProfileModal(page);
-        const updatedName = await page
-          .locator('.ant-modal')
+        const updatedName = await profileModal(page)
           .locator('input#full_name')
           .inputValue();
         expect(updatedName).toBe(testName);
 
         // Cleanup: restore original name
-        await page.locator('.ant-modal').locator('input#full_name').clear();
-        await page
-          .locator('.ant-modal')
-          .locator('input#full_name')
-          .fill(originalName);
-        await page
-          .locator('.ant-modal')
+        await profileModal(page).locator('input#full_name').clear();
+        await profileModal(page).locator('input#full_name').fill(originalName);
+        await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
@@ -454,7 +436,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
         const currentIp = await getCurrentClientIp(page);
 
         const fullNameInput = modal.locator('input#full_name');
@@ -464,7 +446,7 @@ test.describe(
         await fullNameInput.clear();
         await fullNameInput.fill(testName);
 
-        await addIpTags(page.locator('.ant-modal'), [currentIp]);
+        await addIpTags(profileModal(page), [currentIp]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -474,28 +456,21 @@ test.describe(
 
         // Reopen and verify both changes were saved
         await openProfileModal(page);
-        const savedName = await page
-          .locator('.ant-modal')
+        const savedName = await profileModal(page)
           .locator('input#full_name')
           .inputValue();
         expect(savedName).toBe(testName);
 
-        const savedFormItem = getAllowedClientIpFormItem(
-          page.locator('.ant-modal'),
-        );
+        const savedFormItem = getAllowedClientIpFormItem(profileModal(page));
         await expect(
           savedFormItem.locator('.ant-tag').filter({ hasText: currentIp }),
         ).toBeVisible();
 
         // Cleanup: restore original name and clear IPs
-        await page.locator('.ant-modal').locator('input#full_name').clear();
-        await page
-          .locator('.ant-modal')
-          .locator('input#full_name')
-          .fill(originalName);
-        await removeAllIpTags(page.locator('.ant-modal'));
-        await page
-          .locator('.ant-modal')
+        await profileModal(page).locator('input#full_name').clear();
+        await profileModal(page).locator('input#full_name').fill(originalName);
+        await removeAllIpTags(profileModal(page));
+        await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
@@ -515,7 +490,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         await expect(modal.locator('input#password')).toBeVisible();
         await expect(modal.locator('input#passwordConfirm')).toBeVisible();
@@ -530,7 +505,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         await modal.locator('input#password').fill('123');
 
@@ -545,7 +520,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         await modal.locator('input#password').fill('NewPass1!');
         await modal.locator('input#passwordConfirm').fill('DifferentPass2!');
@@ -566,7 +541,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         await modal.locator('input#password').fill('NewPass1!');
 
@@ -591,7 +566,7 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -604,33 +579,31 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = profileModal(page);
 
         const fullNameInput = modal.locator('input#full_name');
         const originalName = await fullNameInput.inputValue();
 
         await fullNameInput.clear();
         await fullNameInput.fill('Should Not Be Saved');
-        await addIpTags(page.locator('.ant-modal'), ['10.0.0.1']);
+        await addIpTags(profileModal(page), ['10.0.0.1']);
 
         await modal.getByRole('button', { name: 'Cancel' }).click();
-        await page.locator('.ant-modal').waitFor({ state: 'hidden' });
+        await profileModal(page).waitFor({ state: 'hidden' });
 
         // Reopen and verify nothing changed
         await openProfileModal(page);
-        const restoredName = await page
-          .locator('.ant-modal')
+        const restoredName = await profileModal(page)
           .locator('input#full_name')
           .inputValue();
         expect(restoredName).toBe(originalName);
 
-        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
+        const formItem = getAllowedClientIpFormItem(profileModal(page));
         await expect(
           formItem.locator('.ant-tag').filter({ hasText: '10.0.0.1' }),
         ).toHaveCount(0);
 
-        await page
-          .locator('.ant-modal')
+        await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });

--- a/e2e/user-profile/user-profile.spec.ts
+++ b/e2e/user-profile/user-profile.spec.ts
@@ -101,10 +101,16 @@ test.describe(
         await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
-        const modal = page.locator('.ant-modal');
+        const modal = page.getByRole('dialog', {
+          name: 'My Account Information',
+        });
 
-        // Verify Allowed Client IPs label is visible
-        await expect(modal.getByText('Allowed client IPs')).toBeVisible();
+        // Verify Allowed Client IPs label is visible.
+        // The FormItem label ("...(optional)") and the inner field's own
+        // label both render "Allowed client IPs" text — scope to the first.
+        await expect(
+          modal.getByText('Allowed client IPs').first(),
+        ).toBeVisible();
 
         // Verify hint text
         await expect(

--- a/e2e/user/bulk-user-creation.spec.ts
+++ b/e2e/user/bulk-user-creation.spec.ts
@@ -3,6 +3,10 @@ import { BulkCreateUserModal } from '../utils/classes/user/BulkCreateUserModal';
 import { PurgeUsersModal } from '../utils/classes/user/PurgeUsersModal';
 import { KeyPairModal } from '../utils/classes/user/UserSettingModal';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import {
+  createUserMoreButton,
+  usersTabButton,
+} from '../utils/user-profile-util';
 import test, { expect, type Page } from '@playwright/test';
 
 // Generate unique identifiers for this test run to avoid conflicts
@@ -99,11 +103,7 @@ test.describe(
         // elements — `role="tab"` is never emitted unless `TabList` is given
         // `role="tablist"`, which this app never does (see
         // registry.spec.ts's identical pattern).
-        await expect(
-          page
-            .getByRole('navigation', { name: 'Tabs' })
-            .getByRole('button', { name: 'Users' }),
-        ).toBeVisible();
+        await expect(usersTabButton(page)).toBeVisible();
 
         // 4. Verify the "Create User" button is visible
         await expect(
@@ -111,9 +111,7 @@ test.describe(
         ).toBeVisible();
 
         // 5. Click the "More" dropdown button adjacent to "Create User".
-        // AdminUserManagement.tsx's DropdownMenu trigger carries
-        // t('button.More') as its accessible name (icon-only button).
-        await page.getByRole('button', { name: 'More' }).click();
+        await createUserMoreButton(page).click();
 
         // 6. Verify the dropdown menu appears containing the item "Bulk Create Users"
         // exact: true avoids a strict-mode collision with the sibling
@@ -185,8 +183,8 @@ test.describe(
             page.getByRole('radio', { name: 'Active', exact: true }),
           ).toBeChecked();
 
-          // 4. Click the "ellipsis" dropdown button next to "Create User"
-          await page.getByRole('button', { name: 'ellipsis' }).click();
+          // 4. Click the "More" dropdown button next to "Create User"
+          await createUserMoreButton(page).click();
 
           // 5. Click "Bulk Create Users"
           await page
@@ -301,8 +299,8 @@ test.describe(
         // 2. Navigate to credential page
         await navigateTo(page, 'credential');
 
-        // 3. Click the "ellipsis" dropdown button and select "Bulk Create Users"
-        await page.getByRole('button', { name: 'ellipsis' }).click();
+        // 3. Click the "More" dropdown button and select "Bulk Create Users"
+        await createUserMoreButton(page).click();
         await page
           .getByRole('menuitem', { name: 'Bulk Create Users', exact: true })
           .click();
@@ -358,8 +356,8 @@ test.describe(
           // 2. Navigate to credential page
           await navigateTo(page, 'credential');
 
-          // 3. Click the "ellipsis" dropdown button and select "Bulk Create Users"
-          await page.getByRole('button', { name: 'ellipsis' }).click();
+          // 3. Click the "More" dropdown button and select "Bulk Create Users"
+          await createUserMoreButton(page).click();
           await page
             .getByRole('menuitem', { name: 'Bulk Create Users', exact: true })
             .click();

--- a/e2e/user/bulk-user-creation.spec.ts
+++ b/e2e/user/bulk-user-creation.spec.ts
@@ -93,16 +93,27 @@ test.describe(
         // 2. Navigate to credential page
         await navigateTo(page, 'credential');
 
-        // 3. Verify the "Users" tab is visible and selected
-        await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+        // 3. Verify the "Users" tab is visible and selected.
+        // `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+        // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab`
+        // elements — `role="tab"` is never emitted unless `TabList` is given
+        // `role="tablist"`, which this app never does (see
+        // registry.spec.ts's identical pattern).
+        await expect(
+          page
+            .getByRole('navigation', { name: 'Tabs' })
+            .getByRole('button', { name: 'Users' }),
+        ).toBeVisible();
 
         // 4. Verify the "Create User" button is visible
         await expect(
           page.getByRole('button', { name: 'Create User' }),
         ).toBeVisible();
 
-        // 5. Click the "ellipsis" dropdown button adjacent to "Create User"
-        await page.getByRole('button', { name: 'ellipsis' }).click();
+        // 5. Click the "More" dropdown button adjacent to "Create User".
+        // AdminUserManagement.tsx's DropdownMenu trigger carries
+        // t('button.More') as its accessible name (icon-only button).
+        await page.getByRole('button', { name: 'More' }).click();
 
         // 6. Verify the dropdown menu appears containing the item "Bulk Create Users"
         // exact: true avoids a strict-mode collision with the sibling

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -104,8 +104,16 @@ test.describe.serial(
       // 2. Navigate to credential page
       await navigateTo(page, 'credential');
 
-      // 3. Wait for Users tab to be visible
-      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      // 3. Wait for Users tab to be visible.
+      // `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+      // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab` elements —
+      // `role="tab"` is never emitted unless `TabList` is given `role="tablist"`,
+      // which this app never does (see registry.spec.ts's identical pattern).
+      await expect(
+        page
+          .getByRole('navigation', { name: 'Tabs' })
+          .getByRole('button', { name: 'Users' }),
+      ).toBeVisible();
 
       // 4. Clean up any existing test user from previous runs
       await cleanupTestUser(page);

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -14,6 +14,7 @@ import {
   webServerEndpoint,
   webuiEndpoint,
 } from '../utils/test-util';
+import { usersTabButton } from '../utils/user-profile-util';
 import test, { expect } from '@playwright/test';
 
 // FR-3331/FR-3339 (PRs #8303/#8315) renamed the User Setting modal's submit
@@ -109,11 +110,7 @@ test.describe.serial(
       // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab` elements —
       // `role="tab"` is never emitted unless `TabList` is given `role="tablist"`,
       // which this app never does (see registry.spec.ts's identical pattern).
-      await expect(
-        page
-          .getByRole('navigation', { name: 'Tabs' })
-          .getByRole('button', { name: 'Users' }),
-      ).toBeVisible();
+      await expect(usersTabButton(page)).toBeVisible();
 
       // 4. Clean up any existing test user from previous runs
       await cleanupTestUser(page);
@@ -159,7 +156,7 @@ test.describe.serial(
       await navigateTo(page, 'credential');
 
       // 3. Wait for the Users tab to confirm the page has fully loaded
-      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await expect(usersTabButton(page)).toBeVisible();
 
       // 4. Locate the user in the table
       const userRow = page.getByRole('row').filter({ hasText: EMAIL });
@@ -220,7 +217,7 @@ test.describe.serial(
 
       // 3. Ensure "Active" filter is selected (should be default)
       // Wait for Users tab to confirm page has fully loaded before interacting with filter
-      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await expect(usersTabButton(page)).toBeVisible();
       await page.getByText('Active', { exact: true }).click();
 
       // 4. Locate the user to deactivate in the table

--- a/e2e/utils/user-profile-util.ts
+++ b/e2e/utils/user-profile-util.ts
@@ -54,7 +54,9 @@ export async function clickRowAction(
 export async function openProfileModal(page: Page) {
   await page.getByTestId('user-dropdown-button').click();
   await page.getByText('My Account').click();
-  await page.locator('.ant-modal').waitFor({ state: 'visible' });
+  await expect(
+    page.getByRole('dialog', { name: 'My Account Information' }),
+  ).toBeVisible();
 }
 
 /**
@@ -140,7 +142,15 @@ export async function createDisposableUser(
   password: string,
 ): Promise<void> {
   await navigateTo(adminPage, 'credential');
-  await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible();
+  // `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+  // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab` elements —
+  // `role="tab"` is never emitted unless `TabList` is given `role="tablist"`,
+  // which this app never does (see registry.spec.ts's identical pattern).
+  await expect(
+    adminPage
+      .getByRole('navigation', { name: 'Tabs' })
+      .getByRole('button', { name: 'Users' }),
+  ).toBeVisible();
 
   await adminPage.getByRole('button', { name: 'Create User' }).click();
   const userSettingModal = UserSettingModal.forCreate(adminPage);

--- a/e2e/utils/user-profile-util.ts
+++ b/e2e/utils/user-profile-util.ts
@@ -6,6 +6,37 @@ import { navigateTo } from './test-util';
 import { expect, type Page, type Locator } from '@playwright/test';
 
 /**
+ * The Credential page's "Users" tab button.
+ *
+ * `BAICard`'s `tabList` renders a `nav[aria-label="Tabs"]` of plain
+ * `<button>`s (BAITabList / Astryx `TabList`); `role="tab"` is never emitted
+ * unless `TabList` is given `role="tablist"`, which this app never does.
+ */
+export function usersTabButton(page: Page): Locator {
+  return page
+    .getByRole('navigation', { name: 'Tabs' })
+    .getByRole('button', { name: 'Users' });
+}
+
+/**
+ * The "My Account Information" profile dialog. Replaces the dead `.ant-modal`
+ * selector — the modal is an Astryx dialog with an accessible name.
+ */
+export function profileModal(page: Page): Locator {
+  return page.getByRole('dialog', { name: 'My Account Information' });
+}
+
+/**
+ * The overflow ("More") dropdown trigger beside the Credential page's
+ * "Create User" button. `AdminUserManagement.tsx`'s `DropdownMenu` trigger
+ * carries `t('button.More')` as its accessible name; the old "ellipsis" name
+ * came from the antd icon glyph and no longer exists.
+ */
+export function createUserMoreButton(page: Page): Locator {
+  return page.getByRole('button', { name: 'More' });
+}
+
+/**
  * Clicks a BAINameActionCell action by its title.
  * Handles both directly visible icon buttons and overflow dropdown menu items.
  *
@@ -146,11 +177,7 @@ export async function createDisposableUser(
   // `<button>`s (BAITabList / Astryx `TabList`), not ARIA `tab` elements —
   // `role="tab"` is never emitted unless `TabList` is given `role="tablist"`,
   // which this app never does (see registry.spec.ts's identical pattern).
-  await expect(
-    adminPage
-      .getByRole('navigation', { name: 'Tabs' })
-      .getByRole('button', { name: 'Users' }),
-  ).toBeVisible();
+  await expect(usersTabButton(adminPage)).toBeVisible();
 
   await adminPage.getByRole('button', { name: 'Create User' }).click();
   const userSettingModal = UserSettingModal.forCreate(adminPage);


### PR DESCRIPTION
Produced automatically by the **daily digest auto-heal** (2026-09-01 run).
Report: `/home/ubuntu/e2e-digest-reports/report-2026-09-01.md`

Both clusters are test-side drift from the antd → Astryx migration. No app source was touched — the diff is `e2e/` only.

## Root causes

**1. `tab-role-missing-role-tablist`** — Astryx `TabList` renders a `<nav aria-label="Tabs">` of plain `<button>`s and never emits `role="tab"` unless `role="tablist"` is passed explicitly (which this app never does). Specs waiting on `getByRole('tab', …)` hang for the full 30s. Switched to `getByRole('navigation', { name: 'Tabs' }).getByRole('button', { name: … })` — the same pattern #9202 and #9316 already established.

The four affected specs all block on the shared `e2e/utils/user-profile-util.ts` helper, so the fix lives there plus the inline call sites.

**2. `astryx-toast-singleton-announcer-duplicate`** — `ToastViewport` renders every toast twice: the visible node plus a singleton screen-reader announcer (intended a11y design). An unscoped `getByText(<toast text>)` is a strict-mode violation. Scoped the assertions to `getByRole('region', { name: 'Notifications' })`.

Two further drifts surfaced once the tab locators cleared and are fixed here too: the More-dropdown trigger's accessible name (`ellipsis` → `t('button.More')` = "More"), and residual `.ant-modal` waits in the profile-modal helper.

## Healed — 6/6, each verified by a re-run

| Spec | Test | Re-run |
|---|---|---|
| `e2e/user/user-crud.spec.ts` | Admin can create a new user | ✅ 18.3s |
| `e2e/user/bulk-user-creation.spec.ts` | Admin can open bulk create modal from dropdown | ✅ 10.1s |
| `e2e/user-profile/user-profile.spec.ts` | User can open profile modal and see Allowed Client IP field | ✅ 5.0s |
| `e2e/user-profile/user-ip-restriction-enforcement.spec.ts` | Admin can create a test user | ✅ 13.0s |
| `e2e/auth/forgot-password.spec.ts` | User can send a password change email successfully | ✅ 3.6s |
| `e2e/auth/forgot-password.spec.ts` | User sees an error when email sending fails | ✅ 3.4s |

No `RETRY BUDGET EXHAUSTED` and no `NEEDS-APP-CHANGE` cases this run.

## Not in this PR

- `tab-role-missing-role-tablist` still affects 5 more specs (`agent-summary`, `my-keypair-management`, `my-environment`, `serving/deployment-access-token`, `session/session-lifecycle`) — held back by `MAX_HEAL_SPECS=5`, queued for the next run.
- The two open heal PRs #9168 (day 5) and #9316 (day 1) cover a further 34 of today's 134 failures and are **still awaiting approval** with zero unresolved review threads. Their specs were deliberately excluded here to avoid duplicate fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
