### PR TITLE
fix(FR-3842): stop double-padding the resource usage panel card

### DIFF
--- a/react/src/components/ConfigurableResourceCard.tsx
+++ b/react/src/components/ConfigurableResourceCard.tsx
@@ -171,12 +171,12 @@ const ConfigurableResourceCard: React.FC<ConfigurableResourceCardProps> = ({
   };
 
   return (
+    // The panel supplies its own inset, so the card must contribute none.
+    // `styles.body` is accepted and ignored by BAICard; `padding` is the knob.
     <BAICard
+      padding={0}
       {..._.omit(props, ['style'])}
       style={{ ...props.style }}
-      styles={{
-        body: { padding: 0 },
-      }}
     >
       <Suspense
         fallback={


### PR DESCRIPTION
Resolves #9394 (FR-3842)

The "My Total Resource Usage" panel on the Session page sits inside a very wide
empty margin. This is a double padding, not a design choice.

## Mechanism

`ConfigurableResourceCard` asked its `BAICard` for a zero-padding body:

```tsx
<BAICard styles={{ body: { padding: 0 } }}>
```

That was load-bearing under antd. `BAICard` renders an **Astryx `Card`** now,
which has one `padding` step for the whole surface, so `styles` is
accepted-and-ignored (the PILOT-DECISION recorded in `BAICard.tsx`). The card
therefore kept its default `padding={6}` (24px) and stacked it on top of the
inset the panel already supplies for itself — `MyResource`'s
`paddingInline: token.paddingXL` (32px) plus `BAIBoardItemTitle`'s
`paddingBlock: token.paddingMD` (20px).

The supported knob is `BAICard`'s `padding` prop. It is placed **before** the
prop spread so a caller can still override it.

Measured live on `/session` (Chromium 1600x1000, `user@lablup.com`), reading
computed styles off the DOM:

| | before | after |
|---|---|---|
| Astryx `.astryx-card` padding | `23px` all round | `0px` |
| Content left inset (card edge -> title) | **56px** | **33px** |
| Content top inset (card edge -> title) | **47px** | **24px** |
| Card height | 248px | 222px |

Identical in light and dark; zero `pageerror` in both passes. The remaining
33px / 24px is the panel's own inset, which is what it looked like before the
Astryx migration.

## Screenshots

| | Light | Dark |
|---|---|---|
| Before | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9395/20260902-084501-before-light.png" width="420"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9395/20260902-084501-before-dark.png" width="420"> |
| After | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9395/20260902-084501-after-light.png" width="420"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9395/20260902-084501-after-dark.png" width="420"> |

## Scope

`ConfigurableResourceCard` is also mounted by Admin Session, Project Admin
Session and Admin Deployment — all four had the same double padding and all
four are fixed. The Dashboard mounts `MyResource` directly (no `BAICard`) and
is unaffected.

## Residue

- The empty space **below** the metrics on the Session page is `CARD_MIN_HEIGHT`
  in `ComputeSessionListPage`'s grid, not padding. This PR does not touch it —
  FR-2690 ("make resource usage panels responsive on session page") is the
  place for that.
- The other three `BAICard` call sites on the Session page keep the default
  24px step; only the resource panel opts out, because only it supplies its own.
- The sibling panels (`MyResourceWithinResourceGroup`,
  `TotalResourceWithinResourceGroup`) share this card, so they stay in sync.

## Verification

- `bash scripts/verify.sh` -> `=== ALL PASS ===` (1 pre-existing warn-only
  terminology finding, `BAIResourceUnitGrid^ChangeGroupColor`, unrelated)
- `pnpm --prefix ./react exec vitest run` -> 110 files / 1752 tests passed
- `pnpm --filter backend.ai-ui exec vitest run` -> 74 files passed, 1 skipped / 1960 passed, 1 skipped
- `pnpm --filter backend.ai-ui build` -> ok
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` -> 2 undeclared
  `var(--bai-dialog-z)` in `BAIDialog.css` / `BAIDrawerPortal.css`; both
  pre-exist on `main` (verified by re-running the gate with this change stashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsV7vybLsq9zemKQgg3Fsz
