### PR TITLE
fix(FR-3831): weld the accelerator type select and restore the number stepper

### DIFF
--- a/react/src/components/InputNumberWithSlider.test.tsx
+++ b/react/src/components/InputNumberWithSlider.test.tsx
@@ -2,22 +2,19 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- Covers the two things the antd -> Astryx conversion had to rebuild rather
- than rename (see the header of InputNumberWithSlider.tsx):
-
- 1. the marks SPLIT — string/number labels go to Astryx (which draws the tick
-    AND the label), node labels go to the overlay (Astryx still draws their
-    tick), and marks above `max` are dropped from both;
- 2. `tooltip.open === false` -> `valueDisplay="none"`.
+ Covers the marks SPLIT (string labels go to Astryx, node labels to the
+ overlay, marks above `max` are dropped from both) and the number input's
+ built-in steppers.
 
  The overlay's *position* is asserted as the percentage it writes, which is
  the same formula Astryx uses for its own marks — jsdom has no layout, so a
- live probe run during the FR-3482 Astryx migration is what confirmed the
- two land on the same pixel.
+ live probe is what confirmed the two land on the same pixel.
 */
 import '../../__test__/matchMedia.mock.js';
 import InputNumberWithSlider from './InputNumberWithSlider';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>();
@@ -105,5 +102,49 @@ describe('InputNumberWithSlider marks', () => {
       0,
     );
     expect(container.querySelector('.bai-slider--empty')).toBeTruthy();
+  });
+});
+
+const ControlledSlider: React.FC = () => {
+  const [value, setValue] = useState(0);
+  return (
+    <InputNumberWithSlider
+      label="Accelerator"
+      min={0}
+      max={4}
+      step={0.5}
+      value={value}
+      onChange={setValue}
+    />
+  );
+};
+
+describe('InputNumberWithSlider number steppers', () => {
+  it('steps the value up by `step` when the increment button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ControlledSlider />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('0');
+
+    const increment = screen.getByRole('button', { name: /increment/i });
+    await user.click(increment);
+    expect(input.value).toBe('0.5');
+
+    await user.click(increment);
+    expect(input.value).toBe('1');
+  });
+});
+
+describe('InputNumberWithSlider addons', () => {
+  it('renders addonAfter as a direct InputGroup child', () => {
+    renderSlider({
+      inputNumberProps: {
+        addonAfter: <span data-testid="addon-after">after</span>,
+      },
+    });
+    const after = screen.getByTestId('addon-after');
+    const inputWrapper = screen.getByRole('spinbutton').parentElement;
+    // Addons must be InputGroup's own children for it to weld them onto the field.
+    expect(after.parentElement).toBe(inputWrapper?.parentElement);
   });
 });

