### PR TITLE
feat(FR-3843): release train prep — QA risk checklist, Teams digest, train kickoff

### DIFF
--- a/.claude/skills/release-risk-digest/SKILL.md
+++ b/.claude/skills/release-risk-digest/SKILL.md
@@ -33,6 +33,9 @@ this skill's job is to run it once, render Korean HTML, and post.
 `$ARGUMENTS` may contain these in any order:
 
 - `--from <ref>` — **required.** The previous release tag, or `origin/main` for a branch.
+  Nothing is inferred: no release tag is an ancestor of `main` in this repository
+  (they live on the release branches), so a guessed base would report a whole
+  release when the caller meant their branch. Ask rather than pick one.
 - `--to <ref>` — defaults to `HEAD`.
 - `--dry-run` — write the HTML to `/tmp/release-risk-digest-preview.html` and skip posting.
 - `--auto` — skip the confirm-before-post prompt (for cron / unattended runs).

--- a/.claude/skills/release-risk-digest/SKILL.md
+++ b/.claude/skills/release-risk-digest/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: release-risk-digest
+description: >
+  Post a Korean release risk digest to a Microsoft Teams thread, grouped by risk
+  category. Runs scripts/release-risk-report.mjs over a ref range and renders the
+  result as a short HTML message: the manager version matrix, untranslated keys,
+  destructive flows touched, UI without e2e cover, and manual gaps. Use when
+  someone gives a Teams thread URL and asks to summarize a release, an rc, or a
+  branch there — "이번 릴리즈 리스크 팀즈에 올려줘", "이 스레드에 정리해서 알려줘",
+  "post the release risk report to Teams", "/release-risk-digest".
+argument-hint: "--from <ref> [--to <ref>] [--dry-run] [--auto] <Teams URL>"
+---
+
+# Release Risk Digest → Teams
+
+Turn a ref range into a QA checklist and post it to a Teams thread, grouped by
+risk category. The analysis is done entirely by `scripts/release-risk-report.mjs`;
+this skill's job is to run it once, render Korean HTML, and post.
+
+> **Skill reference**: Invoke the `teams-workflow` skill for Teams CLI usage.
+
+## Token economics — read this first
+
+- **Data gathering is ONE Bash call**: the script emits the whole report as JSON.
+  Never loop `gh pr view` over the findings — everything needed is already there.
+- **No repository exploration.** Do not open source files, run `git log`, or grep
+  the tree to "understand" a finding. The digest reports what the tool found; the
+  reader opens the PR if they want detail.
+- **No TodoWrite / TaskCreate.** This is linear: run → render → post.
+
+## Arguments
+
+`$ARGUMENTS` may contain these in any order:
+
+- `--from <ref>` — **required.** The previous release tag, or `origin/main` for a branch.
+- `--to <ref>` — defaults to `HEAD`.
+- `--dry-run` — write the HTML to `/tmp/release-risk-digest-preview.html` and skip posting.
+- `--auto` — skip the confirm-before-post prompt (for cron / unattended runs).
+- A Teams thread URL (`teams.microsoft.com/l/message/...`) — **required unless `--dry-run`.**
+  There is deliberately no default: posting a release summary to the wrong thread
+  is not something to get wrong by omission. If the user did not give one, ask.
+
+## Process
+
+### 1. Run the report — ONE Bash call
+
+Must run from a `backend.ai-webui` checkout; the script shells out to `git` in the
+current directory. `--from` is required, so a missing one is a usage error, not a guess.
+
+```bash
+node scripts/release-risk-report.mjs --from "$FROM" --to "$TO" --json > /tmp/release-risk.json
+```
+
+If the script exits non-zero, report the message and stop. Do not fall back to
+reading git history by hand.
+
+### 2. Read the JSON
+
+Top-level fields:
+
+| Field | Meaning |
+| --- | --- |
+| `from`, `to`, `base` | the range, and the merge base file comparisons ran from |
+| `divergedFrom` | true when `to` forked before `from` moved on — mention the base when true |
+| `commits[]` | `{sha, subject, pr, fr, type, scope}` |
+| `featureMatrix[]` | `{flag, version, used}` — gates **added inside the range** |
+| `undeclared[]` | flags used but never declared, i.e. permanently `false` |
+| `risks.noE2E[]` | `{pr, fr, subject, ui[]}` — UI changed, no e2e changed |
+| `risks.destructive[]` | `{pr, fr, subject, destructive[]}` — irreversible-flow files |
+| `risks.noDocs[]` | `{pr, fr, subject}` — user-visible `feat:` with no manual change |
+| `i18n[]` | `{file, addedCount, missing[], placeholder[]}` per locale file |
+
+### 3. Render the HTML
+
+Order sections by how much they block a release, not by risk number:
+
+1. **R2 version matrix** — decides which managers QA needs
+2. **R2b undeclared flags** — a feature silently off everywhere (omit when empty)
+3. **R3 untranslated** — ships visibly broken text
+4. **R4 destructive flows** — the typed-confirm gate must be re-verified
+5. **R1 UI without e2e** — the manual-pass list
+6. **R5 manual gaps**
+
+**Keep it short.** A Teams message is read on a phone. Per section list at most
+**5** items and append `외 N건` when there are more. For R3, do not list 40 locale
+files — collapse to the shape (`대부분의 언어에서 placeholder N개 / 누락 M개`) and
+name only the outliers.
+
+**HTML safety**: escape `&`, `<`, `>`, `"`, `'` in every string taken from the JSON
+(PR subjects, file paths, flag names) before inserting it. Emit only `<b>`, `<i>`,
+`<br/>`, `<ul>`, `<li>`, `<a href="...">`, `<code>`, `<hr/>`. Escape `&` in URLs too.
+
+PR links are `https://github.com/lablup/backend.ai-webui/pull/{pr}`.
+
+Template:
+
+```html
+<b>🚀 릴리즈 리스크 — {from} → {to}</b><br/>
+커밋 {commits.length}건{, 비교 기준 merge-base <code>{base[0:8]}</code> when divergedFrom}<br/><br/>
+
+<b>⚙️ 매니저 버전 매트릭스</b> — 신규 게이트 {n}개<br/>
+<ul>
+  <li><code>{flag}</code> — {version} 이상 필요{, 미사용 when !used}</li>
+</ul>
+<i>각 항목을 버전을 충족하는 매니저와 충족하지 않는 매니저 양쪽에서 확인해야 합니다.
+낮은 버전에서는 숨겨져야 하고, 깨지면 안 됩니다.</i><br/><br/>
+
+<b>🌐 미번역</b> — 신규 영어 키 {addedCount}개<br/>
+{shape line, then outliers}<br/><br/>
+
+<b>⚠️ 파괴적 플로우</b> — {n}건<br/>
+<ul>
+  <li><a href="{prUrl}">#{pr}</a> {subject} — <code>{basename of destructive[0]}</code></li>
+</ul>
+<i>이름을 정확히 입력해야 삭제 버튼이 활성화되는지 재확인이 필요합니다.</i><br/><br/>
+
+<b>🧪 e2e 미커버 UI 변경</b> — {n}건<br/>
+<ul><li><a href="{prUrl}">#{pr}</a> {subject}</li></ul>
+{외 N건}<br/><br/>
+
+<b>📖 매뉴얼 미반영</b> — {n}건<br/>
+<ul><li><a href="{prUrl}">#{pr}</a> {subject}</li></ul>
+<hr/>
+<i>🤖 scripts/release-risk-report.mjs · 결함 목록이 아니라 QA 확인 항목입니다</i>
+```
+
+Drop any section whose count is 0 rather than printing an empty heading. If every
+section is empty, post a single line saying the range has no risk signals.
+
+The closing italic line matters: these are **actions to check**, not confirmed
+defects. Do not phrase a finding as a bug.
+
+### 4. Confirm
+
+Unless `--auto`, show the rendered HTML and ask for approval before posting.
+Posting to Teams is outward-facing and cannot be unsent cleanly.
+
+### 5. Post
+
+```bash
+TEAMS_READER=$(find ~/.claude/plugins -name teams_reader.py 2>/dev/null | head -1)
+[ -z "$TEAMS_READER" ] && { echo "FAIL: teams_reader.py not found. Install the fw plugin."; exit 1; }
+TEAMS_PYTHON="${TEAMS_PYTHON:-python3}"
+export TEAMS_TENANT_ID="${TEAMS_TENANT_ID:-13c6a44d-9b52-4b9e-aa34-0513ee7131f2}"
+export TEAMS_CLIENT_ID="${TEAMS_CLIENT_ID:-7a2e1945-3a1c-407f-9780-c573119d1c1b}"
+
+BODY=$(mktemp); LOG=$(mktemp)
+cat > "$BODY" <<'HTMLEOF'
+<HTML HERE>
+HTMLEOF
+if "$TEAMS_PYTHON" "$TEAMS_READER" --no-ai-label --reply "$(cat "$BODY")" "$TEAMS_URL" >"$LOG" 2>&1; then
+  rm -f "$BODY" "$LOG"; echo "OK"
+else
+  cat "$LOG"; rm -f "$BODY" "$LOG"; exit 1
+fi
+```
+
+Pass `--no-ai-label`: the template already carries its own footer.
+
+For `--dry-run`, write the same HTML to `/tmp/release-risk-digest-preview.html`
+and print the path instead.
+
+## Examples
+
+```bash
+# An rc, posted to the release thread
+/release-risk-digest --from v26.8.1 --to v26.9.0-rc.3 <teams-url>
+
+# What is queued for the next release
+/release-risk-digest --from v26.8.1 <teams-url>
+
+# One PR's checklist, previewed locally first
+/release-risk-digest --from origin/main --to FR-3820 --dry-run
+```
+
+## Related
+
+- `scripts/release-risk-report.mjs` — the analysis; `--help` for its own flags
+- `teams-workflow` (fw) — the Teams CLI, mentions, and images
+- `merged-pr-digest` (fw) — the same post-to-Teams shape for merged PRs
+- `.claude/rules/destructive-confirmation.md` — what R4 asks the reader to re-verify

--- a/.claude/skills/release-risk-digest/SKILL.md
+++ b/.claude/skills/release-risk-digest/SKILL.md
@@ -32,10 +32,8 @@ this skill's job is to run it once, render Korean HTML, and post.
 
 `$ARGUMENTS` may contain these in any order:
 
-- `--from <ref>` — **required.** The previous release tag, or `origin/main` for a branch.
-  Nothing is inferred: no release tag is an ancestor of `main` in this repository
-  (they live on the release branches), so a guessed base would report a whole
-  release when the caller meant their branch. Ask rather than pick one.
+- `--from <ref>` — the base of the comparison. When absent, **offer the choices
+  below rather than erroring or guessing** (see *Resolving `--from`*).
 - `--to <ref>` — defaults to `HEAD`.
 - `--dry-run` — write the HTML to `/tmp/release-risk-digest-preview.html` and skip posting.
 - `--auto` — skip the confirm-before-post prompt (for cron / unattended runs).
@@ -43,12 +41,55 @@ this skill's job is to run it once, render Korean HTML, and post.
   There is deliberately no default: posting a release summary to the wrong thread
   is not something to get wrong by omission. If the user did not give one, ask.
 
+## Resolving `--from`
+
+Nothing is inferred silently: no release tag is an ancestor of `main` in this
+repository (they live on the release branches, so `git describe` fails on main),
+and defaulting to the newest tag would report a whole release to someone who ran
+this on a feature branch. But an error is a dead end — **offer the choices**.
+
+**Refresh first.** A stale `origin/main` moves the merge base and quietly changes
+every file-based finding, so fetch before offering it:
+
+```bash
+git fetch origin main --quiet
+LATEST_TAG=$(git tag --sort=-creatordate | head -1)
+PREV_RC=$(git tag --sort=-creatordate | sed -n 2p)
+# The previous *stable* release, not the previous rc — see the note below.
+PREV_STABLE=$(git tag --sort=-creatordate | grep -Ev '\-(rc|alpha|beta)\.|\+' | head -1)
+BRANCH=$(git branch --show-current)
+```
+
+Then ask with `AskUserQuestion`, putting the option that matches the current HEAD
+first and marking it `(Recommended)`. On a feature branch that is the branch diff;
+on a release branch or a detached tag it is the release comparison.
+
+| Option | `--from` / `--to` | Answers |
+| --- | --- | --- |
+| 현재 브랜치가 추가한 것 | `origin/main` (just fetched) | what this PR puts into a release |
+| 다음 릴리즈에 쌓인 것 | `$LATEST_TAG` → `HEAD` | what is queued but not yet cut |
+| 이번 릴리즈 전체 | `$PREV_STABLE` → `$LATEST_TAG` | what the release as a whole contains |
+| 직전 rc 이후 | `$PREV_RC` → `$LATEST_TAG` | what changed in the last rc turn |
+
+Offer the last row only when `$LATEST_TAG` is a prerelease. The two release rows
+are far apart in size and answer different questions — at the time of writing,
+`$PREV_STABLE..$LATEST_TAG` was 175 commits and `$PREV_RC..$LATEST_TAG` was 18 —
+so do not collapse them into one "previous tag" option.
+
+`AskUserQuestion` always offers **Other**, which is how the user supplies a ref
+this list does not cover (an older tag, another branch, a SHA) — take that string
+verbatim as `--from`. Do not pre-validate it; the script fails loudly on a bad ref.
+
+Say which ref you resolved to in the reply, so a wrong pick is visible before the
+message reaches Teams.
+
 ## Process
 
 ### 1. Run the report — ONE Bash call
 
 Must run from a `backend.ai-webui` checkout; the script shells out to `git` in the
