### PR TITLE
test(FR-3830): cover each share permission type in the Folder Explorer gating test

### DIFF
--- a/react/src/components/FolderExplorerModalV2.test.tsx
+++ b/react/src/components/FolderExplorerModalV2.test.tsx
@@ -218,9 +218,11 @@ const VFOLDER_UUID = '11111111-2222-3333-4444-555555555555';
 const renderModal = ({
   ownershipProjectId,
   legacyPermissions,
+  hostPermissions,
 }: {
   ownershipProjectId: string | null;
   legacyPermissions?: string[];
+  hostPermissions?: string[];
 }) => {
   const environment: RelayMockEnvironment = createMockEnvironment();
   const resolver = (operation: any) =>
@@ -248,9 +250,12 @@ const renderModal = ({
         },
       }),
       KeyPair: () => ({ resource_policy: 'default' }),
+      // The storage-host capability axis. `enableUpload` / `enableEdit` are the
+      // AND of this and the folder-level `write_content`, so both sides need a
+      // knob to be gated independently.
       Domain: () => ({
         allowed_vfolder_hosts: JSON.stringify({
-          'local:volume1': ['download-file', 'upload-file'],
+          'local:volume1': hostPermissions ?? ['download-file', 'upload-file'],
         }),
       }),
       Group: () => ({ allowed_vfolder_hosts: '{}' }),
@@ -413,6 +418,84 @@ describe('FolderExplorerModalV2 share-permission gating (FR-3800)', () => {
       expect(props.enableDelete).toBe(true);
       expect(props.enableUpload).toBe(true);
       expect(props.enableEdit).toBe(true);
+      expect(props.enableDownload).toBe(true);
+    });
+  });
+
+  // The two cases above turn write_content and delete_content on together, so
+  // they pass just as well when the two gates are cross-wired. These separate
+  // them.
+  it('write_content without delete_content enables write but not delete', async () => {
+    renderModal({
+      ownershipProjectId: null,
+      legacyPermissions: ['read_content', 'write_content'],
+    });
+
+    await screen.findByTestId('mock-file-explorer');
+
+    await waitFor(() => {
+      const props = fileExplorerProps.at(-1);
+      expect(props.enableWrite).toBe(true);
+      expect(props.enableDelete).toBe(false);
+      expect(props.enableUpload).toBe(true);
+      expect(props.enableEdit).toBe(true);
+    });
+  });
+
+  it('delete_content without write_content enables delete but not write, upload or edit', async () => {
+    renderModal({
+      ownershipProjectId: null,
+      legacyPermissions: ['read_content', 'delete_content'],
+    });
+
+    await screen.findByTestId('mock-file-explorer');
+
+    await waitFor(() => {
+      const props = fileExplorerProps.at(-1);
+      expect(props.enableDelete).toBe(true);
+      expect(props.enableWrite).toBe(false);
+      expect(props.enableUpload).toBe(false);
+      expect(props.enableEdit).toBe(false);
+    });
+  });
+
+  it('a host without upload-file disables upload and edit even when write_content is granted', async () => {
+    renderModal({
+      ownershipProjectId: null,
+      legacyPermissions: ['read_content', 'write_content', 'delete_content'],
+      hostPermissions: ['download-file'],
+    });
+
+    await screen.findByTestId('mock-file-explorer');
+
+    // The other side of the AND: the folder grants write, the host does not
+    // allow the upload pipeline the upload buttons and the editor save write
+    // through.
+    await waitFor(() => {
+      const props = fileExplorerProps.at(-1);
+      expect(props.enableUpload).toBe(false);
+      expect(props.enableEdit).toBe(false);
+      expect(props.enableWrite).toBe(true);
+      expect(props.enableDelete).toBe(true);
+      expect(props.enableDownload).toBe(true);
+    });
+  });
+
+  it('a host without download-file disables download', async () => {
+    renderModal({
+      ownershipProjectId: null,
+      legacyPermissions: ['read_content', 'write_content', 'delete_content'],
+      hostPermissions: ['upload-file'],
+    });
+
+    await screen.findByTestId('mock-file-explorer');
+
+    await waitFor(() => {
+      const props = fileExplorerProps.at(-1);
+      expect(props.enableDownload).toBe(false);
+      // Download is host-only: the folder-level grants are unaffected.
+      expect(props.enableUpload).toBe(true);
+      expect(props.enableWrite).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Resolves #9347 (FR-3830)

## Context

Follow-up to #9343 (FR-3824), which added the first regression tests for the FR-3800 share-permission gating in `FolderExplorerModalV2`.

Those two cases do pin the bypass regression, but they turn `write_content` and `delete_content` on together and leave the storage-host capability axis hardcoded in the `Domain` resolver. Mutation testing against the merged file — patch `FolderExplorerModalV2.tsx`, re-run the spec, and see whether anything fails — showed four rewiring bugs slipping through.

## Mutation results

| Mutation | Before (#9343) | After |
|---|---|---|
| `hasDeleteContentPermission = true \|\| …` (the FR-3800 bypass) | caught | caught |
| `hasWriteContentPermission = true \|\| …` | caught | caught |
| `hasUploadContentPermission = hasUploadHostPermission` (drop folder write gate) | caught | caught |
| delete gate reads `write_content` | **survived** | caught |
| write gate reads `delete_content` | **survived** | caught |
| `hasUploadContentPermission = hasWriteContentPermission` (drop host `upload-file` gate) | **survived** | caught |
| `hasDownloadContentPermission` forced false | **survived** | caught |
| download gate reads `upload-file` | **survived** | caught |

## What changed

`renderModal` gains a `hostPermissions` knob feeding the `Domain` resolver's `allowed_vfolder_hosts`, so the storage-host axis can be varied independently of the folder RBAC list. Four cases follow from it:

- **`write_content` without `delete_content`** — write/upload/edit enabled, delete disabled.
- **`delete_content` without `write_content`** — delete enabled, write/upload/edit disabled. Together with the case above this separates the two gates, so cross-wiring them is no longer invisible.
- **host without `upload-file`, folder grants `write_content`** — upload/edit disabled while write stays enabled. This is the other side of the `enableUpload` AND; #9343 only covered the folder side.
- **host without `download-file`** — `enableDownload` false while the folder-level grants are unaffected. `enableDownload` was the one permission prop of `BAIFileExplorer`'s five that no case asserted.

## Verification

- `vitest run src/components/FolderExplorerModalV2.test.tsx` → 9 passed (5 existing + 4 new)
- `prettier --check` on the touched file → clean
- All eight mutations above re-run against the extended file → every one fails at least one test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v17auom1vvawqTKvAj4qy
