### PR TITLE
feat(FR-3813): review overlay read side — pins from GitHub with resolved state, panel and deep links

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -120,7 +120,7 @@ Two endpoints back it, both **GET only, with no request parameters**, both dev-o
 | `/__review/state` | the running PR, the served set, the repository and `isPrivate` |
 | `/__review/pins`  | every `#bai=v3` block found on the served PRs, merged by id    |
 
-The served set comes from the dev-server skill's boot record (`BAI_REVIEW_BOOT_RECORD`) when there is one — that is the whole stack below the running branch — and from `gh pr list --head <branch>` otherwise. Reads go through the box's own `gh` credentials, are cached for 15 s with one shared upstream fetch however many people are looking, and are **refused entirely for a private repository**. The token never reaches the browser.
+The served set comes from the dev-server skill's boot record (`BAI_REVIEW_BOOT_RECORD`) when there is one — that is the whole stack below the running branch — and from `gh pr list --head <branch>` otherwise. Reads go through the box's own `gh` credentials, are cached for 15 s with one shared upstream fetch however many people are looking, and are **refused entirely for a private repository**. Only what the PR page already shows is served: a review you have started but not submitted is skipped. The token never reaches the browser.
 
 ## CLI login (`/cli-login`)
 

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -103,6 +103,25 @@ VITE_THEME_HEADER_COLOR=#7C3AED
 
 Vite auto-loads `VITE_*` vars from this file and exposes them on `import.meta.env` for the React app, tinting the header so you can tell multiple instances apart at a glance. You can also export `VITE_THEME_HEADER_COLOR` in the shell — same effect, no file edit needed.
 
+## Review overlay (`VITE_DEV_REVIEW_OVERLAY`)
+
+Off by default. Set it in `.env.development.local` or the shell before `pnpm run dev`:
+
+```bash
+VITE_DEV_REVIEW_OVERLAY=1
+```
+
+With it on, the dev server injects the review overlay (`react/vite-plugins/review-overlay/`). ⌘⌃C — or the dock's **📍 Review** button — picks an element and copies a `#bai=v3` markdown block to paste into the PR comment, the PR's Teams thread, or a Claude prompt. Every such block already posted on the PRs this server serves comes back as a numbered pin on the element it was picked from, with its GitHub state (resolved / replied / reacted / outdated), and opening a block's link lands on that element.
+
+Two endpoints back it, both **GET only, with no request parameters**, both dev-only:
+
+| Endpoint          | Answers                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| `/__review/state` | the running PR, the served set, the repository and `isPrivate` |
+| `/__review/pins`  | every `#bai=v3` block found on the served PRs, merged by id    |
+
+The served set comes from the dev-server skill's boot record (`BAI_REVIEW_BOOT_RECORD`) when there is one — that is the whole stack below the running branch — and from `gh pr list --head <branch>` otherwise. Reads go through the box's own `gh` credentials, are cached for 15 s with one shared upstream fetch however many people are looking, and are **refused entirely for a private repository**. The token never reaches the browser.
+
 ## CLI login (`/cli-login`)
 
 `bai-agent login` (`packages/backend.ai-agent-cli`, the Backend.AI WebUI Agent CLI) hands the CLI the session this dev server is already logged in with, via the `/cli-login` page. The route is always mounted; it is not linked from any menu.