-current directory. `--from` is required, so a missing one is a usage error, not a guess.
+current directory. By this point `$FROM` is whatever *Resolving `--from`* settled on —
+the script itself takes no default and exits 2 without one.
 
 ```bash
 node scripts/release-risk-report.mjs --from "$FROM" --to "$TO" --json > /tmp/release-risk.json

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: release-risk-digest
+name: release-train-prep
 description: >
   Post a Korean release risk digest to a Microsoft Teams thread, grouped by risk
   category. Runs scripts/release-risk-report.mjs over a ref range and renders the
@@ -7,15 +7,20 @@ description: >
   destructive flows touched, UI without e2e cover, and manual gaps. Use when
   someone gives a Teams thread URL and asks to summarize a release, an rc, or a
   branch there — "이번 릴리즈 리스크 팀즈에 올려줘", "이 스레드에 정리해서 알려줘",
-  "post the release risk report to Teams", "/release-risk-digest".
-argument-hint: "--from <ref> [--to <ref>] [--dry-run] [--auto] <Teams URL>"
+  "post the release risk report to Teams", "/release-train-prep". With
+  --train <version> it also opens the release train: creates the
+  "Final Train to v<version>" Jira Story and posts the kickoff + digest into
+  the thread — "트레인 이슈 만들어줘", "릴리즈 트레인 준비해줘", "release train 시작".
+argument-hint: "--from <ref> [--to <ref>] [--train <version>] [--dry-run] [--auto] <Teams URL>"
 ---
 
-# Release Risk Digest → Teams
+# Release Train Prep → Teams
 
-Turn a ref range into a QA checklist and post it to a Teams thread, grouped by
-risk category. The analysis is done entirely by `scripts/release-risk-report.mjs`;
-this skill's job is to run it once, render Korean HTML, and post.
+Prepare a release train: turn a ref range into a QA checklist, post it to the
+train's Teams thread grouped by risk category, and (with `--train`) open the
+`Final Train` Jira Story. The analysis is done entirely by
+`scripts/release-risk-report.mjs`; this skill runs it once, renders Korean
+HTML, and posts.
 
 > **Skill reference**: Invoke the `teams-workflow` skill for Teams CLI usage.
 
@@ -35,11 +40,17 @@ this skill's job is to run it once, render Korean HTML, and post.
 - `--from <ref>` — the base of the comparison. When absent, **offer the choices
   below rather than erroring or guessing** (see *Resolving `--from`*).
 - `--to <ref>` — defaults to `HEAD`.
-- `--dry-run` — write the HTML to `/tmp/release-risk-digest-preview.html` and skip posting.
+- `--dry-run` — write the HTML to `/tmp/release-train-prep-preview.html` and skip posting.
 - `--auto` — skip the confirm-before-post prompt (for cron / unattended runs).
+- `--train <version>` — also open the release train for `v<version>`: create the
+  `Final Train to v<version>` Jira Story and post the kickoff into the thread.
+  See *Train kickoff* below.
 - A Teams thread URL (`teams.microsoft.com/l/message/...`) — **required unless `--dry-run`.**
   There is deliberately no default: posting a release summary to the wrong thread
   is not something to get wrong by omission. If the user did not give one, ask.
+  The Teams CLI can only **reply** to an existing thread — it cannot open a new
+  channel message — so the thread itself is created by a human first, which
+  matches how the team actually runs a train.
 
 ## Resolving `--from`
 
@@ -201,25 +212,94 @@ fi
 
 Pass `--no-ai-label`: the template already carries its own footer.
 
-For `--dry-run`, write the same HTML to `/tmp/release-risk-digest-preview.html`
+For `--dry-run`, write the same HTML to `/tmp/release-train-prep-preview.html`
 and print the path instead.
+
+## Train kickoff (`--train <version>`)
+
+The team's release ritual: a human opens a `🚂 Final train to vX.Y.Z` thread,
+someone creates the `Final Train to vX.Y.Z` Jira Story, and every bug found
+during release testing is linked onto it — `is blocked by` for blockers,
+`relates to` for the rest. The stable tag is cut when no blocker is left open.
+This mode automates the middle step and seeds the thread with the digest.
+
+Runs **in addition to** the normal digest flow, sharing its range resolution
+and its confirm gate. Steps, in order:
+
+1. **Duplicate scan first.** An existing train for the same version is reused,
+   never doubled:
+
+   ```bash
+   $FW_JIRA search "project = FR AND summary ~ \"Final Train\" AND summary ~ \"$VERSION\"" --limit 5
+   ```
+
+   On a hit, skip creation, use the existing key, and say so in the reply.
+
+2. **Create the Story** (see the `jira-workflow` skill; `$FW_JIRA` as documented
+   there). Type **Story**, exact summary format `Final Train to v$VERSION` —
+   the team greps for this shape (FR-3663, FR-3392, FR-3238 all follow it):
+
+   ```bash
+   $FW_JIRA create --type Story --assignee me \
+     --title "Final Train to v$VERSION" \
+     --desc "Release train for v$VERSION. Bugs found during release testing are
+   linked here: **is blocked by** for release blockers, **relates to** for
+   non-blocking findings. The stable tag is cut when no blocking issue is open.
+
+   Kickoff thread: $TEAMS_URL
+   Risk digest at kickoff: see the thread reply posted alongside this issue."
+   ```
+
+3. **Attach the thread as a web link** so the issue points back at the
+   conversation: `$FW_JIRA weblink $KEY --url "$TEAMS_URL" --title "Kickoff thread"`.
+
+4. **Wait for the GitHub clone.** The webhook mirrors the issue within ~a
+   minute; poll `gh issue list --search "$KEY"` a few times. If it has not
+   appeared after ~2 minutes, continue — mention the pending clone in the
+   reply instead of blocking on it.
+
+5. **Post the kickoff reply** into the thread: the digest as usual, prefixed
+   with the train header:
+
+   ```html
+   <b>🚂 Final Train to v{VERSION}</b> — <a href="https://lablup.atlassian.net/browse/{KEY}">{KEY}</a><br/>
+   릴리즈 테스트에서 발견되는 버그는 이 이슈에 연결해주세요 —
+   블로커는 <b>is blocked by</b>, 그 외는 <b>relates to</b>.<br/><br/>
+   {the normal digest body}
+   ```
+
+What this mode deliberately does **not** do:
+
+- **Link bugs to the train.** Whether a finding blocks the release is a human
+  call, made per bug as it is filed (the `astryx-bug-report` /
+  `jira-github-bridge` flow already covers the mechanics).
+- **Decide go / no-go.** The open-blocker list is one Jira view away
+  (`links` on the train issue); it needs no digest.
+- **Cut any tag or release.** The train issue is bookkeeping; releasing is
+  `create-release`'s job, triggered by a human.
 
 ## Examples
 
 ```bash
+# Open the train for 26.10.0: Jira Story + kickoff digest into the thread
+/release-train-prep --train 26.10.0 --from v26.9.0 <teams-url>
+
 # An rc, posted to the release thread
-/release-risk-digest --from v26.8.1 --to v26.9.0-rc.3 <teams-url>
+/release-train-prep --from v26.8.1 --to v26.9.0-rc.3 <teams-url>
 
 # What is queued for the next release
-/release-risk-digest --from v26.8.1 <teams-url>
+/release-train-prep --from v26.8.1 <teams-url>
 
 # One PR's checklist, previewed locally first
-/release-risk-digest --from origin/main --to FR-3820 --dry-run
+/release-train-prep --from origin/main --to FR-3820 --dry-run
 ```
 
 ## Related
 
 - `scripts/release-risk-report.mjs` — the analysis; `--help` for its own flags
 - `teams-workflow` (fw) — the Teams CLI, mentions, and images
+- `jira-workflow` (fw) — `$FW_JIRA` setup, `create`, `weblink`, `search`
+- `jira-github-bridge` (fw) — the webhook clone and `Resolves #N (KEY)` conventions
 - `merged-pr-digest` (fw) — the same post-to-Teams shape for merged PRs
+- `create-release` — cutting the tag itself; out of this skill's scope
 - `.claude/rules/destructive-confirmation.md` — what R4 asks the reader to re-verify

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -8,13 +8,15 @@ description: >
   someone gives a Teams thread URL and asks to summarize a release, an rc, or a
   branch there — "이번 릴리즈 리스크 팀즈에 올려줘", "이 스레드에 정리해서 알려줘",
   "post the release risk report to Teams", "/release-train-prep". With
-  --train <version> it also opens the release train: creates the
-  "Final Train to v<version>" Jira Story and posts the kickoff + digest into
-  the thread — "트레인 이슈 만들어줘", "릴리즈 트레인 준비해줘", "release train 시작".
+  --train it also opens the release train: reads the version from the thread's
+  own "Final train to vX.Y.Z" title, creates the "Final Train to v<version>"
+  Jira Story (after user confirm) and posts the kickoff + digest into the
+  thread — "트레인 이슈 만들어줘", "릴리즈 트레인 준비해줘", "이 스레드로 트레인
+  준비해줘", "release train 시작".
   PREPARATION ONLY — it never creates a release branch, tag, or GitHub release;
   "릴리즈 찍어줘 / 릴리즈 만들어줘 / cut the release / rc 릴리즈" is
   create-release, not this skill.
-argument-hint: "--from <ref> [--to <ref>] [--train <version>] [--dry-run] [--auto] <Teams URL>"
+argument-hint: "--from <ref> [--to <ref>] [--train [version]] [--dry-run] [--auto] <Teams URL>"
 ---
 
 # Release Train Prep → Teams
@@ -54,8 +56,9 @@ HTML, and posts.
   `--train` also skip every Jira action (no Story, no weblink) — describe what
   would be created instead. A dry run must never mutate anything.
 - `--auto` — skip the confirm-before-post prompt (for cron / unattended runs).
-- `--train <version>` — also open the release train for `v<version>`: create the
+- `--train [version]` — also open the release train: create the
   `Final Train to v<version>` Jira Story and post the kickoff into the thread.
+  The version may be omitted — it is read from the thread's own title.
   See *Train kickoff* below.
 - A Teams thread URL (`teams.microsoft.com/l/message/...`) — **required unless `--dry-run`.**
   There is deliberately no default: posting a release summary to the wrong thread
@@ -267,7 +270,7 @@ Pass `--no-ai-label`: the template already carries its own footer.
 For `--dry-run`, write the same HTML to `/tmp/release-train-prep-preview.html`
 and print the path instead.
 
-## Train kickoff (`--train <version>`)
+## Train kickoff (`--train [version]`)
 
 The team's release ritual: a human opens a `🚂 Final train to vX.Y.Z` thread,
 someone creates the `Final Train to vX.Y.Z` Jira Story, and every bug found
@@ -275,9 +278,25 @@ during release testing is linked onto it — `is blocked by` for blockers,
 `relates to` for the rest. The stable tag is cut when no blocker is left open.
 This mode automates the middle step and seeds the thread with the digest.
 
