### PR TITLE
fix: sync BAIVFolderPathPicker.doc.ts with the ComplexSelector rewrite

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.doc.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      "A form control for choosing a sub path inside a given virtual folder. It renders a BAISelect purely as a trigger — the dropdown never opens; every open gesture, mouse or keyboard, is redirected to `BAIDirectoryPickerModal`, so a path can only be picked by browsing and never typed. The value is the sub path within the vfolder: `''` for the vfolder root, `'sub/path'` below it, and `undefined` while nothing has been picked; the trigger displays it with a leading slash so a chosen root is visibly different from an empty field. The vfolder itself is chosen elsewhere and handed in as `vfolderUuid`. `value`, `defaultValue` and `onChange` follow the controllable-value convention, so the component drops into a Form.Item and works controlled or uncontrolled. Opening the picker preloads the modal's query inside a transition, which is what the trigger shows as its loading state.",
+      "A form control for choosing a sub path inside a given virtual folder. It renders an Astryx `ComplexSelector` purely as a trigger — its popover never opens; every open gesture, mouse or keyboard, is redirected to `BAIDirectoryPickerModal`, so a path can only be picked by browsing and never typed. The value is the sub path within the vfolder: `''` for the vfolder root, `'sub/path'` below it, and `undefined` while nothing has been picked; the trigger displays it with a leading slash so a chosen root is visibly different from an empty field. The vfolder itself is chosen elsewhere and handed in as `vfolderUuid`. `value`, `defaultValue` and `onChange` follow the controllable-value convention, so the component drops into a Form.Item and works controlled or uncontrolled. Opening the picker preloads the modal's query inside a transition, which is what the trigger shows as its loading state.",
     bestPractices: [
       {
         guidance: true,
@@ -36,7 +36,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Set `open`, `onOpenChange`, `loading`, `disabled`, `value` or `onChange` through `selectProps`; those keys are removed from its type because the component drives them to redirect the dropdown into the modal.',
+          'Reach for the trigger to open a dropdown of paths — it has no popup of its own, and every open gesture is redirected into the picker modal.',
       },
       {
         guidance: false,
@@ -83,10 +83,10 @@ export const docs = {
         'Inline style forwarded to the trigger select, typically to set its width.',
     },
     {
-      name: 'selectProps',
-      type: "Omit<BAISelectProps, 'value' | 'onChange' | 'open' | 'onOpenChange' | 'loading' | 'disabled'>",
+      name: 'label',
+      type: 'string',
       description:
-        'Extra props spread onto the trigger select, for things like the placeholder or the accessible label. The six keys the component owns are excluded.',
+        'Accessible name of the trigger, kept visually hidden because the surrounding Form.Item renders the visible label. Defaults to the picker\'s own "Select a path" copy.',
     },
   ],
   examples: [


### PR DESCRIPTION
## What

`main` is currently red on `backend-ai-ui-vitest`:

```
AssertionError: BAIVFolderPathPicker.doc.ts documents a prop `selectProps`
                that BAIVFolderPathPicker.tsx never names
Test Files 1 failed (1) | Tests 1 failed | 1074 passed
```

Reproduced on a pristine `origin/main` checkout (ac5cafc89) with nothing else applied.

FR-3675 (#9070) rebuilt `BAIVFolderPathPicker` on Astryx `ComplexSelector`, dropping `selectProps` and adding `label`, but did not touch `BAIVFolderPathPicker.doc.ts` (its diff covers only `.tsx` and `.stories.tsx`). `astryxIntegration.test.ts` asserts that a doc names only props the component source mentions, so the pair has been inconsistent since that merge.

## Why CI did not catch it

A semantic merge conflict — both PRs were green in isolation:

| Time (UTC) | Event |
|---|---|
| 08-25 09:08 | #9070's last `backend-ai-ui-vitest` run — pass |
| 08-26 09:37 | **#9138** merged, writing the `selectProps` entry into `.doc.ts` |
| 09-01 03:20 | **#9070** merged, removing `selectProps` from `.tsx`, CI six days stale and never re-run |

`backend-ai-ui-vitest` is not a required status check on `main`, so nothing blocked the merge.

## Changes

`BAIVFolderPathPicker.doc.ts` only:

- Drop the `selectProps` prop entry (the assertion failure).
- Replace the `selectProps` anti-pattern bullet with one about the trigger having no popup of its own.
- Document `label`, the accessible-name prop the rewrite added.
- Correct the usage prose that still described the trigger as a `BAISelect`.

## Verification

- `vitest run src/astryx-docs/astryxIntegration.test.ts` — **1075 passed** (was 1 failed / 1074 passed).
- `tsc --noEmit` on `backend.ai-ui` — clean.
- `eslint` and `prettier --check` on the changed file — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsqNSo1SP81X26rADDzs9W