### PR TITLE
fix(FR-3106): neutralize CSV formula injection in the export helpers

### DIFF
--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -7,7 +7,7 @@ import {
   GeneratedKeypairListModalFragment$key,
 } from '../__generated__/GeneratedKeypairListModalFragment.graphql';
 import { localeCompare } from '../helper';
-import { exportCSVWithFormattingRules } from '../helper/csv-util';
+import { csvLiteral, exportCSVWithFormattingRules } from '../helper/csv-util';
 import { Banner } from '@astryxdesign/core/Banner';
 import {
   BAIFlex,
@@ -71,6 +71,9 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
         };
       }),
       'backendai_api_keypair',
+      // Secret keys are base64url (they can start with "-") and are pasted
+      // into CLI configs, so they must reach the file unmodified.
+      { 'secret key': csvLiteral },
     );
   };
 

--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -13,7 +13,7 @@ import { MyKeypairManagementModalRevokeMyKeypairMutation } from '../__generated_
 import { MyKeypairManagementModalSwitchMainKeyMutation } from '../__generated__/MyKeypairManagementModalSwitchMainKeyMutation.graphql';
 import { App } from '../app-shim';
 import { convertToOrderBy } from '../helper';
-import { downloadCSV } from '../helper/csv-util';
+import { downloadCSV, escapeCsvValue } from '../helper/csv-util';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { theme } from '../theme-shim';
@@ -90,7 +90,7 @@ const downloadCredentialCSV = (credential: KeypairCredential) => {
     credential.secretKey,
     credential.sshPublicKey,
   ]
-    .map((v) => `"${v.replace(/"/g, '""')}"`)
+    .map(escapeCsvValue)
     .join(',');
 
   const csvContent = `${header}\n${row}\n`;

--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -13,7 +13,7 @@ import { MyKeypairManagementModalRevokeMyKeypairMutation } from '../__generated_
 import { MyKeypairManagementModalSwitchMainKeyMutation } from '../__generated__/MyKeypairManagementModalSwitchMainKeyMutation.graphql';
 import { App } from '../app-shim';
 import { convertToOrderBy } from '../helper';
