### PR TITLE
fix(FR-3838): give the Data page route its own Suspense boundary

### DIFF
--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -428,9 +428,11 @@ export const mainLayoutChildRoutes: RouteObject[] = [
       },
       {
         path: 'data',
-        Component: () => {
-          return <VFolderNodeListPage />;
-        },
+        element: (
+          <Suspense fallback={<BAISkeleton rows={4} />}>
+            <VFolderNodeListPage />
+          </Suspense>
+        ),
         handle: {
           scope: 'project',
           menuKey: 'data',


### PR DESCRIPTION
Resolves #9385 (FR-3838)

## Summary

On the Data page only, the loading skeleton started at the very top of the content area — the page title (breadcrumb) row disappeared while the page loaded. Every other page keeps its title on screen and shows the skeleton only in the body below it.

**Mechanism.** `MainLayout` opens a single `Suspense` that deliberately owns **both** the breadcrumb title row and the routed `<Outlet />` (`react/src/components/MainLayout/MainLayout.tsx:279`, with the comment at 276-278 stating the intent — keep the shell on screen for the whole lazy-route fetch). Nothing in between adds another boundary: `BAIErrorBoundary`, `AutoAdminPrimaryColorProvider`, `ResourceSlotsWrapper`, `ProjectScopeLayout`, `AdminScopeLayout` and `RouteAccessGuard` all have none. So every page route carries its **own** inner `Suspense`, which catches the page's data suspension before it can reach the layout one.

The project-scope `data` route was the only content page mounting its component bare. `VFolderNodeListPage` suspends on every navigation (`useSuspendedBackendaiClient` at `VFolderNodeListPage.tsx:103` + `useLazyLoadQuery` at `:208`), so the suspension escaped all the way up and replaced the title row along with the body.

The fix wraps it in the same `<Suspense fallback={<BAISkeleton rows={4} />}>` the ~30 sibling routes already use, and switches `Component:` to `element:` to match the neighbouring entries (`my-environment` directly below it) since no hook is needed at route level. `Suspense` and `BAISkeleton` were already imported in the file.

This is the page-level counterpart of the convention `.claude/rules/use-bai-card.md` states for cards: header always visible, body shows the skeleton during fetch.

## Scope check

I swept every `Component:` / `element:` entry in `react/src/routes.tsx` for a missing boundary. After this change the only remaining hits are redirect components (`ProjectScopedRedirect`, `AdminRedirect`) and the two `EduAppLauncher` token-login routes, none of which render a suspending page — `data` was the only content page affected.

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, terminology). The one warn is pre-existing and unrelated (`BAIResourceUnitGrid^ChangeGroupColor` locale term).
- [x] **Verified live on the dev server** (see the dev-server comment below). Delaying only `VFolderNodeListPageQuery` and navigating to Data from the sider: the **"Data" title row stays on screen** and the 4-row skeleton renders in the body below it, matching the Sessions page. Asserted programmatically across repeated runs — title row present during load in every one.
- [x] No regression: the Data page loads its folder table normally afterwards, with no error boundary and no failed `/func/*` request beyond the pre-existing benign `404 /func/totp` that the other running dev servers also return.