-Runs **in addition to** the normal digest flow, sharing its range resolution
-and its confirm gate. The thread URL is **required** here even though
-`--dry-run` normally waives it — the Story embeds it — and under `--dry-run`
+**The whole flow works from just the thread URL.** The human's only manual
+step is opening the thread; version and range are inferred from there:
+
+- **Version** — when `--train` carries no version (or the ask is just "이
+  스레드로 트레인 준비해줘"), read the thread's ROOT message first
+  (`teams_reader.py --no-thread <url>` — its `Subject:` line) and parse the
+  version from the title: `/final train to v?(?:WebUI\s*)?(\d+\.\d+\.\d+)/i`
+  matches the team's `🚂 Final train to vWebUI 26.9.0` shape. If the title
+  yields no version, ask — never guess one from tags.
+- **Range** — train mode defaults to `--from $PREV_STABLE --to HEAD` (the
+  "이전 정식 → 다음 정식(예정)" comparison the digest header speaks in),
+  skipping the usual AskUserQuestion. An explicit `--from` still overrides.
+
+Both inferred values are shown in the Story-creation confirm (step 2), which
+is where a wrong parse gets caught — one confirm, not two.
+
+Runs **in addition to** the normal digest flow, sharing its confirm gate. The
+thread URL is **required** here even though `--dry-run` normally waives it —
+the Story embeds it, and version inference reads it — and under `--dry-run`
 every step below is described, not executed. Steps, in order:
 
 1. **Duplicate scan first.** An existing train for the same version is reused,
@@ -339,7 +358,10 @@ What this mode deliberately does **not** do:
 ## Examples
 
 ```bash
-# Open the train for 26.10.0: Jira Story + kickoff digest into the thread
+# Open the train: version and range inferred from the thread's own title
+/release-train-prep --train <teams-url>
+
+# Same, everything explicit
 /release-train-prep --train 26.10.0 --from v26.9.0 <teams-url>
 
 # An rc, posted to the release thread

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -11,6 +11,9 @@ description: >
   --train <version> it also opens the release train: creates the
   "Final Train to v<version>" Jira Story and posts the kickoff + digest into
   the thread — "트레인 이슈 만들어줘", "릴리즈 트레인 준비해줘", "release train 시작".
+  PREPARATION ONLY — it never creates a release branch, tag, or GitHub release;
+  "릴리즈 찍어줘 / 릴리즈 만들어줘 / cut the release / rc 릴리즈" is
+  create-release, not this skill.
 argument-hint: "--from <ref> [--to <ref>] [--train <version>] [--dry-run] [--auto] <Teams URL>"
 ---
 
@@ -21,6 +24,12 @@ train's Teams thread grouped by risk category, and (with `--train`) open the
 `Final Train` Jira Story. The analysis is done entirely by
 `scripts/release-risk-report.mjs`; this skill runs it once, renders Korean
 HTML, and posts.
+
+> **Prep, not release.** This skill touches Jira and Teams only — it never
+> creates a release branch, pushes a tag, or publishes a GitHub release.
+> Cutting an rc or a stable is `create-release`; the post-release version bump
+> is `bump-alpha-version`. If the ask is "릴리즈 찍어줘" rather than
+> "릴리즈 준비해줘", stop and use those.
 
 > **Skill reference**: Invoke the `teams-workflow` skill for Teams CLI usage.
 

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -49,7 +49,10 @@ HTML, and posts.
 - `--from <ref>` — the base of the comparison. When absent, **offer the choices
   below rather than erroring or guessing** (see *Resolving `--from`*).
 - `--to <ref>` — defaults to `HEAD`.
-- `--dry-run` — write the HTML to `/tmp/release-train-prep-preview.html` and skip posting.
+- `--dry-run` — preview only, no side effects anywhere: write the HTML to
+  `/tmp/release-train-prep-preview.html`, skip the Teams post, and with
+  `--train` also skip every Jira action (no Story, no weblink) — describe what
+  would be created instead. A dry run must never mutate anything.
 - `--auto` — skip the confirm-before-post prompt (for cron / unattended runs).
 - `--train <version>` — also open the release train for `v<version>`: create the
   `Final Train to v<version>` Jira Story and post the kickoff into the thread.
@@ -237,7 +240,9 @@ during release testing is linked onto it — `is blocked by` for blockers,
 This mode automates the middle step and seeds the thread with the digest.
 
 Runs **in addition to** the normal digest flow, sharing its range resolution
-and its confirm gate. Steps, in order:
+and its confirm gate. The thread URL is **required** here even though
+`--dry-run` normally waives it — the Story embeds it — and under `--dry-run`
+every step below is described, not executed. Steps, in order:
 
 1. **Duplicate scan first.** An existing train for the same version is reused,
    never doubled:

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -74,9 +74,13 @@ every file-based finding, so fetch before offering it:
 ```bash
 git fetch origin main --quiet
 LATEST_TAG=$(git tag --sort=-creatordate | head -1)
-PREV_RC=$(git tag --sort=-creatordate | sed -n 2p)
-# The previous *stable* release, not the previous rc — see the note below.
-PREV_STABLE=$(git tag --sort=-creatordate | grep -Ev '\-(rc|alpha|beta)\.|\+' | head -1)
+# Previous tag of the SAME release line (v26.9.0-rc.3 -> the v26.9.0 line):
+# an interleaved hotfix tag from another line must not become the "직전 rc".
+RELEASE_LINE=${LATEST_TAG%%-*}
+PREV_RC=$(git tag --sort=-creatordate | grep -F "$RELEASE_LINE" | sed -n 2p)
+# Previous *stable* release, excluding LATEST_TAG itself — when the newest tag
+# is already stable, this must yield the one before it, not an empty range.
+PREV_STABLE=$(git tag --sort=-creatordate | grep -Ev '\-(rc|alpha|beta)\.|\+' | grep -vxF "$LATEST_TAG" | head -1)
 BRANCH=$(git branch --show-current)
 ```
 

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -3,8 +3,9 @@ name: release-train-prep
 description: >
   Post a Korean release risk digest to a Microsoft Teams thread, grouped by risk
   category. Runs scripts/release-risk-report.mjs over a ref range and renders the
-  result as a short HTML message: version-gating gaps (@since), untranslated
-  keys, destructive flows touched, UI without e2e cover, and manual gaps. Use when
+  result as a short HTML message: new features and change hotspots first, then
+  version-gating gaps (@since), untranslated keys, UI without e2e cover, and
+  manual gaps. Use when
   someone gives a Teams thread URL and asks to summarize a release, an rc, or a
   branch there — "이번 릴리즈 리스크 팀즈에 올려줘", "이 스레드에 정리해서 알려줘",
   "post the release risk report to Teams", "/release-train-prep". With
@@ -122,6 +123,7 @@ current directory. By this point `$FROM` is whatever *Resolving `--from`* settle
 the script itself takes no default and exits 2 without one.
 
 ```bash
+TO="${TO:-HEAD}"   # --to is optional; an empty string would override the script's default
 node scripts/release-risk-report.mjs --from "$FROM" --to "$TO" --json > /tmp/release-risk.json
 ```
 

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -136,6 +136,7 @@ Top-level fields:
 | `commits[]` | `{sha, subject, pr, fr, type, scope}` |
 | `featureMatrix[]` | `{flag, version, used}` — gates **added inside the range** |
 | `gating.gaps[]` | `{key, version, kind, ungated[]}` — new schema fields used without `@since` or a `supports()` guard |
+| `hotspots[]` | `{area, commits, prs[]}` — existing-feature churn, most-changed first (`feat` excluded) |
 | `undeclared[]` | flags used but never declared, i.e. permanently `false` |
 | `risks.noE2E[]` | `{pr, fr, subject, ui[]}` — UI changed, no e2e changed |
 | `risks.destructive[]` | `{pr, fr, subject, destructive[]}` — irreversible-flow files |
@@ -144,14 +145,20 @@ Top-level fields:
 
 ### 3. Render the HTML
 
-Order sections by how much they block a release, not by risk number:
+The digest answers one question for the reader: **릴리즈 준비 때 어떤 기능을
+집중적으로 만져봐야 하는가.** Sections in order:
 
-1. **R2 version-gating gaps** — a query that fails outright on older managers
-2. **R2b undeclared flags** — a feature silently off everywhere (omit when empty)
-3. **R3 untranslated** — ships visibly broken text
-4. **R4 destructive flows** — the typed-confirm gate must be re-verified
+1. **✨ 주요 변경** — the user-facing story: new features, then the existing
+   features that changed the most
+2. **R2 version-gating gaps** — a query that fails outright on older managers
+3. **R2b undeclared flags** — a feature silently off everywhere (omit when empty)
+4. **R3 untranslated** — ships visibly broken text
 5. **R1 UI without e2e** — the manual-pass list
 6. **R5 manual gaps**
+
+R4 (destructive-flow touches) stays in the full `--out` report for reviewers,
+but the digest does not carry it — the team asked for feature-level focus, not
+file-level caution.
 
 **Keep it short.** A Teams message is read on a phone. Per section list at most
 **5** items and append `외 N건` when there are more. For R3, do not list 40 locale
@@ -173,8 +180,20 @@ bare `v26.8.1 → origin/main`, which readers cannot place on the release line.
 Template:
 
 ```html
-<b>🚀 릴리즈 리스크 — {이전 정식} → {다음 버전}(예정, 현재 {to} 기준)</b><br/>
+<b>🚀 릴리즈 준비 — {이전 정식} → {다음 버전}(예정, 현재 {to} 기준)</b><br/>
 커밋 {commits.length}건{, 비교 기준 merge-base <code>{base[0:8]}</code> when divergedFrom}<br/><br/>
+
+<b>✨ 새 기능</b> — {feat 커밋 수}건<br/>
+<ul>
+  <li><a href="{prUrl}">#{pr}</a> {사용자 관점 한 줄 설명}</li>
+</ul>
+{외 N건}<br/>
+
+<b>🔧 많이 바뀐 기존 기능</b><br/>
+<ul>
+  <li><b>{영역 한글명}</b> — 변경 {commits}건 (<a>#{pr}</a>, <a>#{pr}</a>, …)</li>
+</ul>
+<i>릴리즈 테스트에서 이 기능들을 우선적으로 확인해 주세요.</i><br/><br/>
 
 <b>⚙️ 버전 게이팅 누락</b> — {gating.gaps.length}건<br/>
 <ul>
@@ -184,12 +203,6 @@ Template:
 
 <b>🌐 미번역</b> — 신규 영어 키 {addedCount}개<br/>
 {shape line, then outliers}<br/><br/>
-
-<b>⚠️ 파괴적 플로우</b> — {n}건<br/>
-<ul>
-  <li><a href="{frUrl}">{fr}</a> · <a href="{prUrl}">#{pr}</a> — {왜 파괴적인지 한 줄}</li>
-</ul>
-<i>이름을 정확히 입력해야 삭제 버튼이 활성화되는지 재확인이 필요합니다.</i><br/><br/>
 
 <b>🧪 e2e 미커버 UI 변경</b> — {n}건<br/>
 <ul><li><a href="{prUrl}">#{pr}</a> {subject}</li></ul>
@@ -201,17 +214,21 @@ Template:
 <i>🤖 scripts/release-risk-report.mjs · 결함 목록이 아니라 QA 확인 항목입니다</i>
 ```
 
-Two sections render differently from the rest:
+How each special section is written:
 
+- **새 기능**: every `feat` commit, but the line is YOURS to write — a Korean
+  sentence describing what the user can now do, synthesized from the subject
+  ("pick the model mount subpath with a directory picker" → "모델 마운트 경로를
+  디렉터리 탐색기로 선택"). Never paste raw commit subjects here. Cap at ~6
+  lines + `외 N건`.
+- **많이 바뀐 기존 기능**: `hotspots[]` top ~5. Translate the area token into
+  the UI's own term (VFolder → 폴더, Deployment → 배포/디플로이먼트 — the i18n
+  label wins, per the terminology precedence), show the change count and 2–3 PR
+  links. This is the "여기를 우선 테스트" list.
 - **버전 게이팅 (R2)**: gaps ONLY — never enumerate every new gate or schema
   field; a correctly annotated usage is not news. When `gating.gaps` is empty,
   keep the section as the single line `⚙️ 버전 게이팅 누락 — 없음 ✅`: for a
   go/no-go reader, "checked and clean" and "not checked" must not look the same.
-- **파괴적 플로우 (R4)**: links and a reason, NO commit title. Each item is the
-  FR link + PR link, then one line saying *why it is destructive* — derived from
-  the `destructive[]` paths (`TerminateSessionModal.tsx` → 세션 강제 종료 확인
-  모달, a typed-confirm host → 어떤 삭제 확인 플로우인지). The reader decides
-  from the reason, not from a commit subject.
 
 Drop any other section whose count is 0 rather than printing an empty heading.
 If every section is empty, post a single line saying the range has no risk

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "릴리즈 찍어줘 / 릴리즈 만들어줘 / cut the release / rc 릴리즈" is
   create-release, not this skill.
 argument-hint: "--from <ref> [--to <ref>] [--train [version]] [--dry-run] [--auto] <Teams URL>"
+disable-model-invocation: true
 ---
 
 # Release Train Prep → Teams

--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -3,8 +3,8 @@ name: release-train-prep
 description: >
   Post a Korean release risk digest to a Microsoft Teams thread, grouped by risk
   category. Runs scripts/release-risk-report.mjs over a ref range and renders the
-  result as a short HTML message: the manager version matrix, untranslated keys,
-  destructive flows touched, UI without e2e cover, and manual gaps. Use when
+  result as a short HTML message: version-gating gaps (@since), untranslated
+  keys, destructive flows touched, UI without e2e cover, and manual gaps. Use when
   someone gives a Teams thread URL and asks to summarize a release, an rc, or a
   branch there — "이번 릴리즈 리스크 팀즈에 올려줘", "이 스레드에 정리해서 알려줘",
   "post the release risk report to Teams", "/release-train-prep". With
@@ -135,6 +135,7 @@ Top-level fields:
 | `divergedFrom` | true when `to` forked before `from` moved on — mention the base when true |
 | `commits[]` | `{sha, subject, pr, fr, type, scope}` |
 | `featureMatrix[]` | `{flag, version, used}` — gates **added inside the range** |
+| `gating.gaps[]` | `{key, version, kind, ungated[]}` — new schema fields used without `@since` or a `supports()` guard |
 | `undeclared[]` | flags used but never declared, i.e. permanently `false` |
 | `risks.noE2E[]` | `{pr, fr, subject, ui[]}` — UI changed, no e2e changed |
 | `risks.destructive[]` | `{pr, fr, subject, destructive[]}` — irreversible-flow files |
@@ -145,7 +146,7 @@ Top-level fields:
 
 Order sections by how much they block a release, not by risk number:
 
-1. **R2 version matrix** — decides which managers QA needs
+1. **R2 version-gating gaps** — a query that fails outright on older managers
 2. **R2b undeclared flags** — a feature silently off everywhere (omit when empty)
 3. **R3 untranslated** — ships visibly broken text
 4. **R4 destructive flows** — the typed-confirm gate must be re-verified
@@ -165,23 +166,28 @@ PR links are `https://github.com/lablup/backend.ai-webui/pull/{pr}`.
 
 Template:
 
+**Name releases, not refs.** The header speaks in release versions: for an
+upcoming stable cut from main, `26.8.1 → 26.9.0(예정, 현재 main 기준)` — never a
+bare `v26.8.1 → origin/main`, which readers cannot place on the release line.
+
+Template:
+
 ```html
-<b>🚀 릴리즈 리스크 — {from} → {to}</b><br/>
+<b>🚀 릴리즈 리스크 — {이전 정식} → {다음 버전}(예정, 현재 {to} 기준)</b><br/>
 커밋 {commits.length}건{, 비교 기준 merge-base <code>{base[0:8]}</code> when divergedFrom}<br/><br/>
 
-<b>⚙️ 매니저 버전 매트릭스</b> — 신규 게이트 {n}개<br/>
+<b>⚙️ 버전 게이팅 누락</b> — {gating.gaps.length}건<br/>
 <ul>
-  <li><code>{flag}</code> — {version} 이상 필요{, 미사용 when !used}</li>
+  <li><code>{key}</code> ({version} 추가) — <code>{ungated file}</code>에서 @since 없이 사용</li>
 </ul>
-<i>각 항목을 버전을 충족하는 매니저와 충족하지 않는 매니저 양쪽에서 확인해야 합니다.
-낮은 버전에서는 숨겨져야 하고, 깨지면 안 됩니다.</i><br/><br/>
+<i>낮은 버전 매니저에서 이 쿼리는 실패합니다. @since(version:) 주석 또는 supports() 게이트가 필요합니다.</i><br/><br/>
 
 <b>🌐 미번역</b> — 신규 영어 키 {addedCount}개<br/>
 {shape line, then outliers}<br/><br/>
 
 <b>⚠️ 파괴적 플로우</b> — {n}건<br/>
 <ul>
-  <li><a href="{prUrl}">#{pr}</a> {subject} — <code>{basename of destructive[0]}</code></li>
+  <li><a href="{frUrl}">{fr}</a> · <a href="{prUrl}">#{pr}</a> — {왜 파괴적인지 한 줄}</li>
 </ul>
 <i>이름을 정확히 입력해야 삭제 버튼이 활성화되는지 재확인이 필요합니다.</i><br/><br/>
 
@@ -195,8 +201,21 @@ Template:
 <i>🤖 scripts/release-risk-report.mjs · 결함 목록이 아니라 QA 확인 항목입니다</i>
 ```
 
-Drop any section whose count is 0 rather than printing an empty heading. If every
-section is empty, post a single line saying the range has no risk signals.
+Two sections render differently from the rest:
+
+- **버전 게이팅 (R2)**: gaps ONLY — never enumerate every new gate or schema
+  field; a correctly annotated usage is not news. When `gating.gaps` is empty,
+  keep the section as the single line `⚙️ 버전 게이팅 누락 — 없음 ✅`: for a
+  go/no-go reader, "checked and clean" and "not checked" must not look the same.
+- **파괴적 플로우 (R4)**: links and a reason, NO commit title. Each item is the
+  FR link + PR link, then one line saying *why it is destructive* — derived from
+  the `destructive[]` paths (`TerminateSessionModal.tsx` → 세션 강제 종료 확인
+  모달, a typed-confirm host → 어떤 삭제 확인 플로우인지). The reader decides
+  from the reason, not from a commit subject.
+
+Drop any other section whose count is 0 rather than printing an empty heading.
+If every section is empty, post a single line saying the range has no risk
+signals.
 
 The closing italic line matters: these are **actions to check**, not confirmed
 defects. Do not phrase a finding as a bug.
@@ -253,9 +272,13 @@ every step below is described, not executed. Steps, in order:
 
    On a hit, skip creation, use the existing key, and say so in the reply.
 
-2. **Create the Story** (see the `jira-workflow` skill; `$FW_JIRA` as documented
-   there). Type **Story**, exact summary format `Final Train to v$VERSION` —
-   the team greps for this shape (FR-3663, FR-3392, FR-3238 all follow it):
+2. **Create the Story — after explicit user confirmation.** Creating a Jira
+   issue is outward-facing: show the exact title, assignee, and description you
+   are about to submit and ask (AskUserQuestion) before every creation — no
+   batch pre-approval, one confirm per issue. Then (see the `jira-workflow`
+   skill; `$FW_JIRA` as documented there) type **Story**, exact summary format
+   `Final Train to v$VERSION` — the team greps for this shape (FR-3663,
+   FR-3392, FR-3238 all follow it):
 
    ```bash
    $FW_JIRA create --type Story --assignee me \

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -539,9 +539,11 @@ function schemaGatingGaps(from, to) {
         hit = asLiteral.test(s.text) && !s.guarded;
       } else if (entry.parentKind === 'input') {
         // Input-object fields are sent as JS values, not selected — @since
-        // cannot apply, so referencing the input type from an unguarded file
-        // is the signal.
-        hit = s.tagLines.some((l) => inputRef.test(l)) && !s.guarded;
+        // cannot apply. Referencing the input type alone is not usage; the
+        // file must also construct the field itself (`field:` object key).
+        const buildsKey = new RegExp(`\\b${entry.field}\\s*:`).test(s.text);
+        hit =
+          s.tagLines.some((l) => inputRef.test(l)) && buildsKey && !s.guarded;
       } else {
         const uses = findSelectionUses(
           s.tagLines,
@@ -549,7 +551,11 @@ function schemaGatingGaps(from, to) {
           entry.parent,
           typeFields,
         );
-        hit = uses.some((u) => !u.annotated) && !s.guarded;
+        // The convention for query fields is @since at the usage (or a gated
+        // ancestor). A supports() call elsewhere in the file guards ITS
+        // operation, not every query the file holds, so it does not excuse an
+        // unannotated selection (ProjectPage.tsx was the counterexample).
+        hit = uses.some((u) => !u.annotated);
       }
       if (hit) ungated.push(s.file);
     }
@@ -565,6 +571,7 @@ function schemaGatingGaps(from, to) {
 export function parseSchemaTypeFields(schemaText) {
   const map = new Map();
   let current = null;
+  let pendingField = null;
   for (const line of schemaText.split('\n')) {
     const block = line.match(/^(?:extend\s+)?(?:type|interface)\s+(\w+)/);
     if (block) {
@@ -577,6 +584,21 @@ export function parseSchemaTypeFields(schemaText) {
       continue;
     }
     if (!current) continue;
+    // Inside a multiline signature the argument lines also look like fields —
+    // only the closing `): ReturnType` matters until it arrives.
+    if (pendingField) {
+      const close = line.match(/^\s*\)\s*:\s*(\S+)/);
+      if (close) {
+        map.get(current).set(pendingField, close[1].replace(/[[\]!]/g, ''));
+        pendingField = null;
+      }
+      continue;
+    }
+    const open = line.match(/^\s{2,}([a-z]\w*)\s*\(\s*$/);
+    if (open) {
+      pendingField = open[1];
+      continue;
+    }
     const f = line.match(/^\s{2,}([a-z]\w*)\s*(?:\([^)]*\))?\s*:\s*(\S+)/);
     if (f) map.get(current).set(f[1], f[2].replace(/[[\]!]/g, ''));
   }
@@ -612,12 +634,18 @@ export function findSelectionUses(tagLines, field, parent, typeFields) {
     }
     chain.reverse(); // root first
 
-    // Resolve the block's type from the outermost `on Type` downward.
+    // Resolve the block's type from the outermost typed root downward: a
+    // fragment/inline `on Type`, or an operation header (query/mutation).
     let cur = null;
     for (const anc of chain) {
       const onType = anc.match(/\bon\s+(\w+)/)?.[1];
       if (onType) {
         cur = onType;
+        continue;
+      }
+      const op = anc.match(/^\s*(query|mutation|subscription)\b/)?.[1];
+      if (op) {
+        cur = op[0].toUpperCase() + op.slice(1);
         continue;
       }
       if (cur === null) continue; // above the first typed root (query header)
@@ -739,6 +767,7 @@ function renderMarkdown(report) {
   L.push(
     `| R2 new schema field used without a version gate | ${gating.gaps.length} |`,
   );
+  L.push(`| R2a new manager feature gate | ${featureMatrix.length} |`);
   L.push(`| R3 locale files with untranslated new keys | ${i18n.length} |`);
   L.push(`| R4 destructive flow touched | ${risks.destructive.length} |`);
   L.push(
@@ -758,6 +787,22 @@ function renderMarkdown(report) {
     for (const g of gating.gaps)
       L.push(
         `| \`${g.key}\`${g.kind === 'enum' ? ' (enum)' : ''} | ${g.version ? `\`${g.version}\`` : '_unannotated_'} | ${g.ungated.map((f) => `\`${f.split('/').pop()}\``).join(', ')} |`,
+      );
+    L.push('');
+  }
+
+  if (featureMatrix.length) {
+    L.push('## R2a — New manager feature gates');
+    L.push('');
+    L.push(
+      'Gates declared inside this range. Exercise each against a manager that **meets** the version and one that does **not** — on the older manager the feature must be hidden, never broken.',
+    );
+    L.push('');
+    L.push('| Feature flag | Requires | Used in app |');
+    L.push('| --- | --- | --- |');
+    for (const f of featureMatrix)
+      L.push(
+        `| \`${f.flag}\` | ${f.version ? `\`${f.version}\`` : '_ungated_'} | ${f.used ? 'yes' : '**no — dead flag**'} |`,
       );
     L.push('');
   }
@@ -824,6 +869,7 @@ function renderMarkdown(report) {
   if (
     !risks.noE2E.length &&
     !gating.gaps.length &&
+    !featureMatrix.length &&
     !undeclared.length &&
     !i18n.length &&
     !risks.destructive.length &&

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -338,6 +338,241 @@ function usedFeatureFlags(ref) {
 }
 
 /**
+ * Fields and enum values ADDED to schema.graphql in the diff, each with the
+ * manager version its docstring declares ("Added in X.Y.Z") and the block it
+ * belongs to. Tracks the enclosing type/input/interface/enum from both context
+ * and added lines, so a field added to an existing type is attributed too.
+ */
+export function extractAddedSchemaFields(diff) {
+  const out = [];
+  let block = null;
+  let pendingVersion = null;
+  for (const raw of diff.split('\n')) {
+    const tag = raw[0];
+    if (tag === '-' || raw.startsWith('+++') || raw.startsWith('---')) continue;
+    const line = tag === '+' || tag === ' ' ? raw.slice(1) : raw;
+
+    const blockDecl = line.match(
+      /^\s*(?:extend\s+)?(type|input|interface|enum)\s+(\w+)/,
+    );
+    if (blockDecl) {
+      // A brand-new type's own "Added in" docstring precedes its declaration;
+      // its fields inherit that version unless they declare their own.
+      block = {
+        kind: blockDecl[1],
+        name: blockDecl[2],
+        version: tag === '+' ? pendingVersion : null,
+      };
+      pendingVersion = null;
+      continue;
+    }
+    if (tag !== '+') continue;
+
+    const ver = line.match(/Added in (\d+\.\d+(?:\.\d+)?)/);
+    if (ver) pendingVersion = ver[1];
+
+    if (!block) continue;
+    if (block.kind === 'enum') {
+      const v = line.match(/^\s{2,}([A-Z][A-Z0-9_]*)\s*$/);
+      if (v) {
+        out.push({
+          parent: block.name,
+          parentKind: block.kind,
+          field: v[1],
+          version: pendingVersion ?? block.version,
+          kind: 'enum',
+        });
+        pendingVersion = null;
+      }
+    } else {
+      const f = line.match(/^\s{2,}([a-z]\w*)\s*[(:]/);
+      if (f) {
+        out.push({
+          parent: block.name,
+          parentKind: block.kind,
+          field: f[1],
+          version: pendingVersion ?? block.version,
+          kind: 'field',
+        });
+        pendingVersion = null;
+      }
+    }
+  }
+  return out;
+}
+
+/** The graphql`…` template contents of a source file, joined. */
+export function extractGraphqlTags(src) {
+  return [...src.matchAll(/graphql`([^`]*)`/g)].map((m) => m[1]).join('\n');
+}
+
+const GUARD_RE = /supports\(|isManagerVersionCompatibleWith/;
+
+/**
+ * The convention under test (data/client-directives.graphql): a query field
+ * that entered the schema at a manager version carries `@since(version:)` /
+ * `@sinceMultiple` on its usage, so older managers never receive it. A usage
+ * line without it — in a file with no supports()/isManagerVersionCompatibleWith
+ * guard either — is a gap. Only gaps are reported: a correctly annotated field
+ * needs no QA callout (FR-3673 was exactly an ungated enum value breaking the
+ * Sessions tab on older managers).
+ */
+function schemaGatingGaps(from, to) {
+  const diff = gitOrNull([
+    'diff',
+    `${from}..${to}`,
+    '--',
+    'data/schema.graphql',
+  ]);
+  if (!diff) return { gaps: [] };
+  const added = extractAddedSchemaFields(diff);
+  if (!added.length) return { gaps: [] };
+
+  const schemaText = gitOrNull(['show', `${to}:data/schema.graphql`]) ?? '';
+
+  const roots = ['react/src', 'packages/backend.ai-ui/src'];
+  const listed = gitOrNull(['ls-tree', '-r', '--name-only', to]) ?? '';
+  const files = listed
+    .split('\n')
+    .filter(
+      (f) =>
+        /\.(tsx?)$/.test(f) &&
+        !isGenerated(f) &&
+        !isTestLike(f) &&
+        !isDocStub(f) &&
+        !BUI_NON_RUNTIME.test(f) &&
+        roots.some((r) => f.startsWith(`${r}/`)),
+    );
+
+  // One pass over the tree: cache each file's graphql-tag text, full text,
+  // and whether it carries any version guard.
+  const sources = [];
+  for (const f of files) {
+    const src = gitOrNull(['show', `${to}:${f}`]);
+    if (!src || !src.includes('graphql`')) continue;
+    sources.push({
+      file: f,
+      text: src,
+      tagLines: extractGraphqlTags(src).split('\n'),
+      guarded: GUARD_RE.test(src),
+    });
+  }
+
+  const typeFields = parseSchemaTypeFields(schemaText);
+
+  const gaps = [];
+  const seen = new Set();
+  for (const entry of added) {
+    const key = `${entry.parent}.${entry.field}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    // An enum value reaches the manager as a plain string literal (status
+    // filters); @since cannot annotate it, so only a file guard can gate it.
+    const asLiteral = new RegExp(`['"]${entry.field}['"]`);
+    const inputRef = new RegExp(`\\b${entry.parent}\\b`);
+    const ungated = [];
+    for (const s of sources) {
+      let hit = false;
+      if (entry.kind === 'enum') {
+        hit = asLiteral.test(s.text) && !s.guarded;
+      } else if (entry.parentKind === 'input') {
+        // Input-object fields are sent as JS values, not selected — @since
+        // cannot apply, so referencing the input type from an unguarded file
+        // is the signal.
+        hit = s.tagLines.some((l) => inputRef.test(l)) && !s.guarded;
+      } else {
+        const uses = findSelectionUses(
+          s.tagLines,
+          entry.field,
+          entry.parent,
+          typeFields,
+        );
+        hit = uses.some((u) => !u.annotated) && !s.guarded;
+      }
+      if (hit) ungated.push(s.file);
+    }
+    if (ungated.length) gaps.push({ ...entry, key, ungated });
+  }
+  return { gaps };
+}
+
+/**
+ * type -> Map(field -> bare return type), for every type/interface block in
+ * the schema. The bare name strips list/non-null wrappers and directives.
+ */
+export function parseSchemaTypeFields(schemaText) {
+  const map = new Map();
+  let current = null;
+  for (const line of schemaText.split('\n')) {
+    const block = line.match(/^(?:extend\s+)?(?:type|interface)\s+(\w+)/);
+    if (block) {
+      current = block[1];
+      if (!map.has(current)) map.set(current, new Map());
+      continue;
+    }
+    if (/^\S/.test(line) && line.trim() && !line.startsWith('{')) {
+      if (/^}/.test(line)) current = null;
+      continue;
+    }
+    if (!current) continue;
+    const f = line.match(/^\s{2,}([a-z]\w*)\s*(?:\([^)]*\))?\s*:\s*(\S+)/);
+    if (f) map.get(current).set(f[1], f[2].replace(/[[\]!]/g, ''));
+  }
+  return map;
+}
+
+/**
+ * Occurrences of `field` whose selection block RESOLVES to `parent`, walking
+ * the indentation-derived ancestor chain from the nearest `on Type` root down
+ * through the schema's field types. Strict: a chain that cannot be resolved is
+ * not attributed (no guess, no false positive). A use counts as annotated when
+ * the field line OR any ancestor selection carries @since — a gated ancestor
+ * strips the whole subtree.
+ */
+export function findSelectionUses(tagLines, field, parent, typeFields) {
+  const uses = [];
+  const selRe = new RegExp(`^\\s*${field}\\b`);
+  for (let i = 0; i < tagLines.length; i += 1) {
+    const line = tagLines[i];
+    if (!selRe.test(line)) continue;
+
+    // Ancestor chain, innermost first: every shallower block-opening line.
+    const chain = [];
+    let indent = line.match(/^\s*/)[0].length;
+    for (let j = i - 1; j >= 0 && indent > 0; j -= 1) {
+      const prev = tagLines[j];
+      if (!prev.trim()) continue;
+      const prevIndent = prev.match(/^\s*/)[0].length;
+      if (prevIndent < indent && prev.includes('{')) {
+        chain.push(prev);
+        indent = prevIndent;
+      }
+    }
+    chain.reverse(); // root first
+
+    // Resolve the block's type from the outermost `on Type` downward.
+    let cur = null;
+    for (const anc of chain) {
+      const onType = anc.match(/\bon\s+(\w+)/)?.[1];
+      if (onType) {
+        cur = onType;
+        continue;
+      }
+      if (cur === null) continue; // above the first typed root (query header)
+      const ownerField = anc.match(/^\s*(\w+)/)?.[1];
+      cur = ownerField ? (typeFields.get(cur)?.get(ownerField) ?? null) : null;
+      if (cur === null) break; // unresolvable — stay strict
+    }
+    if (cur !== parent) continue;
+
+    const annotated =
+      /@since/i.test(line) || chain.some((anc) => /@since/i.test(anc));
+    uses.push({ line, annotated });
+  }
+  return uses;
+}
+
+/**
  * Prettier wraps long calls, so the literal may sit on its own line with a
  * trailing comma: supports(\n  'flag',\n).
  */
