### PR TITLE
fix(FR-3833): send schema-valid order fields from the fair share steps

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.doc.ts
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.doc.ts
@@ -51,7 +51,7 @@ export const docs = {
       name: 'columns',
       type: 'BAIColumnsType<RecordType>',
       description:
-        'antd-shaped column model — title, dataIndex, key, render, sorter, width, align, fixed. Nested children groups are flattened, with the group title rendered as a muted caption above each child header.',
+        'antd-shaped column model — title, dataIndex, key, render, sorter, width, align, fixed. `sortKey` overrides the order-string field name when the dataIndex path is not the field the server sorts by. Nested children groups are flattened, with the group title rendered as a muted caption above each child header.',
     },
     {
       name: 'dataSource',

--- a/packages/backend.ai-ui/src/components/Table/BAITable.sortKey.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.sortKey.test.tsx
@@ -1,0 +1,80 @@
+/*
+ FR-3833 — the order-string field name a sortable column emits.
+
+ The order string is built from the dataIndex path joined with '.', so a
+ column whose dataIndex is a nested DISPLAY path (['calculationSnapshot',
+ 'fairShareFactor']) used to emit 'calculationSnapshot.fairShareFactor' — a
+ string no server order-field enum accepts. `sortKey` overrides the emitted
+ field name; these tests pin the override and the default.
+
+ Structural, not visual — jsdom's lack of layout does not matter.
+*/
+import BAITable from './BAITable';
+import type { BAIColumnsType } from './tableTypes';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+interface Row {
+  id: string;
+  snapshot: { factor: number };
+}
+
+const ROWS: Array<Row> = [
+  { id: '1', snapshot: { factor: 0.5 } },
+  { id: '2', snapshot: { factor: 1.0 } },
+];
+
+const renderSorted = (
+  columns: BAIColumnsType<Row>,
+  onChangeOrder: (order?: string) => void,
+) =>
+  render(
+    <BAITable<Row>
+      rowKey="id"
+      dataSource={ROWS}
+      columns={columns}
+      order={null}
+      onChangeOrder={onChangeOrder}
+    />,
+  );
+
+describe('BAITable sortable column order-string field name', () => {
+  it('emits the sortKey override instead of the dataIndex path', async () => {
+    const onChangeOrder = vi.fn();
+    renderSorted(
+      [
+        {
+          key: 'fairShareFactor',
+          title: 'Factor',
+          dataIndex: ['snapshot', 'factor'],
+          sortKey: 'fairShareFactor',
+          sorter: true,
+        },
+      ],
+      onChangeOrder,
+    );
+
+    await userEvent.click(screen.getByText('Factor'));
+    expect(onChangeOrder).toHaveBeenCalledTimes(1);
+    expect(onChangeOrder.mock.calls[0][0]).toMatch(/^-?fairShareFactor$/);
+  });
+
+  it('defaults to the dot-joined dataIndex path without sortKey', async () => {
+    const onChangeOrder = vi.fn();
+    renderSorted(
+      [
+        {
+          key: 'factor',
+          title: 'Factor',
+          dataIndex: ['snapshot', 'factor'],
+          sorter: true,
+        },
+      ],
+      onChangeOrder,
+    );
+
+    await userEvent.click(screen.getByText('Factor'));
+    expect(onChangeOrder).toHaveBeenCalledTimes(1);
+    expect(onChangeOrder.mock.calls[0][0]).toMatch(/^-?snapshot\.factor$/);
+  });
+});

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -358,13 +358,14 @@ const DENSITY_BY_SIZE: Record<string, TableDensity> = {
 const toAstryxAlign = (align?: string) =>
   align === 'right' ? 'end' : align === 'center' ? 'center' : undefined;
 
-/** antd `dataIndex` -> the field name the order string is built from. */
+/** `sortKey` override, else antd `dataIndex` -> the order-string field name. */
 const sortKeyOf = (column: BAIColumnType<any>, key: string) =>
-  column.dataIndex
+  column.sortKey ??
+  (column.dataIndex
     ? Array.isArray(column.dataIndex)
       ? column.dataIndex.join('.')
       : String(column.dataIndex)
-    : key;
+    : key);
 
 const columnKeyOf = (column: BAIColumnType<any>, index: number) =>
   column.key?.toString() ??

--- a/packages/backend.ai-ui/src/components/Table/tableTypes.ts
+++ b/packages/backend.ai-ui/src/components/Table/tableTypes.ts
@@ -139,6 +139,12 @@ export interface BAIColumnType<RecordType = any> {
   fixed?: BAIColumnFixed;
   sorter?: BAIColumnSorter<RecordType>;
   /**
+   * Field name for the server order string (`order` / `onChangeOrder`).
+   * Defaults to the dataIndex path joined with `.` — set this when that path
+   * is not the field the server sorts by (e.g. a nested display path).
+   */
+  sortKey?: string;
+  /**
    * Initial sort direction for this column. Honoured only by CLIENT-sorted
    * tables (no `order` / `onChangeOrder` wiring); a server-sorted table drives
    * its initial state through the `order` string instead, exactly as antd

--- a/react/src/components/FairShareItems/DomainFairShareStep.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareStep.tsx
@@ -10,6 +10,7 @@ import { convertToOrderBy, handleRowSelectionChange } from '../../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../../hooks/reactPaginationQueryOptions';
 import DomainFairShareTable, {
   availableDomainFairShareSorterValues,
+  domainFairShareOrderFieldMap,
   DomainFairShare,
 } from './DomainFairShareTable';
 import FairShareStepToolbar from './FairShareStepToolbar';
@@ -73,9 +74,10 @@ const DomainFairShareStep: React.FC<DomainFairShareStepProps> = ({
     filter: {
       ...(queryParams.filter || {}),
     },
-    order: convertToOrderBy<DomainFairShareOrderBy>(queryParams.order) || [
-      { field: 'DOMAIN_NAME', direction: 'DESC' },
-    ],
+    order: convertToOrderBy<DomainFairShareOrderBy>(
+      queryParams.order,
+      domainFairShareOrderFieldMap,
+    ) || [{ field: 'DOMAIN_NAME', direction: 'DESC' }],
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
   };

--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -195,6 +195,7 @@ const DomainFairShareTable: React.FC<DomainFairShareTableProps> = ({
       ),
       key: 'fairShareFactor',
       dataIndex: ['calculationSnapshot', 'fairShareFactor'],
+      sortKey: 'fairShareFactor',
       sorter: isEnableSorter('fairShareFactor'),
       render: (fairShareFactor) =>
         fairShareFactor !== null && fairShareFactor !== undefined

--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { DomainFairShareOrderField } from '../../__generated__/DomainFairShareStepQuery.graphql';
 import {
   DomainFairShareTableFragment$data,
   DomainFairShareTableFragment$key,
@@ -39,6 +40,14 @@ const availableDomainFairShareSorterKeys = [
   'fairShareFactor',
   'createdAt',
 ] as const;
+export const domainFairShareOrderFieldMap: Record<
+  (typeof availableDomainFairShareSorterKeys)[number],
+  DomainFairShareOrderField
+> = {
+  domainName: 'DOMAIN_NAME',
+  fairShareFactor: 'FAIR_SHARE_FACTOR',
+  createdAt: 'CREATED_AT',
+};
 export const availableDomainFairShareSorterValues = [
   ...availableDomainFairShareSorterKeys,
   ...availableDomainFairShareSorterKeys.map((key) => `-${key}` as const),

--- a/react/src/components/FairShareItems/ProjectFairShareStep.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareStep.tsx
@@ -12,6 +12,7 @@ import FairShareStepToolbar from './FairShareStepToolbar';
 import FairShareWeightSettingModal from './FairShareWeightSettingModal';
 import ProjectFairShareTable, {
   availableProjectFairShareSorterValues,
+  projectFairShareOrderFieldMap,
   ProjectFairShare,
 } from './ProjectFairShareTable';
 import ResourceGroupSchedulerTypeAlert from './ResourceGroupSchedulerTypeAlert';
@@ -76,9 +77,10 @@ const ProjectFairShareStep: React.FC<ProjectFairShareStepProps> = ({
     filter: {
       ...(queryParams.filter || {}),
     },
-    order: convertToOrderBy<ProjectFairShareOrderBy>(queryParams.order) || [
-      { field: 'CREATED_AT', direction: 'DESC' },
-    ],
+    order: convertToOrderBy<ProjectFairShareOrderBy>(
+      queryParams.order,
+      projectFairShareOrderFieldMap,
+    ) || [{ field: 'CREATED_AT', direction: 'DESC' }],
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
   };

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ProjectFairShareOrderField } from '../../__generated__/ProjectFairShareStepQuery.graphql';
 import {
   ProjectFairShareTableFragment$data,
   ProjectFairShareTableFragment$key,
@@ -36,6 +37,14 @@ const availableProjectFairShareSorterKeys = [
   'fairShareFactor',
   'createdAt',
 ] as const;
+export const projectFairShareOrderFieldMap: Record<
+  (typeof availableProjectFairShareSorterKeys)[number],
+  ProjectFairShareOrderField
+> = {
+  projectName: 'PROJECT_NAME',
+  fairShareFactor: 'FAIR_SHARE_FACTOR',
+  createdAt: 'CREATED_AT',
+};
 export const availableProjectFairShareSorterValues = [
   ...availableProjectFairShareSorterKeys,
   ...availableProjectFairShareSorterKeys.map((key) => `-${key}` as const),

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -185,6 +185,7 @@ const ProjectFairShareTable: React.FC<ProjectFairShareTableProps> = ({
       ),
       key: 'fairShareFactor',
       dataIndex: ['calculationSnapshot', 'fairShareFactor'],
+      sortKey: 'fairShareFactor',
       sorter: isEnableSorter('fairShareFactor'),
       render: (fairShareFactor) =>
         fairShareFactor !== null && fairShareFactor !== undefined

--- a/react/src/components/FairShareItems/ResourceGroupFairShareStep.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareStep.tsx
@@ -11,6 +11,7 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../../hooks/reactPagin
 import FairShareStepToolbar from './FairShareStepToolbar';
 import ResourceGroupFairShareTable, {
   availableResourceGroupSorterValues,
+  resourceGroupOrderFieldMap,
 } from './ResourceGroupFairShareTable';
 import { BAIFlex, INITIAL_FETCH_KEY, useFetchKey } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -55,9 +56,10 @@ const ResourceGroupFairShareStep: React.FC<ResourceGroupFairShareStepProps> = ({
     filter: {
       ...(queryParams.filter || {}),
     },
-    order: convertToOrderBy<ResourceGroupOrderBy>(queryParams.order) || [
-      { field: 'NAME', direction: 'DESC' },
-    ],
+    order: convertToOrderBy<ResourceGroupOrderBy>(
+      queryParams.order,
+      resourceGroupOrderFieldMap,
+    ) || [{ field: 'NAME', direction: 'DESC' }],
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
   };

--- a/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ResourceGroupOrderField } from '../../__generated__/ResourceGroupFairShareStepQuery.graphql';
 import {
   ResourceGroupFairShareTableFragment$data,
   ResourceGroupFairShareTableFragment$key,
@@ -34,6 +35,12 @@ type ResourceGroup = NonNullable<
 >;
 
 const availableResourceGroupSorterKeys = ['name'] as const;
+export const resourceGroupOrderFieldMap: Record<
+  (typeof availableResourceGroupSorterKeys)[number],
+  ResourceGroupOrderField
+> = {
+  name: 'NAME',
+};
 export const availableResourceGroupSorterValues = [
   ...availableResourceGroupSorterKeys,
   ...availableResourceGroupSorterKeys.map((key) => `-${key}` as const),

--- a/react/src/components/FairShareItems/UserFairShareStep.tsx
+++ b/react/src/components/FairShareItems/UserFairShareStep.tsx
@@ -14,6 +14,7 @@ import ResourceGroupSchedulerTypeAlert from './ResourceGroupSchedulerTypeAlert';
 import UsageBucketModal from './UsageBucketModal';
 import UserFairShareTable, {
   availableUserFairShareSorterValues,
+  userFairShareOrderFieldMap,
   UserFairShare,
 } from './UserFairShareTable';
 import UserResourceGroupAlert from './UserResourceGroupAlert';
@@ -78,9 +79,10 @@ const UserFairShareStep: React.FC<UserFairShareStepProps> = ({
     filter: {
       ...(queryParams.filter || {}),
     },
-    order: convertToOrderBy<UserFairShareOrderBy>(queryParams.order) || [
-      { field: 'CREATED_AT', direction: 'DESC' },
-    ],
+    order: convertToOrderBy<UserFairShareOrderBy>(
+      queryParams.order,
+      userFairShareOrderFieldMap,
+    ) || [{ field: 'CREATED_AT', direction: 'DESC' }],
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
   };

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -130,6 +130,7 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       key: 'email',
       fixed: 'left',
       dataIndex: 'userEmail',
+      sortKey: 'email',
       render: (_text, record) => (
         <BAINameActionCell
           title={record?.user?.basicInfo.email}
@@ -153,6 +154,7 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       key: 'username',
       fixed: 'left',
       dataIndex: 'userUsername',
+      sortKey: 'username',
       render: (_text, record) => record?.user?.basicInfo.username,
       sorter: isEnableSorter('username'),
     },
@@ -191,6 +193,7 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       ),
       key: 'fairShareFactor',
       dataIndex: ['calculationSnapshot', 'fairShareFactor'],
+      sortKey: 'fairShareFactor',
       sorter: isEnableSorter('fairShareFactor'),
       render: (fairShareFactor) =>
         fairShareFactor !== null && fairShareFactor !== undefined

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { UserFairShareOrderField } from '../../__generated__/UserFairShareStepQuery.graphql';
 import {
   UserFairShareTableFragment$data,
   UserFairShareTableFragment$key,
@@ -36,6 +37,16 @@ const availableUserFairShareSorterKeys = [
   'fairShareFactor',
   'createdAt',
 ] as const;
+// Snake-casing alone would send EMAIL/USERNAME, which the server enum rejects.
+export const userFairShareOrderFieldMap: Record<
+  (typeof availableUserFairShareSorterKeys)[number],
+  UserFairShareOrderField
+> = {
+  email: 'USER_EMAIL',
+  username: 'USER_USERNAME',
+  fairShareFactor: 'FAIR_SHARE_FACTOR',
+  createdAt: 'CREATED_AT',
+};
 export const availableUserFairShareSorterValues = [
   ...availableUserFairShareSorterKeys,
   ...availableUserFairShareSorterKeys.map((key) => `-${key}` as const),

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -26,8 +26,43 @@ import {
   subNumberWithUnits,
   compareImageVersions,
   resolveImageFullName,
+  convertToOrderBy,
   convertFirstOrderByToString,
 } from './index';
+
+describe('convertToOrderBy', () => {
+  it('returns undefined for empty, null, or undefined input', () => {
+    expect(convertToOrderBy(undefined)).toBeUndefined();
+    expect(convertToOrderBy(null)).toBeUndefined();
+    expect(convertToOrderBy('')).toBeUndefined();
+  });
+  it('snake-cases the field and derives the direction from the prefix', () => {
+    expect(convertToOrderBy('name')).toEqual([
+      { field: 'NAME', direction: 'ASC' },
+    ]);
+    expect(convertToOrderBy('-createdAt')).toEqual([
+      { field: 'CREATED_AT', direction: 'DESC' },
+    ]);
+  });
+  it('uses only the last part of a comma-joined array dataIndex', () => {
+    expect(convertToOrderBy('-calculationSnapshot,fairShareFactor')).toEqual([
+      { field: 'FAIR_SHARE_FACTOR', direction: 'DESC' },
+    ]);
+  });
+  it('maps the field through fieldNameMap when the key is present', () => {
+    expect(convertToOrderBy('-email', { email: 'USER_EMAIL' })).toEqual([
+      { field: 'USER_EMAIL', direction: 'DESC' },
+    ]);
+    expect(convertToOrderBy('username', { username: 'USER_USERNAME' })).toEqual(
+      [{ field: 'USER_USERNAME', direction: 'ASC' }],
+    );
+  });
+  it('falls back to snake-casing for keys missing from fieldNameMap', () => {
+    expect(convertToOrderBy('createdAt', { email: 'USER_EMAIL' })).toEqual([
+      { field: 'CREATED_AT', direction: 'ASC' },
+    ]);
+  });
+});
 
 describe('convertFirstOrderByToString', () => {
   it('returns null for empty, null, or undefined input', () => {
@@ -37,14 +72,14 @@ describe('convertFirstOrderByToString', () => {
     expect(convertFirstOrderByToString([{}])).toBeNull();
   });
   it('converts an ASC entry to a camelCase string with no prefix', () => {
-    expect(convertFirstOrderByToString([{ field: 'NAME', direction: 'ASC' }])).toBe(
-      'name',
-    );
+    expect(
+      convertFirstOrderByToString([{ field: 'NAME', direction: 'ASC' }]),
+    ).toBe('name');
   });
   it('prefixes a DESC entry with a minus sign', () => {
-    expect(convertFirstOrderByToString([{ field: 'NAME', direction: 'DESC' }])).toBe(
-      '-name',
-    );
+    expect(
+      convertFirstOrderByToString([{ field: 'NAME', direction: 'DESC' }]),
+    ).toBe('-name');
   });
   it('camelCases SCREAMING_SNAKE_CASE enum fields', () => {
     expect(

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -44,10 +44,21 @@ describe('convertToOrderBy', () => {
       { field: 'CREATED_AT', direction: 'DESC' },
     ]);
   });
-  it('uses only the last part of a comma-joined array dataIndex', () => {
+  it('uses only the last part of a joined array dataIndex', () => {
+    // '.' is what BAITable emits for array dataIndex; ',' is the antd-era join.
+    expect(convertToOrderBy('-calculationSnapshot.fairShareFactor')).toEqual([
+      { field: 'FAIR_SHARE_FACTOR', direction: 'DESC' },
+    ]);
     expect(convertToOrderBy('-calculationSnapshot,fairShareFactor')).toEqual([
       { field: 'FAIR_SHARE_FACTOR', direction: 'DESC' },
     ]);
+  });
+  it('applies fieldNameMap after extracting the last path segment', () => {
+    expect(
+      convertToOrderBy('-calculationSnapshot.fairShareFactor', {
+        fairShareFactor: 'FAIR_SHARE_FACTOR',
+      }),
+    ).toEqual([{ field: 'FAIR_SHARE_FACTOR', direction: 'DESC' }]);
   });
   it('maps the field through fieldNameMap when the key is present', () => {
     expect(convertToOrderBy('-email', { email: 'USER_EMAIL' })).toEqual([

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -1068,17 +1068,16 @@ export function listenToBackgroundTask<
  * // => [{ field: 'NAME', direction: 'DESC' }]
  *
  * @example
- * // With field name mapping for server compatibility
- * convertToOrderBy<DomainFairShareOrderBy>(
- *   '-calculationSnapshot,fairShareFactor',
- *   { fairShareFactor: 'FAIR_SHARE_FACTOR' }
- * )
- * // => [{ field: 'FAIR_SHARE_FACTOR', direction: 'DESC' }]
+ * // With field name mapping for server compatibility. Without the mapping,
+ * // 'email' would become 'EMAIL', which UserFairShareOrderField rejects.
+ * convertToOrderBy<UserFairShareOrderBy>('-email', { email: 'USER_EMAIL' })
+ * // => [{ field: 'USER_EMAIL', direction: 'DESC' }]
  */
 export const convertToOrderBy = <
   TOrderBy extends { field?: string; direction?: string },
 >(
   order: string | null | undefined,
+  fieldNameMap?: Record<string, NonNullable<TOrderBy['field']>>,
 ): ReadonlyArray<TOrderBy> | undefined => {
   if (!order) return undefined;
 
@@ -1092,7 +1091,7 @@ export const convertToOrderBy = <
 
   return [
     {
-      field: _.snakeCase(lastOrder).toUpperCase(),
+      field: fieldNameMap?.[lastOrder] ?? _.snakeCase(lastOrder).toUpperCase(),
       direction: isDescending ? 'DESC' : 'ASC',
     } as TOrderBy,
   ];

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -1051,8 +1051,8 @@ export function listenToBackgroundTask<
 
 /**
  * Converts an order string (e.g., 'name' or '-name') to a GraphQL v2 (Strawberry) OrderBy array.
- * If the order string contains commas (from array dataIndex like ['spec', 'weight']),
- * only the last part is used as the field name.
+ * If the order string is a joined array dataIndex path ('.' from BAITable,
+ * ',' from the antd era), only the last segment is used as the field name.
  *
  * @template TOrderBy - The type of the order by object (e.g., ResourceGroupOrderBy)
  * @param order - The order string. Prefix with '-' for descending order.
@@ -1085,8 +1085,9 @@ export const convertToOrderBy = <
   const isDescending = order.startsWith('-');
   const cleanOrder = isDescending ? order.slice(1) : order;
 
-  // If order contains comma-separated values, extract the last one
-  const orderParts = cleanOrder.split(',');
+  // A joined array dataIndex path ('.' from BAITable, ',' from the antd-era
+  // table) names the server field in its last segment.
+  const orderParts = cleanOrder.split(/[.,]/);
   const lastOrder = orderParts[orderParts.length - 1].trim();
 
   return [


### PR DESCRIPTION
Resolves #9351 (FR-3833)

## Problem

Follow-up to FR-3430 (#8516): ordering was reported broken on the fair share steps, including a hard crash. Live reproduction against a cluster pinned down the full chain; the webui carried these defects (backend-side defects tracked separately — see Scope):

1. **Clicking the Fair Share Factor sorter crashed the step** (all of domain / project / user). BAITable builds its order string from the dataIndex path joined with `.` — the antd-era table joined with `,` — so the column with `dataIndex: ['calculationSnapshot', 'fairShareFactor']` emitted `calculationSnapshot.fairShareFactor`. `convertToOrderBy`'s comma-only split never fired, snake-casing produced the nonexistent enum value `CALCULATION_SNAPSHOT_FAIR_SHARE_FACTOR`, the server answered 400, and Relay rethrew during render into the error boundary. (The sorter-values allowlist didn't catch it: nuqs re-runs `parseAsStringLiteral` only when reading the URL, not on same-page sets, and the table's `onChangeOrder` cast the emitted string in blind.)
2. **`convertToOrderBy` bypasses type checking.** Its `as TOrderBy` cast means the Relay-generated order-field unions never constrain the produced field name — which is why none of this failed `tsc`.
3. **JSDoc documented a `fieldNameMap` parameter that did not exist.** The mapping escape hatch was designed but never implemented.
4. **Sorter key lists were hand-maintained with nothing tying them to the schema.** Each fair share table hardcoded `available*SorterKeys` free to drift from the `*OrderField` enums, and the keys the table actually *emits* (dataIndex-derived) drifted from those lists too — e.g. the user table emitted `userEmail` / `userUsername` and only reached the correct `USER_EMAIL` / `USER_USERNAME` values by snake-case accident.

## Changes

- **`BAIColumnType` gains a `sortKey` override** (BUI): the order-string field name for a column whose dataIndex is a nested display path. `sortKeyOf` prefers it; default behavior unchanged. Pinned by the new `BAITable.sortKey.test.tsx`.
- **Fair share columns emit canonical keys**: the three fair-share-factor columns set `sortKey: 'fairShareFactor'`, the user table's email/username columns set `sortKey: 'email'` / `'username'`. Emitted keys now match the sorter-values allowlist, so the URL round-trips (sort survives reload) and the header sort indicator lights up.
- **`convertToOrderBy` now implements the documented `fieldNameMap` parameter** (`Record<string, NonNullable<TOrderBy['field']>>`): a mapped key wins; unmapped keys keep the snake-case fallback, so all ~35 existing call sites are unaffected.
- **`convertToOrderBy` splits joined dataIndex paths on `.` as well as `,`**, restoring the antd-era "last segment names the field" contract for any table still emitting a joined path.
- **Each fair share table exports a key→order-field map** typed `Record<SorterKey, *OrderField>` against the Relay-generated enum union (`resourceGroupOrderFieldMap`, `domainFairShareOrderFieldMap`, `projectFairShareOrderFieldMap`, `userFairShareOrderFieldMap`), passed at the step-level `convertToOrderBy` call sites. Adding a sorter key without a mapping, or a schema enum rename, now fails `tsc` instead of failing at runtime.
- **Unit tests** for `convertToOrderBy` (previously untested) and the BAITable `sortKey` override.

## Live verification (cluster at 10.82.0.130)

Before: clicking Fair Share Factor on the domain step → URL `order=calculationSnapshot.fairShareFactor`, request variables `{"field":"CALCULATION_SNAPSHOT_FAIR_SHARE_FACTOR"}`, HTTP 400, error boundary.
After: URL `order=fairShareFactor` / `-fairShareFactor`, request variables `{"field":"FAIR_SHARE_FACTOR","direction":"ASC|DESC"}`, rows re-sort (1.00 → 0.88 on DESC), sort indicator lit, no errors.

## Scope note (backend)

`projectName` / `email` / `username` ordering stays visually inert until the backend restores the order-field mappings dropped in the BA-5127 adapter migration (silently ignored since backend 26.4.0) — tracked in BA-7544. This PR removes the crash, makes every fair share sort send schema-valid values, and wires the whole path drift-proof, so those sorts start working the moment the backend fix lands.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm vitest run src/helper/index.test.tsx` (react) → 140 passed
- `pnpm vitest run src/components/Table/` (backend.ai-ui) → 61 passed
- Live before/after probe as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpTzZ4dhqVaoQyX5Mp1JPt
