### PR TITLE
test: e2e auto-heal 2026-09-02 — Astryx tab-role contract in the last 5 unhealed specs, sortable columnheader names, role=status banner

### DIFF
--- a/e2e/agent-summary/agent-summary.spec.ts
+++ b/e2e/agent-summary/agent-summary.spec.ts
@@ -1,5 +1,9 @@
 // spec: Agent Summary page tests
-import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import {
+  getSortableColumnHeader,
+  loginAsAdmin,
+  navigateTo,
+} from '../utils/test-util';
 import test, { expect } from '@playwright/test';
 
 test.describe(
@@ -13,10 +17,14 @@ test.describe(
       await loginAsAdmin(page, request);
       await navigateTo(page, 'agent-summary');
 
-      // Verify Agent Summary tab is selected
-      await expect(
-        page.getByRole('tab', { name: 'Agent Summary', selected: true }),
-      ).toBeVisible();
+      // Verify Agent Summary tab is selected. `BAITabList` / Astryx `TabList`
+      // renders a `nav[aria-label="Tabs"]` of plain `<button>`s — `role="tab"`
+      // is never emitted — and marks the active one with `aria-current="true"`.
+      const agentSummaryTab = page
+        .getByRole('navigation', { name: 'Tabs' })
+        .getByRole('button', { name: 'Agent Summary' });
+      await expect(agentSummaryTab).toBeVisible();
+      await expect(agentSummaryTab).toHaveAttribute('aria-current', 'true');
 
       // Verify table columns
       await expect(
@@ -28,8 +36,11 @@ test.describe(
       await expect(
         page.getByRole('columnheader', { name: 'Allocation' }),
       ).toBeVisible();
+      // "Resource Group" is sortable — its columnheader's accessible name is
+      // overridden by the sort button's aria-label ("Sort by scaling_group"),
+      // so match the visible text instead (see getSortableColumnHeader).
       await expect(
-        page.getByRole('columnheader', { name: 'Resource Group' }),
+        getSortableColumnHeader(page, 'Resource Group'),
       ).toBeVisible();
       await expect(
         page.getByRole('columnheader', { name: 'Schedulable' }),

--- a/e2e/credential/my-keypair-management.spec.ts
+++ b/e2e/credential/my-keypair-management.spec.ts
@@ -5,10 +5,12 @@ import {
   UserSettingModal,
 } from '../utils/classes/user/UserSettingModal';
 import {
+  getSortableColumnHeader,
   loginAsAdmin,
   loginAsCreatedAccount,
   navigateTo,
 } from '../utils/test-util';
+import { usersTabButton } from '../utils/user-profile-util';
 import test, { expect, type APIRequestContext } from '@playwright/test';
 
 // Helper to open the My Keypair Management modal
@@ -160,9 +162,9 @@ test.describe(
         // remote test backend that boot takes ~5s after goto() returns —
         // right at the 5s default expect timeout — so give it explicit
         // headroom like the sanity check below already does.
-        await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible(
-          { timeout: 15000 },
-        );
+        await expect(usersTabButton(adminPage)).toBeVisible({
+          timeout: 15000,
+        });
         await adminPage.getByRole('button', { name: 'Create User' }).click();
         const userSettingModal = new UserSettingModal(adminPage);
         await userSettingModal.createUser(
@@ -232,30 +234,34 @@ test.describe(
       const modal = page.getByRole('dialog', { name: 'My Keypair Management' });
       await expect(modal).toBeVisible();
 
-      // Verify alert banner shows the main access key
-      await expect(modal.getByRole('alert')).toContainText('Main Access Key:');
+      // Verify banner shows the main access key. The banner (Astryx `Banner`)
+      // renders with role="status", not role="alert" — confirmed against the
+      // live DOM. Scope by its content since the modal also contains several
+      // other role="status" elements (loading spinners on buttons).
+      const mainAccessKeyBanner = modal
+        .getByRole('status')
+        .filter({ hasText: 'Main Access Key:' });
+      await expect(mainAccessKeyBanner).toContainText('Main Access Key:');
 
       // Verify the Active radio button is selected by default
       await expect(
         modal.getByRole('radio', { name: 'Active', exact: true }),
       ).toBeChecked();
 
-      // Verify table columns are visible
-      await expect(
-        modal.getByRole('columnheader', { name: 'Access Key' }),
-      ).toBeVisible();
+      // Verify table columns are visible. "Access Key", "Resource Policy",
+      // "Created At", and "Last Used" are sortable — their columnheaders'
+      // accessible names are overridden by the sort button's aria-label (the
+      // raw field key, e.g. "Sort by accessKey") rather than the display
+      // label, so match the visible text instead (see getSortableColumnHeader).
+      await expect(getSortableColumnHeader(modal, 'Access Key')).toBeVisible();
       await expect(
         modal.getByRole('columnheader', { name: 'Controls' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'Resource Policy' }),
+        getSortableColumnHeader(modal, 'Resource Policy'),
       ).toBeVisible();
-      await expect(
-        modal.getByRole('columnheader', { name: 'Created At' }),
-      ).toBeVisible();
-      await expect(
-        modal.getByRole('columnheader', { name: 'Last Used' }),
-      ).toBeVisible();
+      await expect(getSortableColumnHeader(modal, 'Created At')).toBeVisible();
+      await expect(getSortableColumnHeader(modal, 'Last Used')).toBeVisible();
 
       // Verify at least one keypair row exists
       const rows = getKeypairTableRows(page);

--- a/e2e/my-environment/my-environment.spec.ts
+++ b/e2e/my-environment/my-environment.spec.ts
@@ -1,5 +1,9 @@
 // spec: My Environment page tests
-import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import {
+  getSortableColumnHeader,
+  loginAsAdmin,
+  navigateTo,
+} from '../utils/test-util';
 import test, { expect } from '@playwright/test';
 
 test.describe(
@@ -13,14 +17,23 @@ test.describe(
       await loginAsAdmin(page, request);
       await navigateTo(page, 'my-environment');
 
-      // Verify Images tab is selected by default
-      await expect(
-        page.getByRole('tab', { name: 'Images', selected: true }),
-      ).toBeVisible();
+      // Verify Images tab is selected by default. `BAITabList` / Astryx
+      // `TabList` renders a `nav[aria-label="Tabs"]` of plain `<button>`s —
+      // `role="tab"` is never emitted — and marks the active one with
+      // `aria-current="true"`.
+      const imagesTab = page
+        .getByRole('navigation', { name: 'Tabs' })
+        .getByRole('button', { name: 'Images' });
+      await expect(imagesTab).toBeVisible();
+      await expect(imagesTab).toHaveAttribute('aria-current', 'true');
 
-      // Verify table columns
+      // Verify table columns. "Full image path" and "Base image name" are
+      // sortable — their columnheaders' accessible names are overridden by
+      // the sort button's aria-label (the raw field key, e.g. "Sort by
+      // fullImagePath"/"Sort by base_image_name") rather than the display
+      // label, so match the visible text instead (see getSortableColumnHeader).
       await expect(
-        page.getByRole('columnheader', { name: 'Full image path' }),
+        getSortableColumnHeader(page, 'Full image path'),
       ).toBeVisible();
       await expect(
         page.getByRole('columnheader', { name: 'Control' }),
@@ -32,7 +45,7 @@ test.describe(
         page.getByRole('columnheader', { name: 'Architecture' }),
       ).toBeVisible();
       await expect(
-        page.getByRole('columnheader', { name: 'Base image name' }),
+        getSortableColumnHeader(page, 'Base image name'),
       ).toBeVisible();
       await expect(
         page.getByRole('columnheader', { name: 'Version' }),
@@ -40,7 +53,7 @@ test.describe(
 
       // Scope to the images table to avoid matching other tables or measure rows
       const imagesTable = page.locator('table').filter({
-        has: page.getByRole('columnheader', { name: 'Full image path' }),
+        has: getSortableColumnHeader(page, 'Full image path'),
       });
       const dataRows = imagesTable.locator(
         'tbody tr:not(.ant-table-measure-row)',

--- a/e2e/my-environment/my-environment.spec.ts
+++ b/e2e/my-environment/my-environment.spec.ts
@@ -67,9 +67,11 @@ test.describe(
       await loginAsAdmin(page, request);
       await navigateTo(page, 'my-environment');
 
-      // Scope to the images table
+      // Scope to the images table. "Full image path" is sortable, so match its
+      // visible text rather than its accessible name (see
+      // getSortableColumnHeader).
       const imagesTable = page.locator('table').filter({
-        has: page.getByRole('columnheader', { name: 'Full image path' }),
+        has: getSortableColumnHeader(page, 'Full image path'),
       });
       const dataRows = imagesTable.locator(
         'tbody tr:not(.ant-table-measure-row)',

--- a/e2e/serving/deployment-access-token.spec.ts
+++ b/e2e/serving/deployment-access-token.spec.ts
@@ -71,8 +71,10 @@ async function addProvisionedRevision(
   page: Page,
   fixtures: DeploymentFixtures,
 ): Promise<void> {
+  // `BAITabList` / Astryx `TabList` renders a `nav[aria-label="Tabs"]` of
+  // plain `<button>`s — `role="tablist"` is never emitted.
   await page
-    .getByRole('tablist')
+    .getByRole('navigation', { name: 'Tabs' })
     .getByRole('button', { name: 'Add Revision' })
     .click();
   const dialog = page.getByRole('dialog', { name: /Add Revision/ });
@@ -179,10 +181,17 @@ test.describe(
           name: 'Create Access Token',
         });
         await expect(createTokenDialog).toBeVisible({ timeout: 10000 });
-        await expect(
-          createTokenDialog.getByRole('combobox', { name: 'Expiration' }),
-        ).toBeVisible();
-        await expect(createTokenDialog.getByText('7 Days')).toBeVisible();
+        const expirationCombobox = createTokenDialog.getByRole('combobox', {
+          name: 'Expiration',
+        });
+        await expect(expirationCombobox).toBeVisible();
+        // Verify the default expiration is "7 Days", read off the combobox's
+        // own displayed value. An unscoped `getByText('7 Days')` strict-mode-
+        // violates: the dialog also renders a second, unrelated "7 Days" text
+        // node inside a `getByLabel('Days')` element (observed live), so
+        // scope to the combobox we already anchored above instead of an
+        // ambiguous page-wide text search.
+        await expect(expirationCombobox).toHaveText('7 Days');
         await expect(
           createTokenDialog.getByRole('button', { name: 'Cancel' }),
         ).toBeVisible();

--- a/e2e/utils/classes/session/SessionDetailPage.ts
+++ b/e2e/utils/classes/session/SessionDetailPage.ts
@@ -32,12 +32,12 @@ export class SessionDetailPage extends BasePage {
 
   async verifyPageLoaded(): Promise<void> {
     // Wait for the session type tab list as a reliable page-ready indicator.
-    // The tablist (All / Interactive / Batch / Inference / Upload Sessions) is
+    // The tab nav (All / Interactive / Batch / Inference / Upload Sessions) is
     // always rendered, even when no sessions exist or the data API returns an
-    // error. Unlike `.ant-table` or the hidden radio inputs, this element is
-    // always visible after navigation to the session page.
-    const tablist = this.page.getByRole('tablist');
-    await this.waitForVisible(tablist, 10000);
+    // error. `BAITabList` / Astryx `TabList` renders a `nav[aria-label="Tabs"]`
+    // of plain `<button>`s — `role="tablist"` is never emitted.
+    const tabNav = this.page.getByRole('navigation', { name: 'Tabs' });
+    await this.waitForVisible(tabNav, 10000);
   }
 
   /**

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -500,6 +500,24 @@ export function getTableRefreshButton(page: Page) {
 }
 
 /**
+ * A BAITable column header's accessible NAME is overridden by its sort
+ * button's aria-label ("Sort by <field>", using the raw field key rather than
+ * the display label) for sortable columns; match the header's visible TEXT
+ * instead. Anchored exactly (`^...$`) so a short label doesn't substring-match
+ * a longer header sharing a prefix. See
+ * `e2e/auto-scaling-rule-preset/preset-crud.spec.ts` (`presetColumnHeader`) /
+ * `e2e/environment/registry.spec.ts` (`registryColumnHeader`) for the
+ * original pattern (ledger id
+ * `e2e/*::sortable-column-header-accessible-name-override`).
+ */
+export function getSortableColumnHeader(scope: Page | Locator, label: string) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return scope
+    .getByRole('columnheader')
+    .filter({ hasText: new RegExp(`^${escaped}$`) });
+}
+
+/**
  * Runs `assertion` up to `attempts` times, clicking the table refresh button
  * between failures. The vfolder list never refetches on its own after the
  * initial (filtered) response, so when the backend lags a mutation the ONLY


### PR DESCRIPTION
Produced automatically by the **daily digest pipeline's auto-heal stage** (2026-09-02 run). No Jira issue — this is test-side drift repair only, no app source touched.

Every change below was re-run-verified against `https://webui-nightly.lablup.ai/` before this PR was opened.

## Root cause 1 — Astryx tab-role contract (the last 5 unhealed specs)

`BAITabList` / Astryx `TabList` renders a `nav[aria-label="Tabs"]` of plain `<button>`s and marks the active tab with `aria-current="true"`. `role="tab"` / `role="tablist"` are never emitted, so every `getByRole('tab' | 'tablist', …)` locator is structurally unmatchable and times out.

This is the same root cause #9202 / #9316 / #9344 already healed elsewhere; these were the remaining call sites. The replacement follows the canonical pattern from `e2e/utils/user-profile-util.ts`:

```ts
page.getByRole('navigation', { name: 'Tabs' }).getByRole('button', { name: '<Tab Label>' })
```

- `e2e/agent-summary/agent-summary.spec.ts` — "Agent Summary" tab
- `e2e/credential/my-keypair-management.spec.ts` — reuses the existing `usersTabButton()` helper instead of an inline locator
- `e2e/my-environment/my-environment.spec.ts` — "Images" tab
- `e2e/serving/deployment-access-token.spec.ts` — the `getByRole('tablist')` scope around "Add Revision" (which `DeploymentRevisionCard.tsx` renders as `tabBarExtraContent`, i.e. inside the nav)
- `e2e/utils/classes/session/SessionDetailPage.ts` — `verifyPageLoaded()`, called from every `session-lifecycle` `beforeEach`

## Root cause 2 — sortable columnheader accessible name

A `BAITable` column header with a sorter has its accessible name overridden by the sort button's `aria-label` (`"Sort by scaling_group …"`, built from the raw field key, not the display label), so `getByRole('columnheader', { name: 'Resource Group' })` can never match.

Already fixed locally in `preset-crud.spec.ts` and `registry.spec.ts`; this PR promotes that pattern to a shared helper `getSortableColumnHeader(scope, label)` in `e2e/utils/test-util.ts` (purely additive — no existing importer is affected) and applies it in `agent-summary`, `my-environment`, and `my-keypair-management`.

## Root cause 3 — two single-site locator defects

- `my-keypair-management.spec.ts`: the "Main Access Key" banner renders `role="status"`, not `role="alert"` (confirmed by reading `getAttribute('role')` on the live DOM, not inferred). Scoped with `.filter({ hasText: 'Main Access Key:' })` because the modal has other `role="status"` spinners.
- `deployment-access-token.spec.ts`: unscoped `getByText('7 Days')` strict-mode-violated (combobox display value + radio option label). Now asserts `toHaveText('7 Days')` on the already-located Expiration combobox, which is what the test actually means.

## Verification

| Test | Result |
|---|---|
| `agent-summary` › Admin can see Agent Summary page with expected columns | ✅ pass (9.3s) |
| `my-environment` › User can see custom image list with expected columns | ✅ pass (9.9s) |
| `my-keypair-management` › User can open the My Keypair Management modal from User Settings | ✅ pass (6.6s) |
| `deployment-access-token` › Admin can issue an access token after adding a revision | ✅ pass (1.7m, full E2E incl. fixture provisioning + cleanup) |
| `session-lifecycle` › Create, monitor, and terminate interactive session | ⏭️ correctly reaches `test.fixme(noAgentAvailable, …)` and skips, instead of failing in `beforeEach` — the cluster genuinely has 0 connected agents |

Sibling tests in the touched files were re-run and still pass.

## Known collateral, deliberately left alone

- `my-environment.spec.ts` › "User can search custom images" — separate open issue with an unconfirmed root cause (`search-images-cause-unclear`), untouched.
- `my-keypair-management.spec.ts` › "User can see the current main access key highlighted in the alert banner" — same `alert`→`status` mismatch at a different call site, outside this run's heal scope.
- `getByRole('tablist')` also survives in `e2e/utils/classes/session/SessionLauncher.ts` and `e2e/session/session-dependency.spec.ts` (the latter is unconditionally `test.fixme`), plus `getByRole('tab')` in `rbac-role-crud.spec.ts`, `agent.spec.ts`, `cleanup-util.ts` and the visual-regression suite. Next heal pass.

Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-09-02.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