-import { downloadCSV, escapeCsvValue } from '../helper/csv-util';
+import { csvLiteral, downloadCSV, escapeCsvValue } from '../helper/csv-util';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { theme } from '../theme-shim';
@@ -85,9 +85,11 @@ type KeypairSorterValue =
 // hook once server-side CSV export supports them.
 const downloadCredentialCSV = (credential: KeypairCredential) => {
   const header = 'access_key,secret_key,ssh_public_key';
+  // The secret key is base64url (it can start with "-") and is pasted into CLI
+  // configs, so it must reach the file unmodified.
   const row = [
     credential.accessKey,
-    credential.secretKey,
+    csvLiteral(credential.secretKey),
     credential.sshPublicKey,
   ]
     .map(escapeCsvValue)

--- a/react/src/helper/csv-util.test.ts
+++ b/react/src/helper/csv-util.test.ts
@@ -3,7 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 // csv-util.test.ts
-import { downloadCSV, JSONToCSVBody, parseCSV, UTF8_BOM } from './csv-util';
+import {
+  downloadCSV,
+  escapeCsvValue,
+  JSONToCSVBody,
+  parseCSV,
+  UTF8_BOM,
+} from './csv-util';
 
 describe('JSONToCSVBody', () => {
   it('should convert JSON data to CSV format without formatting rules', () => {
@@ -73,6 +79,46 @@ describe('JSONToCSVBody', () => {
     const expected = '"name","age"\n"John ""Doe""",30\n"Jane, the Great",25';
 
     expect(result).toBe(expected);
+  });
+
+  it('should neutralize a cell that a spreadsheet would run as a formula', () => {
+    const data = [{ email: 'user@example.com', name: '=1+2' }];
+
+    const result = JSONToCSVBody(data);
+
+    expect(result).toBe(`"email","name"\n"user@example.com","'=1+2"`);
+  });
+});
+
+describe('escapeCsvValue', () => {
+  it.each([
+    ['=1+2', `"'=1+2"`],
+    ['@SUM(A1)', `"'@SUM(A1)"`],
+    ['+1+2', `"'+1+2"`],
+    ['-1+2', `"'-1+2"`],
+    ['\t=1+2', `"'\t=1+2"`],
+    ['\r=1+2', `"'\r=1+2"`],
+    [
+      '=HYPERLINK("http://evil.example","click")',
+      `"'=HYPERLINK(""http://evil.example"",""click"")"`,
+    ],
+  ])('neutralizes the formula trigger in %j', (input, expected) => {
+    expect(escapeCsvValue(input)).toBe(expected);
+  });
+
+  it.each([
+    ['-', '"-"'],
+    ['-30', '"-30"'],
+    ['+30', '"+30"'],
+    ['-1.5', '"-1.5"'],
+    ['plain text', '"plain text"'],
+    ['a=b', '"a=b"'],
+  ])('leaves the non-formula value %j intact', (input, expected) => {
+    expect(escapeCsvValue(input)).toBe(expected);
+  });
+
+  it('leaves actual number values unquoted and intact', () => {
+    expect(escapeCsvValue(-30)).toBe('-30');
   });
 });
 

--- a/react/src/helper/csv-util.test.ts
+++ b/react/src/helper/csv-util.test.ts
@@ -4,6 +4,7 @@
  */
 // csv-util.test.ts
 import {
+  csvLiteral,
   downloadCSV,
   escapeCsvValue,
   JSONToCSVBody,
@@ -87,6 +88,41 @@ describe('JSONToCSVBody', () => {
     const result = JSONToCSVBody(data);
 
     expect(result).toBe(`"email","name"\n"user@example.com","'=1+2"`);
+  });
+
+  it('keeps a literal column intact while still neutralizing the others', () => {
+    const data = [
+      {
+        email: '=HYPERLINK("http://evil.example","click")',
+        'secret key': '-Ab3_secret',
+      },
+    ];
+
+    const result = JSONToCSVBody(data, { 'secret key': csvLiteral });
+
+    expect(result).toBe(
+      `"email","secret key"\n"'=HYPERLINK(""http://evil.example"",""click"")","-Ab3_secret"`,
+    );
+  });
+});
+
+describe('csvLiteral', () => {
+  it.each([
+    ['-Ab3_xyz', '"-Ab3_xyz"'],
+    ['=1+2', '"=1+2"'],
+    ['+1+2', '"+1+2"'],
+    ['@SUM(A1)', '"@SUM(A1)"'],
+  ])('skips the formula neutralization for %j', (input, expected) => {
+    expect(escapeCsvValue(csvLiteral(input))).toBe(expected);
+  });
+
+  it('still applies RFC 4180 quoting', () => {
+    expect(escapeCsvValue(csvLiteral('a"b,c'))).toBe('"a""b,c"');
+  });
+
+  it('renders null and undefined as an empty quoted cell', () => {
+    expect(escapeCsvValue(csvLiteral(null))).toBe('""');
+    expect(escapeCsvValue(csvLiteral(undefined))).toBe('""');
   });
 });
 

--- a/react/src/helper/csv-util.ts
+++ b/react/src/helper/csv-util.ts
@@ -5,12 +5,32 @@
 import * as _ from 'lodash-es';
 
 /**
+ * Excel/Sheets evaluate a cell starting with one of these as a formula when
+ * the CSV is opened (CSV formula injection); quoting does not prevent it.
+ */
+const FORMULA_TRIGGER = /^[=@\t\r]/;
+
+const startsFormula = (value: string) => {
+  if (FORMULA_TRIGGER.test(value)) {
+    return true;
+  }
+  // "+"/"-" starts are dangerous too ("-1+2" evaluates), but signed numbers
+  // and the bare "-" placeholder must survive unchanged.
+  return (
+    /^[+-]/.test(value) && value !== '-' && !Number.isFinite(Number(value))
+  );
+};
+
+/**
  * Escapes a value for CSV formatting.
+ *
+ * Cells that a spreadsheet would run as a formula are neutralized with a
+ * leading `'`, which the spreadsheet renders as text.
  *
  * @param value - The value to escape.
  * @returns The escaped value.
  */
-function escapeCsvValue(value: any) {
+export function escapeCsvValue(value: any) {
   if (value === null || value === undefined) {
     return '';
   }
@@ -20,6 +40,10 @@ function escapeCsvValue(value: any) {
 
   // Convert non-string values to string using JSON.stringify
   value = _.isString(value) ? value : JSON.stringify(value);
+
+  if (startsFormula(value)) {
+    value = `'${value}`;
+  }
 
   // Replace double quotes within the value with two double quotes
   return `"${value.replace(/"/g, '""')}"`;

--- a/react/src/helper/csv-util.ts
+++ b/react/src/helper/csv-util.ts
@@ -21,11 +21,35 @@ const startsFormula = (value: string) => {
   );
 };
 
+const CSV_LITERAL = Symbol('csvLiteral');
+
+/** A cell `escapeCsvValue` quotes but never neutralizes. Build one with `csvLiteral`. */
+export interface CsvLiteral {
+  readonly [CSV_LITERAL]: true;
+  readonly value: string;
+}
+
+/**
+ * Opts a cell out of the formula neutralization. Only for server-generated
+ * values that must survive a copy-paste unchanged (a secret key can start
+ * with `-`); never for user input.
+ */
+export const csvLiteral = (value: unknown): CsvLiteral => ({
+  [CSV_LITERAL]: true,
+  value: value === null || value === undefined ? '' : String(value),
+});
+
+const isCsvLiteral = (value: unknown): value is CsvLiteral =>
+  typeof value === 'object' && value !== null && CSV_LITERAL in value;
+
+const quoteCsvValue = (value: string) => `"${value.replace(/"/g, '""')}"`;
+
 /**
  * Escapes a value for CSV formatting.
  *
  * Cells that a spreadsheet would run as a formula are neutralized with a
- * leading `'`, which the spreadsheet renders as text.
+ * leading `'`, which the spreadsheet renders as text, unless the value was
+ * wrapped with `csvLiteral`.
  *
  * @param value - The value to escape.
  * @returns The escaped value.
@@ -33,6 +57,9 @@ const startsFormula = (value: string) => {
 export function escapeCsvValue(value: any) {
   if (value === null || value === undefined) {
     return '';
+  }
+  if (isCsvLiteral(value)) {
+    return quoteCsvValue(value.value);
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
@@ -45,8 +72,7 @@ export function escapeCsvValue(value: any) {
     value = `'${value}`;
   }
 
-  // Replace double quotes within the value with two double quotes
-  return `"${value.replace(/"/g, '""')}"`;
+  return quoteCsvValue(value);
 }
 
 /**

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -8,7 +8,7 @@ import EndpointDiagnosticsSection from '../components/EndpointDiagnosticsSection
 import ErrorBoundaryWithNullFallback from '../components/ErrorBoundaryWithNullFallback';
 import StorageProxyDiagnosticsSection from '../components/StorageProxyDiagnosticsSection';
 import WebServerConfigDiagnosticsSection from '../components/WebServerConfigDiagnosticsSection';
-import { downloadCSV } from '../helper/csv-util';
+import { downloadCSV, escapeCsvValue } from '../helper/csv-util';
 import { DiagnosticResult } from '../types/diagnostics';
 import { Collapsible, CollapsibleGroup } from '@astryxdesign/core/Collapsible';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
@@ -108,11 +108,6 @@ const DiagnosticsPage = () => {
       return;
     }
 
-    const escCsv = (val: string) =>
-      val.includes(',') || val.includes('"') || val.includes('\n')
-        ? `"${val.replace(/"/g, '""')}"`
-        : val;
-
     const header = [
       'ID',
       'Severity',
@@ -133,7 +128,7 @@ const DiagnosticsPage = () => {
     ]);
 
     const csvContent = [header, ...rows]
-      .map((row) => row.map(escCsv).join(','))
+      .map((row) => row.map(escapeCsvValue).join(','))
       .join('\n');
 
     const today = new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
Resolves #7842 (FR-3106)

## What is wrong

Excel and Sheets evaluate a CSV cell whose first character is `=`, `+`, `-`, `@`, tab, or CR as a formula, and RFC 4180 quoting does not prevent it — the parser strips the quotes before interpreting the cell. None of the CSV builders neutralized these cells:

- `escapeCsvValue` in `react/src/helper/csv-util.ts`
- DiagnosticsPage's local `escCsv`
- the keypair row builder in `MyKeypairManagementModal.tsx`

User-controlled data (emails, names, backend export rows) flows into files explicitly intended for spreadsheets, so a crafted value like `=HYPERLINK(...)` executed on open (CSV formula injection).

## How this fixes it

- `escapeCsvValue` now prefixes a dangerous leading character with a single quote (`'`), which spreadsheets render as text. It is exported so all client-side CSV cell escaping goes through the one helper.
- Signed numbers (`-30`, `+1.5`) and the bare `-` placeholder are exempt from the `+`/`-` trigger so exported numeric columns survive unchanged; non-numeric `+`/`-` starts (`-1+2`) are still neutralized.
- DiagnosticsPage's local `escCsv` is deleted and its rows route through `escapeCsvValue`; same for the keypair row builder in `MyKeypairManagementModal.tsx` (which also gains null-safety its inline `v.replace` lacked).
- **Credential cells opt out (review follow-up).** Secret keys are `secrets.token_urlsafe(30)` on the manager, so about 1 in 64 starts with `-`, and the keypair CSVs are pasted into CLI configs rather than opened in a spreadsheet. `csvLiteral()` marks a cell that `escapeCsvValue` quotes but never neutralizes; the two keypair exports (`MyKeypairManagementModal`, `GeneratedKeypairListModal`) wrap only the secret key column. Access keys (`AKIA` prefix) and SSH public keys stay under the default, and any cell not marked is neutralized as before, so the opt-out cannot reach a user-controlled column by accident.
- Vitest cases cover the trigger set, the numeric exemptions, the `csvLiteral` opt-out (including a row where a `-`-leading secret key survives next to a neutralized `=HYPERLINK` cell), and the `JSONToCSVBody` integration path.

## Out of scope

- `POST /export/{nodeKey}/csv` rows arrive pre-serialized from the manager, so the server-side export path is not covered here. That is a backend follow-up.

## Verification

- `pnpm vitest run src/helper/csv-util.test.ts` — 43 passed
- `bash scripts/verify.sh` — `=== ALL PASS ===`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWJPUAzCTZvtFeKYVHe1i7
https://claude.ai/code/session_019KwHghmD57U6i2jcGbnx6D
