### PR TITLE
feat(FR-3683): turn scroll-to-first-error on for every form

### DIFF
--- a/packages/backend.ai-ui/src/form-engine/Form.scrollToFirstError.test.tsx
+++ b/packages/backend.ai-ui/src/form-engine/Form.scrollToFirstError.test.tsx
@@ -13,9 +13,11 @@
      wrapper's `data-bai-field-item`;
    - a `noStyle` field, which has no wrapper of its own, lands on the parent
      item that shows its error;
-   - the switch is off until `<Form scrollToFirstError>` says otherwise;
+   - the switch is off until `<Form scrollToFirstError>` or
+     `<FormConfigProvider scrollToFirstError>` says otherwise, form winning;
    - the store's own `scrollToField` works again on such controls.
  */
+import { FormConfigProvider } from './FormConfigProvider';
 import { Form } from './engine';
 import type { FormInstance } from './interface';
 import { act, render } from '@testing-library/react';
@@ -191,6 +193,32 @@ describe('scroll to the first invalid field', () => {
   it('stays off when the form does not ask — antd’s default', async () => {
     let form!: FormInstance;
     render(<TestForm formRef={(f) => (form = f)} />);
+
+    await submit(form);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('turns on for every form below `FormConfigProvider`', async () => {
+    let form!: FormInstance;
+    render(
+      <FormConfigProvider scrollToFirstError>
+        <TestForm formRef={(f) => (form = f)} />
+      </FormConfigProvider>,
+    );
+
+    await submit(form);
+
+    expect(scrolledField()).toBe('early');
+  });
+
+  it('lets a form override the provider', async () => {
+    let form!: FormInstance;
+    render(
+      <FormConfigProvider scrollToFirstError>
+        <TestForm formRef={(f) => (form = f)} scrollToFirstError={false} />
+      </FormConfigProvider>,
+    );
 
     await submit(form);
 

--- a/packages/backend.ai-ui/src/form-engine/Form.tsx
+++ b/packages/backend.ai-ui/src/form-engine/Form.tsx
@@ -171,9 +171,15 @@ const InternalForm = <Values,>(
       onFinish?.(values);
     },
     onFinishFailed: (errorInfo: ValidateErrorEntity) => {
-      if (scrollToFirstError && errorInfo.errorFields.length) {
+      // The app turns this on for every form through `<FormConfigProvider>`;
+      // a form's own prop still wins either way.
+      const mergedScrollToFirstError =
+        scrollToFirstError ?? formConfig.scrollToFirstError;
+      if (mergedScrollToFirstError && errorInfo.errorFields.length) {
         const options =
-          typeof scrollToFirstError === 'object' ? scrollToFirstError : {};
+          typeof mergedScrollToFirstError === 'object'
+            ? mergedScrollToFirstError
+            : {};
         formInstance.scrollToField(errorInfo.errorFields[0].name, {
           focus: true,
           ...options,

--- a/packages/backend.ai-ui/src/form-engine/FormConfigProvider.tsx
+++ b/packages/backend.ai-ui/src/form-engine/FormConfigProvider.tsx
@@ -173,6 +173,7 @@ export const FormConfigProvider: React.FC<
       config.validateMessages,
       config.requiredMark,
       config.optionalLabel,
+      config.scrollToFirstError,
       localized,
       optionalLabel,
     ],

--- a/packages/backend.ai-ui/src/form-engine/context.ts
+++ b/packages/backend.ai-ui/src/form-engine/context.ts
@@ -15,6 +15,7 @@ import type {
   InternalFormInstance,
   InternalHooks,
   Meta,
+  ScrollOptions,
   ValidateMessages,
 } from './interface';
 import type { InternalNamePath } from './namePath';
@@ -111,6 +112,12 @@ export interface FormConfig {
    * `form.Optional` catalog entry, ported from the same antd strings.
    */
   optionalLabel?: React.ReactNode;
+  /**
+   * Turns scroll-to-first-error on for every form below. Off unless set —
+   * antd's `<Form scrollToFirstError>` default, kept so a consumer without
+   * this provider gets antd's behaviour (FR-3683).
+   */
+  scrollToFirstError?: boolean | ScrollOptions;
 }
 
 /** What antd sourced from `<ConfigProvider form={{...}}>`. */

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -383,8 +383,13 @@ export const DefaultProvidersForReactRoot: React.FC<{
                         appends "(Optional)" to non-required labels instead.
                         That inversion is deliberate product behaviour, not a
                         default — dropping it would put an asterisk on every
-                        required field across the app. */}
+                        required field across the app.
+                      - `scrollToFirstError` is the app-wide opt-in (FR-3683):
+                        a failed `form.submit()` lands on the first invalid
+                        field. The engine keeps antd's off-by-default, so a
+                        consumer without this provider is unsurprised. */}
                   <FormConfigProvider
+                    scrollToFirstError
                     requiredMark={(label, { required }) => (
                       <>
                         {label}


### PR DESCRIPTION
Part of #9073 (FR-3683)

> Stack 2/2 — stacked on #9204, which makes `scrollToFirstError` work at all. Merge that one first.

## What changed

#9204 fixed the mechanism and converted the one modal the report named. This turns it on **app-wide**: one line on the `<FormConfigProvider>` in `DefaultProviders`, next to the `requiredMark` default it already sets there, so a form added next month is covered without remembering the prop. A form's own prop still wins, and the engine's default stays antd's off, so a `backend.ai-ui` consumer mounting no provider is unaffected.

Because the trigger is `form.submit()`, this reaches exactly the forms that submit — today `UserSettingModal` (converted in #9204), `ImportNotebookForm` and `DeploymentAddRevisionModal` — and nothing that validates in the background. **There is no opt-out list.** The remaining modals pick it up as they convert to `submit()` + `onFinish`; that conversion is the follow-up, split by area.

`DeploymentAddRevisionModal` is left as is: its `handleOk` only calls `submit()` after its own `validateFields()` passes, so the engine's scroll never fires there and its hand-rolled DOM-order walk keeps handling the failure case.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`; `backend.ai-ui` `tsc` lane passes.
- `Form.scrollToFirstError.test.tsx` gains 2 cases: the provider turns it on for a form below it; a form's `scrollToFirstError={false}` overrides the provider.
- Full suites green with both PRs applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lefo3KxG9bKDgU2z72sxqU