--- a/react/src/components/InputNumberWithSlider.test.tsx
+++ b/react/src/components/InputNumberWithSlider.test.tsx
@@ -106,6 +106,7 @@ describe('InputNumberWithSlider marks', () => {
 });
 
 const ControlledSlider: React.FC = () => {
+  'use memo';
   const [value, setValue] = useState(0);
   return (
     <InputNumberWithSlider

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -2,104 +2,50 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- antd `InputNumber` + `Slider` -> Astryx `NumberInput` + `Slider`
- (to-astryx final-A). This file was PARKED in W2-B under the frontier rule:
- its public API is two antd prop bags, and two of the keys its four call sites
- pass (`sliderProps.marks` with a JSX label, `sliderProps.tooltip.open`) had no
- Astryx destination. Both are resolved here; nothing is dropped.
+ Node-labelled marks are drawn in a second, absolutely-positioned layer built
+ from Astryx's own mark formula (`inset-inline-start: ${percent}%`), because
+ `Slider.marks` accepts only string labels. Astryx still draws every tick.
 
- The public contract is unchanged. Per the frontier rule the prop bags stay
- antd-SHAPED — restated locally as `SliderMarks` / `InputNumberBag` /
- `SliderBag` rather than imported from antd, which is what kept this module (and
- everything downstream of the session launcher) in the antd import graph (P15).
-
- Mapping:
-
-   `Space.Compact` + addonBefore/addonAfter -> `InputGroup` (the idiom
-                                               `BAIDynamicUnitInputNumber`
-                                               established in W2-D)
-   `InputNumber`                            -> `NumberInput`
-   `InputNumber.suffix`                     -> `NumberInput.units`
-   `Slider.disabled`                        -> `isDisabled`
-   `Slider.tooltip.formatter`               -> `formatValue`
-   `Slider.tooltip.open === false`          -> `valueDisplay="none"`
-   `Slider.marks`                           -> `marks` + the overlay below
-
- RESOLVED — **`tooltip.open`.** W2-B recorded this as having "no Astryx knob".
- It does: `valueDisplay`. The one consumer that passes it
- (`ResourceAllocationFormItems`, force-hiding the accelerator tooltip when the
- image supports no accelerator) passes `false | undefined` and never `true`, so
- `open === false -> valueDisplay="none"` covers the live behaviour exactly.
- A forced-OPEN tooltip would still have no equivalent; no call site wants one.
-
- RESOLVED — **JSX `marks` labels, via a marks overlay.** Astryx `Slider.marks`
- takes `{value, label?: string}[]` — a plain string — and every consumer places
- a `<RemainingMark />` (the "resources remaining" chevron) at a computed
- position. The sibling `BAIDynamicUnitInputNumberWithSlider` degraded those to
- `nodeToAccessibleLabel` in W2-D, which for `RemainingMark` means an unlabelled
- tick: the chevron disappears.
-
- It does not have to. Astryx's own mark geometry is plain and inset-free —
- `marksContainer` spans the track container edge to edge, each mark sits at
- `inset-inline-start: ${percent}%` with `translateX(-50%)`, and the label sits
- `THUMB_SIZE / 2 + 4` below that (`@astryxdesign/core/src/Slider/Slider.tsx`).
- So the node-valued marks are rendered in a second, absolutely-positioned layer
- built from the SAME formula, over a `position: relative` wrapper sized to the
- slider. Every mark value — string or node — is still handed to Astryx so it
- draws its tick; only the label rendering splits. The layer is
- `pointer-events: none`, so dragging the rail underneath is unaffected.
-
- PILOT-DECISION — **per-mark `style` is honoured, `sliderProps.styles` is not.**
- `RuntimeParameterFormSection` tints its max mark with `{style: {color:
- colorTextSecondary}}`; a mark rendered in our own layer can simply take that
- style, so it is applied (the string-labelled marks Astryx draws cannot, and
- Astryx already paints marks in the secondary text colour — which is what that
- style asked for). `styles.track` / `styles.handle` were only ever set by this
- file itself, for `disableMode="empty"`; see `bai-slider--empty` below.
-
- PILOT-DECISION — **the `useUpdatableState` remount hack is deleted.** It held
- a `key` on the `InputNumber` and bumped it once, on a `setTimeout(0)` after
- mount, under a `FIXME: workaround to fix the issue that the value is not
- updated when the value is controlled`. That is an antd `InputNumber` bug:
- Astryx's `NumberInput` is a plain controlled native input, so remounting it
- fixes nothing and only throws away focus. The same call also made the
- `inputRef` DOM read in `onBlur` necessary (antd's own value could lag the
- input's); the step-snapping now reads the controlled value directly.
+ Astryx's `NumberInput` REJECTS an out-of-range entry (`parseNumberInput`
+ returns null past either bound) rather than clamping it, so `onBlur` reads the
+ raw field text — the only surviving trace — and clamps from there.
 */
 import useControllableState_deprecated from '../hooks/useControllableState';
 import './InputNumberWithSlider.css';
 import { InputGroup } from '@astryxdesign/core/InputGroup';
 import { NumberInput } from '@astryxdesign/core/NumberInput';
 import { Slider } from '@astryxdesign/core/Slider';
-import { HStack } from '@astryxdesign/core/Stack';
 import { BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { useEffect } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-/** antd's `SliderMarks`, restated locally (P15 — no antd type imports). */
-export type SliderMarks = Record<
+/** antd-shaped position-keyed marks map — frozen for the call sites. */
+type SliderMarks = Record<
   string | number,
   ReactNode | { style?: CSSProperties; label?: ReactNode }
 >;
 
-/** The `InputNumberProps` slice the four call sites actually pass. */
+/** The number-input prop slice the call sites actually pass. */
 interface InputNumberBag {
   placeholder?: string;
-  /** antd's trailing unit text -> `NumberInput.units`. */
+  /** Trailing unit text -> `NumberInput.units`. */
   suffix?: ReactNode;
-  addonBefore?: ReactNode;
+  /**
+   * Rendered as a direct `InputGroup` child so it welds onto the field — pass
+   * an Astryx-weldable control, or wrap it in `InputGroupText` yourself.
+   */
   addonAfter?: ReactNode;
   style?: CSSProperties;
 }
 
-/** The `SliderSingleProps` slice the four call sites actually pass. */
+/** The slider prop slice the call sites actually pass. */
 interface SliderBag {
   marks?: SliderMarks;
   tooltip?: {
     formatter?: (value?: number) => ReactNode;
-    /** Only `false` is used in the repo — see the header. */
+    /** Only `false` is used in the repo -> `valueDisplay="none"`. */
     open?: boolean;
   };
 }
@@ -131,9 +77,8 @@ interface InputNumberWithSliderProps {
   style?: CSSProperties;
   sliderProps?: SliderBag;
   /**
-   * Accessible name for the pair. Astryx requires one on both controls (antd
-   * required none); surfaced here so a call site can name the field it sits
-   * under instead of taking the generic default.
+   * Accessible name for the pair. Astryx requires one on both controls;
+   * surfaced here so a call site can name the field it sits under.
    */
   label?: string;
 }
@@ -148,7 +93,7 @@ interface NormalizedMark {
   style?: CSSProperties;
 }
 
-/** antd's position-keyed map -> a sorted list, `{label, style}` flattened. */
+/** The position-keyed map -> a sorted list, `{label, style}` flattened. */
 const normalizeMarks = (marks: SliderMarks | undefined): NormalizedMark[] =>
   _.sortBy(
     _.map(marks, (mark, key) => {
@@ -185,6 +130,7 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
   label,
   ...otherProps
 }) => {
+  'use memo';
   const { t } = useTranslation();
   const [value, setValue] = useControllableState_deprecated(otherProps);
 
@@ -240,21 +186,17 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
           isLabelHidden
           isDisabled={isDisabled}
         >
-          {inputNumberProps?.addonBefore ? (
-            <HStack align="center">{inputNumberProps.addonBefore}</HStack>
-          ) : null}
           <NumberInput
             label={accessibleLabel}
             isLabelHidden
             max={max}
             min={min}
             step={step ?? undefined}
+            hasNumberSteppers
             isDisabled={isDisabled}
             value={displayValue ?? null}
             placeholder={inputNumberProps?.placeholder}
-            // antd's `suffix` was a unit hint rendered inside the field —
-            // exactly what `units` is. It is typed `ReactNode` on the antd
-            // side but every call site passes a plain unit string.
+            // Typed `ReactNode`, but every call site passes a plain string.
             units={
               _.isString(inputNumberProps?.suffix)
                 ? inputNumberProps.suffix
@@ -265,12 +207,9 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
               setValue(next);
             }}
             onBlur={(event) => {
-              // RESTORED: antd's `InputNumber` CLAMPED an out-of-range entry
-              // on blur. Astryx's rejects it instead — `parseNumberInput`
-              // returns null past either bound, so `onChange` never fires and
-              // the entry silently reverts. The raw field text is the only
-              // surviving trace; clamp from there. (React 19 does not pool
-              // events, so reading `target.value` in the handler is safe.)
+              // Astryx rejects an out-of-range entry instead of clamping it,
+              // so the raw field text is the only surviving trace. (React 19
+              // does not pool events, so reading `target.value` here is safe.)
               const rawText = (event.target as HTMLInputElement).value;
               const typed = rawText.trim() === '' ? NaN : Number(rawText);
               let current = value;
@@ -289,9 +228,6 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
                   setValue(clamped);
                 }
               }
-              // Snap to the nearest step. antd needed the raw DOM value for
-              // this because its own value could lag; Astryx commits on
-              // change, so the controlled value is already current.
               if (_.isNumber(step) && step > 0 && _.isNumber(current)) {
                 if (_.isNumber(max) && max < current) {
                   return; // do not update value if it is greater than max
@@ -310,9 +246,7 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
             width="100%"
             style={inputNumberProps?.style}
           />
-          {inputNumberProps?.addonAfter ? (
-            <HStack align="center">{inputNumberProps.addonAfter}</HStack>
-          ) : null}
+          {inputNumberProps?.addonAfter}
         </InputGroup>
       </BAIFlex>
       <BAIFlex direction="column" align="stretch" style={{ flex: 3 }}>

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1405,22 +1405,23 @@ const ResourceAllocationFormItems: React.FC<
                               (supportedAcceleratorTypesInRGByImage?.length ??
                                 0) > 0 ? (
                                 <Form.Item
+                                  noStyle
                                   name={['resource', 'acceleratorType']}
                                   initialValue={_.first(
                                     _.keys(acceleratorSlotsInRG),
                                   )}
-                                  style={{
-                                    marginBottom: 0,
-                                    maxWidth: 100,
-                                  }}
                                 >
                                   <BAISelect
+                                    // In an InputGroup the trigger resolves to
+                                    // width:100%; size it to content, bounded,
+                                    // so the number field keeps the row.
                                     style={{
-                                      width: '100%',
+                                      flex: '0 0 auto',
+                                      width: 'auto',
+                                      maxWidth: 100,
                                     }}
                                     autoSelectOption
                                     tabIndex={-1}
-                                    // Do not delete disabled prop. It is necessary to prevent the user from changing the value.
                                     suffixIcon={
                                       _.size(acceleratorSlotsInRG) > 1
                                         ? undefined


### PR DESCRIPTION
Resolves #9349 (FR-3831)

applied test server: https://fr-3831-pr9350-weld-accelerator-type.seungwon.10-82-0-159.sslip.io/

## What & why

The Session Launcher's **AI Accelerator (fGPU) field** rendered as a plain number input with no stepper, plus a fully detached accelerator-type select — visibly inconsistent with the Memory field one row above, which renders as one welded control (input + ▲/▼ stepper + attached unit select).

## Mechanism

Two independent causes, both in `InputNumberWithSlider` and its accelerator call site:

1. **Broken weld** — `InputNumberWithSlider` wrapped `inputNumberProps.addonAfter` in `<HStack align="center">`, and the call site additionally wrapped the `BAISelect` in a styled `Form.Item`. Astryx's `InputGroup` welds only its **direct** children, so the select laid out as a separate bordered box. Fix: addons render as direct `InputGroup` children, and the call site's `Form.Item` goes `noStyle` (pure binding, no wrapper element). The select is sized to content (`flex: '0 0 auto', width: 'auto'`, bounded at the previous `maxWidth: 100`) exactly like `BAIDynamicUnitInputNumber`'s unit `Selector`.
2. **Missing stepper** — antd's `InputNumber` always rendered a built-in spinner stepping **linearly by the `step` prop**; the Astryx conversion never enabled the equivalent. Fix: `hasNumberSteppers` on Astryx `NumberInput`, whose contract (linear by `step`, snapped to a grid anchored at `min`) matches antd's spinner exactly. `AstryxNumberStepper` was deliberately **not** used — it exists for the non-linear ladder components only.

### Step value (verified against the antd-era code)

The stepper references the existing `step={currentAcceleratorStep}` wiring, unchanged from the antd era (`git show 6f27a9c3c`): `accelerator_quantum_size` for `*.shares` accelerators on a single-node cluster (0.1 fallback when the resource group has no quantum size), and `1` for discrete accelerators / multi-node clusters (#868).

Since the composition lives in the shared `InputNumberWithSlider`, its other call sites (CPU, cluster size, runtime parameters, chat sliders) also regain the antd-era stepper — this is a restoration, not a behavior change unique to fGPU.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → **109 files / 1716 tests passed** (touched file: 8/8, two new tests — stepper steps by `step`; `addonAfter` is a direct `InputGroup` child)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → fails with 3 findings that are **pre-existing and unrelated** (`BAIDialog.css`, `BAIDrawerPortal.css`, `BAIText.css` — identical output with these changes stashed)

## Screenshots

| Before — AI Accelerator (reported) | Reference — Memory field (target look) |
|---|---|
| ![fgpu before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9350/20260901-115436-fgpu-before.png) | ![memory reference](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9350/20260901-115440-memory-reference.png) |

## Residue

- Live light/dark probe on a running cluster is still pending (background session had no backend credentials); the "before" screenshots below are the reporter's. Happy to re-capture after/before pairs on a dev session on request.
- `tabIndex={-1}` on the type select is pre-existing — with the control now welded, whether the type select should be keyboard-reachable is a separate a11y question, intentionally not decided here.
- Sibling detached-parts reports FR-3688 / FR-3693 (other call sites, already Done) and the composition discussion FR-3704 are **not** affected by this PR; it fixes the `InputNumberWithSlider` surface only.