--- a/e2e/review-overlay-deeplink.spec.ts
+++ b/e2e/review-overlay-deeplink.spec.ts
@@ -30,13 +30,6 @@ test.describe('@review-overlay review overlay deep link', () => {
         (window as unknown as { __baiReviewOverlay?: boolean })
           .__baiReviewOverlay,
     );
-    // Let the SPA settle on its final route before the anchor is captured —
-    // the deep link reproduces that route, so it must be the resolved one.
-    await page
-      .locator('button:visible, a[href]:visible')
-      .first()
-      .waitFor({ timeout: 30_000 });
-    await page.waitForTimeout(2000);
 
     const link = await page.evaluate(
       async ([anchorUrl, codecUrl, idUrl]) => {
@@ -47,15 +40,52 @@ test.describe('@review-overlay review overlay deep link', () => {
           import(/* @vite-ignore */ codecUrl),
           import(/* @vite-ignore */ idUrl),
         ]);
-        const overlay = document.querySelector('[data-bai-review-overlay]');
-        const target = [
-          ...document.querySelectorAll('[data-testid], button, a[href]'),
-        ].find((element) => {
-          if (overlay?.contains(element)) return false;
+        const usable = (element: Element): boolean => {
+          // react-grab's own hit layer is a full-viewport pointer-events:none
+          // div that matches every "big visible element" filter.
+          if (element.closest('[data-bai-review-overlay]')) return false;
+          if (element.closest('[data-testid="react-grab-overlay"]'))
+            return false;
           const box = element.getBoundingClientRect();
-          return box.width > 8 && box.height > 8;
-        });
-        if (!target) throw new Error('no element to anchor to on this page');
+          if (box.width < 8 || box.height < 8) return false;
+          const style = getComputedStyle(element);
+          if (
+            style.visibility === 'hidden' ||
+            style.display === 'none' ||
+            style.pointerEvents === 'none'
+          )
+            return false;
+          return !!(element as HTMLElement).innerText?.trim();
+        };
+        const find = (selector: string) =>
+          [...document.querySelectorAll(selector)].find(usable);
+        // A real interactive element first: it has text for the anchor's
+        // fallback scan and it survives the SPA re-rendering around it.
+        const pick = () =>
+          find('button, a[href]') ?? find('[data-testid]') ?? null;
+
+        // The anchor carries the route it was captured on and the deep link
+        // reproduces it, so it has to be the SETTLED one: a dev server with
+        // credentials injected leaves `/` for `/project/<name>/start` about
+        // 5 s in, and a `/`-anchored pin is "other page" everywhere after.
+        // Polled in-page on purpose: a Playwright locator pierces the
+        // overlay's shadow root and would settle on its own dock button.
+        const deadline = Date.now() + 25_000;
+        let url = location.href;
+        let since = Date.now();
+        let target: Element | null = null;
+        for (;;) {
+          if (location.href !== url) {
+            url = location.href;
+            since = Date.now();
+          }
+          target = pick();
+          if (target && Date.now() - since >= 1500) break;
+          if (Date.now() > deadline) {
+            throw new Error(`no settled element to anchor to on ${url}`);
+          }
+          await new Promise((resolve) => setTimeout(resolve, 250));
+        }
         const anchor = anchorMod.captureAnchorSignals(target);
         const b64: string = await codecMod.encodeAnchor(anchor);
         return {
@@ -75,8 +105,11 @@ test.describe('@review-overlay review overlay deep link', () => {
       },
     );
 
-    const pin = page.locator('[data-bai-review-overlay] .pin').first();
-    await expect(pin).toBeVisible({ timeout: 30_000 });
+    // By id, not by DOM order: the served PR carries its own real pins, and
+    // one anchored elsewhere sorts first as a hidden orphan.
+    await expect(
+      page.locator(`[data-bai-review-overlay] .pin[data-pin-id="${link.id}"]`),
+    ).toBeVisible({ timeout: 30_000 });
     await expect(
       page.locator(`[data-bai-review-overlay] .item[data-pin-id="${link.id}"]`),
     ).toBeVisible();

--- a/e2e/review-overlay-deeplink.spec.ts
+++ b/e2e/review-overlay-deeplink.spec.ts
@@ -1,0 +1,94 @@
+import { webuiEndpoint } from './utils/test-util';
+import { expect, test } from '@playwright/test';
+
+/**
+ * FR-3813 — review overlay read side, against a dev server started with
+ * `VITE_DEV_REVIEW_OVERLAY=1`. CI has no such server, so the whole file is
+ * opt-in: `E2E_REVIEW_OVERLAY_SMOKE=1 pnpm exec playwright test
+ * e2e/review-overlay-deeplink.spec.ts --project chromium`.
+ *
+ * The login page is enough — no backend session is needed, and the anchor is
+ * built in the page with the overlay's OWN codec, so the test exercises the
+ * real `#bai=v3` round trip rather than a hand-written fixture.
+ */
+test.describe('@review-overlay review overlay deep link', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !!process.env.CI || !process.env.E2E_REVIEW_OVERLAY_SMOKE,
+      'Needs a dev server with VITE_DEV_REVIEW_OVERLAY=1 (set E2E_REVIEW_OVERLAY_SMOKE=1)',
+    );
+  });
+
+  test('@smoke a self-contained link pins the element and opens its panel item', async ({
+    page,
+  }) => {
+    await page.goto(webuiEndpoint, { waitUntil: 'domcontentloaded' });
+    const loginButton = page
+      .getByRole('button', { name: /login|sign in/i })
+      .first();
+    await loginButton.waitFor({ timeout: 30_000 });
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __baiReviewOverlay?: boolean })
+          .__baiReviewOverlay,
+    );
+
+    const target = await loginButton.elementHandle();
+    const link = await page.evaluate(
+      async ([element, anchorUrl, codecUrl, idUrl]) => {
+        // Variable specifiers: these modules are served by the dev plugin at
+        // request time and have no counterpart in the repo's module graph.
+        const [anchorMod, codecMod, idMod] = await Promise.all([
+          import(/* @vite-ignore */ anchorUrl as string),
+          import(/* @vite-ignore */ codecUrl as string),
+          import(/* @vite-ignore */ idUrl as string),
+        ]);
+        const anchor = anchorMod.captureAnchorSignals(element as Element);
+        const b64: string = await codecMod.encodeAnchor(anchor);
+        const at = '2026-09-01T00:00:00Z';
+        return { id: idMod.pinId(0, b64, at) as string, b64 };
+      },
+      [
+        target,
+        '/__review/anchor.js',
+        '/__review/codec.js',
+        '/__review/id.js',
+      ] as const,
+    );
+
+    // A FRESH load, the way a reviewer opens the link from a PR comment.
+    await page.goto(`${webuiEndpoint}/#bai=v3.${link.id}.${link.b64}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const pin = page.locator('[data-bai-review-overlay] .pin').first();
+    await expect(pin).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.locator(`[data-bai-review-overlay] .item[data-pin-id="${link.id}"]`),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-bai-review-overlay] .panel'),
+    ).toBeVisible();
+  });
+
+  test('the endpoints take no parameters, answer GET only and share one read', async ({
+    page,
+  }) => {
+    const first = await page.request.get(`${webuiEndpoint}/__review/pins`);
+    expect(first.ok()).toBe(true);
+    const withJunk = await page.request.get(
+      `${webuiEndpoint}/__review/pins?anything=1`,
+    );
+    // Same 15 s cache entry — identical bodies, `fetchedAt` included.
+    expect(await withJunk.json()).toEqual(await first.json());
+
+    const posted = await page.request.post(`${webuiEndpoint}/__review/pins`);
+    expect(posted.status()).toBe(405);
+
+    const state = await (
+      await page.request.get(`${webuiEndpoint}/__review/state`)
+    ).json();
+    expect(state).toHaveProperty('served');
+    expect(state).toHaveProperty('isPrivate');
+  });
+});

--- a/e2e/review-overlay-deeplink.spec.ts
+++ b/e2e/review-overlay-deeplink.spec.ts
@@ -7,9 +7,11 @@ import { expect, test } from '@playwright/test';
  * opt-in: `E2E_REVIEW_OVERLAY_SMOKE=1 pnpm exec playwright test
  * e2e/review-overlay-deeplink.spec.ts --project chromium`.
  *
- * The login page is enough — no backend session is needed, and the anchor is
- * built in the page with the overlay's OWN codec, so the test exercises the
- * real `#bai=v3` round trip rather than a hand-written fixture.
+ * No backend session is needed: whatever the dev server renders — the login
+ * form, or the app shell when a session is already live — the test picks a
+ * real visible element off that page and builds its anchor with the overlay's
+ * OWN codec, so it exercises the real `#bai=v3` round trip rather than a
+ * hand-written fixture that can drift from the encoder.
  */
 test.describe('@review-overlay review overlay deep link', () => {
   test.beforeEach(() => {
@@ -23,43 +25,55 @@ test.describe('@review-overlay review overlay deep link', () => {
     page,
   }) => {
     await page.goto(webuiEndpoint, { waitUntil: 'domcontentloaded' });
-    const loginButton = page
-      .getByRole('button', { name: /login|sign in/i })
-      .first();
-    await loginButton.waitFor({ timeout: 30_000 });
     await page.waitForFunction(
       () =>
         (window as unknown as { __baiReviewOverlay?: boolean })
           .__baiReviewOverlay,
     );
+    // Let the SPA settle on its final route before the anchor is captured —
+    // the deep link reproduces that route, so it must be the resolved one.
+    await page
+      .locator('button:visible, a[href]:visible')
+      .first()
+      .waitFor({ timeout: 30_000 });
+    await page.waitForTimeout(2000);
 
-    const target = await loginButton.elementHandle();
     const link = await page.evaluate(
-      async ([element, anchorUrl, codecUrl, idUrl]) => {
+      async ([anchorUrl, codecUrl, idUrl]) => {
         // Variable specifiers: these modules are served by the dev plugin at
         // request time and have no counterpart in the repo's module graph.
         const [anchorMod, codecMod, idMod] = await Promise.all([
-          import(/* @vite-ignore */ anchorUrl as string),
-          import(/* @vite-ignore */ codecUrl as string),
-          import(/* @vite-ignore */ idUrl as string),
+          import(/* @vite-ignore */ anchorUrl),
+          import(/* @vite-ignore */ codecUrl),
+          import(/* @vite-ignore */ idUrl),
         ]);
-        const anchor = anchorMod.captureAnchorSignals(element as Element);
+        const overlay = document.querySelector('[data-bai-review-overlay]');
+        const target = [
+          ...document.querySelectorAll('[data-testid], button, a[href]'),
+        ].find((element) => {
+          if (overlay?.contains(element)) return false;
+          const box = element.getBoundingClientRect();
+          return box.width > 8 && box.height > 8;
+        });
+        if (!target) throw new Error('no element to anchor to on this page');
+        const anchor = anchorMod.captureAnchorSignals(target);
         const b64: string = await codecMod.encodeAnchor(anchor);
-        const at = '2026-09-01T00:00:00Z';
-        return { id: idMod.pinId(0, b64, at) as string, b64 };
+        return {
+          id: idMod.pinId(0, b64, '2026-09-01T00:00:00Z') as string,
+          b64,
+          path: `${anchor.p}${anchor.q ? `?${anchor.q}` : ''}`,
+        };
       },
-      [
-        target,
-        '/__review/anchor.js',
-        '/__review/codec.js',
-        '/__review/id.js',
-      ] as const,
+      ['/__review/anchor.js', '/__review/codec.js', '/__review/id.js'] as const,
     );
 
     // A FRESH load, the way a reviewer opens the link from a PR comment.
-    await page.goto(`${webuiEndpoint}/#bai=v3.${link.id}.${link.b64}`, {
-      waitUntil: 'domcontentloaded',
-    });
+    await page.goto(
+      `${webuiEndpoint}${link.path}#bai=v3.${link.id}.${link.b64}`,
+      {
+        waitUntil: 'domcontentloaded',
+      },
+    );
 
     const pin = page.locator('[data-bai-review-overlay] .pin').first();
     await expect(pin).toBeVisible({ timeout: 30_000 });

--- a/react/vite-plugins/review-overlay/boot-record.ts
+++ b/react/vite-plugins/review-overlay/boot-record.ts
@@ -15,7 +15,8 @@ export interface BootRecord {
     pr?: number;
     branch?: string;
     teamsThread?: string;
-    commentId?: string;
+    /** `advertise.sh` writes GitHub's numeric comment id; older files stringify it. */
+    commentId?: number | string | null;
   }>;
 }
 

--- a/react/vite-plugins/review-overlay/client/anchor-guard.ts
+++ b/react/vite-plugins/review-overlay/client/anchor-guard.ts
@@ -1,0 +1,45 @@
+/**
+ * What an anchor must look like before anything acts on it. Both sides check:
+ * the server before `/__review/pins` serves a pin, the client before a pasted
+ * deep link reaches `querySelector` and `location.assign`.
+ */
+import { isSafePath } from './codec.js';
+import type { AnchorV3 } from './types.js';
+
+/** Every string is bounded: the payload comes off a public PR comment. */
+const SELECTOR_MAX = 1024;
+const NAME_MAX = 256;
+const TXT_MAX = 64;
+
+/** A tag name reaches `querySelectorAll`; nothing else may look like one. */
+export const TAG_RE = /^[a-z][a-z0-9-]*$/;
+
+const isText = (value: unknown, max: number): value is string =>
+  typeof value === 'string' && value.length <= max;
+const isFraction = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value);
+
+export function isAnchorV3(value: unknown): value is AnchorV3 {
+  if (!value || typeof value !== 'object') return false;
+  const a = value as Record<string, unknown>;
+  if (a.v !== 3) return false;
+  if (!isText(a.s, SELECTOR_MAX) || !a.s) return false;
+  if (!isSafePath(a.p)) return false;
+  if (a.q !== undefined && (!isText(a.q, SELECTOR_MAX) || /[#\s]/.test(a.q)))
+    return false;
+  if (a.tag !== undefined && (!isText(a.tag, NAME_MAX) || !TAG_RE.test(a.tag)))
+    return false;
+  if (a.txt !== undefined && !isText(a.txt, TXT_MAX)) return false;
+  if (a.tid !== undefined && !isText(a.tid, NAME_MAX)) return false;
+  if (a.rect !== undefined) {
+    const r = a.rect as Record<string, unknown> | null;
+    if (!r || typeof r !== 'object') return false;
+    if (!['x', 'y', 'w', 'h'].every((k) => isFraction(r[k]))) return false;
+  }
+  if (a.c !== undefined) {
+    const c = a.c as Record<string, unknown> | null;
+    if (!c || typeof c !== 'object') return false;
+    if (!isText(c.name, NAME_MAX) || !isText(c.src, NAME_MAX)) return false;
+  }
+  return true;
+}

--- a/react/vite-plugins/review-overlay/client/codec.test.ts
+++ b/react/vite-plugins/review-overlay/client/codec.test.ts
@@ -27,6 +27,13 @@ describe('anchor codec', () => {
     await expect(decodeAnchor(encoded)).resolves.toEqual(anchor);
   });
 
+  // A tiny base64 payload inflates to megabytes; the decoder stops early.
+  it('refuses a payload that inflates past the cap', async () => {
+    const bomb = await encodeAnchor({ ...anchor, s: 'a'.repeat(200_000) });
+    expect(bomb.length).toBeLessThan(2048);
+    await expect(decodeAnchor(bomb)).resolves.toBeNull();
+  });
+
   it('produces a fragment-safe base64url string (no +, /, =)', async () => {
     const encoded = await encodeAnchor({
       ...anchor,

--- a/react/vite-plugins/review-overlay/client/codec.ts
+++ b/react/vite-plugins/review-overlay/client/codec.ts
@@ -8,6 +8,17 @@
  */
 import type { AnchorV3 } from './types.js';
 
+/**
+ * `<id>[.<anchor>]` — the one grammar the comment extractor and the deep-link
+ * parser share. The anchor is bounded: a 40 MB `s` deflates to well under a
+ * GitHub comment's size limit, so an unbounded match is an inflate bomb.
+ */
+export const PIN_BODY_SRC =
+  '(c_[a-z2-7]{7})(?:\\.([A-Za-z0-9_-]{8,2048}))?(?![A-Za-z0-9_-])';
+
+/** Real anchors are 250–300 bytes inflated; this is the refusal threshold. */
+export const MAX_ANCHOR_BYTES = 16_384;
+
 export const b64urlFromBytes = (bytes: Uint8Array): string => {
   let bin = '';
   for (const b of bytes) bin += String.fromCharCode(b);
@@ -38,6 +49,7 @@ export const isSafePath = (p: unknown): p is string =>
 async function pipeStream(
   bytes: Uint8Array,
   stream: CompressionStream | DecompressionStream,
+  limit = Infinity,
 ): Promise<Uint8Array> {
   const source = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -55,6 +67,10 @@ async function pipeStream(
     if (done) break;
     chunks.push(value);
     total += value.length;
+    if (total > limit) {
+      await reader.cancel();
+      throw new Error('anchor too large');
+    }
   }
   const out = new Uint8Array(total);
   let offset = 0;
@@ -77,6 +93,7 @@ export async function decodeAnchor(b64url: string): Promise<AnchorV3 | null> {
     const inflated = await pipeStream(
       bytesFromB64url(b64url),
       new DecompressionStream('deflate-raw'),
+      MAX_ANCHOR_BYTES,
     );
     const obj = JSON.parse(new TextDecoder().decode(inflated));
     if (!obj || typeof obj !== 'object') return null;

--- a/react/vite-plugins/review-overlay/client/deeplink.test.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.test.ts
@@ -1,0 +1,136 @@
+import {
+  parseFragment,
+  pinUrl,
+  pathNeedsChange,
+  retryUntil,
+} from './deeplink.js';
+import type { AnchorV3 } from './types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
+  v: 3,
+  s: 'button',
+  p: '/session',
+  ...over,
+});
+
+describe('parseFragment', () => {
+  it('reads the full self-contained form', () => {
+    expect(parseFragment('#bai=v3.c_zdv3rhz.QUJDREVGR0g')).toEqual({
+      kind: 'v3',
+      id: 'c_zdv3rhz',
+      anchorB64: 'QUJDREVGR0g',
+    });
+  });
+
+  it('reads the short id-only form Claude and humans write by hand', () => {
+    expect(parseFragment('#bai=v3.c_zdv3rhz')).toEqual({
+      kind: 'v3',
+      id: 'c_zdv3rhz',
+      anchorB64: null,
+    });
+  });
+
+  it('finds the pin inside a compound fragment', () => {
+    expect(parseFragment('#tab=logs&bai=v3.c_zdv3rhz')).toMatchObject({
+      id: 'c_zdv3rhz',
+    });
+  });
+
+  it('reports a v1 link so the overlay can say why it did nothing', () => {
+    expect(parseFragment('#bai-review=eJyrVkrLz1eyUlAqSS0uUaoFAB')).toEqual({
+      kind: 'legacy',
+    });
+  });
+
+  it('ignores an unrelated fragment', () => {
+    expect(parseFragment('#section-2')).toBeNull();
+    expect(parseFragment('')).toBeNull();
+  });
+
+  it('ignores a malformed id', () => {
+    expect(parseFragment('#bai=v3.zdv3rhz')).toBeNull();
+  });
+});
+
+describe('pathNeedsChange', () => {
+  it('is true when the anchor names another path', () => {
+    expect(pathNeedsChange(anchor(), { pathname: '/start', search: '' })).toBe(
+      true,
+    );
+  });
+
+  it('is true when only the query differs — filters and tabs matter (R3.3)', () => {
+    expect(
+      pathNeedsChange(anchor({ q: 'status=RUNNING' }), {
+        pathname: '/session',
+        search: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when we are already there', () => {
+    expect(
+      pathNeedsChange(anchor({ q: 'status=RUNNING' }), {
+        pathname: '/session',
+        search: '?status=RUNNING',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a path the codec would refuse to navigate to', () => {
+    expect(
+      pathNeedsChange(
+        { v: 3, s: 'b', p: '//evil.example' },
+        { pathname: '/', search: '' },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('pinUrl', () => {
+  it('rebuilds the link the block carried', () => {
+    expect(
+      pinUrl(anchor({ q: 'status=RUNNING' }), 'c_zdv3rhz', 'QUJDREVGR0g'),
+    ).toBe('/session?status=RUNNING#bai=v3.c_zdv3rhz.QUJDREVGR0g');
+  });
+
+  it('keeps the short form short', () => {
+    expect(pinUrl(anchor(), 'c_zdv3rhz', null)).toBe(
+      '/session#bai=v3.c_zdv3rhz',
+    );
+  });
+});
+
+describe('retryUntil', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stops as soon as the SPA has rendered the element', async () => {
+    vi.useFakeTimers();
+    const attempt = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+    const onGiveUp = vi.fn();
+    retryUntil(attempt, { tries: 20, everyMs: 500, onGiveUp });
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(onGiveUp).not.toHaveBeenCalled();
+  });
+
+  it('gives up after the ladder runs out', async () => {
+    vi.useFakeTimers();
+    const onGiveUp = vi.fn();
+    retryUntil(() => false, { tries: 3, everyMs: 500, onGiveUp });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onGiveUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be cancelled when a later deep link takes over', async () => {
+    vi.useFakeTimers();
+    const attempt = vi.fn().mockReturnValue(false);
+    const cancel = retryUntil(attempt, { tries: 20, everyMs: 500 });
+    cancel();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react/vite-plugins/review-overlay/client/deeplink.test.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.test.ts
@@ -48,6 +48,14 @@ describe('parseFragment', () => {
     expect(parseFragment('')).toBeNull();
   });
 
+  it('drops an anchor longer than any real one, keeping the id', () => {
+    expect(parseFragment(`#bai=v3.c_zdv3rhz.${'A'.repeat(4000)}`)).toEqual({
+      kind: 'v3',
+      id: 'c_zdv3rhz',
+      anchorB64: null,
+    });
+  });
+
   it('ignores a malformed id', () => {
     expect(parseFragment('#bai=v3.zdv3rhz')).toBeNull();
   });

--- a/react/vite-plugins/review-overlay/client/deeplink.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.ts
@@ -1,0 +1,75 @@
+/**
+ * `#bai=v3` deep links (R3.3, R3.6): read the fragment, apply path and query
+ * first, then anchor with a retry ladder while the SPA renders.
+ */
+import { isSafePath } from './codec.js';
+import type { AnchorV3 } from './types.js';
+
+/** `[#&]` because the pin can ride inside a fragment the app already uses. */
+const HASH_RE = /[#&]bai=v3\.(c_[a-z2-7]{7})(?:\.([A-Za-z0-9_-]{8,}))?/;
+/** v1/v2 links are not carried forward — recognised only to say so. */
+const LEGACY_RE = /[#&]bai-review=/;
+
+export type Fragment =
+  | { kind: 'v3'; id: string; anchorB64: string | null }
+  | { kind: 'legacy' }
+  | null;
+
+export function parseFragment(hash: string): Fragment {
+  const match = HASH_RE.exec(hash || '');
+  if (match) return { kind: 'v3', id: match[1], anchorB64: match[2] ?? null };
+  return LEGACY_RE.test(hash || '') ? { kind: 'legacy' } : null;
+}
+
+/** Path AND query, so a filtered list or a tab reproduces (R3.3). */
+export function pathNeedsChange(
+  anchor: AnchorV3,
+  location: { pathname: string; search: string },
+): boolean {
+  if (!isSafePath(anchor.p)) return false;
+  const want = anchor.q ? `?${anchor.q}` : '';
+  return anchor.p !== location.pathname || want !== location.search;
+}
+
+export function pinUrl(
+  anchor: AnchorV3,
+  id: string,
+  anchorB64: string | null,
+): string {
+  const query = anchor.q ? `?${anchor.q}` : '';
+  return `${anchor.p}${query}#bai=v3.${id}${anchorB64 ? `.${anchorB64}` : ''}`;
+}
+
+export interface RetryOptions {
+  tries: number;
+  everyMs: number;
+  onGiveUp?: () => void;
+}
+
+/**
+ * The overlay script runs before React mounts, and the login form is lazy
+ * behind a Suspense splash, so the first attempt at a cold-boot deep link
+ * always fails. Returns a cancel function.
+ */
+export function retryUntil(
+  attempt: () => boolean,
+  { tries, everyMs, onGiveUp }: RetryOptions,
+): () => void {
+  let left = tries;
+  let timer = 0;
+  let cancelled = false;
+  const run = () => {
+    if (cancelled) return;
+    if (attempt()) return;
+    if (--left <= 0) {
+      onGiveUp?.();
+      return;
+    }
+    timer = window.setTimeout(run, everyMs);
+  };
+  run();
+  return () => {
+    cancelled = true;
+    clearTimeout(timer);
+  };
+}

--- a/react/vite-plugins/review-overlay/client/deeplink.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.ts
@@ -2,11 +2,11 @@
  * `#bai=v3` deep links (R3.3, R3.6): read the fragment, apply path and query
  * first, then anchor with a retry ladder while the SPA renders.
  */
-import { isSafePath } from './codec.js';
+import { isSafePath, PIN_BODY_SRC } from './codec.js';
 import type { AnchorV3 } from './types.js';
 
 /** `[#&]` because the pin can ride inside a fragment the app already uses. */
-const HASH_RE = /[#&]bai=v3\.(c_[a-z2-7]{7})(?:\.([A-Za-z0-9_-]{8,}))?/;
+const HASH_RE = new RegExp(`[#&]bai=v3\\.${PIN_BODY_SRC}`);
 /** v1/v2 links are not carried forward — recognised only to say so. */
 const LEGACY_RE = /[#&]bai-review=/;
 

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -183,7 +183,7 @@ function boot() {
     anchoredId = id;
     cancelAnchorRetry();
     cancelAnchorRetry = retryUntil(
-      () => !!panel.locatePin(id, { full: true, quiet: true }),
+      () => !!panel.locatePin(id, { full: true, quiet: true, highlight: true }),
       {
         tries: ANCHOR_TRIES,
         everyMs: ANCHOR_EVERY_MS,

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -1,10 +1,11 @@
 /**
- * Dev review overlay — write side (FR-3811).
+ * Dev review overlay (FR-3811 write side, FR-3813 read side).
  *
  * Pick an element with react-grab (⌘⌃C or the dock button), type a note, press
- * ⌘⏎: a self-describing `#bai=v3` markdown block lands on the clipboard, ready
- * to paste into a GitHub PR comment, the PR's Teams thread, or a Claude
- * prompt. Reading those blocks back and drawing pins is FR-3813.
+ * ⌘⏎: a self-describing `#bai=v3` markdown block lands on the clipboard. Every
+ * such block already pasted on the served PRs comes back from
+ * `/__review/pins` as a numbered pin on the element it was picked from, and
+ * opening the block's link lands on that element.
  */
 import { captureAnchorSignals } from './anchor.js';
 import {
@@ -14,9 +15,29 @@ import {
   resolveRouteLabel,
   type AnchorCapture,
 } from './block.js';
+import { decodeAnchor } from './codec.js';
+import {
+  parseFragment,
+  pathNeedsChange,
+  pinUrl,
+  retryUntil,
+} from './deeplink.js';
+import { createPinPanel } from './panel.js';
 import { createPicker } from './picker.js';
-import type { AnchorV3, ReviewServerState } from './types.js';
+import { onCurrentPage } from './pins-state.js';
+import { createPoller } from './poll.js';
+import type {
+  AnchorV3,
+  ReviewPinsPayload,
+  ReviewServerState,
+} from './types.js';
 import { createOverlayUI } from './ui.js';
+
+/** The SPA's own `<Navigate replace>` redirects drop the fragment on login. */
+const BOOT_HASH = location.hash;
+/** 10 s of SPA boot at 500 ms — the login form is lazy behind the splash. */
+const ANCHOR_TRIES = 20;
+const ANCHOR_EVERY_MS = 500;
 
 if (!window.__baiReviewOverlay) {
   window.__baiReviewOverlay = true;
@@ -35,6 +56,7 @@ function boot() {
 
   const ui = createOverlayUI({
     onStartPick: () => picker.start(),
+    onTogglePanel: () => panel.toggle(),
     onBuildBlock: (text) => {
       const target = ui.getComposeTarget();
       if (!target || capture?.target !== target) return null;
@@ -100,4 +122,99 @@ function boot() {
     });
 
   picker.watchForReactGrab();
+
+  // ------------------------------------------------------ pins (FR-3813)
+
+  const poller = createPoller<ReviewPinsPayload>({
+    load: async () => {
+      const response = await fetch('/__review/pins');
+      if (!response.ok) throw new Error(String(response.status));
+      return response.json();
+    },
+    onPayload: (payload) => onPins(payload),
+    onError: () => panel.setError('dev server unreachable'),
+  });
+
+  const panel = createPinPanel({
+    root: ui.root,
+    host: ui.host,
+    showToast: ui.showToast,
+    copyText: ui.copyText,
+    onCountChange: ui.setPinCount,
+    onOpenChange: ui.setPanelOpen,
+    onStartPick: () => picker.start(),
+    onRefresh: () => poller.refreshNow(),
+  });
+
+  /** The deep link's id, until the payload that describes it arrives. */
+  let pendingId: string | null = null;
+  let navigatedForHash = false;
+  let cancelAnchorRetry = () => undefined as void;
+
+  const anchorWithRetry = (id: string) => {
+    cancelAnchorRetry();
+    cancelAnchorRetry = retryUntil(
+      () => !!panel.locatePin(id, { full: true, quiet: true }),
+      {
+        tries: ANCHOR_TRIES,
+        everyMs: ANCHOR_EVERY_MS,
+        onGiveUp: () =>
+          ui.showToast('Could not find that element — the pin is in the panel'),
+      },
+    );
+  };
+
+  function onPins(payload: ReviewPinsPayload) {
+    panel.applyPayload(payload);
+    if (!pendingId || !panel.has(pendingId)) return;
+    const id = pendingId;
+    pendingId = null;
+    const entry = panel.get(id);
+    const anchor = entry?.anchor ?? null;
+    // The short form learns its page only now, so the jump happens here.
+    if (anchor && !onCurrentPage(anchor, location) && !navigatedForHash) {
+      navigatedForHash = true;
+      location.assign(pinUrl(anchor, id, entry?.pin.anchorB64 ?? null));
+      return;
+    }
+    panel.revealItem(id);
+    if (anchor) anchorWithRetry(id);
+  }
+
+  async function applyFragment(hash: string) {
+    const fragment = parseFragment(hash);
+    if (!fragment) return;
+    if (fragment.kind === 'legacy') {
+      ui.showToast('That is an old #bai-review link — pick the element again');
+      return;
+    }
+    pendingId = fragment.id;
+    panel.open();
+    if (fragment.anchorB64) {
+      const anchor = await decodeAnchor(fragment.anchorB64);
+      if (!anchor) {
+        ui.showToast('Could not read the anchor in that link');
+      } else if (!navigatedForHash && pathNeedsChange(anchor, location)) {
+        // Path and query first (R3.3): a full reload, because React Router
+        // owns the history and re-running our boot is cheap.
+        navigatedForHash = true;
+        location.assign(pinUrl(anchor, fragment.id, fragment.anchorB64));
+        return;
+      } else {
+        panel.ensureProvisional(fragment.id, anchor, fragment.anchorB64);
+        anchorWithRetry(fragment.id);
+      }
+    } else {
+      ui.showToast('Looking for this pin on the served PRs…');
+    }
+    poller.refreshNow();
+  }
+
+  window.addEventListener('hashchange', () => {
+    navigatedForHash = false;
+    void applyFragment(location.hash);
+  });
+
+  poller.start();
+  void applyFragment(BOOT_HASH);
 }

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -7,6 +7,7 @@
  * `/__review/pins` as a numbered pin on the element it was picked from, and
  * opening the block's link lands on that element.
  */
+import { isAnchorV3 } from './anchor-guard.js';
 import { captureAnchorSignals } from './anchor.js';
 import {
   buildBlockFromCapture,
@@ -24,7 +25,6 @@ import {
 } from './deeplink.js';
 import { createPinPanel } from './panel.js';
 import { createPicker } from './picker.js';
-import { onCurrentPage } from './pins-state.js';
 import { createPoller } from './poll.js';
 import type {
   AnchorV3,
@@ -38,6 +38,24 @@ const BOOT_HASH = location.hash;
 /** 10 s of SPA boot at 500 ms — the login form is lazy behind the splash. */
 const ANCHOR_TRIES = 20;
 const ANCHOR_EVERY_MS = 500;
+/** The fragment survives in-app navigation, so a link is followed once a tab. */
+const APPLIED_KEY = 'bai-review-applied';
+
+const appliedHere = (id: string): boolean => {
+  try {
+    return sessionStorage.getItem(APPLIED_KEY) === id;
+  } catch {
+    return false;
+  }
+};
+
+const rememberApplied = (id: string) => {
+  try {
+    sessionStorage.setItem(APPLIED_KEY, id);
+  } catch {
+    // A tab with storage disabled just follows the link again.
+  }
+};
 
 if (!window.__baiReviewOverlay) {
   window.__baiReviewOverlay = true;
@@ -133,6 +151,14 @@ function boot() {
     },
     onPayload: (payload) => onPins(payload),
     onError: () => panel.setError('dev server unreachable'),
+    // `fetchedAt` is new on every build, so it can never mean "changed".
+    signatureOf: (payload) =>
+      JSON.stringify({
+        pins: payload.pins,
+        served: payload.served,
+        sources: payload.sources,
+        error: payload.error,
+      }),
   });
 
   const panel = createPinPanel({
@@ -149,9 +175,12 @@ function boot() {
   /** The deep link's id, until the payload that describes it arrives. */
   let pendingId: string | null = null;
   let navigatedForHash = false;
+  let anchoredId: string | null = null;
   let cancelAnchorRetry = () => undefined as void;
 
   const anchorWithRetry = (id: string) => {
+    if (anchoredId === id) return;
+    anchoredId = id;
     cancelAnchorRetry();
     cancelAnchorRetry = retryUntil(
       () => !!panel.locatePin(id, { full: true, quiet: true }),
@@ -171,14 +200,22 @@ function boot() {
     pendingId = null;
     const entry = panel.get(id);
     const anchor = entry?.anchor ?? null;
-    // The short form learns its page only now, so the jump happens here.
-    if (anchor && !onCurrentPage(anchor, location) && !navigatedForHash) {
-      navigatedForHash = true;
-      location.assign(pinUrl(anchor, id, entry?.pin.anchorB64 ?? null));
+    // The short form learns its page only now, so the jump happens here — and
+    // it is the same jump the full form makes: path AND query (R3.3).
+    if (anchor && pathNeedsChange(anchor, location)) {
+      if (!navigatedForHash && !appliedHere(id)) {
+        navigatedForHash = true;
+        location.assign(pinUrl(anchor, id, entry?.pin.anchorB64 ?? null));
+        return;
+      }
+      panel.revealItem(id);
       return;
     }
     panel.revealItem(id);
-    if (anchor) anchorWithRetry(id);
+    if (anchor) {
+      rememberApplied(id);
+      anchorWithRetry(id);
+    }
   }
 
   async function applyFragment(hash: string) {
@@ -192,15 +229,24 @@ function boot() {
     panel.open();
     if (fragment.anchorB64) {
       const anchor = await decodeAnchor(fragment.anchorB64);
-      if (!anchor) {
+      // The link is a stranger's: `decodeAnchor` checks `v`, `s` and `p`, the
+      // rest of the payload reaches `querySelector` and the DOM unchecked.
+      if (!anchor || !isAnchorV3(anchor)) {
         ui.showToast('Could not read the anchor in that link');
-      } else if (!navigatedForHash && pathNeedsChange(anchor, location)) {
-        // Path and query first (R3.3): a full reload, because React Router
-        // owns the history and re-running our boot is cheap.
-        navigatedForHash = true;
-        location.assign(pinUrl(anchor, fragment.id, fragment.anchorB64));
-        return;
+      } else if (pathNeedsChange(anchor, location)) {
+        if (!navigatedForHash && !appliedHere(fragment.id)) {
+          // Path and query first (R3.3): a full reload, because React Router
+          // owns the history and re-running our boot is cheap.
+          navigatedForHash = true;
+          location.assign(pinUrl(anchor, fragment.id, fragment.anchorB64));
+          return;
+        }
+        // Followed once in this tab already: show the pin in the panel rather
+        // than pulling the reviewer back here on every later reload.
+        panel.ensureProvisional(fragment.id, anchor, fragment.anchorB64);
+        panel.revealItem(fragment.id);
       } else {
+        rememberApplied(fragment.id);
         panel.ensureProvisional(fragment.id, anchor, fragment.anchorB64);
         anchorWithRetry(fragment.id);
       }
@@ -212,6 +258,7 @@ function boot() {
 
   window.addEventListener('hashchange', () => {
     navigatedForHash = false;
+    anchoredId = null;
     void applyFragment(location.hash);
   });
 

--- a/react/vite-plugins/review-overlay/client/panel.test.ts
+++ b/react/vite-plugins/review-overlay/client/panel.test.ts
@@ -1,0 +1,201 @@
+import { createPinPanel, type PinPanel } from './panel.js';
+import type { ReviewPin, ReviewPinsPayload } from './types.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pin = (over: Partial<ReviewPin> = {}): ReviewPin => ({
+  id: 'c_zdv3rhz',
+  number: 1,
+  anchorB64: 'QUJDREVGR0g',
+  anchor: { v: 3, s: 'button', p: '/', tag: 'button', txt: 'Login' },
+  text: 'off by 8px',
+  author: 'reviewer',
+  createdAt: new Date().toISOString(),
+  sources: [
+    {
+      channel: 'github',
+      pr: 9354,
+      kind: 'comment',
+      url: 'https://github.com/l/r/pull/9354#issuecomment-1',
+      author: 'reviewer',
+    },
+  ],
+  sourcePr: 9354,
+  quoted: true,
+  resolved: false,
+  resolvedBy: null,
+  outdated: false,
+  hint: false,
+  replies: [],
+  latestReply: null,
+  replyCount: 0,
+  ...over,
+});
+
+const payload = (pins: ReviewPin[]): ReviewPinsPayload => ({
+  pins,
+  served: [{ pr: 9354, state: 'OPEN' }],
+  sources: { github: { ok: true, count: pins.length } },
+  fetchedAt: new Date().toISOString(),
+});
+
+let panel: PinPanel;
+let root: ShadowRoot;
+let counts: number[] = [];
+
+beforeEach(() => {
+  document.body.innerHTML = '<button>Login</button>';
+  const host = document.createElement('div');
+  host.setAttribute('data-bai-review-overlay', '');
+  document.body.appendChild(host);
+  root = host.attachShadow({ mode: 'open' });
+  counts = [];
+  panel = createPinPanel({
+    root,
+    host,
+    showToast: vi.fn(),
+    copyText: vi.fn().mockReturnValue(true),
+    onCountChange: (count) => counts.push(count),
+    onOpenChange: vi.fn(),
+    onStartPick: vi.fn(),
+    onRefresh: vi.fn(),
+  });
+});
+
+const items = () => [...root.querySelectorAll('.item')];
+
+describe('pin panel', () => {
+  it('renders one flat list in payload number order', () => {
+    panel.applyPayload(
+      payload([
+        pin({ id: 'c_bbbbbbb', number: 2, author: 'second' }),
+        pin({ id: 'c_aaaaaaa', number: 1, author: 'first' }),
+      ]),
+    );
+    expect(items().map((item) => (item as HTMLElement).dataset.pinId)).toEqual([
+      'c_aaaaaaa',
+      'c_bbbbbbb',
+    ]);
+    expect(items()[0].querySelector('.author')?.textContent).toBe('#1 first');
+  });
+
+  it('badges the PR the block was found on and links it', () => {
+    panel.applyPayload(payload([pin()]));
+    const badge = items()[0].querySelector('a.badge') as HTMLAnchorElement;
+    expect(badge.textContent).toBe('🐙 #9354');
+    expect(badge.href).toContain('/pull/9354');
+  });
+
+  // Pin text is a stranger's comment on a public PR.
+  it('renders comment text as text, never as markup', () => {
+    panel.applyPayload(
+      payload([
+        pin({
+          text: '<img src=x onerror="alert(1)">',
+          author: '<script>evil</script>',
+          latestReply: {
+            author: '<b>bold</b>',
+            body: '<iframe src="http://evil"></iframe>',
+            createdAt: null,
+            url: null,
+          },
+          replyCount: 1,
+        }),
+      ]),
+    );
+    expect(root.querySelector('img')).toBeNull();
+    expect(root.querySelector('iframe')).toBeNull();
+    expect(root.querySelector('script')).toBeNull();
+    expect(items()[0].querySelector('.body')?.textContent).toBe(
+      '<img src=x onerror="alert(1)">',
+    );
+  });
+
+  it('shows the reply state and the extra-reply count', () => {
+    panel.applyPayload(
+      payload([
+        pin({
+          replyCount: 3,
+          latestReply: {
+            author: 'claude',
+            body: 'Fixed in abc1234',
+            createdAt: null,
+            url: null,
+          },
+        }),
+      ]),
+    );
+    const item = items()[0];
+    expect(item.querySelector('.badge.replied')?.textContent).toContain(
+      'replied',
+    );
+    expect(item.querySelector('.lastreply')?.textContent).toContain('(+2)');
+  });
+
+  it('dims a resolved pin and names who resolved it', () => {
+    panel.applyPayload(payload([pin({ resolved: true, resolvedBy: 'owner' })]));
+    expect(items()[0].classList.contains('resolved')).toBe(true);
+    expect(items()[0].textContent).toContain('by owner');
+  });
+
+  it('draws a numbered pin for an anchor that resolves on this page', () => {
+    panel.applyPayload(payload([pin()]));
+    const marker = root.querySelector('.pin');
+    expect(marker?.textContent).toBe('1');
+    expect(counts.at(-1)).toBe(1);
+  });
+
+  it('keeps an unlocatable pin out of the page but in the list', () => {
+    document.body.innerHTML = '<p>nothing here</p>';
+    panel.applyPayload(payload([pin()]));
+    expect(root.querySelector('.pin')?.classList.contains('orphan')).toBe(true);
+    expect(items()[0].textContent).toContain('not found on this page');
+  });
+
+  it('badges a pin that lives on another page and never draws it', () => {
+    panel.applyPayload(
+      payload([pin({ anchor: { v: 3, s: 'button', p: '/session' } })]),
+    );
+    expect(root.querySelector('.pin')).toBeNull();
+    expect(items()[0].textContent).toContain('other page');
+  });
+
+  // The panel is rebuilt on every poll, so the highlight has to be state.
+  it('keeps the highlighted item highlighted across a rebuild', () => {
+    panel.applyPayload(payload([pin()]));
+    panel.revealItem('c_zdv3rhz');
+    expect(items()[0].classList.contains('hl')).toBe(true);
+    panel.applyPayload(payload([pin({ text: 'off by 9px' })]));
+    expect(items()[0].classList.contains('hl')).toBe(true);
+  });
+
+  it('reports the served PRs and the per-channel source status', () => {
+    panel.applyPayload({
+      pins: [],
+      served: [{ pr: 9354, state: 'OPEN' }],
+      sources: { github: { ok: false, error: 'upstream' } },
+      fetchedAt: new Date().toISOString(),
+    });
+    const line = root.querySelector('.srcline')?.textContent ?? '';
+    expect(line).toContain('serves #9354');
+    expect(line).toContain('GitHub ✗ upstream');
+  });
+
+  it('holds a deep-link pin until the channel catches up, then replaces it', () => {
+    panel.ensureProvisional(
+      'c_zdv3rhz',
+      { v: 3, s: 'button', p: '/' },
+      'QUJDREVGR0g',
+    );
+    expect(items()[0].textContent).toContain('looking for this pin');
+    panel.applyPayload(payload([pin()]));
+    expect(items()).toHaveLength(1);
+    expect(items()[0].textContent).toContain('off by 8px');
+  });
+
+  it('drops a pin that is gone from the payload', () => {
+    panel.applyPayload(payload([pin()]));
+    panel.applyPayload(payload([]));
+    expect(items()).toHaveLength(0);
+    expect(root.querySelector('.pin')).toBeNull();
+  });
+});

--- a/react/vite-plugins/review-overlay/client/panel.test.ts
+++ b/react/vite-plugins/review-overlay/client/panel.test.ts
@@ -143,9 +143,42 @@ describe('pin panel', () => {
 
   it('draws a numbered pin for an anchor that resolves on this page', () => {
     panel.applyPayload(payload([pin()]));
-    const marker = root.querySelector('.pin');
+    const marker = root.querySelector('.pin') as HTMLElement;
     expect(marker?.textContent).toBe('1');
+    // A page can carry several pins; anything automating one needs its id.
+    expect(marker.dataset.pinId).toBe('c_zdv3rhz');
     expect(counts.at(-1)).toBe(1);
+  });
+
+  // The retry ladder locates the element seconds after the payload arrived,
+  // so a highlight tied to the payload has already expired by then.
+  it('highlights item and pin when the deep link places it, not before', () => {
+    panel.applyPayload(payload([pin()]));
+    expect(root.querySelector('.item.hl')).toBeNull();
+    expect(root.querySelector('.pin.pulse')).toBeNull();
+
+    panel.locatePin('c_zdv3rhz', { full: true, highlight: true });
+    expect((root.querySelector('.item.hl') as HTMLElement)?.dataset.pinId).toBe(
+      'c_zdv3rhz',
+    );
+    expect(
+      (root.querySelector('.pin.pulse') as HTMLElement)?.dataset.pinId,
+    ).toBe('c_zdv3rhz');
+
+    // A poll lands right after: the highlight is state, so it survives.
+    panel.applyPayload(payload([pin({ text: 'off by 9px' })]));
+    expect(root.querySelector('.item.hl')).not.toBeNull();
+    expect(root.querySelector('.pin.pulse')).not.toBeNull();
+  });
+
+  it('stops highlighting item and pin once the highlight expires', () => {
+    vi.useFakeTimers();
+    panel.applyPayload(payload([pin()]));
+    panel.locatePin('c_zdv3rhz', { full: true, highlight: true });
+    vi.advanceTimersByTime(10_000);
+    expect(root.querySelector('.item.hl')).toBeNull();
+    expect(root.querySelector('.pin.pulse')).toBeNull();
+    vi.useRealTimers();
   });
 
   it('keeps an unlocatable pin out of the page but in the list', () => {

--- a/react/vite-plugins/review-overlay/client/panel.test.ts
+++ b/react/vite-plugins/review-overlay/client/panel.test.ts
@@ -1,6 +1,6 @@
 import { createPinPanel, type PinPanel } from './panel.js';
 import type { ReviewPin, ReviewPinsPayload } from './types.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const pin = (over: Partial<ReviewPin> = {}): ReviewPin => ({
   id: 'c_zdv3rhz',
@@ -59,6 +59,10 @@ beforeEach(() => {
     onStartPick: vi.fn(),
     onRefresh: vi.fn(),
   });
+});
+
+afterEach(() => {
+  panel.dispose();
 });
 
 const items = () => [...root.querySelectorAll('.item')];
@@ -190,6 +194,46 @@ describe('pin panel', () => {
     panel.applyPayload(payload([pin()]));
     expect(items()).toHaveLength(1);
     expect(items()[0].textContent).toContain('off by 8px');
+  });
+
+  // The full ladder finds what `quickFindTarget` cannot; a reposition ran
+  // straight over that answer and the pin went orphan a moment later.
+  it('keeps a pin the full ladder located when the layer repositions', () => {
+    document.body.insertAdjacentHTML(
+      'afterbegin',
+      '<div><button>Cancel</button><button>Login</button></div>',
+    );
+    panel.applyPayload(
+      payload([
+        pin({
+          anchor: {
+            v: 3,
+            s: 'button:nth-of-type(1)',
+            p: '/',
+            tag: 'button',
+            txt: 'Login',
+          },
+        }),
+      ]),
+    );
+    expect(panel.locatePin('c_zdv3rhz', { full: true })?.textContent).toBe(
+      'Login',
+    );
+    expect(root.querySelector('.pin')?.classList.contains('orphan')).toBe(
+      false,
+    );
+  });
+
+  it('restores the element style after two flashes in a row', () => {
+    vi.useFakeTimers();
+    panel.applyPayload(payload([pin()]));
+    const button = document.querySelector('button') as HTMLElement;
+    panel.locatePin('c_zdv3rhz', { full: true });
+    vi.advanceTimersByTime(1000);
+    panel.locatePin('c_zdv3rhz', { full: true });
+    vi.advanceTimersByTime(10_000);
+    expect(button.style.outline).toBe('');
+    vi.useRealTimers();
   });
 
   it('drops a pin that is gone from the payload', () => {

--- a/react/vite-plugins/review-overlay/client/panel.ts
+++ b/react/vite-plugins/review-overlay/client/panel.ts
@@ -1,15 +1,12 @@
 /**
- * The pin layer and the review panel (R3.6).
- *
- * Everything rendered here comes from a comment anyone can write on a public
- * PR, so every piece of it goes in through `textContent` — never `innerHTML`.
- * The panel is ONE flat list in the payload's number order: orphan and
- * other-page pins are badges in place, never their own section, because the
- * prototype's sections made items jump when an anchor resolved late.
+ * The pin layer and the review panel (R3.6). Everything rendered here comes
+ * from a comment anyone can write on a public PR, so every piece of it goes in
+ * through `textContent` — never `innerHTML`. One flat list in payload order:
+ * orphan and other-page pins are badges in place, never their own section.
  */
 import { pinUrl } from './deeplink.js';
 import { deriveState, onCurrentPage } from './pins-state.js';
-import { findAnchorTarget, quickFindTarget } from './resolve.js';
+import { findAnchorTarget, quickFindTarget, textMatches } from './resolve.js';
 import type {
   AnchorV3,
   PinState,
@@ -335,7 +332,14 @@ export function createPinPanel(options: PinPanelOptions) {
 
   function positionPin(entry: PinEntry) {
     if (!entry.element) return;
-    entry.located = quickFindTarget(entry.anchor, { ignore: host });
+    // The full ladder finds elements `quickFindTarget` cannot; a reposition
+    // must not throw that answer away while the element is still on the page.
+    const held =
+      entry.located?.isConnected &&
+      textMatches(entry.located, entry.anchor?.txt)
+        ? entry.located
+        : null;
+    entry.located = held ?? quickFindTarget(entry.anchor, { ignore: host });
     if (!entry.located) {
       entry.element.classList.add('orphan');
       return;
@@ -393,27 +397,34 @@ export function createPinPanel(options: PinPanelOptions) {
   });
   observer.observe(document.body, { childList: true, subtree: true });
   window.addEventListener('resize', scheduleReposition);
+  const onScroll = () => {
+    for (const entry of entries.values()) positionPin(entry);
+  };
   // Pins are positioned in viewport coordinates, so a scroll moves all of them.
-  window.addEventListener(
-    'scroll',
-    () => {
-      for (const entry of entries.values()) positionPin(entry);
-    },
-    { capture: true, passive: true },
-  );
+  window.addEventListener('scroll', onScroll, { capture: true, passive: true });
 
   // -------------------------------------------------------------- public
 
+  /** Flashing twice inside `FLASH_MS` must not save the flash as the style. */
+  const flashing = new WeakMap<
+    HTMLElement,
+    { previous: string; offset: string; timer: number }
+  >();
+
   function flash(target: Element) {
     const node = target as HTMLElement;
-    const previous = node.style.outline;
-    const offset = node.style.outlineOffset;
+    const pending = flashing.get(node);
+    if (pending) clearTimeout(pending.timer);
+    const previous = pending?.previous ?? node.style.outline;
+    const offset = pending?.offset ?? node.style.outlineOffset;
     node.style.outline = '3px solid var(--color-icon-orange, #e9690b)';
     node.style.outlineOffset = '2px';
-    setTimeout(() => {
+    const timer = window.setTimeout(() => {
       node.style.outline = previous;
       node.style.outlineOffset = offset;
+      flashing.delete(node);
     }, FLASH_MS);
+    flashing.set(node, { previous, offset, timer });
   }
 
   function revealItem(id: string) {
@@ -454,18 +465,20 @@ export function createPinPanel(options: PinPanelOptions) {
   }
 
   return {
-    panel,
-    isOpen,
     open: () => setOpen(true),
-    close: () => setOpen(false),
     toggle: () => setOpen(!isOpen()),
     has: (id: string) => entries.has(id),
     get: (id: string) => entries.get(id) ?? null,
     revealItem,
     locatePin,
-    refresh: () => {
-      refreshPinLayer();
-      renderPanel();
+
+    /** One panel lives as long as the page; tests make one per case. */
+    dispose() {
+      observer.disconnect();
+      window.removeEventListener('resize', scheduleReposition);
+      window.removeEventListener('scroll', onScroll, { capture: true });
+      clearTimeout(repositionTimer);
+      clearTimeout(highlightTimer);
     },
 
     /**

--- a/react/vite-plugins/review-overlay/client/panel.ts
+++ b/react/vite-plugins/review-overlay/client/panel.ts
@@ -1,0 +1,535 @@
+/**
+ * The pin layer and the review panel (R3.6).
+ *
+ * Everything rendered here comes from a comment anyone can write on a public
+ * PR, so every piece of it goes in through `textContent` — never `innerHTML`.
+ * The panel is ONE flat list in the payload's number order: orphan and
+ * other-page pins are badges in place, never their own section, because the
+ * prototype's sections made items jump when an anchor resolved late.
+ */
+import { pinUrl } from './deeplink.js';
+import { deriveState, onCurrentPage } from './pins-state.js';
+import { findAnchorTarget, quickFindTarget } from './resolve.js';
+import type {
+  AnchorV3,
+  PinState,
+  ReviewPin,
+  ReviewPinsPayload,
+} from './types.js';
+
+const REPOSITION_DEBOUNCE_MS = 300;
+const FLASH_MS = 2400;
+const HIGHLIGHT_MS = 2600;
+
+const STATE_LABEL: Record<PinState, string> = {
+  open: '',
+  replied: '💬 replied — check & resolve',
+  hint: '👍 reacted',
+  resolved: '✅ resolved',
+  outdated: '⌛ outdated',
+  orphan: '⚠️ not found on this page',
+};
+
+export interface PinPanelOptions {
+  root: ShadowRoot;
+  host: Element;
+  showToast: (message: string) => void;
+  copyText: (text: string) => boolean | Promise<boolean>;
+  onCountChange: (count: number) => void;
+  onOpenChange: (open: boolean) => void;
+  onStartPick: () => void;
+  onRefresh: () => void;
+}
+
+interface PinEntry {
+  pin: ReviewPin;
+  anchor: AnchorV3 | null;
+  located: Element | null;
+  element: HTMLElement | null;
+}
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] => {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+
+const age = (iso: string | null): string => {
+  if (!iso) return '';
+  const seconds = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (seconds < 3600) return `${Math.max(1, Math.round(seconds / 60))}m`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86400)}d`;
+};
+
+const STYLE = `
+  .pinlayer {
+    position: fixed; inset: 0; z-index: 2147482999; pointer-events: none;
+  }
+  .pin {
+    position: absolute; width: 24px; height: 24px; margin: -12px 0 0 -12px;
+    border-radius: 50% 50% 50% 0; transform: rotate(-45deg);
+    background: var(--bai-review-accent); color: var(--bai-review-on-accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 700; cursor: pointer; pointer-events: auto;
+    box-shadow: 0 1px 4px var(--bai-review-shadow);
+  }
+  .pin > span { transform: rotate(45deg); }
+  .pin.replied { background: var(--color-icon-blue, #1677ff); }
+  .pin.hint { background: var(--color-icon-yellow, #d4a017); }
+  .pin.resolved { opacity: .35; filter: grayscale(.9); }
+  .pin.outdated {
+    background: var(--bai-review-text-dim); border: 2px dashed var(--bai-review-border);
+  }
+  .pin.orphan { display: none; }
+  .pin.pulse { animation: baipulse 1s ease-in-out 4; }
+  @keyframes baipulse {
+    0%,100% { box-shadow: 0 1px 4px var(--bai-review-shadow); }
+    50% { box-shadow: 0 0 0 8px var(--color-background-orange, rgba(242,121,2,.35)); }
+  }
+  .panel {
+    position: fixed; top: 0; right: 0; bottom: 0; width: 380px; max-width: 92vw;
+    z-index: 2147483000; background: var(--bai-review-surface);
+    color: var(--bai-review-text); border-left: 1px solid var(--bai-review-border);
+    box-shadow: -4px 0 16px var(--bai-review-shadow); display: none;
+    flex-direction: column;
+  }
+  .panel.open { display: flex; }
+  .panel header {
+    padding: 10px 12px; border-bottom: 1px solid var(--bai-review-border);
+    font-weight: 700; font-size: 15px; display: flex; align-items: center;
+    gap: 6px; flex-wrap: wrap;
+  }
+  .panel header .spacer { flex: 1; }
+  .srcline {
+    padding: 6px 12px; border-bottom: 1px solid var(--bai-review-border);
+    font-size: 12px; color: var(--bai-review-text-dim);
+    display: flex; gap: 10px; flex-wrap: wrap;
+  }
+  .srcline .bad { color: var(--bai-review-error); }
+  .items { flex: 1; overflow-y: auto; padding: 8px 12px; }
+  .item {
+    border-bottom: 1px solid var(--bai-review-border); padding: 10px 0;
+    font-size: 14px;
+  }
+  .item.resolved { opacity: .55; }
+  .item.hl {
+    background: var(--color-background-orange, rgba(242,121,2,.12));
+    margin: 0 -6px; padding: 8px 6px; border-radius: 6px;
+  }
+  .item .meta {
+    color: var(--bai-review-text-dim); font-size: 12px; margin-bottom: 3px;
+    display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
+  }
+  .item .meta .author { color: var(--bai-review-text); font-weight: 600; }
+  .item .body { white-space: pre-wrap; word-break: break-word; }
+  .item .lastreply {
+    margin-top: 4px; padding: 4px 6px;
+    border-left: 3px solid var(--color-icon-blue, #1677ff);
+    color: var(--bai-review-text-dim); font-size: 13px;
+    white-space: pre-wrap; word-break: break-word;
+  }
+  .item .actions { margin-top: 6px; display: flex; gap: 6px; flex-wrap: wrap; }
+  .badge {
+    font-size: 11px; border-radius: 9px; padding: 1px 7px;
+    border: 1px solid var(--bai-review-border); text-decoration: none;
+    color: var(--bai-review-text-dim);
+  }
+  .badge.resolved { color: var(--color-text-green, #237804); }
+  .badge.replied { color: var(--color-text-blue, #0958d9); }
+  .badge.hint, .badge.orphan { color: var(--color-text-yellow, #874d00); }
+  .empty {
+    color: var(--bai-review-text-dim); font-size: 13px; text-align: center;
+    padding: 24px 8px;
+  }
+`;
+
+export function createPinPanel(options: PinPanelOptions) {
+  const { root, host } = options;
+
+  const style = document.createElement('style');
+  style.textContent = STYLE;
+  const pinLayer = el('div', 'pinlayer');
+  const panel = el('div', 'panel');
+  const header = el('header');
+  header.append(el('span', '', '📍 Review pins'), el('span', 'spacer'));
+  const pickButton = el('button', 'btn primary', '📋 Copy block');
+  const refreshButton = el('button', 'btn', '↻');
+  refreshButton.title = 'Refresh now';
+  const closeButton = el('button', 'btn', '✕');
+  header.append(pickButton, refreshButton, closeButton);
+  const srcLine = el('div', 'srcline');
+  const items = el('div', 'items');
+  panel.append(header, srcLine, items);
+  root.append(style, pinLayer, panel);
+
+  pickButton.addEventListener('click', () => options.onStartPick());
+  refreshButton.addEventListener('click', () => options.onRefresh());
+  closeButton.addEventListener('click', () => setOpen(false));
+
+  const entries = new Map<string, PinEntry>();
+  let highlightId: string | null = null;
+  let highlightTimer = 0;
+
+  // -------------------------------------------------------------- panel
+
+  function setOpen(open: boolean) {
+    panel.classList.toggle('open', open);
+    options.onOpenChange(open);
+  }
+
+  const isOpen = () => panel.classList.contains('open');
+
+  function placement(entry: PinEntry) {
+    return {
+      located: !!entry.located,
+      onPage: onCurrentPage(entry.anchor, location),
+    };
+  }
+
+  function badge(
+    className: string,
+    text: string,
+    href?: string | null,
+  ): HTMLElement {
+    if (!href) return el('span', `badge ${className}`, text);
+    const link = el('a', `badge ${className}`, text);
+    link.href = href;
+    link.target = '_blank';
+    link.rel = 'noreferrer';
+    return link;
+  }
+
+  function buildItem(entry: PinEntry): HTMLElement {
+    const { pin } = entry;
+    const state = deriveState(pin, placement(entry));
+    const item = el('div', `item ${pin.resolved ? 'resolved' : ''}`);
+    item.dataset.pinId = pin.id;
+
+    const meta = el('div', 'meta');
+    meta.append(
+      el(
+        'span',
+        'author',
+        `#${pin.number || '·'} ${pin.author ?? '(unknown)'}`,
+      ),
+      el('span', '', age(pin.createdAt)),
+    );
+    for (const source of pin.sources) {
+      const label = source.channel === 'github' ? '🐙' : '💬';
+      meta.append(badge('src', `${label} #${source.pr}`, source.url));
+    }
+    if (!pin.quoted) meta.append(badge('hint', '¶ not in a quote block'));
+    if (!onCurrentPage(entry.anchor, location)) {
+      meta.append(badge('', 'other page'));
+    } else if (!entry.located && !pin.resolved) {
+      meta.append(badge('orphan', STATE_LABEL.orphan));
+    }
+    if (STATE_LABEL[state] && state !== 'orphan') {
+      meta.append(badge(state, STATE_LABEL[state]));
+    }
+    if (pin.resolvedBy) meta.append(badge('resolved', `by ${pin.resolvedBy}`));
+    item.append(meta, el('div', 'body', pin.text || '(no text)'));
+
+    if (pin.latestReply) {
+      const suffix = pin.replyCount > 1 ? `  (+${pin.replyCount - 1})` : '';
+      item.append(
+        el(
+          'div',
+          'lastreply',
+          `↳ ${pin.latestReply.author ?? '?'}: ${pin.latestReply.body.slice(0, 160)}${suffix}`,
+        ),
+      );
+    }
+
+    const actions = el('div', 'actions');
+    if (entry.anchor) {
+      if (onCurrentPage(entry.anchor, location)) {
+        const locate = el('button', 'btn', '📍 Locate');
+        locate.addEventListener('click', () =>
+          locatePin(pin.id, { full: true }),
+        );
+        actions.append(locate);
+      } else {
+        const open = el('button', 'btn', '↗ Open page');
+        open.addEventListener('click', () => {
+          location.assign(
+            pinUrl(entry.anchor as AnchorV3, pin.id, pin.anchorB64),
+          );
+        });
+        actions.append(open);
+      }
+    }
+    const copy = el('button', 'btn', '🔗 Copy link');
+    copy.addEventListener('click', () => {
+      const path = entry.anchor
+        ? pinUrl(entry.anchor, pin.id, pin.anchorB64)
+        : `${location.pathname}${location.search}#bai=v3.${pin.id}`;
+      void Promise.resolve(options.copyText(`${location.origin}${path}`)).then(
+        (ok) =>
+          options.showToast(ok ? 'Link copied 📋' : 'Could not copy the link'),
+      );
+    });
+    actions.append(copy);
+    item.append(actions);
+    return item;
+  }
+
+  function renderPanel() {
+    items.textContent = '';
+    const sorted = [...entries.values()].sort(
+      (a, b) => a.pin.number - b.pin.number,
+    );
+    if (!sorted.length) {
+      items.append(
+        el(
+          'div',
+          'empty',
+          'No pins on the served PRs yet — pick an element and paste the block into a PR comment.',
+        ),
+      );
+      return;
+    }
+    for (const entry of sorted) {
+      const item = buildItem(entry);
+      // The highlight is state, not a class someone set once: the panel is
+      // rebuilt on every poll and every reposition.
+      if (entry.pin.id === highlightId) item.classList.add('hl');
+      items.append(item);
+    }
+  }
+
+  function renderStatus(payload: ReviewPinsPayload | null, error?: string) {
+    srcLine.textContent = '';
+    if (error) {
+      srcLine.append(el('span', 'bad', error));
+      return;
+    }
+    if (!payload) return;
+    const served = payload.served.map((entry) => `#${entry.pr}`).join(' ');
+    srcLine.append(
+      el('span', '', served ? `serves ${served}` : 'no PR served'),
+    );
+    for (const [channel, status] of Object.entries(payload.sources)) {
+      if (!status) continue;
+      const label = channel === 'github' ? 'GitHub' : channel;
+      srcLine.append(
+        status.ok
+          ? el(
+              'span',
+              '',
+              `${label} ✓ ${status.count ?? 0}${status.truncated ? ' (first page)' : ''}`,
+            )
+          : el('span', 'bad', `${label} ✗ ${status.error ?? 'error'}`),
+      );
+    }
+    if (payload.error) srcLine.append(el('span', 'bad', payload.error));
+  }
+
+  // ----------------------------------------------------------- pin layer
+
+  function positionPin(entry: PinEntry) {
+    if (!entry.element) return;
+    entry.located = quickFindTarget(entry.anchor, { ignore: host });
+    if (!entry.located) {
+      entry.element.classList.add('orphan');
+      return;
+    }
+    const rect = entry.located.getBoundingClientRect();
+    entry.element.classList.remove('orphan');
+    entry.element.style.left = `${rect.left + 6}px`;
+    entry.element.style.top = `${rect.top + 6}px`;
+  }
+
+  function refreshPinLayer() {
+    for (const entry of entries.values()) {
+      const show = onCurrentPage(entry.anchor, location);
+      if (!show) {
+        entry.element?.remove();
+        entry.element = null;
+        entry.located = null;
+        continue;
+      }
+      if (!entry.element) {
+        const node = el('div', 'pin');
+        node.append(el('span'));
+        node.title = 'Show this pin’s comment';
+        node.addEventListener('click', () => revealItem(entry.pin.id));
+        pinLayer.append(node);
+        entry.element = node;
+      }
+      const state = deriveState(entry.pin, placement(entry));
+      entry.element.className = `pin ${state}`;
+      (entry.element.firstElementChild as HTMLElement).textContent = String(
+        entry.pin.number || '·',
+      );
+      positionPin(entry);
+      if (entry.pin.id === highlightId) entry.element.classList.add('pulse');
+    }
+    const onPage = [...entries.values()].filter(
+      (entry) => onCurrentPage(entry.anchor, location) && !entry.pin.resolved,
+    ).length;
+    options.onCountChange(onPage);
+  }
+
+  let repositionTimer = 0;
+  function scheduleReposition() {
+    clearTimeout(repositionTimer);
+    repositionTimer = window.setTimeout(() => {
+      refreshPinLayer();
+      renderPanel();
+    }, REPOSITION_DEBOUNCE_MS);
+  }
+
+  const observer = new MutationObserver((records) => {
+    if (!entries.size) return;
+    if (records.every((record) => host.contains(record.target as Node))) return;
+    scheduleReposition();
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+  window.addEventListener('resize', scheduleReposition);
+  // Pins are positioned in viewport coordinates, so a scroll moves all of them.
+  window.addEventListener(
+    'scroll',
+    () => {
+      for (const entry of entries.values()) positionPin(entry);
+    },
+    { capture: true, passive: true },
+  );
+
+  // -------------------------------------------------------------- public
+
+  function flash(target: Element) {
+    const node = target as HTMLElement;
+    const previous = node.style.outline;
+    const offset = node.style.outlineOffset;
+    node.style.outline = '3px solid var(--color-icon-orange, #e9690b)';
+    node.style.outlineOffset = '2px';
+    setTimeout(() => {
+      node.style.outline = previous;
+      node.style.outlineOffset = offset;
+    }, FLASH_MS);
+  }
+
+  function revealItem(id: string) {
+    if (!isOpen()) setOpen(true);
+    highlightId = id;
+    clearTimeout(highlightTimer);
+    highlightTimer = window.setTimeout(() => {
+      highlightId = null;
+      items.querySelector('.item.hl')?.classList.remove('hl');
+    }, HIGHLIGHT_MS);
+    renderPanel();
+    const item = items.querySelector(`.item[data-pin-id="${id}"]`);
+    item?.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
+  }
+
+  /** `full` runs the expensive text scan; the poll loop never does. */
+  function locatePin(
+    id: string,
+    { full = false, quiet = false } = {},
+  ): Element | null {
+    const entry = entries.get(id);
+    if (!entry?.anchor) return null;
+    const target = full
+      ? findAnchorTarget(entry.anchor, { ignore: host })
+      : quickFindTarget(entry.anchor, { ignore: host });
+    if (!target) {
+      // A retry ladder calls this every 500 ms while the SPA renders — it
+      // must not narrate each miss.
+      if (!quiet)
+        options.showToast('That element is not on this page any more');
+      return null;
+    }
+    entry.located = target;
+    target.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
+    flash(target);
+    refreshPinLayer();
+    return target;
+  }
+
+  return {
+    panel,
+    isOpen,
+    open: () => setOpen(true),
+    close: () => setOpen(false),
+    toggle: () => setOpen(!isOpen()),
+    has: (id: string) => entries.has(id),
+    get: (id: string) => entries.get(id) ?? null,
+    revealItem,
+    locatePin,
+    refresh: () => {
+      refreshPinLayer();
+      renderPanel();
+    },
+
+    /**
+     * A full-form deep link draws its pin from the fragment alone, before any
+     * channel has been read — the payload only enriches it later.
+     */
+    ensureProvisional(id: string, anchor: AnchorV3, anchorB64: string | null) {
+      if (entries.has(id)) return;
+      entries.set(id, {
+        pin: {
+          id,
+          number: 0,
+          anchorB64,
+          anchor,
+          text: '(looking for this pin in the PR…)',
+          author: null,
+          createdAt: null,
+          sources: [],
+          sourcePr: null,
+          quoted: true,
+          resolved: false,
+          resolvedBy: null,
+          outdated: false,
+          hint: false,
+          replies: [],
+          latestReply: null,
+          replyCount: 0,
+        },
+        anchor,
+        located: null,
+        element: null,
+      });
+      refreshPinLayer();
+      renderPanel();
+    },
+
+    applyPayload(payload: ReviewPinsPayload) {
+      const seen = new Set<string>();
+      for (const pin of payload.pins) {
+        const existing = entries.get(pin.id);
+        entries.set(pin.id, {
+          pin,
+          anchor: pin.anchor ?? existing?.anchor ?? null,
+          located: existing?.located ?? null,
+          element: existing?.element ?? null,
+        });
+        seen.add(pin.id);
+      }
+      for (const [id, entry] of entries) {
+        // A provisional deep-link pin survives until its id shows up (or does
+        // not) in a channel; everything else follows the payload.
+        if (seen.has(id) || entry.pin.number === 0) continue;
+        entry.element?.remove();
+        entries.delete(id);
+      }
+      renderStatus(payload);
+      refreshPinLayer();
+      renderPanel();
+    },
+
+    setError(message: string) {
+      renderStatus(null, message);
+    },
+  };
+}
+
+export type PinPanel = ReturnType<typeof createPinPanel>;

--- a/react/vite-plugins/review-overlay/client/panel.ts
+++ b/react/vite-plugins/review-overlay/client/panel.ts
@@ -361,6 +361,7 @@ export function createPinPanel(options: PinPanelOptions) {
       }
       if (!entry.element) {
         const node = el('div', 'pin');
+        node.dataset.pinId = entry.pin.id;
         node.append(el('span'));
         node.title = 'Show this pin’s comment';
         node.addEventListener('click', () => revealItem(entry.pin.id));
@@ -434,16 +435,21 @@ export function createPinPanel(options: PinPanelOptions) {
     highlightTimer = window.setTimeout(() => {
       highlightId = null;
       items.querySelector('.item.hl')?.classList.remove('hl');
+      pinLayer.querySelector('.pin.pulse')?.classList.remove('pulse');
     }, HIGHLIGHT_MS);
     renderPanel();
     const item = items.querySelector(`.item[data-pin-id="${id}"]`);
     item?.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
   }
 
-  /** `full` runs the expensive text scan; the poll loop never does. */
+  /**
+   * `full` runs the expensive text scan; the poll loop never does. `highlight`
+   * is for a deep link: the highlight belongs to the moment the pin lands on
+   * its element, seconds after the payload that described it arrived.
+   */
   function locatePin(
     id: string,
-    { full = false, quiet = false } = {},
+    { full = false, quiet = false, highlight = false } = {},
   ): Element | null {
     const entry = entries.get(id);
     if (!entry?.anchor) return null;
@@ -458,6 +464,8 @@ export function createPinPanel(options: PinPanelOptions) {
       return null;
     }
     entry.located = target;
+    // Before `refreshPinLayer`, so the marker is rebuilt already pulsing.
+    if (highlight) revealItem(id);
     target.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
     flash(target);
     refreshPinLayer();

--- a/react/vite-plugins/review-overlay/client/pins-state.test.ts
+++ b/react/vite-plugins/review-overlay/client/pins-state.test.ts
@@ -1,0 +1,95 @@
+import { deriveState, onCurrentPage } from './pins-state.js';
+import type { AnchorV3, ReviewPin } from './types.js';
+import { describe, expect, it } from 'vitest';
+
+const pin = (over: Partial<ReviewPin> = {}): ReviewPin => ({
+  id: 'c_zdv3rhz',
+  number: 1,
+  anchorB64: null,
+  anchor: null,
+  text: 'off by 8px',
+  author: 'reviewer',
+  createdAt: '2026-09-01T08:00:00Z',
+  sources: [],
+  sourcePr: 9354,
+  quoted: true,
+  resolved: false,
+  resolvedBy: null,
+  outdated: false,
+  hint: false,
+  replies: [],
+  latestReply: null,
+  replyCount: 0,
+  ...over,
+});
+
+const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
+  v: 3,
+  s: 'button',
+  p: '/session',
+  ...over,
+});
+
+describe('deriveState', () => {
+  const located = { located: true, onPage: true };
+
+  it('is open with no reply and no reaction', () => {
+    expect(deriveState(pin(), located)).toBe('open');
+  });
+
+  it('is replied when someone answered — the "check and resolve" state', () => {
+    expect(deriveState(pin({ replyCount: 1 }), located)).toBe('replied');
+  });
+
+  it('is a hint for a reaction alone', () => {
+    expect(deriveState(pin({ hint: true }), located)).toBe('hint');
+  });
+
+  it('lets resolved win over every conversation state', () => {
+    expect(
+      deriveState(pin({ resolved: true, replyCount: 2, hint: true }), located),
+    ).toBe('resolved');
+  });
+
+  it('ranks outdated above a reply but below resolved', () => {
+    expect(deriveState(pin({ outdated: true, replyCount: 1 }), located)).toBe(
+      'outdated',
+    );
+  });
+
+  it('is orphan when the anchor belongs here but nothing matches it', () => {
+    expect(deriveState(pin(), { located: false, onPage: true })).toBe('orphan');
+  });
+
+  it('is not orphan merely because the pin lives on another page', () => {
+    expect(deriveState(pin(), { located: false, onPage: false })).toBe('open');
+  });
+
+  // Losing "somebody answered you" to "we cannot draw it here" would hide the
+  // only state that asks the reader to do something.
+  it('does not let orphan mask a reply', () => {
+    expect(
+      deriveState(pin({ replyCount: 1 }), { located: false, onPage: true }),
+    ).toBe('replied');
+  });
+});
+
+describe('onCurrentPage', () => {
+  it('matches on pathname alone — a query change is not another page', () => {
+    expect(
+      onCurrentPage(anchor(), { pathname: '/session', search: '?x=1' }),
+    ).toBe(true);
+  });
+
+  it('rejects another path', () => {
+    expect(onCurrentPage(anchor(), { pathname: '/start', search: '' })).toBe(
+      false,
+    );
+  });
+
+  it('is false without an anchor — the short form has nowhere to be', () => {
+    expect(onCurrentPage(null, { pathname: '/session', search: '' })).toBe(
+      false,
+    );
+  });
+});

--- a/react/vite-plugins/review-overlay/client/pins-state.ts
+++ b/react/vite-plugins/review-overlay/client/pins-state.ts
@@ -1,0 +1,33 @@
+/**
+ * The six pin states (R3.6) and the "is this pin about the page I am on?"
+ * question the panel and the pin layer both ask.
+ */
+import type { AnchorV3, PinState, ReviewPin } from './types.js';
+
+export interface PinPlacement {
+  /** An element on this page currently matches the anchor. */
+  located: boolean;
+  /** The anchor names this page at all. */
+  onPage: boolean;
+}
+
+/**
+ * Conversation state first, placement last: `orphan` says "the UI moved under
+ * this pin", which matters less than "somebody answered you and is waiting".
+ */
+export function deriveState(pin: ReviewPin, placement: PinPlacement): PinState {
+  if (pin.resolved) return 'resolved';
+  if (pin.outdated) return 'outdated';
+  if (pin.replyCount > 0) return 'replied';
+  if (pin.hint) return 'hint';
+  if (placement.onPage && !placement.located) return 'orphan';
+  return 'open';
+}
+
+/** The query is reproduced on a jump, but it does not decide the page. */
+export function onCurrentPage(
+  anchor: AnchorV3 | null,
+  location: { pathname: string; search: string },
+): boolean {
+  return !!anchor && anchor.p === location.pathname;
+}

--- a/react/vite-plugins/review-overlay/client/poll.test.ts
+++ b/react/vite-plugins/review-overlay/client/poll.test.ts
@@ -1,0 +1,143 @@
+import { createPoller } from './poll.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setHidden = (hidden: boolean) => {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => hidden,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => false,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createPoller', () => {
+  const poller = (load = vi.fn().mockResolvedValue({ pins: [] })) => {
+    const onPayload = vi.fn();
+    const onError = vi.fn();
+    const instance = createPoller({
+      load,
+      onPayload,
+      onError,
+      visibleMs: 25_000,
+      idleMs: 120_000,
+      quietAfterMs: 300_000,
+    });
+    return { instance, load, onPayload, onError };
+  };
+
+  it('loads once on start and then every 25 s while visible', async () => {
+    const { instance, load, onPayload } = poller();
+    instance.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(onPayload).toHaveBeenCalledWith({ pins: [] });
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(load).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(load).toHaveBeenCalledTimes(3);
+    instance.stop();
+  });
+
+  it('backs off to 120 s once nothing has changed for the quiet period', async () => {
+    const { instance, load } = poller();
+    instance.start();
+    // The back-off is decided when a poll finishes, so it takes hold on the
+    // first tick AFTER the quiet period, not during it.
+    await vi.advanceTimersByTimeAsync(325_001);
+    const before = load.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(load).toHaveBeenCalledTimes(before);
+    await vi.advanceTimersByTimeAsync(95_001);
+    expect(load).toHaveBeenCalledTimes(before + 1);
+    instance.stop();
+  });
+
+  it('returns to the fast cadence when the payload changes', async () => {
+    let pins: unknown[] = [];
+    const load = vi.fn().mockImplementation(async () => ({ pins }));
+    const { instance } = poller(load);
+    instance.start();
+    await vi.advanceTimersByTimeAsync(300_001);
+    pins = [{ id: 'c_zdv3rhz' }];
+    await vi.advanceTimersByTimeAsync(120_000);
+    const after = load.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(load).toHaveBeenCalledTimes(after + 1);
+    instance.stop();
+  });
+
+  it('stops while the tab is hidden and catches up when it comes back', async () => {
+    const { instance, load } = poller();
+    instance.start();
+    await vi.advanceTimersByTimeAsync(0);
+    setHidden(true);
+    await vi.advanceTimersByTimeAsync(200_000);
+    expect(load).toHaveBeenCalledTimes(1);
+    setHidden(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+    instance.stop();
+  });
+
+  it('refetches on focus', async () => {
+    const { instance, load } = poller();
+    instance.start();
+    await vi.advanceTimersByTimeAsync(0);
+    window.dispatchEvent(new Event('focus'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(2);
+    instance.stop();
+  });
+
+  it('reports a failure and keeps polling', async () => {
+    const load = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue({ pins: [] });
+    const { instance, onError, onPayload } = poller(load);
+    instance.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(onPayload).toHaveBeenCalledTimes(1);
+    instance.stop();
+  });
+
+  it('never runs two loads at once', async () => {
+    let release: (value: unknown) => void = () => undefined;
+    const load = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    );
+    const { instance } = poller(load);
+    instance.start();
+    instance.refreshNow();
+    window.dispatchEvent(new Event('focus'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    release({ pins: [] });
+    instance.stop();
+  });
+
+  it('stops for good on stop()', async () => {
+    const { instance, load } = poller();
+    instance.start();
+    await vi.advanceTimersByTimeAsync(0);
+    instance.stop();
+    await vi.advanceTimersByTimeAsync(200_000);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react/vite-plugins/review-overlay/client/poll.test.ts
+++ b/react/vite-plugins/review-overlay/client/poll.test.ts
@@ -77,6 +77,31 @@ describe('createPoller', () => {
     instance.stop();
   });
 
+  // The pins payload carries a server timestamp, which is not a change.
+  it('still backs off when every answer carries a fresh timestamp', async () => {
+    let at = 0;
+    const load = vi
+      .fn()
+      .mockImplementation(async () => ({ pins: [], fetchedAt: ++at }));
+    const onPayload = vi.fn();
+    const onError = vi.fn();
+    const instance = createPoller<{ pins: unknown[]; fetchedAt: number }>({
+      load,
+      onPayload,
+      onError,
+      visibleMs: 25_000,
+      idleMs: 120_000,
+      quietAfterMs: 300_000,
+      signatureOf: (payload) => JSON.stringify(payload.pins),
+    });
+    instance.start();
+    await vi.advanceTimersByTimeAsync(325_001);
+    const before = load.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(load).toHaveBeenCalledTimes(before);
+    instance.stop();
+  });
+
   it('stops while the tab is hidden and catches up when it comes back', async () => {
     const { instance, load } = poller();
     instance.start();

--- a/react/vite-plugins/review-overlay/client/poll.ts
+++ b/react/vite-plugins/review-overlay/client/poll.ts
@@ -1,9 +1,6 @@
 /**
- * The pins poll (R3.4): 25 s while visible, 120 s once the conversation has
- * gone quiet, nothing at all while the tab is hidden, and an immediate read
- * when the reviewer comes back. The server's 15 s cache is what keeps
- * concurrent viewers down to one upstream call, so this only has to be
- * polite, not clever.
+ * The pins poll (R3.4). The server's 15 s cache is what keeps concurrent
+ * viewers down to one upstream call, so this only has to be polite.
  */
 
 export interface PollerOptions<T> {
@@ -14,6 +11,12 @@ export interface PollerOptions<T> {
   idleMs?: number;
   /** How long without a change before the slow cadence takes over. */
   quietAfterMs?: number;
+  /**
+   * What counts as "the same answer". The default compares the whole payload,
+   * which never repeats when it carries a server timestamp — pass the parts
+   * that mean something changed instead.
+   */
+  signatureOf?: (payload: T) => string;
 }
 
 export function createPoller<T>({
@@ -23,6 +26,7 @@ export function createPoller<T>({
   visibleMs = 25_000,
   idleMs = 120_000,
   quietAfterMs = 300_000,
+  signatureOf = (payload: T) => JSON.stringify(payload),
 }: PollerOptions<T>) {
   let timer = 0;
   let busy = false;
@@ -35,7 +39,7 @@ export function createPoller<T>({
     busy = true;
     try {
       const payload = await load();
-      const next = JSON.stringify(payload);
+      const next = signatureOf(payload);
       if (next !== signature) {
         signature = next;
         lastChangeAt = Date.now();

--- a/react/vite-plugins/review-overlay/client/poll.ts
+++ b/react/vite-plugins/review-overlay/client/poll.ts
@@ -1,0 +1,95 @@
+/**
+ * The pins poll (R3.4): 25 s while visible, 120 s once the conversation has
+ * gone quiet, nothing at all while the tab is hidden, and an immediate read
+ * when the reviewer comes back. The server's 15 s cache is what keeps
+ * concurrent viewers down to one upstream call, so this only has to be
+ * polite, not clever.
+ */
+
+export interface PollerOptions<T> {
+  load: () => Promise<T>;
+  onPayload: (payload: T) => void;
+  onError: (error: unknown) => void;
+  visibleMs?: number;
+  idleMs?: number;
+  /** How long without a change before the slow cadence takes over. */
+  quietAfterMs?: number;
+}
+
+export function createPoller<T>({
+  load,
+  onPayload,
+  onError,
+  visibleMs = 25_000,
+  idleMs = 120_000,
+  quietAfterMs = 300_000,
+}: PollerOptions<T>) {
+  let timer = 0;
+  let busy = false;
+  let running = false;
+  let signature = '';
+  let lastChangeAt = Date.now();
+
+  async function run() {
+    if (busy || !running) return;
+    busy = true;
+    try {
+      const payload = await load();
+      const next = JSON.stringify(payload);
+      if (next !== signature) {
+        signature = next;
+        lastChangeAt = Date.now();
+      }
+      onPayload(payload);
+    } catch (error) {
+      onError(error);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function schedule() {
+    clearTimeout(timer);
+    if (!running || document.hidden) return;
+    const quiet = Date.now() - lastChangeAt > quietAfterMs;
+    timer = window.setTimeout(
+      async () => {
+        await run();
+        schedule();
+      },
+      quiet ? idleMs : visibleMs,
+    );
+  }
+
+  const refreshNow = () => {
+    void run().then(schedule);
+  };
+
+  const onVisibility = () => {
+    if (document.hidden) {
+      clearTimeout(timer);
+      return;
+    }
+    refreshNow();
+  };
+  const onFocus = () => refreshNow();
+
+  return {
+    start() {
+      if (running) return;
+      running = true;
+      document.addEventListener('visibilitychange', onVisibility);
+      window.addEventListener('focus', onFocus);
+      refreshNow();
+    },
+    refreshNow,
+    stop() {
+      running = false;
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', onFocus);
+    },
+  };
+}
+
+export type Poller = ReturnType<typeof createPoller>;

--- a/react/vite-plugins/review-overlay/client/resolve.test.ts
+++ b/react/vite-plugins/review-overlay/client/resolve.test.ts
@@ -1,0 +1,95 @@
+import { findAnchorTarget, quickFindTarget } from './resolve.js';
+import type { AnchorV3 } from './types.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const mount = (html: string) => {
+  document.body.innerHTML = html;
+};
+
+const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
+  v: 3,
+  s: 'button:nth-of-type(1)',
+  p: '/',
+  tag: 'button',
+  txt: 'Login',
+  ...over,
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('quickFindTarget', () => {
+  it('takes the selector when its text agrees', () => {
+    mount('<button>Login</button>');
+    expect(quickFindTarget(anchor())?.textContent).toBe('Login');
+  });
+
+  it('refuses a selector whose element now says something else', () => {
+    mount('<button>Sign out</button>');
+    expect(quickFindTarget(anchor())).toBeNull();
+  });
+
+  it('falls back to a unique testid landmark', () => {
+    mount('<section data-testid="page-start"><button>Login</button></section>');
+    expect(
+      quickFindTarget(anchor({ s: 'nope:nth-of-type(9)', tid: 'page-start' })),
+    ).toBe(document.querySelector('[data-testid="page-start"]'));
+  });
+
+  it('does not guess when the landmark is ambiguous', () => {
+    mount('<i data-testid="row"></i><i data-testid="row"></i>');
+    expect(quickFindTarget(anchor({ s: 'nope', tid: 'row' }))).toBeNull();
+  });
+
+  it('survives a selector the browser cannot parse', () => {
+    mount('<button>Login</button>');
+    expect(quickFindTarget(anchor({ s: 'button:has(' }))).toBeNull();
+  });
+});
+
+describe('findAnchorTarget', () => {
+  it('scans by tag and text when the selector moved', () => {
+    mount(
+      '<div><span>x</span><button>Cancel</button><button>Login</button></div>',
+    );
+    expect(
+      findAnchorTarget(anchor({ s: 'button:nth-of-type(7)' }))?.textContent,
+    ).toBe('Login');
+  });
+
+  it('prefers the innermost element carrying the text', () => {
+    mount('<button><span>Login</span></button>');
+    const found = findAnchorTarget(anchor({ s: 'nope', tag: undefined }));
+    expect(found?.tagName).toBe('SPAN');
+  });
+
+  it('scopes the scan to a unique testid landmark', () => {
+    mount(`
+      <div><button>Login</button></div>
+      <section data-testid="page-start"><button>Login</button></section>
+    `);
+    const found = findAnchorTarget(anchor({ s: 'nope', tid: 'page-start' }));
+    expect(found?.closest('[data-testid="page-start"]')).toBeTruthy();
+  });
+
+  it('keeps the selector hit as a weak answer when the text scan finds nothing', () => {
+    mount('<button>Sign out</button>');
+    expect(findAnchorTarget(anchor())?.textContent).toBe('Sign out');
+  });
+
+  it('never returns the overlay’s own chrome', () => {
+    mount('<div data-bai-review-overlay><button>Login</button></div>');
+    expect(findAnchorTarget(anchor({ s: 'nope' }))).toBeNull();
+  });
+
+  it('returns null when the page has nothing like the anchor', () => {
+    mount('<p>empty page</p>');
+    expect(findAnchorTarget(anchor({ s: 'nope' }))).toBeNull();
+  });
+
+  it('refuses an anchor with no selector at all', () => {
+    mount('<button>Login</button>');
+    expect(findAnchorTarget({ v: 3, p: '/' } as AnchorV3)).toBeNull();
+  });
+});

--- a/react/vite-plugins/review-overlay/client/resolve.test.ts
+++ b/react/vite-plugins/review-overlay/client/resolve.test.ts
@@ -30,6 +30,12 @@ describe('quickFindTarget', () => {
     expect(quickFindTarget(anchor())).toBeNull();
   });
 
+  // `includes('')` would otherwise confirm every icon-only button.
+  it('refuses a selector hit that carries no text at all', () => {
+    mount('<button><svg></svg></button>');
+    expect(quickFindTarget(anchor())).toBeNull();
+  });
+
   it('falls back to a unique testid landmark', () => {
     mount('<section data-testid="page-start"><button>Login</button></section>');
     expect(

--- a/react/vite-plugins/review-overlay/client/resolve.ts
+++ b/react/vite-plugins/review-overlay/client/resolve.ts
@@ -1,0 +1,149 @@
+/**
+ * Resolving a `#bai=v3` anchor back to an element (FR-3813).
+ *
+ * The selector alone is not enough — a React `useId` never survives a reload
+ * and an nth-of-type path does not survive a refactor — so the signals are
+ * tried in order of how much they promise: selector (confirmed by text),
+ * testid landmark, text scan, rect projection, and the bare selector hit as a
+ * last resort.
+ */
+import { normText } from './anchor.js';
+import type { AnchorV3 } from './types.js';
+
+/** How many candidates a text scan will look at before giving up. */
+const SCAN_LIMIT = 5000;
+
+export interface ResolveOptions {
+  doc?: Document;
+  /** The overlay's own shadow host — never a valid answer. */
+  ignore?: Element | null;
+}
+
+const esc = (value: string) =>
+  typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(value) : value;
+
+const elementText = (element: Element) =>
+  normText((element as HTMLElement).innerText || element.textContent);
+
+/** A moved element keeps its words; a recycled selector usually does not. */
+export const textMatches = (element: Element, txt?: string): boolean => {
+  if (!txt) return true;
+  const text = elementText(element).slice(0, 160);
+  return text.includes(txt) || txt.includes(text.slice(0, 64));
+};
+
+const safeTag = (tag?: string) =>
+  tag && /^[a-z][a-z0-9-]*$/.test(tag) ? tag : '*';
+
+const isOurs = (element: Element | null, ignore?: Element | null) =>
+  !!element &&
+  (!!element.closest('[data-bai-review-overlay]') ||
+    (!!ignore && (element === ignore || ignore.contains(element))));
+
+function querySafe(
+  doc: Document,
+  selector: string,
+  ignore?: Element | null,
+): Element | null {
+  try {
+    const hit = doc.querySelector(selector);
+    return isOurs(hit, ignore) ? null : hit;
+  } catch {
+    // A selector from a pasted comment is not guaranteed to parse.
+    return null;
+  }
+}
+
+/**
+ * The fractional rect inside the landmark, projected back onto the page. Only
+ * useful in a real browser: jsdom has no layout, so every rect is zero and
+ * this returns null there.
+ */
+function rectProjectedTarget(
+  container: Element,
+  anchor: AnchorV3,
+  doc: Document,
+  ignore?: Element | null,
+): Element | null {
+  const rect = anchor.rect;
+  const view = doc.defaultView;
+  if (!rect || !view || typeof doc.elementFromPoint !== 'function') return null;
+  const box = container.getBoundingClientRect();
+  if (!box.width || !box.height) return null;
+  const x = box.left + (rect.x + rect.w / 2) * box.width;
+  const y = box.top + (rect.y + rect.h / 2) * box.height;
+  if (x < 0 || y < 0 || x >= view.innerWidth || y >= view.innerHeight)
+    return null;
+  const hit = doc.elementFromPoint(x, y);
+  if (!hit || isOurs(hit, ignore) || !container.contains(hit)) return null;
+  return hit;
+}
+
+function uniqueLandmark(
+  anchor: AnchorV3,
+  doc: Document,
+  ignore?: Element | null,
+): Element | null {
+  if (!anchor.tid) return null;
+  const found = doc.querySelectorAll(`[data-testid="${esc(anchor.tid)}"]`);
+  if (found.length !== 1) return null;
+  return isOurs(found[0], ignore) ? null : found[0];
+}
+
+/** Cheap enough to run on every reposition: no text scan, no projection. */
+export function quickFindTarget(
+  anchor: AnchorV3 | null,
+  options: ResolveOptions = {},
+): Element | null {
+  if (!anchor || typeof anchor.s !== 'string') return null;
+  const doc = options.doc ?? document;
+  const bySelector = querySafe(doc, anchor.s, options.ignore);
+  if (bySelector && textMatches(bySelector, anchor.txt)) return bySelector;
+  const landmark = uniqueLandmark(anchor, doc, options.ignore);
+  if (landmark) {
+    return (
+      rectProjectedTarget(landmark, anchor, doc, options.ignore) ?? landmark
+    );
+  }
+  return null;
+}
+
+/** The full ladder, for a deep link or an explicit "locate" click. */
+export function findAnchorTarget(
+  anchor: AnchorV3 | null,
+  options: ResolveOptions = {},
+): Element | null {
+  if (!anchor || typeof anchor.s !== 'string') return null;
+  const doc = options.doc ?? document;
+  const bySelector = querySafe(doc, anchor.s, options.ignore);
+  if (bySelector && textMatches(bySelector, anchor.txt)) return bySelector;
+
+  const scan = (scope: Element | Document): Element | null => {
+    if (!anchor.txt) return null;
+    const candidates = scope.querySelectorAll(safeTag(anchor.tag));
+    let best: Element | null = null;
+    for (let i = 0; i < candidates.length && i < SCAN_LIMIT; i++) {
+      const candidate = candidates[i];
+      if (isOurs(candidate, options.ignore)) continue;
+      if (!elementText(candidate).includes(anchor.txt)) continue;
+      // Deeper wins: the outer wrappers all contain the same words.
+      if (!best || best.contains(candidate)) best = candidate;
+    }
+    return best;
+  };
+
+  const landmark = uniqueLandmark(anchor, doc, options.ignore);
+  if (landmark) {
+    const inner = scan(landmark);
+    if (inner) return inner;
+    const projected = rectProjectedTarget(
+      landmark,
+      anchor,
+      doc,
+      options.ignore,
+    );
+    if (projected) return projected;
+    if (textMatches(landmark, anchor.txt)) return landmark;
+  }
+  return scan(doc) ?? bySelector;
+}

--- a/react/vite-plugins/review-overlay/client/resolve.ts
+++ b/react/vite-plugins/review-overlay/client/resolve.ts
@@ -1,12 +1,9 @@
 /**
- * Resolving a `#bai=v3` anchor back to an element (FR-3813).
- *
- * The selector alone is not enough — a React `useId` never survives a reload
- * and an nth-of-type path does not survive a refactor — so the signals are
- * tried in order of how much they promise: selector (confirmed by text),
- * testid landmark, text scan, rect projection, and the bare selector hit as a
- * last resort.
+ * Resolving a `#bai=v3` anchor back to an element: the selector alone cannot
+ * do it — a React `useId` never survives a reload and an nth-of-type path
+ * never survives a refactor — so every other signal is tried in turn.
  */
+import { TAG_RE } from './anchor-guard.js';
 import { normText } from './anchor.js';
 import type { AnchorV3 } from './types.js';
 
@@ -29,11 +26,13 @@ const elementText = (element: Element) =>
 export const textMatches = (element: Element, txt?: string): boolean => {
   if (!txt) return true;
   const text = elementText(element).slice(0, 160);
+  // An element with no text at all matches nothing: `includes('')` would
+  // otherwise confirm every recycled selector that now hits an icon button.
+  if (!text) return false;
   return text.includes(txt) || txt.includes(text.slice(0, 64));
 };
 
-const safeTag = (tag?: string) =>
-  tag && /^[a-z][a-z0-9-]*$/.test(tag) ? tag : '*';
+const safeTag = (tag?: string) => (tag && TAG_RE.test(tag) ? tag : '*');
 
 const isOurs = (element: Element | null, ignore?: Element | null) =>
   !!element &&

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -59,11 +59,82 @@ declare global {
   }
 }
 
-/** `/__review/state` — the write side needs only the PR number. */
+/** `/__review/state` — the running layer, plus the whole served set (R3.7). */
 export interface ReviewServerState {
   pr: number | null;
   repo: string | null;
   branch: string | null;
   source: 'boot-record' | 'gh' | 'none';
+  /** Every PR this server serves; the running layer is `pr`. */
+  served: Array<{ pr: number; branch: string | null }>;
+  /** A private repository disables both endpoints (R3.4). */
+  isPrivate: boolean;
   error?: string | null;
+}
+
+// --------------------------------------------------- read side (FR-3813)
+
+/** Teams (FR-3816) folds in as a second channel without reshaping a pin. */
+export type PinChannel = 'github' | 'teams';
+
+/** One place the same block was found. Several = the block was pasted twice. */
+export interface PinSource {
+  channel: PinChannel;
+  /** The PR the occurrence was found on — a stack's layer badge (R3.7). */
+  pr: number;
+  kind: string;
+  url: string | null;
+  author: string | null;
+}
+
+export interface PinReply {
+  author: string | null;
+  body: string;
+  createdAt: string | null;
+  url: string | null;
+}
+
+/** Every occurrence of one `#bai=v3` id, merged (R3.6). */
+export interface ReviewPin {
+  id: string;
+  /** `createdAt` rank, fixed per payload so numbers never shift on a poll. */
+  number: number;
+  anchorB64: string | null;
+  /** Decoded and field-checked on the server; `null` for the short form. */
+  anchor: AnchorV3 | null;
+  text: string;
+  author: string | null;
+  createdAt: string | null;
+  sources: PinSource[];
+  /** The PR the primary occurrence was found on. */
+  sourcePr: number | null;
+  /** A pin pasted outside a quote block is accepted and flagged (R3.4). */
+  quoted: boolean;
+  resolved: boolean;
+  resolvedBy: string | null;
+  outdated: boolean;
+  hint: boolean;
+  replies: PinReply[];
+  latestReply: PinReply | null;
+  replyCount: number;
+}
+
+export type PinState =
+  'open' | 'replied' | 'hint' | 'resolved' | 'outdated' | 'orphan';
+
+export interface PinSourceStatus {
+  ok: boolean;
+  count?: number;
+  error?: string;
+  /** More comments than one page holds — surfaced, never paginated (R3.4). */
+  truncated?: boolean;
+}
+
+/** `/__review/pins` — a whitelisted shape; no upstream output is echoed. */
+export interface ReviewPinsPayload {
+  pins: ReviewPin[];
+  served: Array<{ pr: number; state: string | null }>;
+  sources: Partial<Record<PinChannel, PinSourceStatus>>;
+  fetchedAt: string;
+  error?: string;
 }

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -20,6 +20,8 @@ const FOCUS_GUARD_MS = 1000;
 
 export interface OverlayUICallbacks {
   onStartPick: () => void;
+  /** Open/close the pins panel (FR-3813); absent on a write-only overlay. */
+  onTogglePanel?: () => void;
   /**
    * Render the block for this note, SYNCHRONOUSLY — everything async was done
    * at pick time. `null` means the capture is not ready, which the composer
@@ -102,6 +104,16 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
     .toggle.active {
       background: var(--bai-review-inverted); color: var(--bai-review-on-inverted);
     }
+    .toggle .cnt {
+      background: var(--bai-review-on-accent); color: var(--bai-review-accent);
+      border-radius: 10px; padding: 0 6px; font-size: 11px; margin-left: 6px;
+    }
+    .pinsbtn {
+      border: 1px solid var(--bai-review-border); border-radius: 24px;
+      padding: 8px 14px; cursor: pointer; font-size: 13px; font-weight: 600;
+      background: var(--bai-review-surface); color: var(--bai-review-text);
+      box-shadow: 0 2px 10px var(--bai-review-shadow);
+    }
     .btn {
       border: 1px solid var(--bai-review-border);
       background: var(--bai-review-surface); color: var(--bai-review-text);
@@ -153,10 +165,13 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
   root.appendChild(style);
 
   const toggle = el('button', 'toggle', '📍 Review');
+  const pinCountBadge = el('span', 'cnt');
+  const pinsButton = el('button', 'pinsbtn', '📌 Pins');
   const alwaysChk = el('label', 'alwayschk');
   alwaysChk.innerHTML = '<input type="checkbox" /> Always show';
   const dock = el('div', 'dock');
-  dock.append(alwaysChk, toggle);
+  dock.append(alwaysChk, pinsButton, toggle);
+  if (!callbacks.onTogglePanel) pinsButton.remove();
 
   const hoverbox = el('div', 'hoverbox');
   const compose = el('div', 'compose');
@@ -192,6 +207,8 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
   let pickTarget: Element | null = null;
   let dockPinned = false;
   let focusGuardUntil = 0;
+  let panelOpen = false;
+  let pinCount = 0;
 
   /**
    * The dock is hidden until something is happening — a dev server should not
@@ -203,9 +220,28 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
   function updateDock() {
     dock.classList.toggle(
       'show',
-      alwaysShow || dockPinned || pickActive || isComposeOpen(),
+      alwaysShow ||
+        dockPinned ||
+        pickActive ||
+        isComposeOpen() ||
+        panelOpen ||
+        pinCount > 0,
     );
     toggle.classList.toggle('active', pickActive);
+  }
+
+  /** Pins waiting on THIS page — the reason the dock shows itself unasked. */
+  function setPinCount(count: number) {
+    pinCount = count;
+    pinCountBadge.textContent = String(count);
+    if (count && !pinCountBadge.parentNode) toggle.appendChild(pinCountBadge);
+    if (!count && pinCountBadge.parentNode) pinCountBadge.remove();
+    updateDock();
+  }
+
+  function setPanelOpen(open: boolean) {
+    panelOpen = open;
+    updateDock();
   }
 
   const isComposeOpen = () => compose.style.display === 'block';
@@ -344,6 +380,7 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
   // ---------------------------------------------------------------- events
 
   toggle.addEventListener('click', () => callbacks.onStartPick());
+  pinsButton.addEventListener('click', () => callbacks.onTogglePanel?.());
 
   function runCopy() {
     // Empty text is allowed — the block still carries label, stack and link.
@@ -432,6 +469,8 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
     setComposeReady,
     getComposeTarget,
     setPickActive,
+    setPinCount,
+    setPanelOpen,
     pinDock,
     copyText,
     isOwnEvent,

--- a/react/vite-plugins/review-overlay/index.ts
+++ b/react/vite-plugins/review-overlay/index.ts
@@ -1,5 +1,8 @@
 import { readBootRecord, servedEntry } from './boot-record.js';
-import type { ReviewServerState } from './client/types.js';
+import type { ReviewPinsPayload, ReviewServerState } from './client/types.js';
+import { createPinsService, type RepoInfo } from './pins-service.js';
+import { fetchPrOccurrences } from './pins/github.js';
+import { servedPrs } from './served.js';
 import { execFile } from 'node:child_process';
 import { readFile, stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
@@ -8,9 +11,15 @@ import { promisify } from 'node:util';
 import { transformWithEsbuild, type Plugin } from 'vite';
 
 /**
- * FR-3811 — dev-only review overlay, write side. Serves the Shadow-DOM picker
- * client and the `/__review/state` endpoint that answers "which PR is this
- * dev server?". The read side (pins, panel, polling) is FR-3813.
+ * FR-3811 / FR-3813 — dev-only review overlay. Serves the Shadow-DOM picker
+ * and pin client, `/__review/state` ("which PRs is this dev server?") and
+ * `/__review/pins` (every `#bai=v3` block found on those PRs, merged).
+ *
+ * Endpoint posture (R3.4), all of it load-bearing because the dev server
+ * binds `0.0.0.0`: GET only, zero request parameters, owner/repo pinned to
+ * the served set, a private repository disables both endpoints, one shared
+ * cached read, and a whitelisted response shape — the `gh` token never leaves
+ * the process and no upstream text is echoed.
  *
  * Dev-only by construction: `apply: 'serve'` keeps the plugin out of
  * `vite build` entirely, and it is opt-in per session with
@@ -49,7 +58,49 @@ const NO_STATE: ReviewServerState = {
   repo: null,
   branch: null,
   source: 'none',
+  served: [],
+  isPrivate: false,
 };
+
+async function gh(args: string[]): Promise<string> {
+  const { stdout } = await pexecFile('gh', args, {
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+let repoInfoPromise: Promise<RepoInfo> | null = null;
+
+/**
+ * Asked once per server. A failure is an unreadable repository, which the
+ * pins service treats exactly like a private one — the endpoints stay shut
+ * rather than opening up because `gh` had a bad day.
+ */
+function repoInfo(): Promise<RepoInfo> {
+  repoInfoPromise ??= gh([
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner,isPrivate',
+  ]).then(
+    (stdout) => {
+      const parsed = JSON.parse(stdout) as {
+        nameWithOwner?: string;
+        isPrivate?: boolean;
+      };
+      return {
+        nameWithOwner: parsed.nameWithOwner ?? null,
+        isPrivate: !!parsed.isPrivate,
+      };
+    },
+    () => ({
+      nameWithOwner: null,
+      isPrivate: true,
+      error: 'gh repo view failed',
+    }),
+  );
+  return repoInfoPromise;
+}
 
 async function currentBranch(): Promise<string | null> {
   try {
@@ -68,37 +119,53 @@ async function currentBranch(): Promise<string | null> {
 /** Total by construction: every failure resolves to a `source: 'none'` state. */
 async function discoverState(): Promise<ReviewServerState> {
   try {
+    const repo = await repoInfo();
+    // R3.4 disables BOTH endpoints for a private repository: the write side's
+    // block would otherwise name a PR this server refuses to read back.
+    if (repo.error || repo.isPrivate) {
+      return {
+        ...NO_STATE,
+        isPrivate: true,
+        error: repo.error ?? 'private repository',
+      };
+    }
     const branch = await currentBranch();
     const record = await readBootRecord();
     const entry = servedEntry(record, branch);
     if (entry?.pr) {
       return {
         pr: entry.pr,
-        repo: record?.repo ?? null,
+        repo: repo.nameWithOwner ?? record?.repo ?? null,
         branch: entry.branch ?? record?.branch ?? branch,
         source: 'boot-record',
+        served: servedPrs(record, branch),
+        isPrivate: false,
       };
     }
     if (!branch) return NO_STATE;
     try {
-      const { stdout } = await pexecFile('gh', [
-        'pr',
-        'list',
-        '--head',
-        branch,
-        '--state',
-        'open',
-        '--json',
-        'number',
-        '--limit',
-        '1',
-      ]);
-      const list = JSON.parse(stdout) as Array<{ number?: number }>;
+      const list = JSON.parse(
+        await gh([
+          'pr',
+          'list',
+          '--head',
+          branch,
+          '--state',
+          'open',
+          '--json',
+          'number',
+          '--limit',
+          '1',
+        ]),
+      ) as Array<{ number?: number }>;
+      const pr = list[0]?.number ?? null;
       return {
-        pr: list[0]?.number ?? null,
-        repo: record?.repo ?? null,
+        pr,
+        repo: repo.nameWithOwner ?? record?.repo ?? null,
         branch,
-        source: list[0]?.number ? 'gh' : 'none',
+        source: pr ? 'gh' : 'none',
+        served: pr ? [{ pr, branch }] : [],
+        isPrivate: false,
       };
     } catch {
       return {
@@ -143,6 +210,12 @@ export function devReviewOverlayPlugin(): Plugin {
     return inFlight;
   }
 
+  const pins = createPinsService({
+    repoInfo,
+    servedSet: () => reviewState().then((state) => state.served),
+    fetchPr: (repo, pr) => fetchPrOccurrences(repo, pr, gh),
+  });
+
   async function clientModule(file: string): Promise<string> {
     const info = await stat(file);
     const hit = transformed.get(file);
@@ -173,19 +246,27 @@ export function devReviewOverlayPlugin(): Plugin {
           return res.end();
         }
 
+        const json = (body: string, status = 200) => {
+          res.statusCode = status;
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Cache-Control', 'no-store');
+          res.end(body);
+        };
+
         if (path === '/__review/state') {
           reviewState().then(
-            (state) => {
-              res.statusCode = 200;
-              res.setHeader('Content-Type', 'application/json');
-              res.setHeader('Cache-Control', 'no-store');
-              res.end(JSON.stringify(state));
-            },
-            () => {
-              res.statusCode = 500;
-              res.setHeader('Content-Type', 'application/json');
-              res.end('{"error":"discovery failed"}');
-            },
+            (state) => json(JSON.stringify(state)),
+            () => json('{"error":"discovery failed"}', 500),
+          );
+          return;
+        }
+
+        // Zero request parameters by construction — `path` is already the
+        // query-stripped url, so `?anything=1` answers the same payload.
+        if (path === '/__review/pins') {
+          pins.getPins().then(
+            (payload: ReviewPinsPayload) => json(JSON.stringify(payload)),
+            () => json('{"error":"upstream"}', 500),
           );
           return;
         }

--- a/react/vite-plugins/review-overlay/index.ts
+++ b/react/vite-plugins/review-overlay/index.ts
@@ -35,8 +35,18 @@ const CLIENT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'client');
 /** `/__review/overlay.js` is the entry; every other name maps 1:1 to a module. */
 const ENTRY_MODULE = 'main';
 const MODULE_NAME_RE = /^[a-z][a-z0-9-]*$/;
-/** A `pr: null` answer is retried this often — a PR opened after boot recovers. */
+/** An unsettled answer is retried this often — a PR opened after boot recovers. */
 const REDISCOVER_AFTER_MS = 30_000;
+
+/**
+ * The boot record is written only once the server has come up, so the first
+ * discovery of a stacked checkout usually predates it and falls back to
+ * `gh pr list`, which knows the top layer alone. Keep asking until the record
+ * that names the whole stack shows up.
+ */
+const isSettled = (state: ReviewServerState): boolean =>
+  state.source === 'boot-record' ||
+  (state.pr !== null && !process.env.BAI_REVIEW_BOOT_RECORD);
 
 const pexecFile = promisify(execFile);
 
@@ -198,7 +208,7 @@ export function devReviewOverlayPlugin(): Plugin {
     const now = Date.now();
     if (
       cached &&
-      (cached.state.pr !== null || now - cached.at < REDISCOVER_AFTER_MS)
+      (isSettled(cached.state) || now - cached.at < REDISCOVER_AFTER_MS)
     ) {
       return Promise.resolve(cached.state);
     }

--- a/react/vite-plugins/review-overlay/pins-service.test.ts
+++ b/react/vite-plugins/review-overlay/pins-service.test.ts
@@ -7,13 +7,14 @@ const PIN_BODY = '📍 **Start › button** · `c_zdv3rhz`';
 const prResult = (
   pr: number,
   over: Partial<PrOccurrences> = {},
+  id = 'c_zdv3rhz',
 ): PrOccurrences => ({
   pr,
   state: 'OPEN',
   truncated: false,
   occurrences: [
     {
-      id: 'c_zdv3rhz',
+      id,
       anchorB64: null,
       quoted: true,
       pr,
@@ -23,7 +24,8 @@ const prResult = (
       author: 'reviewer',
       createdAt: '2026-09-01T08:00:00Z',
       text: PIN_BODY,
-      normalized: 'start button c_zdv3rhz',
+      normalized: `start button ${id}`,
+      remainder: '',
       resolved: false,
       resolvedBy: null,
       outdated: false,
@@ -133,13 +135,11 @@ describe('createPinsService', () => {
 
   it('fails closed when the repository check itself fails', async () => {
     const d = deps({
-      repoInfo: vi
-        .fn()
-        .mockResolvedValue({
-          nameWithOwner: null,
-          isPrivate: true,
-          error: 'gh repo view failed',
-        }),
+      repoInfo: vi.fn().mockResolvedValue({
+        nameWithOwner: null,
+        isPrivate: true,
+        error: 'gh repo view failed',
+      }),
     });
     const payload = await createPinsService(d).getPins();
     expect(payload.pins).toEqual([]);
@@ -154,9 +154,11 @@ describe('createPinsService', () => {
     expect(payload.pins).toEqual([]);
   });
 
-  it('stops polling a layer that merged, on the next poll', async () => {
+  it('stops polling a layer that merged but freezes its pins', async () => {
     const fetchPr = vi.fn(async (_repo: string, pr: number) =>
-      prResult(pr, pr === 9320 ? { state: 'MERGED' } : {}),
+      pr === 9320
+        ? prResult(pr, { state: 'MERGED' }, 'c_frozen1')
+        : prResult(pr),
     );
     const service = createPinsService(
       deps({
@@ -170,10 +172,45 @@ describe('createPinsService', () => {
     await service.getPins();
     clock += 20_000;
     const second = await service.getPins();
-    expect(second.served).toEqual([{ pr: 9354, state: 'OPEN' }]);
     expect(fetchPr.mock.calls.map((call) => call[1])).toEqual([
       9320, 9354, 9354,
     ]);
+    // R3.7.5: the layer stops being polled, its pins stay on the board.
+    expect(second.pins.map((pin) => [pin.id, pin.sourcePr]).sort()).toEqual([
+      ['c_frozen1', 9320],
+      ['c_zdv3rhz', 9354],
+    ]);
+    expect(second.served).toContainEqual({ pr: 9320, state: 'MERGED' });
+  });
+
+  it('asks discovery again while no PR is served yet', async () => {
+    const servedSet = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ pr: 9360, branch: 'top' }]);
+    const service = createPinsService(deps({ servedSet }));
+    expect((await service.getPins()).sources.github).toEqual({
+      ok: false,
+      error: 'no open PR',
+    });
+    clock += 20_000;
+    const second = await service.getPins();
+    expect(servedSet).toHaveBeenCalledTimes(2);
+    expect(second.pins).toHaveLength(1);
+    expect(second.served).toEqual([{ pr: 9360, state: 'OPEN' }]);
+  });
+
+  it('does not re-adopt a layer that already merged', async () => {
+    const servedSet = vi.fn().mockResolvedValue([{ pr: 9320, branch: 'only' }]);
+    const fetchPr = vi.fn(async (_repo: string, pr: number) =>
+      prResult(pr, { state: 'MERGED' }),
+    );
+    const service = createPinsService(deps({ servedSet, fetchPr }));
+    await service.getPins();
+    clock += 20_000;
+    const second = await service.getPins();
+    expect(fetchPr).toHaveBeenCalledTimes(1);
+    expect(second.pins).toHaveLength(1);
   });
 
   it('badges a block pasted on a lower layer with that layer’s PR', async () => {

--- a/react/vite-plugins/review-overlay/pins-service.test.ts
+++ b/react/vite-plugins/review-overlay/pins-service.test.ts
@@ -1,0 +1,215 @@
+import { createPinsService } from './pins-service.js';
+import type { PrOccurrences } from './pins/github.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PIN_BODY = '📍 **Start › button** · `c_zdv3rhz`';
+
+const prResult = (
+  pr: number,
+  over: Partial<PrOccurrences> = {},
+): PrOccurrences => ({
+  pr,
+  state: 'OPEN',
+  truncated: false,
+  occurrences: [
+    {
+      id: 'c_zdv3rhz',
+      anchorB64: null,
+      quoted: true,
+      pr,
+      channel: 'github',
+      kind: 'comment',
+      url: `https://github.com/l/r/pull/${pr}#issuecomment-1`,
+      author: 'reviewer',
+      createdAt: '2026-09-01T08:00:00Z',
+      text: PIN_BODY,
+      normalized: 'start button c_zdv3rhz',
+      resolved: false,
+      resolvedBy: null,
+      outdated: false,
+      hint: false,
+      native: false,
+      replies: [],
+    },
+  ],
+  ...over,
+});
+
+let clock = 1_000_000;
+const now = () => clock;
+
+const deps = (over: Partial<Parameters<typeof createPinsService>[0]> = {}) => ({
+  repoInfo: vi.fn().mockResolvedValue({
+    nameWithOwner: 'lablup/backend.ai-webui',
+    isPrivate: false,
+  }),
+  servedSet: vi.fn().mockResolvedValue([{ pr: 9354, branch: 'top' }]),
+  fetchPr: vi.fn(async (_repo: string, pr: number) => prResult(pr)),
+  now,
+  ...over,
+});
+
+beforeEach(() => {
+  clock = 1_000_000;
+});
+
+describe('createPinsService', () => {
+  it('serves one merged payload for a served PR', async () => {
+    const service = createPinsService(deps());
+    const payload = await service.getPins();
+    expect(payload.pins).toHaveLength(1);
+    expect(payload.pins[0]).toMatchObject({
+      id: 'c_zdv3rhz',
+      number: 1,
+      sourcePr: 9354,
+    });
+    expect(payload.served).toEqual([{ pr: 9354, state: 'OPEN' }]);
+    expect(payload.sources.github).toEqual({ ok: true, count: 1 });
+  });
+
+  // Concurrent viewers cost one GitHub request per 15 s, not one each (R3.4).
+  it('shares one upstream fetch between concurrent requests', async () => {
+    const d = deps();
+    const service = createPinsService(d);
+    const [a, b, c] = await Promise.all([
+      service.getPins(),
+      service.getPins(),
+      service.getPins(),
+    ]);
+    expect(d.fetchPr).toHaveBeenCalledTimes(1);
+    expect(a.fetchedAt).toBe(b.fetchedAt);
+    expect(b.fetchedAt).toBe(c.fetchedAt);
+  });
+
+  it('answers from cache inside the 15 s floor and refetches after it', async () => {
+    const d = deps();
+    const service = createPinsService(d);
+    await service.getPins();
+    clock += 14_999;
+    await service.getPins();
+    expect(d.fetchPr).toHaveBeenCalledTimes(1);
+    clock += 2;
+    await service.getPins();
+    expect(d.fetchPr).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches a failure too, so a flapping gh is not retried per viewer', async () => {
+    const d = deps({
+      fetchPr: vi.fn().mockRejectedValue(new Error('gh: 502 boom')),
+    });
+    const service = createPinsService(d);
+    const payload = await service.getPins();
+    expect(payload).toMatchObject({ pins: [], error: 'upstream' });
+    expect(payload.sources.github).toEqual({ ok: false, error: 'upstream' });
+    await service.getPins();
+    expect(d.fetchPr).toHaveBeenCalledTimes(1);
+  });
+
+  it('never leaks the upstream error text', async () => {
+    const d = deps({
+      fetchPr: vi
+        .fn()
+        .mockRejectedValue(new Error('gh: token ghp_secret rejected')),
+    });
+    const body = JSON.stringify(await createPinsService(d).getPins());
+    expect(body).not.toContain('ghp_secret');
+    expect(body).not.toContain('token');
+  });
+
+  it('refuses to read a private repository', async () => {
+    const d = deps({
+      repoInfo: vi
+        .fn()
+        .mockResolvedValue({ nameWithOwner: 'l/secret', isPrivate: true }),
+    });
+    const payload = await createPinsService(d).getPins();
+    expect(payload).toMatchObject({
+      pins: [],
+      served: [],
+      error: 'private repository',
+    });
+    expect(d.fetchPr).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the repository check itself fails', async () => {
+    const d = deps({
+      repoInfo: vi
+        .fn()
+        .mockResolvedValue({
+          nameWithOwner: null,
+          isPrivate: true,
+          error: 'gh repo view failed',
+        }),
+    });
+    const payload = await createPinsService(d).getPins();
+    expect(payload.pins).toEqual([]);
+    expect(payload.error).toBe('gh repo view failed');
+    expect(d.fetchPr).not.toHaveBeenCalled();
+  });
+
+  it('says so when no PR is served at all', async () => {
+    const d = deps({ servedSet: vi.fn().mockResolvedValue([]) });
+    const payload = await createPinsService(d).getPins();
+    expect(payload.sources.github).toEqual({ ok: false, error: 'no open PR' });
+    expect(payload.pins).toEqual([]);
+  });
+
+  it('stops polling a layer that merged, on the next poll', async () => {
+    const fetchPr = vi.fn(async (_repo: string, pr: number) =>
+      prResult(pr, pr === 9320 ? { state: 'MERGED' } : {}),
+    );
+    const service = createPinsService(
+      deps({
+        servedSet: vi.fn().mockResolvedValue([
+          { pr: 9320, branch: 'bottom' },
+          { pr: 9354, branch: 'top' },
+        ]),
+        fetchPr,
+      }),
+    );
+    await service.getPins();
+    clock += 20_000;
+    const second = await service.getPins();
+    expect(second.served).toEqual([{ pr: 9354, state: 'OPEN' }]);
+    expect(fetchPr.mock.calls.map((call) => call[1])).toEqual([
+      9320, 9354, 9354,
+    ]);
+  });
+
+  it('badges a block pasted on a lower layer with that layer’s PR', async () => {
+    const d = deps({
+      servedSet: vi.fn().mockResolvedValue([
+        { pr: 9320, branch: 'bottom' },
+        { pr: 9354, branch: 'top' },
+      ]),
+      fetchPr: vi.fn(async (_repo: string, pr: number) =>
+        pr === 9320 ? prResult(pr) : prResult(pr, { occurrences: [] }),
+      ),
+    });
+    const payload = await createPinsService(d).getPins();
+    expect(payload.pins[0].sourcePr).toBe(9320);
+  });
+
+  it('surfaces truncation without paginating', async () => {
+    const d = deps({
+      fetchPr: vi.fn(async (_repo: string, pr: number) =>
+        prResult(pr, { truncated: true }),
+      ),
+    });
+    expect((await createPinsService(d).getPins()).sources.github).toEqual({
+      ok: true,
+      count: 1,
+      truncated: true,
+    });
+  });
+
+  it('answers with a whitelisted shape only', async () => {
+    const payload = await createPinsService(deps()).getPins();
+    expect(Object.keys(payload).sort()).toEqual([
+      'fetchedAt',
+      'pins',
+      'served',
+      'sources',
+    ]);
+  });
+});

--- a/react/vite-plugins/review-overlay/pins-service.ts
+++ b/react/vite-plugins/review-overlay/pins-service.ts
@@ -1,0 +1,122 @@
+/**
+ * `/__review/pins` behind a 15 s cache with a single shared upstream fetch
+ * (R3.4): a dev server is read by everyone on the VPN, and one poll per
+ * viewer would be a rate-limit and a privacy problem both.
+ *
+ * No vite import here on purpose — the whole endpoint's behaviour is testable
+ * by injecting `repoInfo` / `servedSet` / `fetchPr`.
+ */
+import type { ReviewPinsPayload, PinSourceStatus } from './client/types.js';
+import type { Occurrence, PrOccurrences } from './pins/github.js';
+import { attachAnchors, mergePins } from './pins/merge.js';
+import { dropClosed, type ServedPr } from './served.js';
+
+export const PINS_CACHE_MS = 15_000;
+
+export interface RepoInfo {
+  nameWithOwner: string | null;
+  isPrivate: boolean;
+  /** Set when the check itself failed — treated exactly like a private repo. */
+  error?: string;
+}
+
+export interface PinsServiceDeps {
+  repoInfo: () => Promise<RepoInfo>;
+  servedSet: () => Promise<ServedPr[]>;
+  fetchPr: (repo: string, pr: number) => Promise<PrOccurrences>;
+  now?: () => number;
+}
+
+export function createPinsService(deps: PinsServiceDeps) {
+  const now = deps.now ?? Date.now;
+  let boot: Promise<{ repo: RepoInfo; served: ServedPr[] }> | null = null;
+  let served: ServedPr[] | null = null;
+  let cached: { payload: ReviewPinsPayload; at: number } | null = null;
+  let inFlight: Promise<ReviewPinsPayload> | null = null;
+
+  const empty = (error: string): ReviewPinsPayload => ({
+    pins: [],
+    served: [],
+    sources: { github: { ok: false, error } },
+    fetchedAt: new Date(now()).toISOString(),
+    error,
+  });
+
+  async function bootOnce() {
+    boot ??= (async () => {
+      const [repo, initial] = await Promise.all([
+        deps.repoInfo(),
+        deps.servedSet(),
+      ]);
+      served = initial;
+      return { repo, served: initial };
+    })();
+    return boot;
+  }
+
+  async function build(): Promise<ReviewPinsPayload> {
+    const { repo } = await bootOnce();
+    // Fail closed: an unreadable repository is treated as a private one, so a
+    // broken `gh` never turns into an open read surface.
+    if (repo.error || repo.isPrivate || !repo.nameWithOwner) {
+      return empty(repo.error ?? 'private repository');
+    }
+    const set = served ?? [];
+    if (!set.length) {
+      return {
+        pins: [],
+        served: [],
+        sources: { github: { ok: false, error: 'no open PR' } },
+        fetchedAt: new Date(now()).toISOString(),
+      };
+    }
+
+    const results = await Promise.all(
+      set.map((entry) =>
+        deps.fetchPr(repo.nameWithOwner as string, entry.pr).then(
+          (result) => ({ ok: true as const, result }),
+          // The upstream message can carry a token or a URL — it never
+          // reaches the response, only the generic marker does.
+          () => ({ ok: false as const, pr: entry.pr }),
+        ),
+      ),
+    );
+
+    const okResults = results.flatMap((r) => (r.ok ? [r.result] : []));
+    if (!okResults.length) return empty('upstream');
+
+    const occurrences: Occurrence[] = okResults.flatMap((r) => r.occurrences);
+    const pins = await attachAnchors(mergePins(occurrences));
+    const states = okResults.map((r) => ({ pr: r.pr, state: r.state }));
+    served = dropClosed(set, states);
+
+    const github: PinSourceStatus = { ok: true, count: pins.length };
+    if (okResults.some((r) => r.truncated)) github.truncated = true;
+    if (okResults.length < set.length) github.error = 'upstream';
+    return {
+      pins,
+      served: states,
+      sources: { github },
+      fetchedAt: new Date(now()).toISOString(),
+    };
+  }
+
+  /** One in-flight build, shared; the result — success or failure — is cached. */
+  function getPins(): Promise<ReviewPinsPayload> {
+    if (cached && now() - cached.at < PINS_CACHE_MS) {
+      return Promise.resolve(cached.payload);
+    }
+    inFlight ??= build()
+      .catch(() => empty('upstream'))
+      .then((payload) => {
+        cached = { payload, at: now() };
+        inFlight = null;
+        return payload;
+      });
+    return inFlight;
+  }
+
+  return { getPins };
+}
+
+export type PinsService = ReturnType<typeof createPinsService>;

--- a/react/vite-plugins/review-overlay/pins-service.ts
+++ b/react/vite-plugins/review-overlay/pins-service.ts
@@ -29,10 +29,14 @@ export interface PinsServiceDeps {
 
 export function createPinsService(deps: PinsServiceDeps) {
   const now = deps.now ?? Date.now;
-  let boot: Promise<{ repo: RepoInfo; served: ServedPr[] }> | null = null;
+  let boot: Promise<RepoInfo> | null = null;
   let served: ServedPr[] | null = null;
   let cached: { payload: ReviewPinsPayload; at: number } | null = null;
   let inFlight: Promise<ReviewPinsPayload> | null = null;
+  /** The last read of a layer that has since merged or closed (R3.7.5). */
+  const frozen = new Map<number, PrOccurrences>();
+  /** Merged or closed once: never polled again, whatever discovery says. */
+  const gone = new Set<number>();
 
   const empty = (error: string): ReviewPinsPayload => ({
     pins: [],
@@ -42,27 +46,31 @@ export function createPinsService(deps: PinsServiceDeps) {
     error,
   });
 
-  async function bootOnce() {
-    boot ??= (async () => {
-      const [repo, initial] = await Promise.all([
-        deps.repoInfo(),
-        deps.servedSet(),
-      ]);
-      served = initial;
-      return { repo, served: initial };
-    })();
+  async function repoOnce(): Promise<RepoInfo> {
+    boot ??= deps.repoInfo();
     return boot;
   }
 
+  /**
+   * Asked again whenever the set is empty: `pnpm dev` before `gh pr create`
+   * must not freeze the endpoint at "no open PR" for the life of the process.
+   * Discovery upstream is what rate-limits the question.
+   */
+  async function currentSet(): Promise<ServedPr[]> {
+    if (served?.length) return served;
+    served = (await deps.servedSet()).filter((entry) => !gone.has(entry.pr));
+    return served;
+  }
+
   async function build(): Promise<ReviewPinsPayload> {
-    const { repo } = await bootOnce();
+    const repo = await repoOnce();
     // Fail closed: an unreadable repository is treated as a private one, so a
     // broken `gh` never turns into an open read surface.
     if (repo.error || repo.isPrivate || !repo.nameWithOwner) {
       return empty(repo.error ?? 'private repository');
     }
-    const set = served ?? [];
-    if (!set.length) {
+    const set = await currentSet();
+    if (!set.length && !frozen.size) {
       return {
         pins: [],
         served: [],
@@ -83,19 +91,33 @@ export function createPinsService(deps: PinsServiceDeps) {
     );
 
     const okResults = results.flatMap((r) => (r.ok ? [r.result] : []));
-    if (!okResults.length) return empty('upstream');
+    if (!okResults.length && !frozen.size) return empty('upstream');
 
-    const occurrences: Occurrence[] = okResults.flatMap((r) => r.occurrences);
-    const pins = await attachAnchors(mergePins(occurrences));
     const states = okResults.map((r) => ({ pr: r.pr, state: r.state }));
-    served = dropClosed(set, states);
+    const stillServed = dropClosed(set, states);
+    for (const result of okResults) {
+      if (stillServed.some((entry) => entry.pr === result.pr)) continue;
+      // Last read of a layer that just merged: kept so its pins freeze there
+      // rather than vanishing from the panel mid-review (R3.7.5).
+      frozen.set(result.pr, result);
+      gone.add(result.pr);
+    }
+    served = stillServed;
+
+    const fresh = new Set(okResults.map((r) => r.pr));
+    const kept = [...frozen.values()].filter((r) => !fresh.has(r.pr));
+    const occurrences: Occurrence[] = [...okResults, ...kept].flatMap(
+      (r) => r.occurrences,
+    );
+    const pins = await attachAnchors(mergePins(occurrences));
 
     const github: PinSourceStatus = { ok: true, count: pins.length };
-    if (okResults.some((r) => r.truncated)) github.truncated = true;
+    if ([...okResults, ...kept].some((r) => r.truncated))
+      github.truncated = true;
     if (okResults.length < set.length) github.error = 'upstream';
     return {
       pins,
-      served: states,
+      served: [...states, ...kept.map((r) => ({ pr: r.pr, state: r.state }))],
       sources: { github },
       fetchedAt: new Date(now()).toISOString(),
     };

--- a/react/vite-plugins/review-overlay/pins/extract.test.ts
+++ b/react/vite-plugins/review-overlay/pins/extract.test.ts
@@ -1,0 +1,138 @@
+import { buildBlockText } from '../client/block.js';
+import { encodeAnchor } from '../client/codec.js';
+import type { AnchorV3 } from '../client/types.js';
+import {
+  extractPinLinks,
+  isAnchorV3,
+  normalizedText,
+  pinText,
+} from './extract.js';
+import { describe, expect, it } from 'vitest';
+
+const anchor: AnchorV3 = {
+  v: 3,
+  s: 'button:nth-of-type(1)',
+  p: '/session',
+  q: 'status=RUNNING',
+  tag: 'button',
+  txt: 'Login',
+};
+
+const block = async (id: string, text = 'Pin is 8px off.') =>
+  buildBlockText({
+    label: 'Start › page-start › button "Login"',
+    id,
+    stack: [],
+    text,
+    url: `http://dev.example/session?status=RUNNING#bai=v3.${id}.${await encodeAnchor(anchor)}`,
+    pr: 9337,
+    at: '2026-09-01T08:12:00Z',
+  });
+
+describe('extractPinLinks', () => {
+  it('reads the id and the anchor out of a real block', async () => {
+    const body = await block('c_zdv3rhz');
+    const [link] = extractPinLinks(body);
+    expect(link.id).toBe('c_zdv3rhz');
+    expect(link.anchorB64).toBe(await encodeAnchor(anchor));
+    expect(link.quoted).toBe(true);
+  });
+
+  it('matches after percent-decoding', () => {
+    const body = 'see http://dev/x%23bai%3Dv3.c_abc2345.QUJDREVGR0g';
+    expect(extractPinLinks(body)).toEqual([
+      { id: 'c_abc2345', anchorB64: 'QUJDREVGR0g', quoted: false },
+    ]);
+  });
+
+  it('matches after HTML-unescaping', () => {
+    const body = '&gt; [x](http://dev/p#bai&#61;v3.c_abc2345&amp;t=1)';
+    expect(extractPinLinks(body)[0].id).toBe('c_abc2345');
+  });
+
+  it('accepts the short id-only form', () => {
+    expect(extractPinLinks('look at #bai=v3.c_zdv3rhz please')).toEqual([
+      { id: 'c_zdv3rhz', anchorB64: null, quoted: false },
+    ]);
+  });
+
+  it('collapses a duplicated id inside one body and keeps the anchor', async () => {
+    const body = `${await block('c_zdv3rhz')}\n\nsame pin: #bai=v3.c_zdv3rhz`;
+    const links = extractPinLinks(body);
+    expect(links).toHaveLength(1);
+    expect(links[0].anchorB64).toBeTruthy();
+  });
+
+  it('flags a pin that is not inside a quote block', () => {
+    const body = 'no quote here #bai=v3.c_zdv3rhz.QUJDREVGR0g';
+    expect(extractPinLinks(body)[0].quoted).toBe(false);
+  });
+
+  it('ignores v1 links and malformed ids', () => {
+    expect(extractPinLinks('#bai-review=eJxxx and #bai=v3.zdv3rhz')).toEqual(
+      [],
+    );
+  });
+});
+
+describe('pinText', () => {
+  it('keeps the quote block and drops the link and the marker', async () => {
+    const text = pinText(await block('c_zdv3rhz'));
+    expect(text).toContain('📍 **Start › page-start › button "Login"**');
+    expect(text).toContain('Pin is 8px off.');
+    expect(text).not.toContain('Open on dev server');
+    expect(text).not.toContain('bai-review v3');
+  });
+
+  it('falls back to the whole body when nothing is quoted', () => {
+    expect(pinText('Fixed in abc1234 — padding.')).toBe(
+      'Fixed in abc1234 — padding.',
+    );
+  });
+
+  it('caps runaway bodies', () => {
+    expect(pinText('x'.repeat(900))).toHaveLength(400);
+  });
+});
+
+describe('normalizedText', () => {
+  it('ignores the formatting a channel applies to the same block', () => {
+    expect(normalizedText('> 📍 **Start › button** · `c_x`')).toBe(
+      normalizedText('📍 Start button c_x'),
+    );
+  });
+
+  it('separates a reply from the block it answers', () => {
+    expect(normalizedText('Fixed in abc1234')).not.toBe(
+      normalizedText('Pin is 8px off'),
+    );
+  });
+});
+
+describe('isAnchorV3', () => {
+  it('accepts a full anchor', () => {
+    expect(
+      isAnchorV3({ ...anchor, rect: { x: 0, y: 0.5, w: 1, h: 0.2 } }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['a v1 payload', { v: 1, s: 'button', p: '/' }],
+    ['no selector', { v: 3, p: '/' }],
+    ['an off-origin path', { v: 3, s: 'button', p: '//evil.example' }],
+    ['a query with a fragment', { v: 3, s: 'b', p: '/', q: 'a=1#x' }],
+    ['a hostile tag', { v: 3, s: 'b', p: '/', tag: 'script[x]' }],
+    ['a non-string testid', { v: 3, s: 'b', p: '/', tid: 7 }],
+    ['a partial rect', { v: 3, s: 'b', p: '/', rect: { x: 0, y: 0 } }],
+    [
+      'a non-finite rect',
+      { v: 3, s: 'b', p: '/', rect: { x: NaN, y: 0, w: 1, h: 1 } },
+    ],
+    [
+      'a component that is not an object',
+      { v: 3, s: 'b', p: '/', c: 'Button' },
+    ],
+  ])('rejects %s', (_label, value) => {
+    expect(isAnchorV3(value)).toBe(false);
+  });
+});

--- a/react/vite-plugins/review-overlay/pins/extract.test.ts
+++ b/react/vite-plugins/review-overlay/pins/extract.test.ts
@@ -3,6 +3,7 @@ import { encodeAnchor } from '../client/codec.js';
 import type { AnchorV3 } from '../client/types.js';
 import {
   extractPinLinks,
+  extractPins,
   isAnchorV3,
   normalizedText,
   pinText,
@@ -45,6 +46,27 @@ describe('extractPinLinks', () => {
     ]);
   });
 
+  it('still matches when the same comment holds a bare percent sign', () => {
+    const body =
+      'CPU at 90%\nsee http://dev/x%23bai%3Dv3.c_abc2345.QUJDREVGR0g';
+    expect(extractPinLinks(body)).toEqual([
+      { id: 'c_abc2345', anchorB64: 'QUJDREVGR0g', quoted: false },
+    ]);
+  });
+
+  it('matches a hex-escaped link a sanitiser produced', () => {
+    const body = '[x](http://dev/p&#x23;bai&#x3D;v3.c_abc2345)';
+    expect(extractPinLinks(body)[0].id).toBe('c_abc2345');
+  });
+
+  // An unbounded anchor is an inflate bomb: 40 MB deflates into one comment.
+  it('refuses an anchor far longer than any real one', () => {
+    const body = `#bai=v3.c_abc2345.${'A'.repeat(4000)}`;
+    expect(extractPinLinks(body)).toEqual([
+      { id: 'c_abc2345', anchorB64: null, quoted: false },
+    ]);
+  });
+
   it('matches after HTML-unescaping', () => {
     const body = '&gt; [x](http://dev/p#bai&#61;v3.c_abc2345&amp;t=1)';
     expect(extractPinLinks(body)[0].id).toBe('c_abc2345');
@@ -72,6 +94,33 @@ describe('extractPinLinks', () => {
     expect(extractPinLinks('#bai-review=eJxxx and #bai=v3.zdv3rhz')).toEqual(
       [],
     );
+  });
+});
+
+describe('extractPins', () => {
+  it('gives each block in one comment its own words (R3.3)', async () => {
+    const body = `${await block('c_aaaaaaa', 'Button A is 8px off.')}\n\n${await block('c_bbbbbbb', 'Label B is truncated.')}`;
+    const [a, b] = extractPins(body);
+    expect(a.text).toContain('Button A is 8px off.');
+    expect(a.text).not.toContain('Label B is truncated.');
+    expect(b.text).toContain('Label B is truncated.');
+    expect(a.normalized).not.toBe(b.normalized);
+  });
+
+  it('reads a quote-reply as the same block plus its own answer', async () => {
+    const quoted = (await block('c_zdv3rhz'))
+      .split('\n')
+      .map((line) => `> ${line}`)
+      .join('\n');
+    const [pin] = extractPins(`${quoted}\n\nFixed in abc1234 — padding.`);
+    expect(pin.remainder).toBe('Fixed in abc1234 — padding.');
+    expect(pin.normalized).toBe(
+      extractPins(await block('c_zdv3rhz'))[0].normalized,
+    );
+  });
+
+  it('leaves a plain block with no answer of its own', async () => {
+    expect(extractPins(await block('c_zdv3rhz'))[0].remainder).toBe('');
   });
 });
 
@@ -132,6 +181,9 @@ describe('isAnchorV3', () => {
       'a component that is not an object',
       { v: 3, s: 'b', p: '/', c: 'Button' },
     ],
+    ['an unbounded selector', { v: 3, s: 'b'.repeat(2000), p: '/' }],
+    ['an unbounded text', { v: 3, s: 'b', p: '/', txt: 'x'.repeat(65) }],
+    ['an unbounded testid', { v: 3, s: 'b', p: '/', tid: 'x'.repeat(300) }],
   ])('rejects %s', (_label, value) => {
     expect(isAnchorV3(value)).toBe(false);
   });

--- a/react/vite-plugins/review-overlay/pins/extract.ts
+++ b/react/vite-plugins/review-overlay/pins/extract.ts
@@ -3,14 +3,14 @@
  *
  * Everything here runs on the dev server against text a stranger can write
  * into a public PR, so it is deliberately total: no throw, no regex over
- * attacker-chosen input beyond the fixed pin pattern, and the anchor is
- * type-checked field by field before any consumer trusts it.
+ * attacker-chosen input beyond the fixed pin pattern.
  */
-import { isSafePath } from '../client/codec.js';
-import type { AnchorV3 } from '../client/types.js';
+import { PIN_BODY_SRC } from '../client/codec.js';
+
+export { isAnchorV3 } from '../client/anchor-guard.js';
 
 /** `#bai=v3.<id>` with the anchor payload optional — R3.3's two valid forms. */
-export const PIN_RE = /#bai=v3\.(c_[a-z2-7]{7})(?:\.([A-Za-z0-9_-]{8,}))?/g;
+export const PIN_RE = new RegExp(`#bai=v3\\.${PIN_BODY_SRC}`, 'g');
 
 const PIN_TEXT_MAX = 400;
 const NORMALIZED_MAX = 80;
@@ -22,15 +22,42 @@ export interface PinLink {
   quoted: boolean;
 }
 
+/** One pin, with the words of the block it actually sits in (R3.3). */
+export interface PinMention extends PinLink {
+  text: string;
+  normalized: string;
+  /** Words outside every quote block — a quote-reply's own answer (R3.8). */
+  remainder: string;
+}
+
 const htmlUnescape = (text: string): string =>
   text
     .replace(/&amp;/g, '&')
-    .replace(/&#0*61;|&equals;/g, '=')
-    .replace(/&#0*35;|&num;/g, '#')
+    .replace(/&#0*61;|&#x0*3d;|&equals;/gi, '=')
+    .replace(/&#0*35;|&#x0*23;|&num;/gi, '#')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#0*39;|&apos;/g, "'");
+    .replace(/&#0*39;|&apos;/gi, "'");
+
+/**
+ * A bare `%` in prose ("CPU at 90%") makes a whole-body decode throw, which
+ * would drop every percent-encoded link in that comment, so a failed body
+ * falls back to decoding each `%XX` run on its own.
+ */
+function percentDecode(text: string): string {
+  try {
+    return decodeURIComponent(text);
+  } catch {
+    return text.replace(/(?:%[0-9A-Fa-f]{2})+/g, (run) => {
+      try {
+        return decodeURIComponent(run);
+      } catch {
+        return run;
+      }
+    });
+  }
+}
 
 /**
  * GitHub stores what the author typed, but a link that went through a mail
@@ -42,36 +69,43 @@ function textVariants(text: string): string[] {
   const add = (value: string) => {
     if (value && !seen.has(value)) seen.add(value);
   };
-  let decoded = text;
-  try {
-    decoded = decodeURIComponent(text);
-    add(decoded);
-  } catch {
-    // A bare `%` in prose is not a percent-escape; the raw scan still counts.
-  }
+  const decoded = percentDecode(text);
+  add(decoded);
   add(htmlUnescape(text));
   add(htmlUnescape(decoded));
   return [...seen];
 }
 
-export function extractPinLinks(text: string): PinLink[] {
-  const found = new Map<string, PinLink>();
-  for (const variant of textVariants(text || '')) {
-    for (const line of variant.split('\n')) {
-      const quoted = /^\s*>/.test(line);
-      for (const match of line.matchAll(PIN_RE)) {
-        const [, id, anchorB64] = match;
-        const hit = found.get(id);
-        if (!hit) {
-          found.set(id, { id, anchorB64: anchorB64 || null, quoted });
-          continue;
-        }
-        if (!hit.anchorB64 && anchorB64) hit.anchorB64 = anchorB64;
-        if (quoted) hit.quoted = true;
-      }
-    }
+const isQuoted = (line: string) => /^\s*>/.test(line);
+const stripQuote = (line: string) => line.replace(/^\s*>\s?/, '');
+
+const cleanText = (lines: string[]): string =>
+  lines
+    .filter(
+      (line) => !/^\[Open on dev server\]/.test(line) && !/^!\[/.test(line),
+    )
+    .join('\n')
+    .replace(/<!--[^]*?-->/g, '')
+    .replace(/\[Open on dev server\]\([^)]*\)/g, '')
+    .trim()
+    .slice(0, PIN_TEXT_MAX);
+
+interface Segment {
+  quoted: boolean;
+  lines: string[];
+}
+
+/** Consecutive quoted lines are one block; R3.3 allows several per comment. */
+function segments(body: string): Segment[] {
+  const out: Segment[] = [];
+  for (const line of body.split('\n')) {
+    const quoted = isQuoted(line);
+    const text = quoted ? stripQuote(line) : line;
+    const last = out[out.length - 1];
+    if (last && last.quoted === quoted) last.lines.push(text);
+    else out.push({ quoted, lines: [text] });
   }
-  return [...found.values()];
+  return out;
 }
 
 /**
@@ -81,26 +115,14 @@ export function extractPinLinks(text: string): PinLink[] {
  */
 export function pinText(body: string): string {
   const lines = (body || '').split('\n');
-  const quoted = lines
-    .filter((line) => line.startsWith('>'))
-    .map((line) => line.replace(/^>\s?/, ''))
-    .filter(
-      (line) => !/^\[Open on dev server\]/.test(line) && !/^!\[/.test(line),
-    );
-  return (quoted.length ? quoted : lines)
-    .join('\n')
-    .replace(/<!--[^]*?-->/g, '')
-    .replace(/\[Open on dev server\]\([^)]*\)/g, '')
-    .trim()
-    .slice(0, PIN_TEXT_MAX);
+  const quoted = lines.filter(isQuoted).map(stripQuote);
+  return cleanText(quoted.length ? quoted : lines);
 }
 
 /**
- * Word content only. Channels reformat the same pasted block — quote
- * prefixes, escaped markdown, collapsed whitespace — so "is this the same
- * block again (a second source) or an answer to it (a reply)?" can only be
- * asked of the words. One definition for every channel, so FR-3816's Teams
- * source folds in without a second rule.
+ * Word content only. Channels reformat the same pasted block, so "is this the
+ * same block again (a second source) or an answer to it (a reply)?" can only
+ * be asked of the words.
  */
 export function normalizedText(body: string): string {
   return (body || '')
@@ -110,40 +132,47 @@ export function normalizedText(body: string): string {
     .slice(0, NORMALIZED_MAX);
 }
 
-const isString = (value: unknown): value is string => typeof value === 'string';
-const isFraction = (value: unknown): boolean =>
-  typeof value === 'number' && Number.isFinite(value);
+export function extractPins(body: string): PinMention[] {
+  const found = new Map<string, PinMention>();
+  for (const variant of textVariants(body || '')) {
+    const parts = segments(variant);
+    const hasQuote = parts.some(
+      (part) => part.quoted && part.lines.some((line) => line.trim()),
+    );
+    const remainder = hasQuote
+      ? cleanText(parts.filter((part) => !part.quoted).flatMap((p) => p.lines))
+      : '';
+    const whole = cleanText(parts.flatMap((part) => part.lines));
+    for (const part of parts) {
+      const text = part.quoted ? cleanText(part.lines) : whole;
+      for (const line of part.lines) {
+        for (const match of line.matchAll(PIN_RE)) {
+          const [, id, anchorB64] = match;
+          const hit = found.get(id);
+          if (!hit) {
+            found.set(id, {
+              id,
+              anchorB64: anchorB64 || null,
+              quoted: part.quoted,
+              text,
+              normalized: normalizedText(text),
+              remainder: part.quoted ? remainder : '',
+            });
+            continue;
+          }
+          if (!hit.anchorB64 && anchorB64) hit.anchorB64 = anchorB64;
+          if (part.quoted) hit.quoted = true;
+        }
+      }
+    }
+  }
+  return [...found.values()];
+}
 
-/**
- * `decodeAnchor` only guarantees `v`, `s` and a safe `p`. A pin arrives from
- * whoever can comment on the PR, and the client feeds these fields to
- * `querySelector`, `location.assign` and the DOM, so every optional field is
- * checked here before the payload leaves the server.
- */
-export function isAnchorV3(value: unknown): value is AnchorV3 {
-  if (!value || typeof value !== 'object') return false;
-  const a = value as Record<string, unknown>;
-  if (a.v !== 3) return false;
-  if (!isString(a.s) || !a.s) return false;
-  if (!isSafePath(a.p)) return false;
-  if (a.q !== undefined && (!isString(a.q) || /[#\s]/.test(a.q))) return false;
-  if (
-    a.tag !== undefined &&
-    (!isString(a.tag) || !/^[a-z][a-z0-9-]*$/.test(a.tag))
-  )
-    return false;
-  if (a.txt !== undefined && (!isString(a.txt) || a.txt.length > 64))
-    return false;
-  if (a.tid !== undefined && !isString(a.tid)) return false;
-  if (a.rect !== undefined) {
-    const r = a.rect as Record<string, unknown> | null;
-    if (!r || typeof r !== 'object') return false;
-    if (!['x', 'y', 'w', 'h'].every((k) => isFraction(r[k]))) return false;
-  }
-  if (a.c !== undefined) {
-    const c = a.c as Record<string, unknown> | null;
-    if (!c || typeof c !== 'object') return false;
-    if (!isString(c.name) || !isString(c.src)) return false;
-  }
-  return true;
+export function extractPinLinks(text: string): PinLink[] {
+  return extractPins(text).map(({ id, anchorB64, quoted }) => ({
+    id,
+    anchorB64,
+    quoted,
+  }));
 }

--- a/react/vite-plugins/review-overlay/pins/extract.ts
+++ b/react/vite-plugins/review-overlay/pins/extract.ts
@@ -1,0 +1,149 @@
+/**
+ * Reading `#bai=v3` blocks back out of a comment body (FR-3813).
+ *
+ * Everything here runs on the dev server against text a stranger can write
+ * into a public PR, so it is deliberately total: no throw, no regex over
+ * attacker-chosen input beyond the fixed pin pattern, and the anchor is
+ * type-checked field by field before any consumer trusts it.
+ */
+import { isSafePath } from '../client/codec.js';
+import type { AnchorV3 } from '../client/types.js';
+
+/** `#bai=v3.<id>` with the anchor payload optional — R3.3's two valid forms. */
+export const PIN_RE = /#bai=v3\.(c_[a-z2-7]{7})(?:\.([A-Za-z0-9_-]{8,}))?/g;
+
+const PIN_TEXT_MAX = 400;
+const NORMALIZED_MAX = 80;
+
+export interface PinLink {
+  id: string;
+  anchorB64: string | null;
+  /** A pin pasted outside a quote block is accepted and flagged (R3.4). */
+  quoted: boolean;
+}
+
+const htmlUnescape = (text: string): string =>
+  text
+    .replace(/&amp;/g, '&')
+    .replace(/&#0*61;|&equals;/g, '=')
+    .replace(/&#0*35;|&num;/g, '#')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0*39;|&apos;/g, "'");
+
+/**
+ * GitHub stores what the author typed, but a link that went through a mail
+ * client, Teams or a markdown renderer comes back percent-encoded or
+ * HTML-escaped — `%23bai%3Dv3` and `#bai&#61;v3` are the same pin.
+ */
+function textVariants(text: string): string[] {
+  const seen = new Set<string>([text]);
+  const add = (value: string) => {
+    if (value && !seen.has(value)) seen.add(value);
+  };
+  let decoded = text;
+  try {
+    decoded = decodeURIComponent(text);
+    add(decoded);
+  } catch {
+    // A bare `%` in prose is not a percent-escape; the raw scan still counts.
+  }
+  add(htmlUnescape(text));
+  add(htmlUnescape(decoded));
+  return [...seen];
+}
+
+export function extractPinLinks(text: string): PinLink[] {
+  const found = new Map<string, PinLink>();
+  for (const variant of textVariants(text || '')) {
+    for (const line of variant.split('\n')) {
+      const quoted = /^\s*>/.test(line);
+      for (const match of line.matchAll(PIN_RE)) {
+        const [, id, anchorB64] = match;
+        const hit = found.get(id);
+        if (!hit) {
+          found.set(id, { id, anchorB64: anchorB64 || null, quoted });
+          continue;
+        }
+        if (!hit.anchorB64 && anchorB64) hit.anchorB64 = anchorB64;
+        if (quoted) hit.quoted = true;
+      }
+    }
+  }
+  return [...found.values()];
+}
+
+/**
+ * The pin's display text: the block's own quote lines, minus the link and the
+ * HTML marker, so a pin reads like the note the reviewer wrote rather than
+ * like markdown source.
+ */
+export function pinText(body: string): string {
+  const lines = (body || '').split('\n');
+  const quoted = lines
+    .filter((line) => line.startsWith('>'))
+    .map((line) => line.replace(/^>\s?/, ''))
+    .filter(
+      (line) => !/^\[Open on dev server\]/.test(line) && !/^!\[/.test(line),
+    );
+  return (quoted.length ? quoted : lines)
+    .join('\n')
+    .replace(/<!--[^]*?-->/g, '')
+    .replace(/\[Open on dev server\]\([^)]*\)/g, '')
+    .trim()
+    .slice(0, PIN_TEXT_MAX);
+}
+
+/**
+ * Word content only. Channels reformat the same pasted block — quote
+ * prefixes, escaped markdown, collapsed whitespace — so "is this the same
+ * block again (a second source) or an answer to it (a reply)?" can only be
+ * asked of the words. One definition for every channel, so FR-3816's Teams
+ * source folds in without a second rule.
+ */
+export function normalizedText(body: string): string {
+  return (body || '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .toLowerCase()
+    .slice(0, NORMALIZED_MAX);
+}
+
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isFraction = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value);
+
+/**
+ * `decodeAnchor` only guarantees `v`, `s` and a safe `p`. A pin arrives from
+ * whoever can comment on the PR, and the client feeds these fields to
+ * `querySelector`, `location.assign` and the DOM, so every optional field is
+ * checked here before the payload leaves the server.
+ */
+export function isAnchorV3(value: unknown): value is AnchorV3 {
+  if (!value || typeof value !== 'object') return false;
+  const a = value as Record<string, unknown>;
+  if (a.v !== 3) return false;
+  if (!isString(a.s) || !a.s) return false;
+  if (!isSafePath(a.p)) return false;
+  if (a.q !== undefined && (!isString(a.q) || /[#\s]/.test(a.q))) return false;
+  if (
+    a.tag !== undefined &&
+    (!isString(a.tag) || !/^[a-z][a-z0-9-]*$/.test(a.tag))
+  )
+    return false;
+  if (a.txt !== undefined && (!isString(a.txt) || a.txt.length > 64))
+    return false;
+  if (a.tid !== undefined && !isString(a.tid)) return false;
+  if (a.rect !== undefined) {
+    const r = a.rect as Record<string, unknown> | null;
+    if (!r || typeof r !== 'object') return false;
+    if (!['x', 'y', 'w', 'h'].every((k) => isFraction(r[k]))) return false;
+  }
+  if (a.c !== undefined) {
+    const c = a.c as Record<string, unknown> | null;
+    if (!c || typeof c !== 'object') return false;
+    if (!isString(c.name) || !isString(c.src)) return false;
+  }
+  return true;
+}

--- a/react/vite-plugins/review-overlay/pins/github.test.ts
+++ b/react/vite-plugins/review-overlay/pins/github.test.ts
@@ -1,0 +1,225 @@
+import { fetchPrOccurrences, PR_QUERY } from './github.js';
+import { describe, expect, it, vi } from 'vitest';
+
+const PIN = '#bai=v3.c_zdv3rhz.QUJDREVGR0hJSg';
+
+const comment = (over: Record<string, unknown> = {}) => ({
+  id: 'IC_1',
+  url: 'https://github.com/lablup/backend.ai-webui/pull/9337#issuecomment-1',
+  body: `> 📍 **Start › button "Login"** · \`c_zdv3rhz\`\n> off by 8px\n> [Open on dev server](http://dev/${PIN})`,
+  author: { login: 'reviewer' },
+  createdAt: '2026-09-01T08:00:00Z',
+  isMinimized: false,
+  minimizedReason: null,
+  reactionGroups: [],
+  ...over,
+});
+
+const response = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    data: {
+      rateLimit: { cost: 1, remaining: 4999 },
+      repository: {
+        isPrivate: false,
+        pullRequest: {
+          number: 9337,
+          state: 'OPEN',
+          comments: { totalCount: 1, nodes: [comment()] },
+          reviews: { totalCount: 0, nodes: [] },
+          reviewThreads: { totalCount: 0, nodes: [] },
+          ...over,
+        },
+      },
+    },
+  });
+
+describe('fetchPrOccurrences', () => {
+  it('asks for one PR with typed variables and no interpolation', async () => {
+    const runGh = vi.fn().mockResolvedValue(response());
+    await fetchPrOccurrences('lablup/backend.ai-webui', 9337, runGh);
+    expect(runGh).toHaveBeenCalledWith([
+      'api',
+      'graphql',
+      '-f',
+      `query=${PR_QUERY}`,
+      '-f',
+      'owner=lablup',
+      '-f',
+      'name=backend.ai-webui',
+      '-F',
+      'number=9337',
+    ]);
+  });
+
+  it('maps an issue comment to an occurrence carrying the PR it was found on', async () => {
+    const runGh = vi.fn().mockResolvedValue(response());
+    const result = await fetchPrOccurrences(
+      'lablup/backend.ai-webui',
+      9337,
+      runGh,
+    );
+    expect(result.state).toBe('OPEN');
+    expect(result.truncated).toBe(false);
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0]).toMatchObject({
+      id: 'c_zdv3rhz',
+      anchorB64: 'QUJDREVGR0hJSg',
+      pr: 9337,
+      channel: 'github',
+      kind: 'comment',
+      author: 'reviewer',
+      native: false,
+      resolved: false,
+      hint: false,
+    });
+    expect(result.occurrences[0].text).toContain('off by 8px');
+  });
+
+  it('treats Hide → Resolved as resolved whatever the case', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: {
+          totalCount: 1,
+          nodes: [comment({ isMinimized: true, minimizedReason: 'RESOLVED' })],
+        },
+      }),
+    );
+    const [pin] = (await fetchPrOccurrences('l/r', 1, runGh)).occurrences;
+    expect(pin.resolved).toBe(true);
+  });
+
+  it('does not let a minimized-as-spam comment count as resolved', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: {
+          totalCount: 1,
+          nodes: [comment({ isMinimized: true, minimizedReason: 'spam' })],
+        },
+      }),
+    );
+    expect(
+      (await fetchPrOccurrences('l/r', 1, runGh)).occurrences[0].resolved,
+    ).toBe(false);
+  });
+
+  it('reads a positive reaction as a hint only', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: {
+          totalCount: 1,
+          nodes: [
+            comment({
+              reactionGroups: [
+                { content: 'THUMBS_UP', reactors: { totalCount: 2 } },
+                { content: 'CONFUSED', reactors: { totalCount: 1 } },
+              ],
+            }),
+          ],
+        },
+      }),
+    );
+    const [pin] = (await fetchPrOccurrences('l/r', 1, runGh)).occurrences;
+    expect(pin.hint).toBe(true);
+    expect(pin.resolved).toBe(false);
+  });
+
+  it('ignores a reaction nobody actually left', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: {
+          totalCount: 1,
+          nodes: [
+            comment({
+              reactionGroups: [
+                { content: 'ROCKET', reactors: { totalCount: 0 } },
+              ],
+            }),
+          ],
+        },
+      }),
+    );
+    expect(
+      (await fetchPrOccurrences('l/r', 1, runGh)).occurrences[0].hint,
+    ).toBe(false);
+  });
+
+  it('takes a review thread’s own state and its later comments as replies', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: { totalCount: 0, nodes: [] },
+        reviewThreads: {
+          totalCount: 1,
+          nodes: [
+            {
+              id: 'PRRT_1',
+              isResolved: true,
+              isOutdated: true,
+              resolvedBy: { login: 'owner' },
+              path: 'react/src/App.tsx',
+              comments: {
+                totalCount: 2,
+                nodes: [
+                  comment({
+                    id: 'PRRC_1',
+                    url: 'https://github.com/l/r/pull/1#discussion_r1',
+                  }),
+                  comment({
+                    id: 'PRRC_2',
+                    url: 'https://github.com/l/r/pull/1#discussion_r2',
+                    body: 'Fixed in abc1234 — padding.',
+                    author: { login: 'claude' },
+                    createdAt: '2026-09-01T09:00:00Z',
+                  }),
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const [pin] = (await fetchPrOccurrences('l/r', 1, runGh)).occurrences;
+    expect(pin).toMatchObject({
+      kind: 'thread',
+      native: true,
+      resolved: true,
+      outdated: true,
+      resolvedBy: 'owner',
+    });
+    expect(pin.replies).toEqual([
+      {
+        author: 'claude',
+        body: 'Fixed in abc1234 — padding.',
+        createdAt: '2026-09-01T09:00:00Z',
+        url: 'https://github.com/l/r/pull/1#discussion_r2',
+      },
+    ]);
+  });
+
+  it('flags truncation instead of paginating', async () => {
+    const runGh = vi
+      .fn()
+      .mockResolvedValue(
+        response({ comments: { totalCount: 90, nodes: [comment()] } }),
+      );
+    expect((await fetchPrOccurrences('l/r', 1, runGh)).truncated).toBe(true);
+  });
+
+  it('returns nothing for a PR whose comments carry no pins', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: { totalCount: 1, nodes: [comment({ body: 'looks good' })] },
+      }),
+    );
+    expect((await fetchPrOccurrences('l/r', 1, runGh)).occurrences).toEqual([]);
+  });
+
+  it('reports a deleted PR as missing rather than throwing', async () => {
+    const runGh = vi
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({ data: { repository: { pullRequest: null } } }),
+      );
+    const result = await fetchPrOccurrences('l/r', 1, runGh);
+    expect(result).toMatchObject({ state: null, occurrences: [] });
+  });
+});

--- a/react/vite-plugins/review-overlay/pins/github.test.ts
+++ b/react/vite-plugins/review-overlay/pins/github.test.ts
@@ -195,6 +195,79 @@ describe('fetchPrOccurrences', () => {
     ]);
   });
 
+  // The R3.8 reply carries the same 📍 link, so it also parses as an occurrence.
+  it('counts a thread reply carrying the pin link once', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: { totalCount: 0, nodes: [] },
+        reviewThreads: {
+          totalCount: 1,
+          nodes: [
+            {
+              id: 'PRRT_1',
+              isResolved: false,
+              isOutdated: false,
+              resolvedBy: null,
+              comments: {
+                totalCount: 2,
+                nodes: [
+                  comment({
+                    url: 'https://github.com/l/r/pull/1#discussion_r1',
+                  }),
+                  comment({
+                    url: 'https://github.com/l/r/pull/1#discussion_r2',
+                    body: `Fixed in abc1234 — padding. [📍](http://dev/${PIN})`,
+                    author: { login: 'claude' },
+                    createdAt: '2026-09-01T09:00:00Z',
+                  }),
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const { occurrences } = await fetchPrOccurrences('l/r', 1, runGh);
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0].replies).toHaveLength(1);
+  });
+
+  // A draft review is visible to its author alone; the endpoint is not.
+  it('never reads a review the author has not submitted', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: { totalCount: 0, nodes: [] },
+        reviews: {
+          totalCount: 1,
+          nodes: [comment({ state: 'PENDING' })],
+        },
+      }),
+    );
+    expect((await fetchPrOccurrences('l/r', 1, runGh)).occurrences).toEqual([]);
+  });
+
+  it('never reads a pending inline comment either', async () => {
+    const runGh = vi.fn().mockResolvedValue(
+      response({
+        comments: { totalCount: 0, nodes: [] },
+        reviewThreads: {
+          totalCount: 1,
+          nodes: [
+            {
+              id: 'PRRT_1',
+              isResolved: false,
+              comments: {
+                totalCount: 1,
+                nodes: [comment({ pullRequestReview: { state: 'PENDING' } })],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect((await fetchPrOccurrences('l/r', 1, runGh)).occurrences).toEqual([]);
+  });
+
   it('flags truncation instead of paginating', async () => {
     const runGh = vi
       .fn()

--- a/react/vite-plugins/review-overlay/pins/github.ts
+++ b/react/vite-plugins/review-overlay/pins/github.ts
@@ -1,0 +1,201 @@
+/**
+ * The GitHub half of the read side (R3.4): one GraphQL query per served PR
+ * per poll — issue comments, review bodies and review threads — turned into
+ * flat pin occurrences. `gh` is injected so the whole mapping is unit-testable
+ * without a network or a token.
+ *
+ * REST is not an option here: it carries no reactions and no
+ * `reviewThreads.isResolved`.
+ */
+import { extractPinLinks, normalizedText, pinText } from './extract.js';
+
+/** Page sizes are the query's cost driver (R3.4: 2 points at these numbers). */
+export const PR_QUERY = `query($owner:String!,$name:String!,$number:Int!){
+  rateLimit{cost remaining}
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      number
+      state
+      comments(first:50){totalCount nodes{id url body createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}
+      reviews(first:50){totalCount nodes{id url body createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}
+      reviewThreads(first:50){totalCount nodes{id isResolved isOutdated resolvedBy{login} comments(first:10){totalCount nodes{id url body createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}}}
+    }
+  }
+}`;
+
+/** A 👍🚀🎉❤️ is a hint that someone acted, never `resolved` (R3.4). */
+const HINT_REACTIONS = new Set(['THUMBS_UP', 'ROCKET', 'HOORAY', 'HEART']);
+const REPLY_MAX = 300;
+
+export type RunGh = (args: string[]) => Promise<string>;
+
+export interface OccurrenceReply {
+  author: string | null;
+  body: string;
+  createdAt: string | null;
+  url: string | null;
+}
+
+export interface Occurrence {
+  id: string;
+  anchorB64: string | null;
+  quoted: boolean;
+  /** The PR this occurrence was found on — the panel's source badge. */
+  pr: number;
+  channel: 'github';
+  kind: 'comment' | 'review' | 'thread';
+  url: string | null;
+  author: string | null;
+  createdAt: string | null;
+  text: string;
+  normalized: string;
+  resolved: boolean;
+  resolvedBy: string | null;
+  outdated: boolean;
+  hint: boolean;
+  /** True when the state came from a review thread, which outranks the rest. */
+  native: boolean;
+  replies: OccurrenceReply[];
+}
+
+export interface PrOccurrences {
+  pr: number;
+  state: string | null;
+  /** More comments exist than one page holds — shown, never paginated. */
+  truncated: boolean;
+  occurrences: Occurrence[];
+}
+
+interface GhNode {
+  id?: string;
+  url?: string | null;
+  body?: string | null;
+  createdAt?: string | null;
+  isMinimized?: boolean;
+  minimizedReason?: string | null;
+  author?: { login?: string | null } | null;
+  reactionGroups?: Array<{
+    content?: string;
+    reactors?: { totalCount?: number };
+  }>;
+}
+
+interface GhThread {
+  isResolved?: boolean;
+  isOutdated?: boolean;
+  resolvedBy?: { login?: string | null } | null;
+  comments?: { totalCount?: number; nodes?: GhNode[] };
+}
+
+const login = (node: GhNode): string | null => node.author?.login ?? null;
+
+/** GitHub's own Hide → Resolved, compared case-insensitively (R3.4). */
+const hiddenAsResolved = (node: GhNode): boolean =>
+  !!node.isMinimized &&
+  String(node.minimizedReason ?? '').toLowerCase() === 'resolved';
+
+const hasHintReaction = (node: GhNode): boolean =>
+  (node.reactionGroups ?? []).some(
+    (group) =>
+      HINT_REACTIONS.has(String(group.content)) &&
+      (group.reactors?.totalCount ?? 0) > 0,
+  );
+
+const asReply = (node: GhNode): OccurrenceReply => ({
+  author: login(node),
+  body: (node.body ?? '').trim().slice(0, REPLY_MAX),
+  createdAt: node.createdAt ?? null,
+  url: node.url ?? null,
+});
+
+function occurrencesIn(
+  node: GhNode,
+  pr: number,
+  kind: Occurrence['kind'],
+  state: Partial<Occurrence> = {},
+): Occurrence[] {
+  const body = node.body ?? '';
+  return extractPinLinks(body).map((link) => ({
+    id: link.id,
+    anchorB64: link.anchorB64,
+    quoted: link.quoted,
+    pr,
+    channel: 'github' as const,
+    kind,
+    url: node.url ?? null,
+    author: login(node),
+    createdAt: node.createdAt ?? null,
+    text: pinText(body),
+    normalized: normalizedText(pinText(body)),
+    resolved: hiddenAsResolved(node),
+    resolvedBy: null,
+    outdated: false,
+    hint: hasHintReaction(node),
+    native: false,
+    replies: [],
+    ...state,
+  }));
+}
+
+export async function fetchPrOccurrences(
+  repo: string,
+  pr: number,
+  runGh: RunGh,
+): Promise<PrOccurrences> {
+  const [owner, name] = repo.split('/');
+  const raw = await runGh([
+    'api',
+    'graphql',
+    '-f',
+    `query=${PR_QUERY}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `name=${name}`,
+    '-F',
+    `number=${pr}`,
+  ]);
+  const parsed = JSON.parse(raw);
+  const pull = parsed?.data?.repository?.pullRequest;
+  if (!pull) return { pr, state: null, truncated: false, occurrences: [] };
+
+  const occurrences: Occurrence[] = [];
+  let truncated = false;
+  const page = (
+    collection?: { totalCount?: number; nodes?: unknown[] } | null,
+  ) => {
+    const nodes = collection?.nodes ?? [];
+    if ((collection?.totalCount ?? 0) > nodes.length) truncated = true;
+    return nodes;
+  };
+
+  for (const node of page(pull.comments) as GhNode[]) {
+    occurrences.push(...occurrencesIn(node, pr, 'comment'));
+  }
+  for (const node of page(pull.reviews) as GhNode[]) {
+    occurrences.push(...occurrencesIn(node, pr, 'review'));
+  }
+  for (const thread of page(pull.reviewThreads) as GhThread[]) {
+    const comments = page(thread.comments) as GhNode[];
+    comments.forEach((node, index) => {
+      occurrences.push(
+        ...occurrencesIn(node, pr, 'thread', {
+          resolved: !!thread.isResolved || hiddenAsResolved(node),
+          resolvedBy: thread.resolvedBy?.login ?? null,
+          outdated: !!thread.isOutdated,
+          native: true,
+          // Everything posted after the pinned comment in its own thread is
+          // an answer to it — Claude's `Fixed in <sha>` included (R3.8).
+          replies: comments.slice(index + 1).map(asReply),
+        }),
+      );
+    });
+  }
+
+  return {
+    pr,
+    state: typeof pull.state === 'string' ? pull.state : null,
+    truncated,
+    occurrences,
+  };
+}

--- a/react/vite-plugins/review-overlay/pins/github.ts
+++ b/react/vite-plugins/review-overlay/pins/github.ts
@@ -7,7 +7,7 @@
  * REST is not an option here: it carries no reactions and no
  * `reviewThreads.isResolved`.
  */
-import { extractPinLinks, normalizedText, pinText } from './extract.js';
+import { extractPins } from './extract.js';
 
 /** Page sizes are the query's cost driver (R3.4: 2 points at these numbers). */
 export const PR_QUERY = `query($owner:String!,$name:String!,$number:Int!){
@@ -17,8 +17,8 @@ export const PR_QUERY = `query($owner:String!,$name:String!,$number:Int!){
       number
       state
       comments(first:50){totalCount nodes{id url body createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}
-      reviews(first:50){totalCount nodes{id url body createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}
-      reviewThreads(first:50){totalCount nodes{id isResolved isOutdated resolvedBy{login} comments(first:10){totalCount nodes{id url body createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}}}
+      reviews(first:50){totalCount nodes{id url body state createdAt isMinimized minimizedReason author{login} reactionGroups{content reactors{totalCount}}}}
+      reviewThreads(first:50){totalCount nodes{id isResolved isOutdated resolvedBy{login} comments(first:10){totalCount nodes{id url body createdAt isMinimized minimizedReason pullRequestReview{state} author{login} reactionGroups{content reactors{totalCount}}}}}}
     }
   }
 }`;
@@ -49,6 +49,8 @@ export interface Occurrence {
   createdAt: string | null;
   text: string;
   normalized: string;
+  /** Words the author added outside the quoted block, if any (R3.8). */
+  remainder: string;
   resolved: boolean;
   resolvedBy: string | null;
   outdated: boolean;
@@ -73,6 +75,9 @@ interface GhNode {
   createdAt?: string | null;
   isMinimized?: boolean;
   minimizedReason?: string | null;
+  /** Review state, or the parent review's state for a thread comment. */
+  state?: string | null;
+  pullRequestReview?: { state?: string | null } | null;
   author?: { login?: string | null } | null;
   reactionGroups?: Array<{
     content?: string;
@@ -94,6 +99,14 @@ const hiddenAsResolved = (node: GhNode): boolean =>
   !!node.isMinimized &&
   String(node.minimizedReason ?? '').toLowerCase() === 'resolved';
 
+/**
+ * A review the token's owner has started but not submitted is visible to
+ * them alone; the endpoint may only carry what the PR page already shows.
+ */
+const isPending = (node: GhNode): boolean =>
+  String(node.state ?? node.pullRequestReview?.state ?? '').toUpperCase() ===
+  'PENDING';
+
 const hasHintReaction = (node: GhNode): boolean =>
   (node.reactionGroups ?? []).some(
     (group) =>
@@ -114,19 +127,19 @@ function occurrencesIn(
   kind: Occurrence['kind'],
   state: Partial<Occurrence> = {},
 ): Occurrence[] {
-  const body = node.body ?? '';
-  return extractPinLinks(body).map((link) => ({
-    id: link.id,
-    anchorB64: link.anchorB64,
-    quoted: link.quoted,
+  return extractPins(node.body ?? '').map((mention) => ({
+    id: mention.id,
+    anchorB64: mention.anchorB64,
+    quoted: mention.quoted,
     pr,
     channel: 'github' as const,
     kind,
     url: node.url ?? null,
     author: login(node),
     createdAt: node.createdAt ?? null,
-    text: pinText(body),
-    normalized: normalizedText(pinText(body)),
+    text: mention.text,
+    normalized: mention.normalized,
+    remainder: mention.remainder,
     resolved: hiddenAsResolved(node),
     resolvedBy: null,
     outdated: false,
@@ -173,22 +186,31 @@ export async function fetchPrOccurrences(
     occurrences.push(...occurrencesIn(node, pr, 'comment'));
   }
   for (const node of page(pull.reviews) as GhNode[]) {
+    if (isPending(node)) continue;
     occurrences.push(...occurrencesIn(node, pr, 'review'));
   }
   for (const thread of page(pull.reviewThreads) as GhThread[]) {
-    const comments = page(thread.comments) as GhNode[];
+    const comments = (page(thread.comments) as GhNode[]).filter(
+      (node) => !isPending(node),
+    );
+    // An id that already appeared earlier in this thread is that pin's reply,
+    // which `replies` below already carries — never a second occurrence.
+    const pinned = new Set<string>();
     comments.forEach((node, index) => {
-      occurrences.push(
-        ...occurrencesIn(node, pr, 'thread', {
-          resolved: !!thread.isResolved || hiddenAsResolved(node),
-          resolvedBy: thread.resolvedBy?.login ?? null,
-          outdated: !!thread.isOutdated,
-          native: true,
-          // Everything posted after the pinned comment in its own thread is
-          // an answer to it — Claude's `Fixed in <sha>` included (R3.8).
-          replies: comments.slice(index + 1).map(asReply),
-        }),
-      );
+      const found = occurrencesIn(node, pr, 'thread', {
+        resolved: !!thread.isResolved || hiddenAsResolved(node),
+        resolvedBy: thread.resolvedBy?.login ?? null,
+        outdated: !!thread.isOutdated,
+        native: true,
+        // Everything posted after the pinned comment in its own thread is
+        // an answer to it — Claude's `Fixed in <sha>` included (R3.8).
+        replies: comments.slice(index + 1).map(asReply),
+      });
+      for (const occurrence of found) {
+        if (pinned.has(occurrence.id)) continue;
+        pinned.add(occurrence.id);
+        occurrences.push(occurrence);
+      }
     });
   }
 

--- a/react/vite-plugins/review-overlay/pins/merge.test.ts
+++ b/react/vite-plugins/review-overlay/pins/merge.test.ts
@@ -1,0 +1,170 @@
+import { encodeAnchor } from '../client/codec.js';
+import type { AnchorV3 } from '../client/types.js';
+import type { Occurrence } from './github.js';
+import { attachAnchors, mergePins } from './merge.js';
+import { describe, expect, it } from 'vitest';
+
+const BLOCK = '📍 **Start › button "Login"** · `c_zdv3rhz`\noff by 8px';
+
+const occurrence = (over: Partial<Occurrence> = {}): Occurrence => ({
+  id: 'c_zdv3rhz',
+  anchorB64: null,
+  quoted: true,
+  pr: 9337,
+  channel: 'github',
+  kind: 'comment',
+  url: 'https://github.com/l/r/pull/9337#issuecomment-1',
+  author: 'reviewer',
+  createdAt: '2026-09-01T08:00:00Z',
+  text: BLOCK,
+  normalized: BLOCK.replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .toLowerCase()
+    .slice(0, 80),
+  resolved: false,
+  resolvedBy: null,
+  outdated: false,
+  hint: false,
+  native: false,
+  replies: [],
+  ...over,
+});
+
+const reply = (over: Partial<Occurrence> = {}) =>
+  occurrence({
+    text: 'Fixed in abc1234 — padding.',
+    normalized: 'fixed in abc1234 padding',
+    createdAt: '2026-09-01T09:00:00Z',
+    author: 'claude',
+    ...over,
+  });
+
+describe('mergePins', () => {
+  it('keys pins by id and numbers them by createdAt rank', () => {
+    const pins = mergePins([
+      occurrence({ id: 'c_bbbbbbb', createdAt: '2026-09-01T10:00:00Z' }),
+      occurrence({ id: 'c_aaaaaaa', createdAt: '2026-09-01T08:00:00Z' }),
+    ]);
+    expect(pins.map((pin) => [pin.id, pin.number])).toEqual([
+      ['c_aaaaaaa', 1],
+      ['c_bbbbbbb', 2],
+    ]);
+  });
+
+  it('folds the same block pasted again into a second source, not a reply', () => {
+    const [pin] = mergePins([
+      occurrence(),
+      // A stack's lower layer, reformatted by the channel it went through.
+      occurrence({
+        pr: 9320,
+        createdAt: '2026-09-01T08:30:00Z',
+        text: `> ${BLOCK}`,
+        url: 'https://github.com/l/r/pull/9320#issuecomment-2',
+      }),
+    ]);
+    expect(pin.sources).toHaveLength(2);
+    expect(pin.sources.map((source) => source.pr)).toEqual([9337, 9320]);
+    expect(pin.replies).toEqual([]);
+  });
+
+  it('treats a later comment with different words as a reply', () => {
+    const [pin] = mergePins([occurrence(), reply()]);
+    expect(pin.replyCount).toBe(1);
+    expect(pin.latestReply).toMatchObject({ author: 'claude' });
+    expect(pin.sources).toHaveLength(2);
+  });
+
+  it('carries a review thread’s own replies through', () => {
+    const [pin] = mergePins([
+      occurrence({
+        kind: 'thread',
+        native: true,
+        replies: [
+          {
+            author: 'claude',
+            body: 'Fixed in abc1234',
+            createdAt: '2026-09-01T09:00:00Z',
+            url: null,
+          },
+        ],
+      }),
+    ]);
+    expect(pin.replyCount).toBe(1);
+  });
+
+  it('lets the native thread record win over an earlier quote-reply copy', () => {
+    const [pin] = mergePins([
+      occurrence({
+        createdAt: '2026-09-01T07:00:00Z',
+        url: 'https://github.com/l/r/pull/9337#issuecomment-1',
+      }),
+      occurrence({
+        kind: 'thread',
+        native: true,
+        resolved: true,
+        resolvedBy: 'owner',
+        createdAt: '2026-09-01T08:00:00Z',
+        url: 'https://github.com/l/r/pull/9337#discussion_r1',
+      }),
+    ]);
+    expect(pin.sources[0].kind).toBe('thread');
+    expect(pin.sourcePr).toBe(9337);
+    expect(pin.createdAt).toBe('2026-09-01T08:00:00Z');
+  });
+
+  it('ORs resolved, outdated and hint across occurrences', () => {
+    const [pin] = mergePins([
+      occurrence(),
+      occurrence({
+        createdAt: '2026-09-01T08:30:00Z',
+        resolved: true,
+        resolvedBy: 'owner',
+        outdated: true,
+        hint: true,
+      }),
+    ]);
+    expect(pin).toMatchObject({
+      resolved: true,
+      resolvedBy: 'owner',
+      outdated: true,
+      hint: true,
+    });
+  });
+
+  it('keeps the anchor from whichever occurrence carried the full link', () => {
+    const [pin] = mergePins([
+      occurrence(),
+      occurrence({
+        createdAt: '2026-09-01T08:30:00Z',
+        anchorB64: 'QUJDREVGR0g',
+      }),
+    ]);
+    expect(pin.anchorB64).toBe('QUJDREVGR0g');
+  });
+});
+
+describe('attachAnchors', () => {
+  const anchor: AnchorV3 = { v: 3, s: 'button', p: '/', tag: 'button' };
+
+  it('decodes a real anchor payload', async () => {
+    const b64 = await encodeAnchor(anchor);
+    const [pin] = await attachAnchors(
+      mergePins([occurrence({ anchorB64: b64 })]),
+    );
+    expect(pin.anchor).toMatchObject({ v: 3, s: 'button', p: '/' });
+  });
+
+  it('drops an anchor that fails the field check', async () => {
+    const b64 = await encodeAnchor({ v: 3, s: 'b', p: '//evil.example' });
+    const [pin] = await attachAnchors(
+      mergePins([occurrence({ anchorB64: b64 })]),
+    );
+    expect(pin.anchor).toBeNull();
+    expect(pin.anchorB64).toBeNull();
+  });
+
+  it('leaves the short form alone', async () => {
+    const [pin] = await attachAnchors(mergePins([occurrence()]));
+    expect(pin.anchor).toBeNull();
+  });
+});

--- a/react/vite-plugins/review-overlay/pins/merge.test.ts
+++ b/react/vite-plugins/review-overlay/pins/merge.test.ts
@@ -1,5 +1,6 @@
 import { encodeAnchor } from '../client/codec.js';
 import type { AnchorV3 } from '../client/types.js';
+import { normalizedText } from './extract.js';
 import type { Occurrence } from './github.js';
 import { attachAnchors, mergePins } from './merge.js';
 import { describe, expect, it } from 'vitest';
@@ -17,10 +18,8 @@ const occurrence = (over: Partial<Occurrence> = {}): Occurrence => ({
   author: 'reviewer',
   createdAt: '2026-09-01T08:00:00Z',
   text: BLOCK,
-  normalized: BLOCK.replace(/[^\p{L}\p{N}]+/gu, ' ')
-    .trim()
-    .toLowerCase()
-    .slice(0, 80),
+  normalized: normalizedText(BLOCK),
+  remainder: '',
   resolved: false,
   resolvedBy: null,
   outdated: false,
@@ -33,7 +32,7 @@ const occurrence = (over: Partial<Occurrence> = {}): Occurrence => ({
 const reply = (over: Partial<Occurrence> = {}) =>
   occurrence({
     text: 'Fixed in abc1234 — padding.',
-    normalized: 'fixed in abc1234 padding',
+    normalized: normalizedText('Fixed in abc1234 — padding.'),
     createdAt: '2026-09-01T09:00:00Z',
     author: 'claude',
     ...over,
@@ -71,7 +70,38 @@ describe('mergePins', () => {
     const [pin] = mergePins([occurrence(), reply()]);
     expect(pin.replyCount).toBe(1);
     expect(pin.latestReply).toMatchObject({ author: 'claude' });
+    // A reply is not also a source: the panel badges one PR once (R3.6).
+    expect(pin.sources).toHaveLength(1);
+  });
+
+  it('reads a quote-reply as the block again plus its own answer', () => {
+    const [pin] = mergePins([
+      occurrence(),
+      occurrence({
+        pr: 9320,
+        createdAt: '2026-09-01T09:00:00Z',
+        author: 'claude',
+        remainder: 'Fixed in abc1234 — padding.',
+        url: 'https://github.com/l/r/pull/9320#issuecomment-2',
+      }),
+    ]);
     expect(pin.sources).toHaveLength(2);
+    expect(pin.replyCount).toBe(1);
+    expect(pin.latestReply).toMatchObject({
+      author: 'claude',
+      body: 'Fixed in abc1234 — padding.',
+    });
+  });
+
+  it('badges one PR once however many copies it holds', () => {
+    const [pin] = mergePins([
+      occurrence(),
+      occurrence({
+        createdAt: '2026-09-01T08:30:00Z',
+        url: 'https://github.com/l/r/pull/9337#issuecomment-2',
+      }),
+    ]);
+    expect(pin.sources).toHaveLength(1);
   });
 
   it('carries a review thread’s own replies through', () => {

--- a/react/vite-plugins/review-overlay/pins/merge.ts
+++ b/react/vite-plugins/review-overlay/pins/merge.ts
@@ -1,0 +1,96 @@
+/**
+ * Merge rules (R3.6). One id is one pin however many times the block was
+ * pasted: the same words again are a second SOURCE, different words later are
+ * a REPLY, and resolved / outdated / hint are ORed across every occurrence.
+ */
+import { decodeAnchor } from '../client/codec.js';
+import type { PinReply, ReviewPin } from '../client/types.js';
+import { isAnchorV3 } from './extract.js';
+import type { Occurrence } from './github.js';
+
+const byCreatedAt = (
+  a: { createdAt: string | null },
+  b: { createdAt: string | null },
+) => String(a.createdAt ?? '9999').localeCompare(String(b.createdAt ?? '9999'));
+
+/**
+ * A review thread knows its own resolution, so it is the record to believe
+ * when the same block also exists as an issue comment (GitHub's "Quote reply"
+ * makes copies); otherwise the earliest occurrence is the original.
+ */
+const primaryFirst = (a: Occurrence, b: Occurrence) =>
+  a.native !== b.native ? (a.native ? -1 : 1) : byCreatedAt(a, b);
+
+export function mergePins(occurrences: Occurrence[]): ReviewPin[] {
+  const byId = new Map<string, Occurrence[]>();
+  for (const occurrence of occurrences) {
+    byId.set(occurrence.id, [...(byId.get(occurrence.id) ?? []), occurrence]);
+  }
+
+  const pins = [...byId.entries()].map(([id, list]) => {
+    const sorted = [...list].sort(primaryFirst);
+    const primary = sorted[0];
+    const replies: PinReply[] = [
+      ...primary.replies,
+      ...sorted
+        .slice(1)
+        .filter((occurrence) => occurrence.normalized !== primary.normalized)
+        .map((occurrence) => ({
+          author: occurrence.author,
+          body: occurrence.text,
+          createdAt: occurrence.createdAt,
+          url: occurrence.url,
+        })),
+    ].sort(byCreatedAt);
+    return {
+      id,
+      number: 0,
+      anchorB64:
+        list.find((occurrence) => occurrence.anchorB64)?.anchorB64 ?? null,
+      anchor: null,
+      text: primary.text,
+      author: primary.author,
+      createdAt: primary.createdAt,
+      sources: sorted.map((occurrence) => ({
+        channel: occurrence.channel,
+        pr: occurrence.pr,
+        kind: occurrence.kind,
+        url: occurrence.url,
+        author: occurrence.author,
+      })),
+      sourcePr: primary.pr,
+      quoted: list.some((occurrence) => occurrence.quoted),
+      resolved: list.some((occurrence) => occurrence.resolved),
+      resolvedBy:
+        list.find((occurrence) => occurrence.resolvedBy)?.resolvedBy ?? null,
+      outdated: list.some((occurrence) => occurrence.outdated),
+      hint: list.some((occurrence) => occurrence.hint),
+      replies,
+      latestReply: replies.length ? replies[replies.length - 1] : null,
+      replyCount: replies.length,
+    } satisfies ReviewPin;
+  });
+
+  // Numbering is assigned here, once per payload, so a pin keeps its number
+  // across renders and a late-resolving anchor never renumbers the panel.
+  return pins
+    .sort(byCreatedAt)
+    .map((pin, index) => ({ ...pin, number: index + 1 }));
+}
+
+/**
+ * Decode on the server so a browser never inflates a stranger's payload
+ * blindly, and drop anything that fails the field check — the client then
+ * only ever sees an anchor whose `s`, `p`, `q` and `rect` are the shapes it
+ * feeds to `querySelector` and `location`.
+ */
+export async function attachAnchors(pins: ReviewPin[]): Promise<ReviewPin[]> {
+  return Promise.all(
+    pins.map(async (pin) => {
+      if (!pin.anchorB64) return pin;
+      const anchor = await decodeAnchor(pin.anchorB64);
+      if (!isAnchorV3(anchor)) return { ...pin, anchor: null, anchorB64: null };
+      return { ...pin, anchor };
+    }),
+  );
+}

--- a/react/vite-plugins/review-overlay/pins/merge.ts
+++ b/react/vite-plugins/review-overlay/pins/merge.ts
@@ -30,18 +30,32 @@ export function mergePins(occurrences: Occurrence[]): ReviewPin[] {
   const pins = [...byId.entries()].map(([id, list]) => {
     const sorted = [...list].sort(primaryFirst);
     const primary = sorted[0];
+    // A later occurrence is either the block again (a source) or an answer to
+    // it (a reply) — and a GitHub "Quote reply" is both: the same words back,
+    // plus whatever the answerer wrote underneath the quote.
+    const isSameBlock = (occurrence: Occurrence) =>
+      occurrence.normalized === primary.normalized;
+    const answer = (occurrence: Occurrence, body: string): PinReply => ({
+      author: occurrence.author,
+      body,
+      createdAt: occurrence.createdAt,
+      url: occurrence.url,
+    });
     const replies: PinReply[] = [
       ...primary.replies,
       ...sorted
         .slice(1)
-        .filter((occurrence) => occurrence.normalized !== primary.normalized)
-        .map((occurrence) => ({
-          author: occurrence.author,
-          body: occurrence.text,
-          createdAt: occurrence.createdAt,
-          url: occurrence.url,
-        })),
+        .flatMap((occurrence) =>
+          isSameBlock(occurrence)
+            ? occurrence.remainder
+              ? [answer(occurrence, occurrence.remainder)]
+              : []
+            : [answer(occurrence, occurrence.text)],
+        ),
     ].sort(byCreatedAt);
+
+    const sources = [primary, ...sorted.slice(1).filter(isSameBlock)];
+    const seenSource = new Set<string>();
     return {
       id,
       number: 0,
@@ -51,13 +65,20 @@ export function mergePins(occurrences: Occurrence[]): ReviewPin[] {
       text: primary.text,
       author: primary.author,
       createdAt: primary.createdAt,
-      sources: sorted.map((occurrence) => ({
-        channel: occurrence.channel,
-        pr: occurrence.pr,
-        kind: occurrence.kind,
-        url: occurrence.url,
-        author: occurrence.author,
-      })),
+      sources: sources
+        .filter((occurrence) => {
+          const key = `${occurrence.channel}:${occurrence.pr}`;
+          if (seenSource.has(key)) return false;
+          seenSource.add(key);
+          return true;
+        })
+        .map((occurrence) => ({
+          channel: occurrence.channel,
+          pr: occurrence.pr,
+          kind: occurrence.kind,
+          url: occurrence.url,
+          author: occurrence.author,
+        })),
       sourcePr: primary.pr,
       quoted: list.some((occurrence) => occurrence.quoted),
       resolved: list.some((occurrence) => occurrence.resolved),
@@ -80,17 +101,23 @@ export function mergePins(occurrences: Occurrence[]): ReviewPin[] {
 
 /**
  * Decode on the server so a browser never inflates a stranger's payload
- * blindly, and drop anything that fails the field check — the client then
- * only ever sees an anchor whose `s`, `p`, `q` and `rect` are the shapes it
- * feeds to `querySelector` and `location`.
+ * blindly, and drop anything that fails the field check. One anchor at a time:
+ * every payload is a comment anyone can write, and `decodeAnchor`'s size cap
+ * bounds one inflate, not fifty of them at once.
  */
 export async function attachAnchors(pins: ReviewPin[]): Promise<ReviewPin[]> {
-  return Promise.all(
-    pins.map(async (pin) => {
-      if (!pin.anchorB64) return pin;
-      const anchor = await decodeAnchor(pin.anchorB64);
-      if (!isAnchorV3(anchor)) return { ...pin, anchor: null, anchorB64: null };
-      return { ...pin, anchor };
-    }),
-  );
+  const out: ReviewPin[] = [];
+  for (const pin of pins) {
+    if (!pin.anchorB64) {
+      out.push(pin);
+      continue;
+    }
+    const anchor = await decodeAnchor(pin.anchorB64);
+    out.push(
+      isAnchorV3(anchor)
+        ? { ...pin, anchor }
+        : { ...pin, anchor: null, anchorB64: null },
+    );
+  }
+  return out;
 }

--- a/react/vite-plugins/review-overlay/served.test.ts
+++ b/react/vite-plugins/review-overlay/served.test.ts
@@ -1,0 +1,77 @@
+import { dropClosed, servedPrs } from './served.js';
+import { describe, expect, it } from 'vitest';
+
+const stack = {
+  schemaVersion: 1,
+  branch: 'feat/FR-3813-top',
+  served: [
+    { pr: 9320, branch: 'feat/FR-3803-bottom' },
+    { pr: 9321, branch: 'feat/FR-3804-middle' },
+    { pr: 9354, branch: 'feat/FR-3813-top' },
+  ],
+};
+
+describe('servedPrs', () => {
+  it('serves the whole stack, bottom-first, when the record names our branch', () => {
+    expect(servedPrs(stack, 'feat/FR-3813-top')).toEqual([
+      { pr: 9320, branch: 'feat/FR-3803-bottom' },
+      { pr: 9321, branch: 'feat/FR-3804-middle' },
+      { pr: 9354, branch: 'feat/FR-3813-top' },
+    ]);
+  });
+
+  it('serves a middle layer’s record the same way — the file already sliced it', () => {
+    expect(servedPrs(stack, 'feat/FR-3804-middle').map((e) => e.pr)).toEqual([
+      9320, 9321, 9354,
+    ]);
+  });
+
+  // Same rule as `servedEntry`: a record from another checkout claims nothing,
+  // and the caller falls back to `gh pr list --head`.
+  it('claims nothing when the record does not name the branch we are on', () => {
+    expect(servedPrs(stack, 'some-other-branch')).toEqual([]);
+  });
+
+  it('claims nothing without a record', () => {
+    expect(servedPrs(null, 'feat/FR-3813-top')).toEqual([]);
+  });
+
+  it('falls back to the record’s own branch when git could not answer', () => {
+    expect(servedPrs(stack, null).map((e) => e.pr)).toEqual([9320, 9321, 9354]);
+  });
+
+  it('ignores entries with no PR', () => {
+    expect(
+      servedPrs(
+        { schemaVersion: 1, served: [{ branch: 'b' }, { pr: 7, branch: 'b' }] },
+        'b',
+      ),
+    ).toEqual([{ pr: 7, branch: 'b' }]);
+  });
+});
+
+describe('dropClosed', () => {
+  const served = [
+    { pr: 9320, branch: 'bottom' },
+    { pr: 9354, branch: 'top' },
+  ];
+
+  it('drops a layer that merged while the server was running', () => {
+    expect(
+      dropClosed(served, [
+        { pr: 9320, state: 'MERGED' },
+        { pr: 9354, state: 'OPEN' },
+      ]),
+    ).toEqual([{ pr: 9354, branch: 'top' }]);
+  });
+
+  it('drops a closed layer too', () => {
+    expect(
+      dropClosed(served, [{ pr: 9320, state: 'CLOSED' }]).map((e) => e.pr),
+    ).toEqual([9354]);
+  });
+
+  it('keeps a PR the poll could not read — a failed fetch is not a merge', () => {
+    expect(dropClosed(served, [{ pr: 9320, state: null }])).toEqual(served);
+  });
+});

--- a/react/vite-plugins/review-overlay/served.ts
+++ b/react/vite-plugins/review-overlay/served.ts
@@ -1,0 +1,52 @@
+/**
+ * The served set (R3.7): the branch this server runs on plus every layer
+ * below it. `advertise.sh` already sliced the stack when it wrote the boot
+ * record, so the file's `served[]` IS the set — the only question is whether
+ * the record describes this checkout at all.
+ */
+import type { BootRecord } from './boot-record.js';
+
+export interface ServedPr {
+  pr: number;
+  branch: string | null;
+}
+
+/** GitHub PR states that stop a layer from being polled again (R3.7.5). */
+const GONE = new Set(['MERGED', 'CLOSED']);
+
+/**
+ * Empty means "this record is not about us" — the caller falls back to
+ * `gh pr list --head <branch>`, which is a served set of one. Same rule as
+ * `servedEntry`: a record whose served set does not name our branch was
+ * written by another checkout, and its PRs are somebody else's.
+ */
+export function servedPrs(
+  record: BootRecord | null,
+  branch: string | null,
+): ServedPr[] {
+  const served = (record?.served ?? []).filter(
+    (entry): entry is { pr: number; branch?: string } => !!entry.pr,
+  );
+  if (!served.length) return [];
+  const target = branch || record?.branch || null;
+  if (target && !served.some((entry) => entry.branch === target)) return [];
+  return served.map((entry) => ({
+    pr: entry.pr,
+    branch: entry.branch ?? null,
+  }));
+}
+
+/**
+ * A layer that merged or closed since boot stops being polled; its pins
+ * freeze at the last payload rather than disappearing mid-review. An
+ * unreadable state is not a merge — keep polling it.
+ */
+export function dropClosed(
+  served: ServedPr[],
+  states: Array<{ pr: number; state: string | null }>,
+): ServedPr[] {
+  const gone = new Set(
+    states.filter((s) => s.state && GONE.has(s.state)).map((s) => s.pr),
+  );
+  return served.filter((entry) => !gone.has(entry.pr));
+}


### PR DESCRIPTION
Resolves #9354 (FR-3813)

## What

The write side (#9337) gave people a `#bai=v3` block to paste into a PR comment. This reads those blocks back: every one pasted on the PRs this dev server serves shows up as a numbered pin on the element it was picked from, with its GitHub state, and a link from a comment or a Claude prompt opens the exact element.

- **`GET /__review/pins`** — every block found on the served PRs, merged by id. **`GET /__review/state`** grows the served set and `isPrivate` alongside the fields it already had. Both take zero request parameters, answer GET only (anything else → 405), and are refused outright for a private repository.
- **GitHub read** — one GraphQL query per served PR per poll: issue comments, review bodies and review threads with `isResolved` / `isOutdated`, `isMinimized` + `minimizedReason` (Hide → Resolved, case-insensitive), and reactions as a hint only. Links are matched after percent-decoding and HTML-unescaping; a pin outside a quote block is accepted and flagged.
- **Merge** — one id is one pin: the same block again (word content equal) is a second source with its own PR badge, a later comment carrying the id is a reply, and resolved / outdated / hint are ORed. Word content is taken per quote block, so a comment carrying two blocks gives each pin its own words, and a GitHub "Quote reply" is both — the block again plus, as the reply, whatever was written under the quote. A PR is badged once however many copies it holds. Numbers are the `createdAt` rank, fixed per payload.
- **Client** — poll at 25 s while visible, 120 s once quiet, nothing while hidden, an immediate read on focus; pins drawn at the anchor with a badge when it cannot be found; one flat panel list with source-PR badges, a per-channel status line and a click-to-highlight that survives re-renders; deep links in both forms, `#bai-review=` v1 ignored with a toast.
- **Served set** — the boot record's `served[]` (the whole stack below the running branch) when the record names this branch, else `gh pr list --head`; MERGED / CLOSED layers drop out on the next poll.

## How

Server, all under `react/vite-plugins/review-overlay/`:

| File | Owns |
| --- | --- |
| `pins/extract.ts` | the link pattern, display text, the normalisation that decides "same block again", `isAnchorV3` |
| `pins/github.ts` | `PR_QUERY` and one PR's response → occurrences, with `gh` injected |
| `pins/merge.ts` | the merge rules, the `createdAt` numbering, anchor decode + validation |
| `served.ts` | the served set and the merged/closed drop |
| `pins-service.ts` | the 15 s cache with a single shared upstream fetch, the private gate |
| `index.ts` | the two routes; nothing else moved |

Client, under `client/`: `resolve.ts` (the anchor ladder), `pins-state.ts` (the six states), `deeplink.ts` (fragment, path+query, retry ladder), `poll.ts`, `panel.ts` (pin layer + panel), plus wiring in `main.ts` and a pins count / panel toggle in `ui.ts`.

Four decisions worth flagging for review:

1. **The fragment is read once, synchronously, at module scope.** React Router keeps it on load, but the app's own `<Navigate replace>` redirects (`/` → default menu, `/start`, the scope roots) rewrite the URL without it as soon as a logged-in session resolves — a later read finds nothing. **The hash is left in the URL rather than cleared**: it is what makes the link re-openable and shareable, and the session pages that forward `hash: location.hash` on their own `navigate()` calls keep it alive across in-app navigation. Because it survives that navigation, the jump it describes is **followed once per tab** (the applied id is remembered in `sessionStorage`): a later reload of a page the reviewer navigated to themselves shows the pin in the panel instead of pulling them back to the pinned view.
2. **Path and query are applied before anchoring, with `location.assign`** — a full reload. `pushState` alone does not re-render React Router, and re-running the overlay boot is cheap; `navigatedForHash` guards the loop.
3. **A private repository disables `/__review/state` too**, not just `/__review/pins` (R3.4 says both). The repository check **fails closed**: an unreadable repo is treated exactly like a private one, so a broken `gh` shuts the endpoints instead of opening them.
4. **`orphan` sits below `replied` in the state ladder**, so "somebody answered you and is waiting" is never masked by "we cannot draw it here". The "not found on this page" badge still renders independently.

Trust boundary: pin text, author logins, resolver names and reply bodies come from anyone who can comment on a public PR, so every one of them reaches the DOM through `textContent` — `panel.test.ts` asserts an `<img onerror>` in a body stays text. `decodeAnchor` only guarantees `v`, `s` and a safe `p`, so `isAnchorV3` type-checks every remaining field on the server before the payload leaves it. The response is a whitelist built field by field; an upstream failure becomes the marker `upstream`, never the `gh` message, which can carry a token or a URL.

## Verification

```
bash scripts/verify.sh
  Relay PASS · Lint PASS · Format PASS · TypeScript PASS · TypeScript (agent-cli) PASS
  Vite warmup paths PASS · StyleX PASS · Astryx theme build PASS · Astryx integration PASS
  z-index ladder mirrors PASS · Agent mappings PASS · Terminology PASS
  === ALL PASS ===

pnpm --filter ./react exec vitest run vite-plugins
  Test Files  15 passed (15)
       Tests  221 passed (221)

E2E_REVIEW_OVERLAY_SMOKE=1 E2E_WEBUI_ENDPOINT=http://127.0.0.1:9081 \
  pnpm exec playwright test e2e/review-overlay-deeplink.spec.ts --project chromium
  ✓ @smoke a self-contained link pins the element and opens its panel item (16.0s)
  ✓ the endpoints take no parameters, answer GET only and share one read (276ms)
  2 passed
```

The smoke ran against the dev server this PR advertises (the worktree's own
`pnpm dev` with `VITE_DEV_REVIEW_OVERLAY=1`), and passed 3 runs out of 3. The
two `[cleanup]` teardown failures in that run are the suite's pre-existing
global vfolder sweep, which logs in against a backend this server does not
have; they are unrelated to this file.

It failed 2/2 before this branch's last two commits, for reasons that were
about the test and one real product gap, not the deep link: a Playwright
`button:visible` wait pierces the overlay's shadow root and matched its own
dock button, so the anchor was captured on the transient `/` rather than the
`/project/<name>/start` this logged-in dev server settles on ~5 s in; the
candidate filter picked react-grab's full-viewport `[data-testid="react-grab-overlay"]`
div; and it asserted on the first `.pin` in DOM order, which on this very PR is
a real pin anchored to `/`, hidden as an orphan. The settle is now polled
in-page, the filter skips both overlays and prefers a visible interactive
element with text, and both the pin marker and the panel item are addressed by
`data-pin-id`.

The product gap the smoke exposed: the deep link's highlight fired when the
pins payload arrived (~0.5 s) and `HIGHLIGHT_MS` is 2600, so it had expired by
the time the anchor retry ladder placed the pin (~5 s) — the link landed on the
element with nothing highlighted but the element's own flash. `locatePin` now
takes `highlight`, the retry ladder passes it, and the expiry stops the marker
pulsing as well as the item highlighting. Two new unit tests in
`client/panel.test.ts` pin the ordering (highlight at placement, not at
payload) and its survival across a poll (219 → 221).

New unit coverage (120 of those tests): extraction and the anchor field check, the GraphQL mapping (Hide → Resolved case-insensitively, a 👍 as a hint only, thread replies), the merge rules and numbering, the served set and the merged drop, the cache (one fetch for concurrent callers, failures cached, no token in the payload, a whitelisted key set), the anchor ladder, the six states, the fragment forms and the retry ladder, the poll cadence, and the panel's rendering, escaping and highlight stability. The review round added the rest: the per-block attribution and the quote-reply's own answer, a source counted once per PR, a thread reply carrying the pin link counted once, an unsubmitted review never read, a merged layer's pins frozen and an empty served set re-asked, the anchor size bound (a 200 KB payload that fits in one comment is refused), a selector hit with no text refused, the quiet cadence with a fresh `fetchedAt` on every answer, and the pin layer keeping what the full ladder found across a reposition and two flashes.

Live checks against a dev server booted from this worktree with `VITE_DEV_REVIEW_OVERLAY=1` are in a comment below.

## Not in this PR

- **Teams as a pin source** — FR-3816. The merge is written around a `channel` union and a `sources[]` list so it folds in without reshaping a pin, but nothing here reads Teams.
- **Pagination** — the query is one page per PR (50 / 50 / 50 × 10, the spec's 2-point shape); more than that is flagged as `truncated` in the panel's status line, never paged.
- **`dev.mjs` and the dev-server skill are untouched.** `VITE_DEV_REVIEW_OVERLAY` stays a manual opt-in, and "dev.mjs is unchanged and learns nothing new" stays true (R3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165N2Y5PnF5AnzvuTx96k64