@@ -407,8 +642,17 @@ function i18nGaps(from, to) {
 }
 
 function renderMarkdown(report) {
-  const { from, to, base, commits, risks, featureMatrix, undeclared, i18n } =
-    report;
+  const {
+    from,
+    to,
+    base,
+    commits,
+    risks,
+    featureMatrix,
+    gating,
+    undeclared,
+    i18n,
+  } = report;
   const L = [];
   const link = (c) =>
     c.pr
@@ -430,7 +674,9 @@ function renderMarkdown(report) {
   L.push('| Risk | Count |');
   L.push('| --- | --- |');
   L.push(`| R1 UI change with no e2e change | ${risks.noE2E.length} |`);
-  L.push(`| R2 new manager feature gate | ${featureMatrix.length} |`);
+  L.push(
+    `| R2 new schema field used without a version gate | ${gating.gaps.length} |`,
+  );
   L.push(`| R3 locale files with untranslated new keys | ${i18n.length} |`);
   L.push(`| R4 destructive flow touched | ${risks.destructive.length} |`);
   L.push(
@@ -438,18 +684,18 @@ function renderMarkdown(report) {
   );
   L.push('');
 
-  if (featureMatrix.length) {
-    L.push('## R2 — Manager version matrix');
+  if (gating.gaps.length) {
+    L.push('## R2 — New schema fields used without a version gate');
     L.push('');
     L.push(
-      'These gates are new in this range. Exercise each one against a manager that **meets** the version and one that does **not** — on the older manager the feature must be hidden, never broken.',
+      'These fields entered the schema in this range and at least one usage carries no `@since(version:)` annotation (data/client-directives.graphql) and no file-level `supports()` guard. Against a manager that predates the field, the query fails instead of the feature hiding — FR-3673 was this class. Correctly annotated usages are not listed.',
     );
     L.push('');
-    L.push('| Feature flag | Requires | Used in app |');
+    L.push('| Field | Added in | Ungated use |');
     L.push('| --- | --- | --- |');
-    for (const f of featureMatrix)
+    for (const g of gating.gaps)
       L.push(
-        `| \`${f.flag}\` | ${f.version ? `\`${f.version}\`` : '_ungated_'} | ${f.used ? 'yes' : '**no — dead flag**'} |`,
+        `| \`${g.key}\`${g.kind === 'enum' ? ' (enum)' : ''} | ${g.version ? `\`${g.version}\`` : '_unannotated_'} | ${g.ungated.map((f) => `\`${f.split('/').pop()}\``).join(', ')} |`,
       );
     L.push('');
   }
@@ -515,7 +761,7 @@ function renderMarkdown(report) {
 
   if (
     !risks.noE2E.length &&
-    !featureMatrix.length &&
+    !gating.gaps.length &&
     !undeclared.length &&
     !i18n.length &&
     !risks.destructive.length &&
@@ -598,6 +844,7 @@ function main() {
     commits,
     risks,
     featureMatrix,
+    gating: schemaGatingGaps(base, args.to),
     undeclared,
     i18n: i18nGaps(base, args.to),
   };

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -514,10 +514,18 @@ function main() {
         {
           ...report,
           commits: commits.map(({ files, classified, ...rest }) => rest),
+          // Keep the touched paths: a consumer rendering a digest needs to name
+          // the destructive file, not just the PR.
           risks: Object.fromEntries(
             Object.entries(risks).map(([k, v]) => [
               k,
-              v.map((c) => ({ pr: c.pr, fr: c.fr, subject: c.subject })),
+              v.map((c) => ({
+                pr: c.pr,
+                fr: c.fr,
+                subject: c.subject,
+                ui: c.classified.ui,
+                destructive: c.classified.destructive,
+              })),
             ]),
           ),
         },

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -148,19 +148,26 @@ function readCommits(from, to) {
 const isGenerated = (f) => f.includes('__generated__');
 const isTestLike = (f) => /\.(test|spec|stories)\.[tj]sx?$/.test(f);
 
+// Non-runtime corners of the BUI package; everything else under src/ ships.
+const BUI_NON_RUNTIME =
+  /^packages\/backend\.ai-ui\/src\/(__test__|tests|astryx-docs|locale)\//;
+
 export function classify(files) {
   const ui = files.filter(
     (f) =>
       !isGenerated(f) &&
       !isTestLike(f) &&
       (/^react\/src\/.*\.tsx?$/.test(f) ||
-        /^packages\/backend\.ai-ui\/src\/(components|hooks)\/.*\.tsx?$/.test(
-          f,
-        )),
+        (/^packages\/backend\.ai-ui\/src\/.*\.tsx?$/.test(f) &&
+          !BUI_NON_RUNTIME.test(f))),
   );
   return {
     ui,
-    e2e: files.filter((f) => f.startsWith('e2e/')),
+    // Executable tests only: e2e/ also holds docs and plans (e.g. the
+    // coverage report), and touching those is not test coverage.
+    e2e: files.filter(
+      (f) => f.startsWith('e2e/') && /\.(spec|test)\.[tj]sx?$/.test(f),
+    ),
     docs: files.filter((f) => f.startsWith('packages/backend.ai-webui-docs/')),
     i18n: files.filter(
       (f) =>
@@ -169,6 +176,15 @@ export function classify(files) {
     ),
     destructive: ui.filter((f) => DESTRUCTIVE_NAME.test(f.split('/').pop())),
   };
+}
+
+/**
+ * The typed-confirm contract of rules/destructive-confirmation.md. A file can
+ * host an irreversible flow without carrying an action word in its name
+ * (ProjectPage.tsx holds a purge), so R4 also checks changed UI files' content.
+ */
+export function hasDestructiveContract(src) {
+  return /BAIDeleteConfirmModal|requireConfirmInput/.test(src);
 }
 
 function readFeatureVersionMap(ref) {
@@ -194,6 +210,8 @@ export function parseFeatureVersionMap(src) {
   const map = new Map();
   /** Guards currently in scope, innermost last. blockDepth = depth inside the block. */
   const guards = [];
+  /** A guard whose opening brace prettier moved to a later line. */
+  let pendingGuard = null;
   let depth = 0;
   let entered = false;
 
@@ -203,27 +221,28 @@ export function parseFeatureVersionMap(src) {
     const closes = (line.match(/\}/g) ?? []).length;
     const depthBefore = depth;
 
-    // Prettier may push the value onto the next line: _features['x'] =\n  true;
-    const decl = line.match(/_features\['([^']+)'\]\s*=\s*(true|false)?/);
+    const decl = readFeatureDeclaration(lines, i);
     if (decl) {
-      const value =
-        decl[2] ??
-        lines
-          .slice(i + 1, i + 3)
-          .join(' ')
-          .match(/^\s*(true|false)/)?.[1];
       const active = guards.filter((g) => g.blockDepth <= depthBefore);
-      map.set(decl[1], {
+      map.set(decl.key, {
         version: active.length ? active[active.length - 1].version : null,
-        value: value === 'true',
+        value: decl.value === 'true',
       });
     }
 
+    // Accepts a single version or an array; an array's first entry is the
+    // primary manager line and stands for the guard.
     const guard = line.match(
-      /is(?:Manager|API)VersionCompatibleWith\(\s*'([^']+)'\s*\)/,
+      /is(?:Manager|API)VersionCompatibleWith\(\s*\[?\s*'([^']+)'/,
     );
-    if (guard && opens > 0)
-      guards.push({ version: guard[1], blockDepth: depthBefore + 1 });
+    if (guard) {
+      if (opens > 0)
+        guards.push({ version: guard[1], blockDepth: depthBefore + 1 });
+      else pendingGuard = guard[1];
+    } else if (pendingGuard && opens > 0) {
+      guards.push({ version: pendingGuard, blockDepth: depthBefore + 1 });
+      pendingGuard = null;
+    }
 
     depth = depthBefore + opens - closes;
     if (!entered && depth > 0) entered = true;
@@ -232,6 +251,19 @@ export function parseFeatureVersionMap(src) {
     if (entered && depth <= 0) break;
   }
   return map;
+}
+
+/**
+ * Read one `_features[…] = true|false` anchored at line i. Prettier splits
+ * long declarations three ways — key on its own line inside the brackets,
+ * value on the line after `=` — so match against a small joined window
+ * rather than the single line.
+ */
+function readFeatureDeclaration(lines, i) {
+  if (!lines[i].includes('_features[')) return null;
+  const window = lines.slice(i, i + 5).join(' ');
+  const m = window.match(/_features\[\s*'([^']+)'\s*\]\s*=\s*(true|false)/);
+  return m ? { key: m[1], value: m[2] } : null;
 }
 
 /** Feature flags whose declaration line was ADDED between from and to. */
@@ -247,17 +279,23 @@ function newFeatureFlags(from, to) {
   return extractAddedFeatureFlags(diff);
 }
 
-/** Added `_features['x'] = true`, including the form prettier wraps onto two lines. */
+/**
+ * Added `_features[…] = true`, in any of the shapes prettier emits — single
+ * line, value wrapped, or key wrapped inside the brackets. Joins consecutive
+ * ADDED lines only, so a declaration edited half-in-place (context lines
+ * between the added ones) is out of scope for this heuristic.
+ */
 export function extractAddedFeatureFlags(diff) {
   const lines = diff
     .split('\n')
-    .filter((l) => l.startsWith('+') && !l.startsWith('+++'));
+    .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+    .map((l) => l.slice(1));
   const added = new Set();
   for (let i = 0; i < lines.length; i += 1) {
-    const m = lines[i].match(/_features\['([^']+)'\]\s*=\s*(true|false)?/);
-    if (!m) continue;
-    const value = m[2] ?? lines[i + 1]?.match(/^\+\s*(true|false)/)?.[1];
-    if (value === 'true') added.add(m[1]);
+    if (!lines[i].includes('_features[')) continue;
+    const window = lines.slice(i, i + 5).join(' ');
+    const m = window.match(/_features\[\s*'([^']+)'\s*\]\s*=\s*(true|false)/);
+    if (m && m[2] === 'true') added.add(m[1]);
   }
   return [...added];
 }
@@ -467,6 +505,7 @@ function renderMarkdown(report) {
   if (
     !risks.noE2E.length &&
     !featureMatrix.length &&
+    !undeclared.length &&
     !i18n.length &&
     !risks.destructive.length &&
     !risks.noDocs.length
@@ -488,6 +527,24 @@ function main() {
     ...c,
     classified: classify(c.files),
   }));
+
+  // R4 by content: a changed UI file hosting the typed-confirm contract is a
+  // destructive-flow touch even when its name carries no action word.
+  const contractCache = new Map();
+  const hostsContract = (f) => {
+    if (!contractCache.has(f)) {
+      const src = gitOrNull(['show', `${args.to}:${f}`]);
+      contractCache.set(f, Boolean(src && hasDestructiveContract(src)));
+    }
+    return contractCache.get(f);
+  };
+  for (const c of commits) {
+    c.classified.destructive.push(
+      ...c.classified.ui.filter(
+        (f) => !c.classified.destructive.includes(f) && hostsContract(f),
+      ),
+    );
+  }
 
   const userFacing = commits.filter(
     (c) => c.type && USER_FACING_TYPES.has(c.type),
@@ -562,5 +619,8 @@ function main() {
 }
 
 // Importing this module (tests) must not run the CLI.
-if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url))
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+)
   main();

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -147,18 +147,26 @@ function readCommits(from, to) {
 
 const isGenerated = (f) => f.includes('__generated__');
 const isTestLike = (f) => /\.(test|spec|stories)\.[tj]sx?$/.test(f);
+// BUI component doc stubs are CLI-only, never imported by the library.
+const isDocStub = (f) => /\.doc\.ts$/.test(f);
 
 // Non-runtime corners of the BUI package; everything else under src/ ships.
 const BUI_NON_RUNTIME =
   /^packages\/backend\.ai-ui\/src\/(__test__|tests|astryx-docs|locale)\//;
+
+// Runtime UI is not only TypeScript: components import co-located styles and
+// assets directly, so a style-only commit is still a UI change.
+const UI_EXT = /\.(tsx?|css|scss|svg|png)$/;
 
 export function classify(files) {
   const ui = files.filter(
     (f) =>
       !isGenerated(f) &&
       !isTestLike(f) &&
-      (/^react\/src\/.*\.tsx?$/.test(f) ||
-        (/^packages\/backend\.ai-ui\/src\/.*\.tsx?$/.test(f) &&
+      !isDocStub(f) &&
+      UI_EXT.test(f) &&
+      (f.startsWith('react/src/') ||
+        (f.startsWith('packages/backend.ai-ui/src/') &&
           !BUI_NON_RUNTIME.test(f))),
   );
   return {
@@ -311,14 +319,17 @@ function usedFeatureFlags(ref) {
   const used = new Set();
   const listed = gitOrNull(['ls-tree', '-r', '--name-only', ref]);
   if (!listed) return used;
-  const files = listed
-    .split('\n')
-    .filter(
-      (f) =>
-        /\.(tsx?|jsx?)$/.test(f) &&
-        !isGenerated(f) &&
-        roots.some((r) => f.startsWith(`${r}/`)),
-    );
+  const files = listed.split('\n').filter(
+    (f) =>
+      /\.(tsx?|jsx?)$/.test(f) &&
+      !isGenerated(f) &&
+      // Runtime code only: a supports() inside a test, story, doc stub, or
+      // docs dir must not mark a gate as live in the app.
+      !isTestLike(f) &&
+      !isDocStub(f) &&
+      !BUI_NON_RUNTIME.test(f) &&
+      roots.some((r) => f.startsWith(`${r}/`)),
+  );
   for (const f of files) {
     const src = gitOrNull(['show', `${ref}:${f}`]);
     if (src) for (const flag of extractSupportsUsages(src)) used.add(flag);
@@ -528,16 +539,23 @@ function main() {
     classified: classify(c.files),
   }));
 
+  const base = mergeBase(args.from, args.to);
+
   // R4 by content: a changed UI file hosting the typed-confirm contract is a
-  // destructive-flow touch even when its name carries no action word.
+  // destructive-flow touch even when its name carries no action word. Checked
+  // at BOTH ends of the range — a commit that removes the contract (or the
+  // file) is exactly the regression this signal exists to surface.
   const contractCache = new Map();
-  const hostsContract = (f) => {
-    if (!contractCache.has(f)) {
-      const src = gitOrNull(['show', `${args.to}:${f}`]);
-      contractCache.set(f, Boolean(src && hasDestructiveContract(src)));
+  const refHasContract = (ref, f) => {
+    const key = `${ref}:${f}`;
+    if (!contractCache.has(key)) {
+      const src = gitOrNull(['show', key]);
+      contractCache.set(key, Boolean(src && hasDestructiveContract(src)));
     }
-    return contractCache.get(f);
+    return contractCache.get(key);
   };
+  const hostsContract = (f) =>
+    refHasContract(args.to, f) || refHasContract(base, f);
   for (const c of commits) {
     c.classified.destructive.push(
       ...c.classified.ui.filter(
@@ -563,7 +581,6 @@ function main() {
     ),
   };
 
-  const base = mergeBase(args.from, args.to);
   const versionMap = readFeatureVersionMap(args.to);
   const used = usedFeatureFlags(args.to);
   const featureMatrix = newFeatureFlags(base, args.to).map((flag) => ({

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * release-risk-report.mjs — build a QA checklist for a release range.
+ *
+ * Read-only. Reads git history plus the tree at --to; writes only when --out is
+ * given. Every check below maps to a rule this repo already enforces elsewhere,
+ * so a finding is always actionable rather than advisory.
+ *
+ *   R1  UI change with no e2e change            -> needs a manual pass
+ *   R2  new manager feature gate                -> needs a two-manager pass
+ *   R3  i18n keys added but not translated      -> ships raw keys / English
+ *   R4  destructive-flow file touched           -> re-verify the typed confirm
+ *   R5  user-visible feat with no manual change -> docs gap
+ *
+ * Usage:
+ *   node scripts/release-risk-report.mjs --from v26.8.1 [--to HEAD] [--out FILE] [--json]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const REC = '\x1e';
+const FIELD = '\x1f';
+
+/** Conventional-commit types that put user-visible behaviour into a release. */
+const USER_FACING_TYPES = new Set(['feat', 'fix', 'style']);
+
+/** Files whose names mark an irreversible flow (see rules/destructive-confirmation.md). */
+const DESTRUCTIVE_NAME =
+  /(Delete|DeleteForever|Purge|Terminate|Destroy|Revoke)/;
+
+/** Each store is a flat directory of per-language files beside its own en.json. */
+const LOCALE_STORES = [
+  { dir: 'resources/i18n', source: 'resources/i18n/en.json' },
+  {
+    dir: 'packages/backend.ai-ui/src/locale',
+    source: 'packages/backend.ai-ui/src/locale/en.json',
+  },
+];
+// locale/astryx is deliberately absent: it is a translation-only overlay with no
+// en.json source, so "keys added to the English source" is undefined there.
+
+const PLACEHOLDER = '__NOT_TRANSLATED__';
+
+function git(args) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+}
+
+/** A missing path at a ref is expected (files come and go); stay quiet about it. */
+function gitOrNull(args) {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      maxBuffer: 256 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function parseArgs(argv) {
+  const out = { to: 'HEAD', json: false, out: null, from: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--from') out.from = argv[++i];
+    else if (a === '--to') out.to = argv[++i];
+    else if (a === '--out') out.out = argv[++i];
+    else if (a === '--json') out.json = true;
+    else if (a === '--help' || a === '-h') out.help = true;
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  return out;
+}
+
+/**
+ * Where `to` forked from `from`. Diffing `from..to` directly would also report
+ * what `from` changed since — harmless between release tags, wrong for a branch.
+ */
+function mergeBase(from, to) {
+  return gitOrNull(['merge-base', from, to])?.trim() || from;
+}
+
+/** True when `to` forked before `from`, i.e. `from` moved on without it. */
+function forkedEarly(from, base) {
+  const resolved = gitOrNull(['rev-parse', `${from}^{commit}`])?.trim();
+  return Boolean(resolved && base && resolved !== base);
+}
+
+/** One record per non-merge commit in from..to, with its changed files. */
+function readCommits(from, to) {
+  const raw = git([
+    'log',
+    '--no-merges',
+    `--format=%H${FIELD}%s${FIELD}%b${REC}`,
+    `${from}..${to}`,
+  ]);
+  return raw
+    .split(REC)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk) => {
+      const [sha, subject, body = ''] = chunk.split(FIELD);
+      const files = git(['show', '--pretty=format:', '--name-only', sha])
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      const pr = subject.match(/\(#(\d+)\)\s*$/)?.[1] ?? null;
+      const typeMatch = subject.match(/^(\w+)(?:\(([^)]*)\))?:/);
+      return {
+        sha,
+        subject,
+        pr,
+        type: typeMatch?.[1] ?? null,
+        scope: typeMatch?.[2] ?? null,
+        fr: (subject + body).match(/FR-\d+/)?.[0] ?? null,
+        files,
+      };
+    });
+}
+
+const isGenerated = (f) => f.includes('__generated__');
+const isTestLike = (f) => /\.(test|spec|stories)\.[tj]sx?$/.test(f);
+
+export function classify(files) {
+  const ui = files.filter(
+    (f) =>
+      !isGenerated(f) &&
+      !isTestLike(f) &&
+      (/^react\/src\/.*\.tsx?$/.test(f) ||
+        /^packages\/backend\.ai-ui\/src\/(components|hooks)\/.*\.tsx?$/.test(
+          f,
+        )),
+  );
+  return {
+    ui,
+    e2e: files.filter((f) => f.startsWith('e2e/')),
+    docs: files.filter((f) => f.startsWith('packages/backend.ai-webui-docs/')),
+    i18n: files.filter(
+      (f) =>
+        f.startsWith('resources/i18n/') ||
+        f.startsWith('packages/backend.ai-ui/src/locale/'),
+    ),
+    destructive: ui.filter((f) => DESTRUCTIVE_NAME.test(f.split('/').pop())),
+  };
+}
+
+function readFeatureVersionMap(ref) {
+  const src = gitOrNull([
+    'show',
+    `${ref}:packages/backend.ai-client/src/client.ts`,
+  ]);
+  return src ? parseFeatureVersionMap(src) : new Map();
+}
+
+/**
+ * Map every feature flag declared in client.ts to the version guard it sits
+ * under, by walking `_updateSupportList` and tracking the enclosing condition.
+ */
+export function parseFeatureVersionMap(src) {
+  const lines = src.split('\n');
+  // The definition, not the call site in supports() that precedes it.
+  const start = lines.findIndex((l) =>
+    /^\s*(?:private\s+|public\s+)?_updateSupportList\s*\([^)]*\)\s*\{/.test(l),
+  );
+  if (start === -1) return new Map();
+
+  const map = new Map();
+  /** Guards currently in scope, innermost last. blockDepth = depth inside the block. */
+  const guards = [];
+  let depth = 0;
+  let entered = false;
+
+  for (let i = start; i < lines.length; i += 1) {
+    const line = lines[i];
+    const opens = (line.match(/\{/g) ?? []).length;
+    const closes = (line.match(/\}/g) ?? []).length;
+    const depthBefore = depth;
+
+    // Prettier may push the value onto the next line: _features['x'] =\n  true;
+    const decl = line.match(/_features\['([^']+)'\]\s*=\s*(true|false)?/);
+    if (decl) {
+      const value =
+        decl[2] ??
+        lines
+          .slice(i + 1, i + 3)
+          .join(' ')
+          .match(/^\s*(true|false)/)?.[1];
+      const active = guards.filter((g) => g.blockDepth <= depthBefore);
+      map.set(decl[1], {
+        version: active.length ? active[active.length - 1].version : null,
+        value: value === 'true',
+      });
+    }
+
+    const guard = line.match(
+      /is(?:Manager|API)VersionCompatibleWith\(\s*'([^']+)'\s*\)/,
+    );
+    if (guard && opens > 0)
+      guards.push({ version: guard[1], blockDepth: depthBefore + 1 });
+
+    depth = depthBefore + opens - closes;
+    if (!entered && depth > 0) entered = true;
+    while (guards.length && guards[guards.length - 1].blockDepth > depth)
+      guards.pop();
+    if (entered && depth <= 0) break;
+  }
+  return map;
+}
+
+/** Feature flags whose declaration line was ADDED between from and to. */
+function newFeatureFlags(from, to) {
+  const diff = gitOrNull([
+    'diff',
+    '--unified=0',
+    `${from}..${to}`,
+    '--',
+    'packages/backend.ai-client/src/client.ts',
+  ]);
+  if (!diff) return [];
+  return extractAddedFeatureFlags(diff);
+}
+
+/** Added `_features['x'] = true`, including the form prettier wraps onto two lines. */
+export function extractAddedFeatureFlags(diff) {
+  const lines = diff
+    .split('\n')
+    .filter((l) => l.startsWith('+') && !l.startsWith('+++'));
+  const added = new Set();
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = lines[i].match(/_features\['([^']+)'\]\s*=\s*(true|false)?/);
+    if (!m) continue;
+    const value = m[2] ?? lines[i + 1]?.match(/^\+\s*(true|false)/)?.[1];
+    if (value === 'true') added.add(m[1]);
+  }
+  return [...added];
+}
+
+/** Every supports('x') literal used in the app at ref. */
+function usedFeatureFlags(ref) {
+  const roots = [
+    'react/src',
+    'packages/backend.ai-ui/src',
+    'src',
+    'packages/backend.ai-client/src',
+  ];
+  const used = new Set();
+  const listed = gitOrNull(['ls-tree', '-r', '--name-only', ref]);
+  if (!listed) return used;
+  const files = listed
+    .split('\n')
+    .filter(
+      (f) =>
+        /\.(tsx?|jsx?)$/.test(f) &&
+        !isGenerated(f) &&
+        roots.some((r) => f.startsWith(`${r}/`)),
+    );
+  for (const f of files) {
+    const src = gitOrNull(['show', `${ref}:${f}`]);
+    if (src) for (const flag of extractSupportsUsages(src)) used.add(flag);
+  }
+  return used;
+}
+
+/**
+ * Prettier wraps long calls, so the literal may sit on its own line with a
+ * trailing comma: supports(\n  'flag',\n).
+ */
+export function extractSupportsUsages(src) {
+  return [...src.matchAll(/supports\(\s*'([a-zA-Z0-9._-]+)'\s*,?\s*\)/g)].map(
+    (m) => m[1],
+  );
+}
+
+export function flatten(obj, prefix = '', out = {}) {
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) flatten(v, key, out);
+    else out[key] = v;
+  }
+  return out;
+}
+
+function readJsonAt(ref, path) {
+  const raw = gitOrNull(['show', `${ref}:${path}`]);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Non-recursive: a nested store (locale/astryx) is its own namespace, listed separately. */
+function listLocaleFiles(ref, dir) {
+  const listed = gitOrNull(['ls-tree', '--name-only', ref, `${dir}/`]);
+  if (!listed) return [];
+  return listed.split('\n').filter((f) => f.endsWith('.json'));
+}
+
+/** Keys added to the English source in the range that never reached a locale. */
+function i18nGaps(from, to) {
+  const findings = [];
+  for (const store of LOCALE_STORES) {
+    const before = readJsonAt(from, store.source);
+    const after = readJsonAt(to, store.source);
+    if (!after) continue;
+    const beforeKeys = new Set(before ? Object.keys(flatten(before)) : []);
+    const afterFlat = flatten(after);
+    const addedKeys = Object.keys(afterFlat).filter((k) => !beforeKeys.has(k));
+    if (addedKeys.length === 0) continue;
+
+    for (const file of listLocaleFiles(to, store.dir)) {
+      if (file === store.source) continue;
+      const data = readJsonAt(to, file);
+      if (!data) continue;
+      const flat = flatten(data);
+      const missing = addedKeys.filter((k) => !(k in flat));
+      const placeholder = addedKeys.filter(
+        (k) => typeof flat[k] === 'string' && flat[k].includes(PLACEHOLDER),
+      );
+      if (missing.length || placeholder.length)
+        findings.push({
+          file,
+          addedCount: addedKeys.length,
+          missing,
+          placeholder,
+        });
+    }
+  }
+  return findings;
+}
+
+function renderMarkdown(report) {
+  const { from, to, base, commits, risks, featureMatrix, undeclared, i18n } =
+    report;
+  const L = [];
+  const link = (c) =>
+    c.pr
+      ? `[#${c.pr}](https://github.com/lablup/backend.ai-webui/pull/${c.pr})`
+      : `\`${c.sha.slice(0, 8)}\``;
+
+  L.push(`# Release risk report — \`${from}\` → \`${to}\``);
+  L.push('');
+  L.push(
+    `${commits.length} commits. Every item below is a QA action, not a defect.`,
+  );
+  if (report.divergedFrom) {
+    L.push('');
+    L.push(
+      `File comparisons use the merge base \`${base.slice(0, 8)}\`, so what \`${from}\` changed since the fork is not counted.`,
+    );
+  }
+  L.push('');
+  L.push('| Risk | Count |');
+  L.push('| --- | --- |');
+  L.push(`| R1 UI change with no e2e change | ${risks.noE2E.length} |`);
+  L.push(`| R2 new manager feature gate | ${featureMatrix.length} |`);
+  L.push(`| R3 locale files with untranslated new keys | ${i18n.length} |`);
+  L.push(`| R4 destructive flow touched | ${risks.destructive.length} |`);
+  L.push(
+    `| R5 user-visible feat with no manual change | ${risks.noDocs.length} |`,
+  );
+  L.push('');
+
+  if (featureMatrix.length) {
+    L.push('## R2 — Manager version matrix');
+    L.push('');
+    L.push(
+      'These gates are new in this range. Exercise each one against a manager that **meets** the version and one that does **not** — on the older manager the feature must be hidden, never broken.',
+    );
+    L.push('');
+    L.push('| Feature flag | Requires | Used in app |');
+    L.push('| --- | --- | --- |');
+    for (const f of featureMatrix)
+      L.push(
+        `| \`${f.flag}\` | ${f.version ? `\`${f.version}\`` : '_ungated_'} | ${f.used ? 'yes' : '**no — dead flag**'} |`,
+      );
+    L.push('');
+  }
+
+  if (undeclared.length) {
+    L.push('## R2b — Flags used but never declared (always `false`)');
+    L.push('');
+    L.push(
+      '`supports()` returns `false` for an unregistered key, so these features are silently off in every deployment.',
+    );
+    L.push('');
+    for (const f of undeclared) L.push(`- \`${f}\``);
+    L.push('');
+  }
+
+  const section = (title, note, items, render) => {
+    if (!items.length) return;
+    L.push(`## ${title}`);
+    L.push('');
+    L.push(note);
+    L.push('');
+    for (const it of items) L.push(render(it));
+    L.push('');
+  };
+
+  section(
+    'R1 — UI changed, no e2e changed',
+    'Each of these needs a manual pass, or an e2e spec before the next release.',
+    risks.noE2E,
+    (c) =>
+      `- [ ] ${link(c)} ${c.fr ? `(${c.fr}) ` : ''}${c.subject.replace(/\s*\(#\d+\)$/, '')}\n  - touched: ${c.classified.ui.slice(0, 4).join(', ')}${c.classified.ui.length > 4 ? ` +${c.classified.ui.length - 4}` : ''}`,
+  );
+
+  section(
+    'R3 — New keys not translated',
+    'Keys added to the English source in this range that never reached a locale. The UI falls back to the raw key or English.',
+    i18n,
+    (f) =>
+      `- [ ] \`${f.file}\` — ${f.missing.length} missing, ${f.placeholder.length} placeholder (of ${f.addedCount} new keys)${
+        f.missing.length
+          ? `\n  - e.g. ${f.missing
+              .slice(0, 3)
+              .map((k) => `\`${k}\``)
+              .join(', ')}`
+          : ''
+      }`,
+  );
+
+  section(
+    'R4 — Destructive flow touched',
+    'Re-verify the typed-confirmation gate (rules/destructive-confirmation.md): the danger button stays disabled until the exact name is typed.',
+    risks.destructive,
+    (c) =>
+      `- [ ] ${link(c)} ${c.subject.replace(/\s*\(#\d+\)$/, '')}\n  - ${c.classified.destructive.join(', ')}`,
+  );
+
+  section(
+    'R5 — User-visible feature with no manual change',
+    'A `feat:` that changed the UI but not the user manual. Confirm the manual does not need it.',
+    risks.noDocs,
+    (c) => `- [ ] ${link(c)} ${c.subject.replace(/\s*\(#\d+\)$/, '')}`,
+  );
+
+  if (
+    !risks.noE2E.length &&
+    !featureMatrix.length &&
+    !i18n.length &&
+    !risks.destructive.length &&
+    !risks.noDocs.length
+  ) {
+    L.push('No risk signals in this range.');
+    L.push('');
+  }
+  return L.join('\n');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.from) {
+    process.stdout.write(
+      'Usage: node scripts/release-risk-report.mjs --from <ref> [--to <ref>] [--out <file>] [--json]\n',
+    );
+    process.exit(args.help ? 0 : 2);
+  }
+
+  const commits = readCommits(args.from, args.to).map((c) => ({
+    ...c,
+    classified: classify(c.files),
+  }));
+
+  const userFacing = commits.filter(
+    (c) => c.type && USER_FACING_TYPES.has(c.type),
+  );
+
+  const risks = {
+    noE2E: userFacing.filter(
+      (c) => c.classified.ui.length > 0 && c.classified.e2e.length === 0,
+    ),
+    destructive: commits.filter((c) => c.classified.destructive.length > 0),
+    noDocs: commits.filter(
+      (c) =>
+        c.type === 'feat' &&
+        c.classified.ui.length > 0 &&
+        c.classified.docs.length === 0,
+    ),
+  };
+
+  const base = mergeBase(args.from, args.to);
+  const versionMap = readFeatureVersionMap(args.to);
+  const used = usedFeatureFlags(args.to);
+  const featureMatrix = newFeatureFlags(base, args.to).map((flag) => ({
+    flag,
+    version: versionMap.get(flag)?.version ?? null,
+    used: used.has(flag),
+  }));
+  const undeclared = [...used].filter((f) => !versionMap.has(f)).sort();
+
+  const report = {
+    from: args.from,
+    to: args.to,
+    base,
+    divergedFrom: forkedEarly(args.from, base),
+    commits,
+    risks,
+    featureMatrix,
+    undeclared,
+    i18n: i18nGaps(base, args.to),
+  };
+
+  const output = args.json
+    ? JSON.stringify(
+        {
+          ...report,
+          commits: commits.map(({ files, classified, ...rest }) => rest),
+          risks: Object.fromEntries(
+            Object.entries(risks).map(([k, v]) => [
+              k,
+              v.map((c) => ({ pr: c.pr, fr: c.fr, subject: c.subject })),
+            ]),
+          ),
+        },
+        null,
+        2,
+      )
+    : renderMarkdown(report);
+
+  if (args.out) {
+    writeFileSync(args.out, output.endsWith('\n') ? output : `${output}\n`);
+    process.stdout.write(`wrote ${args.out}\n`);
+  } else {
+    process.stdout.write(`${output}\n`);
+  }
+}
+
+// Importing this module (tests) must not run the CLI.
+if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url))
+  main();

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -195,6 +195,68 @@ export function hasDestructiveContract(src) {
   return /BAIDeleteConfirmModal|requireConfirmInput/.test(src);
 }
 
