### PR TITLE
fix(FR-3680): keep a tooltip open while the pointer is on its surface

### DIFF
--- a/packages/backend.ai-ui/src/form-engine/FormItemVisual.tooltip.test.tsx
+++ b/packages/backend.ai-ui/src/form-engine/FormItemVisual.tooltip.test.tsx
@@ -18,17 +18,25 @@
  * the popup renders is Astryx's business and needs a real layout engine.
  */
 import BAIFormItemVisual from './FormItemVisual';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HELP = 'Computer memory is temporary.';
+
+const renderMemoryItem = () =>
+  render(
+    <BAIFormItemVisual label="Memory" tooltip={HELP}>
+      <input aria-label="memory" />
+    </BAIFormItemVisual>,
+  );
+
+const tooltipTrigger = () =>
+  document.querySelector<HTMLElement>('[data-bai-form-item-tooltip]');
 
 describe('BAIFormItemVisual — tooltip', () => {
   it('puts the tooltip text in an overlay layer, not in the label flow', () => {
-    render(
-      <BAIFormItemVisual label="Memory" tooltip="Computer memory is temporary.">
-        <input aria-label="memory" />
-      </BAIFormItemVisual>,
-    );
-    const text = screen.getByText('Computer memory is temporary.');
+    renderMemoryItem();
+    const text = screen.getByText(HELP);
     // jsdom implements neither the Popover API nor CSS anchor positioning, so
     // Astryx's layer sits in the tree and reads as "visible" here. What makes
     // it a TOOLTIP rather than inline prose is the pair of attributes the
@@ -41,12 +49,8 @@ describe('BAIFormItemVisual — tooltip', () => {
   });
 
   it('renders a focusable trigger after the label', () => {
-    render(
-      <BAIFormItemVisual label="Memory" tooltip="Computer memory is temporary.">
-        <input aria-label="memory" />
-      </BAIFormItemVisual>,
-    );
-    const trigger = document.querySelector('[data-bai-form-item-tooltip]');
+    renderMemoryItem();
+    const trigger = tooltipTrigger();
     expect(trigger).not.toBeNull();
     expect(trigger?.getAttribute('tabindex')).toBe('0');
     // The glyph, not the prose.
@@ -60,19 +64,99 @@ describe('BAIFormItemVisual — tooltip', () => {
         <input aria-label="memory" />
       </BAIFormItemVisual>,
     );
-    expect(document.querySelector('[data-bai-form-item-tooltip]')).toBeNull();
+    expect(tooltipTrigger()).toBeNull();
   });
 
   it('uses antd’s `tooltip.icon` as the trigger glyph when given', () => {
     render(
       <BAIFormItemVisual
         label="Memory"
-        tooltip="Computer memory is temporary."
+        tooltip={HELP}
         tooltipIcon={<span data-testid="custom-glyph">i</span>}
       >
         <input aria-label="memory" />
       </BAIFormItemVisual>,
     );
     expect(screen.getByTestId('custom-glyph')).toBeInTheDocument();
+  });
+});
+
+/*
+ FR-3680 — guards `react/patches/@astryxdesign__core@0.5.2.patch`: the tip must
+ survive the pointer landing on its own surface (mechanism in the commit body).
+ jsdom has no Popover API, so Astryx falls back to `style.display`.
+*/
+describe('BAIFormItemVisual — tooltip stays open on its own surface (FR-3680)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const advance = (ms: number) => {
+    act(() => {
+      vi.advanceTimersByTime(ms);
+    });
+  };
+  const expectOpen = (tip: HTMLElement) =>
+    expect(tip.style.display).toBe('block');
+  const expectClosed = (tip: HTMLElement) =>
+    expect(tip.style.display).toBe('none');
+
+  // The browser's order for a pointer moving from A to B:
+  // mouseout(A) → mouseleave(A) → mouseover(B) → mouseenter(B).
+  // Raw events on purpose: RTL's `fireEvent.mouseLeave` fires a second
+  // `mouseout` AFTER `mouseleave`, the reversed order the bug never sees.
+  const moveTo = (from: HTMLElement, to: HTMLElement) => {
+    act(() => {
+      from.dispatchEvent(
+        new MouseEvent('mouseout', { bubbles: true, relatedTarget: to }),
+      );
+      from.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: to }));
+      to.dispatchEvent(
+        new MouseEvent('mouseover', { bubbles: true, relatedTarget: from }),
+      );
+      to.dispatchEvent(new MouseEvent('mouseenter', { relatedTarget: from }));
+    });
+  };
+
+  // Open by hover, then park the pointer on the tip.
+  const openOverTip = () => {
+    renderMemoryItem();
+    const trigger = tooltipTrigger() as HTMLElement;
+    const tip = screen.getByRole('tooltip', { hidden: true });
+    moveTo(document.body, trigger);
+    advance(300);
+    expectOpen(tip);
+    moveTo(trigger, tip);
+    advance(500);
+    expectOpen(tip);
+    return { trigger, tip };
+  };
+
+  it('survives the pointer travelling onto the tip and a click on its text', () => {
+    const { tip } = openOverTip();
+    fireEvent.mouseDown(tip);
+    fireEvent.click(tip);
+    advance(500);
+    expectOpen(tip);
+  });
+
+  it('closes once the pointer leaves the tip for elsewhere', () => {
+    const { tip } = openOverTip();
+    moveTo(tip, document.body);
+    advance(500);
+    expectClosed(tip);
+  });
+
+  it('lets the pointer return to the trigger and leave from there', () => {
+    const { trigger, tip } = openOverTip();
+    moveTo(tip, trigger);
+    advance(500);
+    expectOpen(tip);
+    moveTo(trigger, document.body);
+    advance(500);
+    expectClosed(tip);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ overrides:
   lodash: ^4.18.0
 
 patchedDependencies:
-  '@astryxdesign/core@0.5.2': c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed
+  '@astryxdesign/core@0.5.2': d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d
   '@astryxdesign/lab@0.3.0-canary.12db2a1': 0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08
   '@cloudscape-design/board-components@3.0.176': 06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98
   ansi_up@6.0.6: 99856fc7fa4571c6ef4716cfd2dbf1151a025690c737775e248e8b7fe08a4459
@@ -580,16 +580,16 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 'catalog:'
-        version: 0.5.2(99e8f36cd61c267b6ec7c7832be69752)
+        version: 0.5.2(7858432013a4634fc287b559cc93f169)
       '@astryxdesign/core':
         specifier: 'catalog:'
-        version: 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/lab':
         specifier: 'catalog:'
-        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/theme-neutral':
         specifier: 'catalog:'
-        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.5
@@ -763,13 +763,13 @@ importers:
         version: 2.0.230(react@19.2.8)(zod@4.4.3)
       '@astryxdesign/core':
         specifier: 'catalog:'
-        version: 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/lab':
         specifier: 'catalog:'
-        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/theme-neutral':
         specifier: 'catalog:'
-        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@cloudscape-design/board-components':
         specifier: 3.0.176
         version: 3.0.176(patch_hash=06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98)(@cloudscape-design/components@3.0.1341(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -1007,7 +1007,7 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 'catalog:'
-        version: 0.5.2(99e8f36cd61c267b6ec7c7832be69752)
+        version: 0.5.2(7858432013a4634fc287b559cc93f169)
       '@babel/core':
         specifier: 'catalog:'
         version: 7.29.7(supports-color@8.1.1)
@@ -11207,7 +11207,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astryxdesign/cli@0.5.2(99e8f36cd61c267b6ec7c7832be69752)':
+  '@astryxdesign/cli@0.5.2(7858432013a4634fc287b559cc93f169)':
     dependencies:
       commander: 12.1.0
       gpt-tokenizer: 3.4.0
@@ -11215,23 +11215,23 @@ snapshots:
       jscodeshift: 17.4.0(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       zod: 4.4.3
     optionalDependencies:
-      '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@astryxdesign/theme-neutral': 0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/theme-neutral': 0.5.2(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@stylexjs/stylex': 0.19.0
       intl-messageformat: 11.2.13
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@stylexjs/stylex': 0.19.0
       d3-array: 3.2.4
       d3-scale: 4.0.2
@@ -11251,9 +11251,9 @@ snapshots:
       '@lexical/utils': 0.46.0(typescript@6.0.3)
       lexical: 0.46.0(typescript@6.0.3)
 
-  '@astryxdesign/theme-neutral@0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/theme-neutral@0.5.2(@astryxdesign/core@0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.2(patch_hash=d1cb1c987a7bbf0523fd57183f5ecb129e7eeae1ada3d0ff77611a117d80262d)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react: 1.29.0(react@19.2.8)
       react: 19.2.8
 

--- a/react/patches/@astryxdesign__core@0.5.2.patch
+++ b/react/patches/@astryxdesign__core@0.5.2.patch
@@ -1,3 +1,80 @@
+diff --git a/dist/Tooltip/useTooltip.js b/dist/Tooltip/useTooltip.js
+index cc9b4218200ee52a1d1ee3ad8fdc40f8703da83f..81e7be5bb873233def8c2dce4f0e619b0e31063c 100644
+--- a/dist/Tooltip/useTooltip.js
++++ b/dist/Tooltip/useTooltip.js
+@@ -117,6 +117,7 @@ export function useTooltip(options = {}) {
+   const showTimeoutRef = useRef(null);
+   const hideTimeoutRef = useRef(null);
+   const triggerRef = useRef(null);
++  const isHoveringSurfaceRef = useRef(false);
+ 
+   // Clear all timeouts
+   const clearTimeouts = useCallback(() => {
+@@ -138,6 +139,7 @@ export function useTooltip(options = {}) {
+   }, [clearTimeouts, layer]);
+   const hideNow = useCallback(() => {
+     clearTimeouts();
++    isHoveringSurfaceRef.current = false;
+     layer.hide();
+   }, [clearTimeouts, layer]);
+   const touch = useTouchTrigger({
+@@ -173,7 +175,11 @@ export function useTooltip(options = {}) {
+     clearTimeouts();
+     const effectiveHideDelay = hideDelay > 0 ? hideDelay : HOVER_BRIDGE_DELAY;
+     hideTimeoutRef.current = setTimeout(() => {
+-      layer.hide();
++      // Checked here, not cancelled on enter: the surface's React onMouseEnter
++      // arrives before the trigger's mouseleave arms this timer (FR-3680).
++      if (!isHoveringSurfaceRef.current) {
++        layer.hide();
++      }
+     }, effectiveHideDelay);
+   }, [isOpen, clearTimeouts, layer, hideDelay]);
+ 
+@@ -250,7 +256,8 @@ export function useTooltip(options = {}) {
+   // Interaction ref that handles event listeners only
+   const {
+     handlePointerEnter,
+-    clearTapOpen
++    clearTapOpen,
++    isTouchPointerRef
+   } = touch;
+   const interactionRef = useCallback(el => {
+     // Cleanup previous element
+@@ -375,8 +382,22 @@ export function useTooltip(options = {}) {
+       // (WCAG 1.4.13 hoverable). These sit on the layer container — the
+       // element the user actually hovers — not the inner content div, since
+       // mouseenter/leave do not bubble.
+-      onMouseEnter: cancelHide,
+-      onMouseLeave: scheduleHide
++      onMouseEnter: () => {
++        // A tap synthesises these over the tip too; letting it register as
++        // "hovering the surface" would block every later hide.
++        if (isTouchPointerRef.current) {
++          return;
++        }
++        isHoveringSurfaceRef.current = true;
++        cancelHide();
++      },
++      onMouseLeave: () => {
++        if (isTouchPointerRef.current) {
++          return;
++        }
++        isHoveringSurfaceRef.current = false;
++        scheduleHide();
++      }
+     };
+     return layer.render(/*#__PURE__*/_jsx("div", {
+       ...{
+@@ -384,7 +405,7 @@ export function useTooltip(options = {}) {
+       },
+       children: children
+     }), renderProps);
+-  }, [layer, placement, alignment, popoverXstyle, cancelHide, scheduleHide]);
++  }, [layer, placement, alignment, popoverXstyle, cancelHide, scheduleHide, isTouchPointerRef]);
+   return {
+     ref,
+     positionRef: layer.ref,
 diff --git a/dist/hooks/useFocusTrap.js b/dist/hooks/useFocusTrap.js
 index ead7e0af25144043c863026cfe48bcfdaf10f6cf..f3f192ad226e80cffad26e02b2e1c696cd808100 100644
 --- a/dist/hooks/useFocusTrap.js
@@ -28,6 +105,90 @@ index ead7e0af25144043c863026cfe48bcfdaf10f6cf..f3f192ad226e80cffad26e02b2e1c696
        const active = document.activeElement;
        const focusWasLost = active == null || active === document.body || active === document.documentElement || container != null && container.contains(active);
        if (!focusWasLost) {
+diff --git a/src/Tooltip/useTooltip.tsx b/src/Tooltip/useTooltip.tsx
+index 72ef454d13539307bfbd8de34bdc1945cdb36238..46666d287add1ce3438ebb9e873d582c778ab1f4 100644
+--- a/src/Tooltip/useTooltip.tsx
++++ b/src/Tooltip/useTooltip.tsx
+@@ -290,6 +290,7 @@ export function useTooltip(options: TooltipOptions = {}): TooltipReturn {
+   const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+   const triggerRef = useRef<HTMLElement | null>(null);
++  const isHoveringSurfaceRef = useRef(false);
+ 
+   // Clear all timeouts
+   const clearTimeouts = useCallback(() => {
+@@ -312,6 +313,7 @@ export function useTooltip(options: TooltipOptions = {}): TooltipReturn {
+ 
+   const hideNow = useCallback(() => {
+     clearTimeouts();
++    isHoveringSurfaceRef.current = false;
+     layer.hide();
+   }, [clearTimeouts, layer]);
+ 
+@@ -348,7 +350,11 @@ export function useTooltip(options: TooltipOptions = {}): TooltipReturn {
+     clearTimeouts();
+     const effectiveHideDelay = hideDelay > 0 ? hideDelay : HOVER_BRIDGE_DELAY;
+     hideTimeoutRef.current = setTimeout(() => {
+-      layer.hide();
++      // Checked here, not cancelled on enter: the surface's React onMouseEnter
++      // arrives before the trigger's mouseleave arms this timer (FR-3680).
++      if (!isHoveringSurfaceRef.current) {
++        layer.hide();
++      }
+     }, effectiveHideDelay);
+   }, [isOpen, clearTimeouts, layer, hideDelay]);
+ 
+@@ -432,7 +438,7 @@ export function useTooltip(options: TooltipOptions = {}): TooltipReturn {
+   );
+ 
+   // Interaction ref that handles event listeners only
+-  const {handlePointerEnter, clearTapOpen} = touch;
++  const {handlePointerEnter, clearTapOpen, isTouchPointerRef} = touch;
+   const interactionRef: RefCallback<HTMLElement> = useCallback(
+     (el: HTMLElement | null) => {
+       // Cleanup previous element
+@@ -588,8 +594,22 @@ export function useTooltip(options: TooltipOptions = {}): TooltipReturn {
+         // (WCAG 1.4.13 hoverable). These sit on the layer container — the
+         // element the user actually hovers — not the inner content div, since
+         // mouseenter/leave do not bubble.
+-        onMouseEnter: cancelHide,
+-        onMouseLeave: scheduleHide,
++        onMouseEnter: () => {
++          // A tap synthesises these over the tip too; letting it register as
++          // "hovering the surface" would block every later hide.
++          if (isTouchPointerRef.current) {
++            return;
++          }
++          isHoveringSurfaceRef.current = true;
++          cancelHide();
++        },
++        onMouseLeave: () => {
++          if (isTouchPointerRef.current) {
++            return;
++          }
++          isHoveringSurfaceRef.current = false;
++          scheduleHide();
++        },
+       };
+ 
+       return layer.render(
+@@ -597,7 +617,15 @@ export function useTooltip(options: TooltipOptions = {}): TooltipReturn {
+         renderProps,
+       );
+     },
+-    [layer, placement, alignment, popoverXstyle, cancelHide, scheduleHide],
++    [
++      layer,
++      placement,
++      alignment,
++      popoverXstyle,
++      cancelHide,
++      scheduleHide,
++      isTouchPointerRef,
++    ],
+   );
+ 
+   return {
 diff --git a/src/hooks/useFocusTrap.ts b/src/hooks/useFocusTrap.ts
 index c05638a06c1e35345b33d9b13ecda5578821a82f..525c410546c39477b787f9cc787ba0341bf3c21d 100644
 --- a/src/hooks/useFocusTrap.ts


### PR DESCRIPTION
Resolves #9069 (FR-3680)

## What

Every Astryx `Tooltip` in the app closed ~100 ms after the pointer left its trigger, whether or not the pointer had moved onto the tooltip's own surface. The reported symptom, "clicking inside the tooltip body dismisses it", is how users met it: the tip was already going away by the time they reached for the text. This fixes the hover bridge in `useTooltip` itself, through the existing pnpm patch of `@astryxdesign/core@0.5.2`, so every "?" help icon, `BAIQuestionIconWithTooltip`, `BAIFormItem tooltip`, and truncation tooltip is covered at once.

## Mechanism (measured, not inferred)

`useTooltip` keeps the tip open over its surface by cancelling the pending hide from the surface's React `onMouseEnter`. React derives that synthetic enter from the trigger's native `mouseout`, and the browser fires `mouseout` **before** `mouseleave`. The trigger's `mouseleave` is the native listener that arms the 100 ms hover-bridge timer, so the order in the live app is:

1. `mouseout(trigger → tip)` → React dispatches the tip's `onMouseEnter` → `cancelHide()` finds no timer.
2. `mouseleave(trigger)` → `scheduleHide()` arms the 100 ms timer.
3. `mouseover(tip)` → React ignores it (its `relatedTarget` is React-managed; the enter was already dispatched in step 1).
4. Timer fires → `layer.hide()`.

Traced with patched `setTimeout`/`clearTimeout` on `https://fr-3680.localhost:1355` (backend 10.82.0.241): the hide always came from the `scheduleHide` timer, and `cancelHide` never ran with a timer to clear. Proof of the mechanism: dispatching the same two events in the reverse order (synthetic `mouseleave` first, then `mouseout` with `relatedTarget` on the tip) made `cancelHide` clear the timer and the tip survive. Two hypotheses were ruled out on the way: the `<label htmlFor>` wrapping the form-item trigger is not involved (the popover is portalled out of the label, and focus stays on `body` after the click), and the dev-only `react-grab` inspector is not involved (same result with it disposed).

`HoverCard` in the same package already handles this correctly: its hide timer re-checks an `isHoveringContentRef` when it fires instead of relying on the cancel. The patch gives `useTooltip` the same shape (`isHoveringSurfaceRef`, set/cleared by the surface's enter/leave with the same touch guard, reset in `hideNow`). Astryx `latest` is 0.5.2, the installed version, so there is no upstream release to bump to.

## Before / after (real app, both modes)

| Step | Before | After |
|---|---|---|
| Pointer moves trigger → tooltip surface, wait 1 s | closed at ~100 ms | open |
| Click inside the tooltip text | closed | open, text selectable, focus stays on `body` |
| Pointer leaves the surface | closed | closed after the 100 ms bridge |
| Escape while on the surface | closed | closed |
| `pageerror` / unhandled rejections | 0 | 0 |

Measured on the deployments list header "리비전" help icon (dark, `data-theme="dark"`) and on the "배포 생성" modal's "배포 이름" `BAIFormItem tooltip` (light, `data-theme="light"`). Same mechanism and same result in both, so the mount-path field named in the issue (also a `BAIFormItem tooltip`) is covered.

## Screenshots (after)

The "before" state is the tooltip being absent after the click, so only the "after" state is pictured.

| Dark, deployments header "리비전" help icon, after a click inside the text | Light, "배포 생성" modal "배포 이름" `BAIFormItem tooltip`, after a click inside the text |
|---|---|
| ![after dark header](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9388/20260902-114431-after-dark-header-click-inside.jpg) | ![after light modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9388/20260902-114431-after-light-modal-click-inside.jpg) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (after `pnpm --filter backend.ai-ui build`; the theme-build step needs BUI's dist in a fresh worktree)
- `pnpm --filter backend.ai-ui exec vitest run` → 73 files pass, 1962 tests pass. One unrelated flake: `BAIComplexSelect.popup.test.tsx › clears the query and reports the clear upstream` (`user.type` dropped a keystroke, `"b"` vs `"br"`); it passes on rerun and touches no tooltip code.
- `pnpm --prefix ./react exec vitest run` → 110 files, 1730 tests pass
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 2 pre-existing findings, both `var(--bai-dialog-z)` in `BAIDialog.css` / `BAIDrawerPortal.css`. This diff touches no stylesheet or `var()` usage.
- New regression test in `FormItemVisual.tooltip.test.tsx` replays the browser's exact event order with raw DOM events (RTL's `fireEvent.mouseLeave` fires a second `mouseout` afterwards, which is the reversed, working order). Confirmed it fails with the patch's fire-time check disabled (`Expected "block", Received "none"`) and passes with it.

## Residue

- The pnpm patch is the fix's home until Astryx ships it upstream; the patch file is the review surface (`react/patches/@astryxdesign__core@0.5.2.patch`, both `dist` and `src` copies as with the existing `useFocusTrap` hunk).
- A tooltip whose trigger is reached by touch is unchanged: the new ref is guarded by `touch.isTouchPointerRef`, mirroring HoverCard, so a tap on the surface cannot pin the tip open.
- `astryx component Tooltip` docs still say "Don't place interactive elements inside a tooltip"; this restores hoverable/selectable text (WCAG 1.4.13), not interactive content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
