### PR TITLE
fix(FR-3828): keep macOS window controls clear of the top band in Electron

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -364,7 +364,10 @@ function createWindow() {
     height: windowHeight,
     title: 'Backend.AI',
     frame: true,
-    titleBarStyle: 'customButtonsOnHover',
+    // Always-visible traffic lights at their native title-bar position
+    // (FR-3828); the renderer grows the topmost band by the title-bar height
+    // to clear them (`electron-macos` rules in the web styles).
+    titleBarStyle: 'hidden',
     webPreferences: {
       nativeWindowOpen: true,
       nodeIntegration: false,

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -364,10 +364,11 @@ function createWindow() {
     height: windowHeight,
     title: 'Backend.AI',
     frame: true,
-    // Always-visible traffic lights at their native title-bar position
-    // (FR-3828); the renderer grows the topmost band by the title-bar height
-    // to clear them (`electron-macos` rules in the web styles).
-    titleBarStyle: 'hidden',
+    // macOS only: always-visible traffic lights at their native title-bar
+    // position (FR-3828); the renderer grows the topmost band by the
+    // title-bar height to clear them (`electron-macos` rules in the web
+    // styles). Elsewhere 'hidden' would drop the native window controls.
+    ...(process.platform === 'darwin' ? { titleBarStyle: 'hidden' } : {}),
     webPreferences: {
       nativeWindowOpen: true,
       nodeIntegration: false,

--- a/react/src/components/AnnouncementBanner.css
+++ b/react/src/components/AnnouncementBanner.css
@@ -30,6 +30,13 @@
 body.electron-macos .webui-announcement-banner > .astryx-banner {
   min-height: calc(var(--webui-header-height) + var(--webui-titlebar-height));
   padding-block-start: calc(var(--webui-titlebar-height) + var(--spacing-3));
+  /* Topmost band = window drag surface, like the header (#9345). */
+  -webkit-app-region: drag;
+}
+
+body.electron-macos .webui-announcement-banner button,
+body.electron-macos .webui-announcement-banner a {
+  -webkit-app-region: no-drag;
 }
 
 .webui-announcement-title {

--- a/react/src/components/AnnouncementBanner.css
+++ b/react/src/components/AnnouncementBanner.css
@@ -10,6 +10,28 @@
  as part of the announcement text.
 */
 
+/* Match the WebUI header's height and inline padding (vars set from the same
+   theme tokens in AnnouncementBanner.tsx) so the two stacked bands share one
+   rhythm (FR-3828). On the status-colored header element, not the Banner
+   root, which is transparent layout-only: sizing the root leaves the page
+   background showing through. min-height, so the expanded body can grow. */
+.webui-announcement-banner > .astryx-banner {
+  min-height: var(--webui-header-height);
+  padding-inline: var(--webui-header-padding-inline);
+  align-content: center;
+}
+
+/* Electron/macOS: the banner is the window's topmost band, so it grows by the
+   native title-bar strip the traffic lights sit in (var from BAISider.css).
+   Top padding = strip + the banner's own --spacing-3 block padding, so the
+   text stays centered in the lower 60px band, level with the header text —
+   the strip alone would float it 6px high (the banner, unlike the header,
+   already pads its block axis). */
+body.electron-macos .webui-announcement-banner > .astryx-banner {
+  min-height: calc(var(--webui-header-height) + var(--webui-titlebar-height));
+  padding-block-start: calc(var(--webui-titlebar-height) + var(--spacing-3));
+}
+
 .webui-announcement-title {
   display: flex;
   align-items: center;

--- a/react/src/components/AnnouncementBanner.tsx
+++ b/react/src/components/AnnouncementBanner.tsx
@@ -9,6 +9,7 @@ import {
 } from '../helper/announcementSummary';
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useSuspenseGetAnnouncement } from '../hooks/useSuspenseGetAnnouncement';
+import { theme } from '../theme-shim';
 import './AnnouncementBanner.css';
 import AnnouncementEditModal from './AnnouncementEditModal';
 import { Banner } from '@astryxdesign/core/Banner';
@@ -35,6 +36,7 @@ const AnnouncementBanner: React.FC = () => {
   'use memo';
 
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const userRole = useCurrentUserRole();
   const isSuperAdmin = userRole === 'superadmin';
   const [isEditOpen, { toggle: toggleEditModal }] = useToggle(false);
@@ -71,6 +73,15 @@ const AnnouncementBanner: React.FC = () => {
       <Banner
         status="info"
         container="section"
+        className="webui-announcement-banner"
+        // The header's own height/inline-padding sources (WebUIHeader.tsx), so
+        // the two bands share one vertical rhythm (FR-3828 review feedback).
+        style={
+          {
+            '--webui-header-height': `${Number(token.Layout?.headerHeight) || 60}px`,
+            '--webui-header-padding-inline': `${token.marginLG}px`,
+          } as React.CSSProperties
+        }
         isDismissable
         onDismiss={() => setDismissedMessage(message)}
         // Collapsible shape: the first line is the title in BOTH states, with

--- a/react/src/components/AnnouncementBanner.tsx
+++ b/react/src/components/AnnouncementBanner.tsx
@@ -74,11 +74,11 @@ const AnnouncementBanner: React.FC = () => {
         status="info"
         container="section"
         className="webui-announcement-banner"
-        // The header's own height/inline-padding sources (WebUIHeader.tsx), so
-        // the two bands share one vertical rhythm (FR-3828 review feedback).
+        // The header's own inline-padding source (WebUIHeader.tsx), so the two
+        // bands share one rhythm (FR-3828 review feedback); the height token
+        // is bridged globally as --webui-header-height (CSSTokenVariables).
         style={
           {
-            '--webui-header-height': `${Number(token.Layout?.headerHeight) || 60}px`,
             '--webui-header-padding-inline': `${token.marginLG}px`,
           } as React.CSSProperties
         }

--- a/react/src/components/BAISider.css
+++ b/react/src/components/BAISider.css
@@ -111,7 +111,7 @@ body.electron-macos {
 body.electron-macos:not(:has(.webui-announcement-banner))
   .bai-sider
   .logo-and-text-container {
-  height: calc(60px + var(--webui-titlebar-height));
+  height: calc(var(--webui-header-height, 60px) + var(--webui-titlebar-height));
   padding-block-start: var(--webui-titlebar-height);
 }
 

--- a/react/src/components/BAISider.css
+++ b/react/src/components/BAISider.css
@@ -145,7 +145,7 @@ body.electron-macos:not(:has(.webui-announcement-banner))
   justify-content: center;
   margin: calc(var(--spacing-2) * -1);
   padding-inline: var(--spacing-8);
-  height: 60px;
+  height: var(--webui-header-height, 60px);
   background-color: var(--color-accent);
   transition: all 0.2s ease-in-out;
 }

--- a/react/src/components/BAISider.css
+++ b/react/src/components/BAISider.css
@@ -95,6 +95,26 @@
   scrollbar-color: var(--color-border-emphasized) transparent;
 }
 
+/*
+ * Electron/macOS (FR-3828): main.js hides the title bar but keeps the traffic
+ * lights at their native position (bottom edge ~24px from the window top), so
+ * the window's topmost band grows by a strip in its own color for the lights.
+ * 16px, not the full 28px native bar: the band's centered content already
+ * carries ~13px of its own top whitespace, which absorbs the rest. The sider
+ * brand band and the header (WebUIHeader.css) grow only when the announcement
+ * banner is not stacked above them; the banner case is AnnouncementBanner.css's.
+ */
+body.electron-macos {
+  --webui-titlebar-height: 16px;
+}
+
+body.electron-macos:not(:has(.webui-announcement-banner))
+  .bai-sider
+  .logo-and-text-container {
+  height: calc(60px + var(--webui-titlebar-height));
+  padding-block-start: var(--webui-titlebar-height);
+}
+
 .bai-sider .draggable {
   -webkit-app-region: drag;
 }

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -436,7 +436,12 @@ const usePageTestId = () => {
 export const CSSTokenVariables = () => {
   const { token } = theme.useToken();
   const { colorPrimary, colorBgBase, colorBgContainer, colorBorder } = token;
-  const headerHeight = Number(token.Layout?.headerHeight) || 60;
+  // The token may be a number or a CSS length string; only a number gets px.
+  const rawHeaderHeight = token.Layout?.headerHeight ?? 60;
+  const headerHeight =
+    typeof rawHeaderHeight === 'number'
+      ? `${rawHeaderHeight}px`
+      : rawHeaderHeight;
 
   useLayoutEffect(() => {
     const root = document.documentElement;
@@ -445,7 +450,7 @@ export const CSSTokenVariables = () => {
       '--token-colorBgBase': colorBgBase,
       '--token-colorBgContainer': colorBgContainer,
       '--token-colorBorder': colorBorder,
-      '--webui-header-height': `${headerHeight}px`,
+      '--webui-header-height': headerHeight,
     };
     _.forEach(bridged, (value, name) => root.style.setProperty(name, value));
     return () => {

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -436,6 +436,7 @@ const usePageTestId = () => {
 export const CSSTokenVariables = () => {
   const { token } = theme.useToken();
   const { colorPrimary, colorBgBase, colorBgContainer, colorBorder } = token;
+  const headerHeight = Number(token.Layout?.headerHeight) || 60;
 
   useLayoutEffect(() => {
     const root = document.documentElement;
@@ -444,12 +445,13 @@ export const CSSTokenVariables = () => {
       '--token-colorBgBase': colorBgBase,
       '--token-colorBgContainer': colorBgContainer,
       '--token-colorBorder': colorBorder,
+      '--webui-header-height': `${headerHeight}px`,
     };
     _.forEach(bridged, (value, name) => root.style.setProperty(name, value));
     return () => {
       _.forEach(bridged, (_value, name) => root.style.removeProperty(name));
     };
-  }, [colorPrimary, colorBgBase, colorBgContainer, colorBorder]);
+  }, [colorPrimary, colorBgBase, colorBgContainer, colorBorder, headerHeight]);
 
   return null;
 };

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -118,6 +118,16 @@ function MainLayout() {
   // These were previously in the Lit shell (backend-ai-webui.ts).
   useLogoutEventListeners();
 
+  // Gates the title-bar-strip rules (BAISider.css, WebUIHeader.css,
+  // AnnouncementBanner.css) to the desktop app, where main.js keeps the macOS
+  // window controls always visible above the top band (FR-3828).
+  useLayoutEffect(() => {
+    if (globalThis.isElectron && /Mac/i.test(navigator.platform)) {
+      document.body.classList.add('electron-macos');
+      return () => document.body.classList.remove('electron-macos');
+    }
+  }, []);
+
   useLayoutEffect(() => {
     const handleNavigate = (e: Event) => {
       const { detail } = e as CustomEvent<string>;

--- a/react/src/components/MainLayout/WebUIHeader.css
+++ b/react/src/components/MainLayout/WebUIHeader.css
@@ -21,6 +21,8 @@
    on its root — without it the content centers across the full grown height,
    8px off the sider band. */
 body.electron-macos:not(:has(.webui-announcement-banner)) .bai-webui-header {
-  height: calc(60px + var(--webui-titlebar-height)) !important;
+  height: calc(
+    var(--webui-header-height, 60px) + var(--webui-titlebar-height)
+  ) !important;
   padding-block-start: var(--webui-titlebar-height) !important;
 }

--- a/react/src/components/MainLayout/WebUIHeader.css
+++ b/react/src/components/MainLayout/WebUIHeader.css
@@ -14,3 +14,13 @@
 .bai-webui-header .non-draggable {
   -webkit-app-region: no-drag;
 }
+
+/* Electron/macOS (FR-3828): grow by the native title-bar strip when the header
+   is the topmost band (no banner above). Both !important: the 60px height is
+   an inline style in WebUIHeader.tsx, and BAIFlex resets inline `padding: 0`
+   on its root — without it the content centers across the full grown height,
+   8px off the sider band. */
+body.electron-macos:not(:has(.webui-announcement-banner)) .bai-webui-header {
+  height: calc(60px + var(--webui-titlebar-height)) !important;
+  padding-block-start: var(--webui-titlebar-height) !important;
+}


### PR DESCRIPTION
Resolves #9345 (FR-3828)

## What & why

In the Electron desktop app the announcement banner rendered at the very top of the window, where it read as a native title bar: its dismiss (X) button sat where a window control is expected, the topmost strip was not draggable, and the hover-only traffic lights (`customButtonsOnHover`) overlapped whatever band was topmost.

## Changes

- **`electron-app/main.js`**: `titleBarStyle: 'hidden'` — the traffic lights are always visible at their native position instead of appearing on hover.
- **Topmost-band strip (Electron macOS only)**: the window's topmost band grows by a 16px title-bar strip in its own color for the lights to sit in, gated by an `electron-macos` body class set in `MainLayout` (`globalThis.isElectron` + macOS). When the announcement banner is present it owns the strip; otherwise the header and the sider brand band grow together so the top line stays level. 16px rather than the native 28px bar: the bands' centered content already carries ~13px of its own top whitespace, which absorbs the rest of the clearance (lights' bottom edge ≈ 24px).
- **Banner rhythm**: the announcement banner's height and inline padding now come from the same theme tokens as the header (`Layout.headerHeight` = 60px, `marginLG`), passed as CSS variables — review feedback was that the banner's ad-hoc sizing broke the page's padding rhythm. The banner and header now stack as two same-height, same-inset bands; an expanded long announcement still grows past the min-height.
- **Alignment corrections** (both measured against the sider band): `WebUIHeader` needs `!important` for the grown height *and* the strip padding because the 60px height is an inline style and `BAIFlex` resets inline `padding: 0` on its root — without it the header content centers across the grown height, 8px off. The banner's strip padding adds its own `--spacing-3` block padding so its text stays level with the header text (the strip alone floats it 6px high).

The web build is untouched: every Electron rule is behind the `electron-macos` class, which never gets set in a browser.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, terminology)
- Live-checked in the Electron app against the dev server: traffic lights always visible in the strip, banner/header/sider bands level in both banner-present and banner-dismissed states, web rendering unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)