+/**
+ * Whether a diff's CHANGED lines reach destructive-flow logic — the confirm
+ * components/props or a destructive action call — as opposed to incidental
+ * edits (styling, layout) inside a file that merely hosts such a flow.
+ */
+export function diffTouchesDestructiveFlow(diff) {
+  const changed = diff
+    .split('\n')
+    .filter(
+      (l) =>
+        (l.startsWith('+') || l.startsWith('-')) &&
+        !l.startsWith('+++') &&
+        !l.startsWith('---'),
+    );
+  return changed.some((l) =>
+    /BAIDeleteConfirmModal|requireConfirmInput|confirmText|BAIPopconfirm|delete|purge|terminate|destroy|revoke/i.test(
+      l,
+    ),
+  );
+}
+
+/**
+ * The feature area a UI file belongs to, from its basename's leading word
+ * (wrapper/role prefixes stripped): BAIUserNodes -> User,
+ * AdminDeploymentPresetTable -> Deployment, VFolderNodesV2 -> VFolder.
+ * Coarse on purpose — it feeds a "which existing features changed the most"
+ * ranking, not a taxonomy.
+ */
+export function areaOf(file) {
+  const base = file
+    .split('/')
+    .pop()
+    .replace(/\.[^.]+$/, '');
+  const m = base.replace(/^(BAI|Admin|Legacy)+/, '').match(/^[A-Z]+[a-z0-9]*/);
+  return m ? m[0] : null;
+}
+
+/**
+ * Existing-feature churn, ranked: user-facing commits grouped by the areas
+ * their UI files belong to. `feat` commits are excluded — new features get
+ * their own digest section straight from the commit list.
+ */
+export function computeHotspots(commits) {
+  const areas = new Map();
+  for (const c of commits) {
+    if (c.type === 'feat' || !USER_FACING_TYPES.has(c.type ?? '')) continue;
+    const seen = new Set();
+    for (const f of c.classified.ui) {
+      const area = areaOf(f);
+      if (!area || seen.has(area)) continue;
+      seen.add(area);
+      if (!areas.has(area)) areas.set(area, { commits: 0, prs: [] });
+      const a = areas.get(area);
+      a.commits += 1;
+      if (c.pr && a.prs.length < 5) a.prs.push(c.pr);
+    }
+  }
+  return [...areas.entries()]
+    .map(([area, a]) => ({ area, ...a }))
+    .sort((x, y) => y.commits - x.commits);
+}
+
 function readFeatureVersionMap(ref) {
   const src = gitOrNull([
     'show',
@@ -808,6 +870,20 @@ function main() {
         (f) => !c.classified.destructive.includes(f) && hostsContract(f),
       ),
     );
+    // Touching a file that hosts a flow is not the signal — CHANGING the flow
+    // is. Only a diff whose changed lines reach the confirm logic counts.
+    if (c.classified.destructive.length) {
+      const diff = gitOrNull([
+        'show',
+        '--unified=0',
+        '--pretty=format:',
+        c.sha,
+        '--',
+        ...c.classified.destructive,
+      ]);
+      if (!diff || !diffTouchesDestructiveFlow(diff))
+        c.classified.destructive = [];
+    }
   }
 
   const userFacing = commits.filter(
@@ -845,6 +921,7 @@ function main() {
     risks,
     featureMatrix,
     gating: schemaGatingGaps(base, args.to),
+    hotspots: computeHotspots(commits),
     undeclared,
     i18n: i18nGaps(base, args.to),
   };

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -79,6 +79,27 @@ export function parseArgs(argv) {
 }
 
 /**
+ * `--from` has no default on purpose. No release tag is an ancestor of main here
+ * (they live on the release branches), so an inferred base would silently report
+ * a whole release when the caller meant their branch.
+ */
+function usage() {
+  const latestTag =
+    gitOrNull(['tag', '--sort=-creatordate'])?.split('\n')[0]?.trim() ||
+    '<tag>';
+  return [
+    'Usage: node scripts/release-risk-report.mjs --from <ref> [--to <ref>] [--out <file>] [--json]',
+    '',
+    '  --from <ref>  required; --to defaults to HEAD',
+    '',
+    'No default is inferred for --from — pick the one that matches the question:',
+    `  what is queued for the next release   --from ${latestTag}`,
+    `  what a shipped release contained      --from <previous tag> --to ${latestTag}`,
+    '  what my branch adds                   --from origin/main',
+  ].join('\n');
+}
+
+/**
  * Where `to` forked from `from`. Diffing `from..to` directly would also report
  * what `from` changed since — harmless between release tags, wrong for a branch.
  */
@@ -459,9 +480,7 @@ function renderMarkdown(report) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help || !args.from) {
-    process.stdout.write(
-      'Usage: node scripts/release-risk-report.mjs --from <ref> [--to <ref>] [--out <file>] [--json]\n',
-    );
+    process.stdout.write(`${usage()}\n`);
     process.exit(args.help ? 0 : 2);
   }
 

--- a/scripts/release-risk-report.test.ts
+++ b/scripts/release-risk-report.test.ts
@@ -1,7 +1,10 @@
 // @ts-nocheck
 import {
   classify,
+  findSelectionUses,
   extractAddedFeatureFlags,
+  extractAddedSchemaFields,
+  extractGraphqlTags,
   extractSupportsUsages,
   flatten,
   hasDestructiveContract,
@@ -206,6 +209,126 @@ describe('release risk report', () => {
       expect(c.e2e).toHaveLength(1);
       expect(c.docs).toHaveLength(1);
       expect(c.i18n).toHaveLength(1);
+    });
+  });
+
+  describe('extractAddedSchemaFields', () => {
+    it('reads added fields and enum values with their Added-in versions', () => {
+      const diff = [
+        '+++ b/data/schema.graphql',
+        ' type RuntimeVariantPresetUIOption',
+        ' {',
+        '+  """Added in 26.9.0. UI category group for organizing parameters."""',
+        '+  category: String',
+        '+',
+        '+  """Human-readable display label."""',
+        '+  displayName: String',
+        ' }',
+        '+enum SessionStatus',
+        '+{',
+        '+  PREEMPTED',
+        '+}',
+        ' enum OldEnum',
+        ' {',
+        '-  REMOVED_VALUE',
+        ' }',
+      ].join('\n');
+      expect(extractAddedSchemaFields(diff)).toEqual([
+        {
+          parent: 'RuntimeVariantPresetUIOption',
+          parentKind: 'type',
+          field: 'category',
+          version: '26.9.0',
+          kind: 'field',
+        },
+        {
+          parent: 'RuntimeVariantPresetUIOption',
+          parentKind: 'type',
+          field: 'displayName',
+          version: null,
+          kind: 'field',
+        },
+        {
+          parent: 'SessionStatus',
+          parentKind: 'enum',
+          field: 'PREEMPTED',
+          version: null,
+          kind: 'enum',
+        },
+      ]);
+    });
+  });
+
+  describe('findSelectionUses', () => {
+    // ModelRevision.modelDefinition -> ModelDefinition.models ->
+    // ModelDefinitionModel.service -> ModelServiceConfig
+    const typeFields = new Map([
+      ['ModelRevision', new Map([['modelDefinition', 'ModelDefinition']])],
+      ['ModelDefinition', new Map([['models', 'ModelDefinitionModel']])],
+      ['ModelDefinitionModel', new Map([['service', 'ModelServiceConfig']])],
+    ]);
+    const tag = [
+      '  fragment F on ModelRevision {',
+      '    modelDefinition {',
+      '      models {',
+      '        service {',
+      '          command @since(version: "26.7.0")',
+      '          startCommand',
+      '        }',
+      '      }',
+      '    }',
+      '  }',
+    ];
+
+    it('attributes a nested selection through its owner field type', () => {
+      const uses = findSelectionUses(
+        tag,
+        'startCommand',
+        'ModelServiceConfig',
+        typeFields,
+      );
+      expect(uses).toHaveLength(1);
+      expect(uses[0].annotated).toBe(false);
+    });
+
+    it('sees @since on the annotated sibling', () => {
+      const uses = findSelectionUses(
+        tag,
+        'command',
+        'ModelServiceConfig',
+        typeFields,
+      );
+      expect(uses).toHaveLength(1);
+      expect(uses[0].annotated).toBe(true);
+    });
+
+    it('attributes a field selected directly under `on Parent`', () => {
+      const uses = findSelectionUses(
+        ['  ... on Foo {', '    bar', '  }'],
+        'bar',
+        'Foo',
+        new Map(),
+      );
+      expect(uses).toHaveLength(1);
+    });
+
+    it('does not attribute the same field under an unrelated owner', () => {
+      const uses = findSelectionUses(
+        tag,
+        'startCommand',
+        'SomeOtherType',
+        typeFields,
+      );
+      expect(uses).toHaveLength(0);
+    });
+  });
+
+  describe('extractGraphqlTags', () => {
+    it('returns only the template contents of graphql tags', () => {
+      const src =
+        'const q = graphql`\n  query Foo { bar @since(version: "26.9.0") }\n`;\nconst other = `not a tag`;';
+      expect(extractGraphqlTags(src)).toContain('bar @since');
+      expect(extractGraphqlTags(src)).not.toContain('not a tag');
     });
   });
 

