### PR TITLE
fix(FR-3837): keep help tooltips hover-reachable inside disabled controls

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIIconWithTooltip.tsx
+++ b/packages/backend.ai-ui/src/components/BAIIconWithTooltip.tsx
@@ -15,8 +15,10 @@ import { Text } from '@astryxdesign/core/Text';
 import { Tooltip, type TooltipProps } from '@astryxdesign/core/Tooltip';
 import type { CSSProperties, ReactNode } from 'react';
 
-export interface BAIIconWithTooltipProps
-  extends Omit<TooltipProps, 'children' | 'anchorRef'> {
+export interface BAIIconWithTooltipProps extends Omit<
+  TooltipProps,
+  'children' | 'anchorRef'
+> {
   /** The glyph the tooltip is attached to. */
   icon: ReactNode;
   /**
@@ -29,6 +31,15 @@ export interface BAIIconWithTooltipProps
   style?: CSSProperties;
   className?: string;
 }
+
+// Shared by both trigger variants. pointer-events inherits, so a disabled
+// ancestor row (Astryx Item sets `none`) would otherwise swallow the hover
+// that opens the hint (FR-3837).
+const triggerStyle: CSSProperties = {
+  cursor: 'help',
+  display: 'inline-flex',
+  pointerEvents: 'auto',
+};
 
 const BAIIconWithTooltip = ({
   icon,
@@ -63,8 +74,7 @@ const BAIIconWithTooltip = ({
             padding: 0,
             font: 'inherit',
             color: 'inherit',
-            cursor: 'help',
-            display: 'inline-flex',
+            ...triggerStyle,
             ...style,
           }}
         >
@@ -74,7 +84,7 @@ const BAIIconWithTooltip = ({
         <span
           aria-label={label}
           className={className}
-          style={{ cursor: 'help', display: 'inline-flex', ...style }}
+          style={{ ...triggerStyle, ...style }}
         >
           {iconNode}
         </span>


### PR DESCRIPTION
Resolves #9369 (FR-3837)

## What

The "?" help icon next to the **Auto Mount** usage-mode radio option in the New Folder modal never showed its tooltip on hover when the option was disabled (project-admin Data page, where only project folders can be created and the option renders `disabled`).

## Mechanism

- Astryx `RadioListItem` renders its row via `Item`, whose disabled style applies `pointer-events: none` to the whole row (`@astryxdesign/core` `Item.tsx`, `styles.disabled`).
- `pointer-events` is an **inherited** CSS property, so the `BAIIconWithTooltip` trigger button rendered in the option's `endContent` computes `pointer-events: none` too — hover never reaches it and Astryx `Tooltip` never opens. Measured live: the trigger's computed `pointer-events` was `none` and `document.elementFromPoint` at the button's center returned the outer radio-list container, not the button.
- Astryx's own docs note the class of problem: "disabled controls swallow the hover events" (RadioList `disabledMessage` guidance) — but `disabledMessage` covers only whole-group disabling, not a per-item help icon.

The fix declares `pointerEvents: 'auto'` on the trigger (both the focusable `<button>` and the `focusable={false}` `<span>` variant), which overrides the inherited `none`. Keyboard focus already reached the trigger inside a disabled row, so hover and keyboard behavior now agree. Component-level fix, so all importers of `BAIIconWithTooltip` / `BAIQuestionIconWithTooltip` (43 files) get the same guarantee.

## Measured before/after (live app, project-admin New Folder modal, Auto Mount disabled)

| Probe | Before | After |
|---|---|---|
| Tooltip on hover, dark (`data-theme='dark'` asserted) | does not appear | appears |
| Tooltip on hover, light | — (same mechanism) | appears |
| Trigger computed `pointer-events` | `none` (inherited) | `auto` |
| `elementFromPoint` at trigger center | radio-list container | the trigger button |
| Enabled option (user Data page modal), light & dark | tooltip appears | tooltip appears (no regression) |

### Before (disabled, dark)

![before disabled dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260901-190106-fr3837-before-disabled-dark.png)

### After (disabled, dark)

![after disabled dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260901-190106-fr3837-after-disabled-dark.png)

### After (disabled, light)

![after disabled light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260901-190106-fr3837-after-disabled-light.png)

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → 110 files / 1724 tests passed
- `pnpm --filter backend.ai-ui exec vitest run` → 73 passed + 1 skipped / 1958 tests passed (one earlier `BAIComplexSelect.popup.test.tsx` failure was flaky — passes standalone and on the full re-run, and also fails/passes independently of this change)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 2 findings, both **pre-existing on `main`** (`BAIDialog.css:17` / `BAIDrawerPortal.css:18`, `var(--bai-dialog-z)`), untouched by this diff
- Live probe: zero new console errors in both modes (the only console errors are pre-existing `RelayResponseNormalizer` warnings about the backend returning the same id for `Group` and `UserGroup`)

## Residue

- Clicks on the "?" inside a disabled row now also reach the trigger; the trigger has no click behavior, so this is inert.
- The disabled row's `opacity: 0.5` still dims the icon — intentional, it reads as part of the disabled option while staying hoverable.
- The pre-existing token-gate findings and the Relay normalizer warnings above are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