--- a/scripts/release-risk-report.test.ts
+++ b/scripts/release-risk-report.test.ts
@@ -4,6 +4,7 @@ import {
   extractAddedFeatureFlags,
   extractSupportsUsages,
   flatten,
+  hasDestructiveContract,
   parseArgs,
   parseFeatureVersionMap,
 } from './release-risk-report.mjs';
@@ -31,6 +32,19 @@ const CLIENT_SOURCE = `
     if (this.isManagerVersionCompatibleWith('26.9.0')) {
       this._features['allow-only-ro-permission-for-model-project-folder'] =
         true;
+    }
+    if (this.isManagerVersionCompatibleWith('23.09.2')) {
+      this._features[
+        'max-quota-scope-size-in-user-and-project-resource-policy'
+      ] = true;
+    }
+    if (this.isManagerVersionCompatibleWith(['24.03.10'])) {
+      this._features['endpoint-lifecycle-stage-filter'] = true;
+    }
+    if (
+      this.isManagerVersionCompatibleWith(['25.1.0', '24.09.6', '24.03.12'])
+    ) {
+      this._features['vfolder-id-based'] = true;
     }
     this._features['ungated'] = true;
   }
@@ -64,6 +78,25 @@ describe('release risk report', () => {
       expect(entry.value).toBe(true);
     });
 
+    it('reads a declaration whose key prettier wrapped inside the brackets', () => {
+      const entry = map.get(
+        'max-quota-scope-size-in-user-and-project-resource-policy',
+      );
+      expect(entry).toBeDefined();
+      expect(entry.version).toBe('23.09.2');
+      expect(entry.value).toBe(true);
+    });
+
+    it('reads an array guard, taking the first entry as the version', () => {
+      expect(map.get('endpoint-lifecycle-stage-filter').version).toBe(
+        '24.03.10',
+      );
+    });
+
+    it('reads a guard whose opening brace sits on a later line', () => {
+      expect(map.get('vfolder-id-based').version).toBe('25.1.0');
+    });
+
     it('records an unguarded flag with a null version', () => {
       expect(map.get('ungated').version).toBeNull();
     });
@@ -79,28 +112,36 @@ describe('release risk report', () => {
 
   describe('extractSupportsUsages', () => {
     it('finds a single-line call', () => {
-      expect(extractSupportsUsages("baiClient.supports('agent-select')")).toEqual([
-        'agent-select',
-      ]);
+      expect(
+        extractSupportsUsages("baiClient.supports('agent-select')"),
+      ).toEqual(['agent-select']);
     });
 
     it('finds the multi-line form with a trailing comma', () => {
-      const src = "const ok = baiClient.supports(\n  'model-mount-subpath',\n);";
+      const src =
+        "const ok = baiClient.supports(\n  'model-mount-subpath',\n);";
       expect(extractSupportsUsages(src)).toEqual(['model-mount-subpath']);
     });
   });
 
   describe('extractAddedFeatureFlags', () => {
-    it('collects added true declarations, including the wrapped form', () => {
+    it('collects added true declarations, including the wrapped forms', () => {
       const diff = [
         '+++ b/client.ts',
         "+      this._features['one'] = true;",
         "+      this._features['two'] =",
         '+        true;',
-        "+      this._features['three'] = false;",
+        '+      this._features[',
+        "+        'three-with-a-very-long-key'",
+        '+      ] = true;',
+        "+      this._features['four'] = false;",
         "-      this._features['removed'] = true;",
       ].join('\n');
-      expect(extractAddedFeatureFlags(diff).sort()).toEqual(['one', 'two']);
+      expect(extractAddedFeatureFlags(diff).sort()).toEqual([
+        'one',
+        'three-with-a-very-long-key',
+        'two',
+      ]);
     });
   });
 
@@ -116,8 +157,32 @@ describe('release risk report', () => {
     });
 
     it('flags a destructive-flow file by name', () => {
-      const c = classify(['react/src/components/DeleteForeverVFolderModal.tsx']);
+      const c = classify([
+        'react/src/components/DeleteForeverVFolderModal.tsx',
+      ]);
       expect(c.destructive).toHaveLength(1);
+    });
+
+    it('counts BUI runtime dirs beyond components/hooks as UI', () => {
+      const c = classify([
+        'packages/backend.ai-ui/src/app-shim/appShim.tsx',
+        'packages/backend.ai-ui/src/form-engine/Form.tsx',
+        'packages/backend.ai-ui/src/__test__/helpers.tsx',
+        'packages/backend.ai-ui/src/astryx-docs/Intro.tsx',
+      ]);
+      expect(c.ui).toEqual([
+        'packages/backend.ai-ui/src/app-shim/appShim.tsx',
+        'packages/backend.ai-ui/src/form-engine/Form.tsx',
+      ]);
+    });
+
+    it('counts only executable specs as e2e, not e2e/ docs', () => {
+      const c = classify([
+        'e2e/vfolder/delete.spec.ts',
+        'e2e/E2E_COVERAGE_REPORT.md',
+        'e2e/README.md',
+      ]);
+      expect(c.e2e).toEqual(['e2e/vfolder/delete.spec.ts']);
     });
 
     it('separates e2e, docs, and locale changes', () => {
@@ -132,9 +197,21 @@ describe('release risk report', () => {
     });
   });
 
+  describe('hasDestructiveContract', () => {
+    it('detects the typed-confirm contract regardless of filename', () => {
+      expect(
+        hasDestructiveContract('<BAIDeleteConfirmModal requireConfirmInput'),
+      ).toBe(true);
+      expect(hasDestructiveContract('const x = useState()')).toBe(false);
+    });
+  });
+
   describe('flatten', () => {
     it('joins nested keys with dots', () => {
-      expect(flatten({ a: { b: 'x' }, c: 'y' })).toEqual({ 'a.b': 'x', c: 'y' });
+      expect(flatten({ a: { b: 'x' }, c: 'y' })).toEqual({
+        'a.b': 'x',
+        c: 'y',
+      });
     });
   });
 

--- a/scripts/release-risk-report.test.ts
+++ b/scripts/release-risk-report.test.ts
@@ -2,6 +2,7 @@
 import {
   classify,
   findSelectionUses,
+  parseSchemaTypeFields,
   extractAddedFeatureFlags,
   extractAddedSchemaFields,
   extractGraphqlTags,
@@ -312,6 +313,16 @@ describe('release risk report', () => {
       expect(uses).toHaveLength(1);
     });
 
+    it('resolves an operation header as the Query root type', () => {
+      const uses = findSelectionUses(
+        ['query Foo {', '  group_nodes {', '    newField', '  }', '}'],
+        'newField',
+        'GroupConnection',
+        new Map([['Query', new Map([['group_nodes', 'GroupConnection']])]]),
+      );
+      expect(uses).toHaveLength(1);
+    });
+
     it('does not attribute the same field under an unrelated owner', () => {
       const uses = findSelectionUses(
         tag,
@@ -320,6 +331,24 @@ describe('release risk report', () => {
         typeFields,
       );
       expect(uses).toHaveLength(0);
+    });
+  });
+
+  describe('parseSchemaTypeFields', () => {
+    it('reads single-line and multiline field signatures', () => {
+      const schema = [
+        'type Query',
+        '{',
+        '  simple: String',
+        '  group_nodes(',
+        '    filter: String',
+        '    first: Int',
+        '  ): GroupConnection',
+        '}',
+      ].join('\n');
+      const map = parseSchemaTypeFields(schema);
+      expect(map.get('Query').get('simple')).toBe('String');
+      expect(map.get('Query').get('group_nodes')).toBe('GroupConnection');
     });
   });
 

--- a/scripts/release-risk-report.test.ts
+++ b/scripts/release-risk-report.test.ts
@@ -176,6 +176,18 @@ describe('release risk report', () => {
       ]);
     });
 
+    it('counts co-located styles and assets as UI, but not doc stubs', () => {
+      const c = classify([
+        'react/src/components/AnnouncementBanner.css',
+        'react/src/components/logo.svg',
+        'packages/backend.ai-ui/src/components/BAIDomainSelectV2.doc.ts',
+      ]);
+      expect(c.ui).toEqual([
+        'react/src/components/AnnouncementBanner.css',
+        'react/src/components/logo.svg',
+      ]);
+    });
+
     it('counts only executable specs as e2e, not e2e/ docs', () => {
       const c = classify([
         'e2e/vfolder/delete.spec.ts',

--- a/scripts/release-risk-report.test.ts
+++ b/scripts/release-risk-report.test.ts
@@ -1,0 +1,150 @@
+// @ts-nocheck
+import {
+  classify,
+  extractAddedFeatureFlags,
+  extractSupportsUsages,
+  flatten,
+  parseArgs,
+  parseFeatureVersionMap,
+} from './release-risk-report.mjs';
+
+// Mirrors client.ts: a call site precedes the definition, guards nest, and
+// prettier wraps long declarations onto a second line.
+const CLIENT_SOURCE = `
+  supports(feature: string): boolean {
+    if (Object.keys(this._features).length === 0) {
+      this._updateSupportList();
+    }
+    return this._features[feature] ?? false;
+  }
+
+  _updateSupportList() {
+    if (this.isAPIVersionCompatibleWith('v4.20190601')) {
+      this._features['scaling-group'] = true;
+    }
+    if (this.isManagerVersionCompatibleWith('22.09')) {
+      this._features['force2FA'] = true;
+      if (this.isManagerVersionCompatibleWith('25.09.0')) {
+        this._features['force2FA'] = false;
+      }
+    }
+    if (this.isManagerVersionCompatibleWith('26.9.0')) {
+      this._features['allow-only-ro-permission-for-model-project-folder'] =
+        true;
+    }
+    this._features['ungated'] = true;
+  }
+
+  somethingElse() {
+    this._features['after-the-method'] = true;
+  }
+`;
+
+describe('release risk report', () => {
+  describe('parseFeatureVersionMap', () => {
+    const map = parseFeatureVersionMap(CLIENT_SOURCE);
+
+    it('starts at the definition, not the call site that precedes it', () => {
+      // The call site sits inside supports(); starting there ended the walk early.
+      expect(map.has('scaling-group')).toBe(true);
+      expect(map.get('scaling-group').version).toBe('v4.20190601');
+    });
+
+    it('attributes a flag to its enclosing version guard', () => {
+      expect(map.get('force2FA').version).toBe('25.09.0');
+      expect(map.get('force2FA').value).toBe(false);
+    });
+
+    it('reads a declaration prettier wrapped onto the next line', () => {
+      const entry = map.get(
+        'allow-only-ro-permission-for-model-project-folder',
+      );
+      expect(entry).toBeDefined();
+      expect(entry.version).toBe('26.9.0');
+      expect(entry.value).toBe(true);
+    });
+
+    it('records an unguarded flag with a null version', () => {
+      expect(map.get('ungated').version).toBeNull();
+    });
+
+    it('stops at the end of the method', () => {
+      expect(map.has('after-the-method')).toBe(false);
+    });
+
+    it('returns an empty map when the method is absent', () => {
+      expect(parseFeatureVersionMap('class A {}').size).toBe(0);
+    });
+  });
+
+  describe('extractSupportsUsages', () => {
+    it('finds a single-line call', () => {
+      expect(extractSupportsUsages("baiClient.supports('agent-select')")).toEqual([
+        'agent-select',
+      ]);
+    });
+
+    it('finds the multi-line form with a trailing comma', () => {
+      const src = "const ok = baiClient.supports(\n  'model-mount-subpath',\n);";
+      expect(extractSupportsUsages(src)).toEqual(['model-mount-subpath']);
+    });
+  });
+
+  describe('extractAddedFeatureFlags', () => {
+    it('collects added true declarations, including the wrapped form', () => {
+      const diff = [
+        '+++ b/client.ts',
+        "+      this._features['one'] = true;",
+        "+      this._features['two'] =",
+        '+        true;',
+        "+      this._features['three'] = false;",
+        "-      this._features['removed'] = true;",
+      ].join('\n');
+      expect(extractAddedFeatureFlags(diff).sort()).toEqual(['one', 'two']);
+    });
+  });
+
+  describe('classify', () => {
+    it('counts source components as UI but not tests, stories, or generated', () => {
+      const c = classify([
+        'react/src/pages/DataPage.tsx',
+        'react/src/pages/DataPage.test.tsx',
+        'packages/backend.ai-ui/src/components/BAICard.stories.tsx',
+        'react/src/__generated__/Foo.graphql.ts',
+      ]);
+      expect(c.ui).toEqual(['react/src/pages/DataPage.tsx']);
+    });
+
+    it('flags a destructive-flow file by name', () => {
+      const c = classify(['react/src/components/DeleteForeverVFolderModal.tsx']);
+      expect(c.destructive).toHaveLength(1);
+    });
+
+    it('separates e2e, docs, and locale changes', () => {
+      const c = classify([
+        'e2e/vfolder/delete.spec.ts',
+        'packages/backend.ai-webui-docs/src/en/data.md',
+        'resources/i18n/ko.json',
+      ]);
+      expect(c.e2e).toHaveLength(1);
+      expect(c.docs).toHaveLength(1);
+      expect(c.i18n).toHaveLength(1);
+    });
+  });
+
+  describe('flatten', () => {
+    it('joins nested keys with dots', () => {
+      expect(flatten({ a: { b: 'x' }, c: 'y' })).toEqual({ 'a.b': 'x', c: 'y' });
+    });
+  });
+
+  describe('parseArgs', () => {
+    it('defaults --to to HEAD', () => {
+      expect(parseArgs(['--from', 'v1']).to).toBe('HEAD');
+    });
+
+    it('rejects an unknown argument', () => {
+      expect(() => parseArgs(['--nope'])).toThrow(/unknown argument/);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #9396 (FR-3843)

## Problem

Preparing a release train is manual every time: read the commit list by hand to know what needs QA, create the `Final Train to vX.Y.Z` Jira Story, seed the Teams thread. The questions are the same every train — what UI changed without an e2e test, which new manager feature gates need a two-manager pass, what shipped untranslated, which irreversible flows were touched, what user-visible work never reached the manual.

## What this adds

**1. The analysis** — `scripts/release-risk-report.mjs --from <ref> [--to <ref>] [--out FILE] [--json]`, read-only and dependency-free. Five checks, each mapped to a rule the repo already enforces elsewhere, so a finding is an action rather than advice:

| | Check | QA action |
| --- | --- | --- |
| R1 | UI changed, no e2e changed | manual pass, or write the spec |
| R2 | new manager feature gate | exercise on a manager that meets the version and one that does not |
| R3 | English keys added that never reached a locale | ships raw keys / English |
| R4 | destructive-flow file touched | re-verify the typed confirm (`rules/destructive-confirmation.md`) |
| R5 | user-visible `feat:` with no manual change | docs gap |

R2 reports only gates whose declaration was **added inside the range**, so flags kept for older LTS support stay out of it. It also lists any flag used but never declared — `supports()` returns `false` for an unregistered key, so such a feature would be silently off everywhere.

File comparisons run from the **merge base**, not from `--from` directly: two-dot `git diff A..B` also carries what `A` changed since the fork. The report says so in its header whenever the two differ — which includes `v26.8.1..v26.9.0-rc.3`, since 26.8 and 26.9 are separate release branches.

**2. The skill** — `.claude/skills/release-train-prep/`. Give it a Teams thread URL and it runs the report once as JSON and posts a short Korean digest ordered by how much each finding blocks the release (sections cap at five items; the 40 locale files collapse to their shape plus outliers). When `--from` is missing it fetches `origin/main` and offers four bases via AskUserQuestion — branch diff / queued for next release / whole release / since last rc — with free-form input for anything else.

With **`--train <version>`** it also opens the train the way the team already does it: duplicate-scan, create the `Final Train to v<version>` Story in the exact summary shape the team greps for, weblink the kickoff thread, wait briefly for the webhook's GitHub clone, and post the kickoff header above the digest. Deliberately out of scope, and written down as such: linking bugs to the train (a per-bug human call), go/no-go (one Jira view away), and cutting the tag (`create-release`'s job). The Teams CLI can only reply to an existing thread, so the thread itself stays human-created — matching the actual ritual.

## What it reported for v26.8.1 → v26.9.0-rc.3

114 English keys added; at the rc.3 tag, 18 of 20 host locales carried 34 `__NOT_TRANSLATED__` placeholders + 2 missing keys, and 20 BUI-store keys had reached no locale at all (`resources/i18n` placeholder count 40 → 690 across the range, measured independently of the tool). Those gaps were since fixed on main by FR-3729 / FR-3839 / FR-3841 — the report correctly describes the ref it is pointed at, and pointing it at the next rc candidate is what the "queued for next release" base is for. FR-3417 remains the gate that would stop this class recurring.

## Note for reviewers

Three parser bugs during development had one cause: prettier wraps long lines, so `supports(\n  'flag',\n)` and `_features['x'] =\n  true;` both slip past a single-line regex. Any grep-based scanner in this repo likely shares that blind spot. The tests pin all three forms.

`scripts/**` is outside `lint-staged`, the `format` glob, and the lint scope, so nothing here reformats on commit — consistent with the existing `scripts/*.mjs`.

R4 deliberately includes `refactor:` commits, not just user-facing types: FR-3533's twin-component consolidation is exactly the kind of change that can regress a confirm gate without touching its behaviour on purpose.

## Verification

- `npx vitest run scripts/release-risk-report.test.ts` — **15 passed**
- Ran on a release range (`v26.8.1..v26.9.0-rc.3`) and a branch range (`origin/main..FR-3820`). The branch range reported 20 phantom i18n findings before the merge-base fix and 0 after; release-range counts unchanged.
- Rendered the Teams digest from the real JSON as a rehearsal: 3.8 KB, every section populated from data.
- Train mode follows the existing FR-3663 / FR-3392 / FR-3238 summary shape; verified the duplicate-scan JQL against live Jira.
- No production code touched — a script, its test, and a skill.