### PR TITLE
test: e2e auto-heal 2026-09-03 — antd nav-name/nested-anchor drift, Refresh aria-label, columnheader strict-mode

### DIFF
--- a/e2e/admin-model-card/admin-model-card-page-load.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-page-load.spec.ts
@@ -3,6 +3,7 @@
 import { AdminModelCardPage } from '../utils/classes/AdminModelCardPage';
 import {
   deleteForeverAndVerifyFromTrash,
+  getSortableColumnHeader,
   loginAsAdmin,
   moveToTrashAndVerify,
   webuiEndpoint,
@@ -56,31 +57,21 @@ test.describe(
       // Verify the refresh button is visible
       await expect(adminModelCardPage.getRefreshButton()).toBeVisible();
 
-      // Verify the table is rendered with the correct column headers
-      await expect(
-        page.getByRole('columnheader', { name: 'Name' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Title' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Category' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Task' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Access Level' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Domain' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Project' }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('columnheader', { name: 'Created At' }),
-      ).toBeVisible();
+      // Verify the table is rendered with the correct column headers.
+      // A columnheader's accessible name is "<label> Resize column <raw
+      // column key>" (e.g. "Domain Resize column domainName") or, for
+      // sortable columns, "Sort by <raw key>" instead of the label — both
+      // forms can substring-match an unrelated label (e.g. 'Name' matches
+      // "domainName"). Match the header's visible TEXT instead (see
+      // getSortableColumnHeader).
+      await expect(getSortableColumnHeader(page, 'Name')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Title')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Category')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Task')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Access Level')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Domain')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Project')).toBeVisible();
+      await expect(getSortableColumnHeader(page, 'Created At')).toBeVisible();
     });
 
     // 1.2 Superadmin can see model card rows with correct data in the table

--- a/e2e/agent/agent.spec.ts
+++ b/e2e/agent/agent.spec.ts
@@ -1,54 +1,50 @@
 import { loginAsAdmin } from '../utils/test-util';
-import { checkActiveTab, findColumnIndex } from '../utils/test-util-antd';
-import { test, expect, Locator } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page, request }) => {
   await loginAsAdmin(page, request);
   await page.getByRole('link', { name: 'Admin Settings' }).click();
-  await page.getByRole('link', { name: 'hdd Resources' }).click();
+  // antd is gone; the sidebar icon no longer prefixes the link's accessible
+  // name with its glyph name ("hdd").
+  await page.getByRole('link', { name: 'Resources' }).click();
   await expect(
     page.getByTestId('webui-breadcrumb').getByText('Resources'),
   ).toBeVisible();
-  await page.waitForLoadState('networkidle');
-  // Click on Agent tab if not already active
-  await page.getByRole('tab', { name: 'Agent' }).click();
+  // Click on Agent tab if not already active. `BAITabList` / Astryx
+  // `TabList` renders a `nav[aria-label="Tabs"]` of plain `<button>`s —
+  // `role="tab"` is never emitted.
+  await page
+    .getByRole('navigation', { name: 'Tabs' })
+    .getByRole('button', { name: 'Agent' })
+    .click();
 });
 
 test.describe(
   'Agent list',
   { tag: ['@regression', '@agent', '@functional'] },
   () => {
-    let agentListTable: Locator;
-
-    test.beforeEach(async ({ page }) => {
-      const firstCard = await page
-        .locator('.ant-layout-content .ant-card')
-        .first();
-      agentListTable = await firstCard.locator('.ant-table');
-    });
-
     test('should have at least one connected agent', async ({ page }) => {
-      const firstCard = await page
-        .locator('.ant-layout-content .ant-card')
-        .first();
-      await checkActiveTab(firstCard.locator('.ant-tabs'), 'Agent');
+      // The active tab is marked with `aria-current="true"`, not an antd
+      // `.ant-tabs-tab-active` class.
+      await expect(
+        page
+          .getByRole('navigation', { name: 'Tabs' })
+          .getByRole('button', { name: 'Agent' }),
+      ).toHaveAttribute('aria-current', 'true');
 
-      await page.getByText('Connected', { exact: true }).click();
+      await page.getByRole('radio', { name: 'Connected', exact: true }).check();
       await expect(page.getByRole('main')).toContainText('Connected');
 
-      const rows = await agentListTable.locator('.ant-table-row');
-      const rowCount = await rows.count();
+      // BAITable renders a plain HTML table, not antd's `.ant-table-row` /
+      // `.ant-table-cell` markup.
+      const dataRows = page.getByRole('table').locator('tbody tr');
+      const rowCount = await dataRows.count();
       expect(rowCount).toBeGreaterThan(0);
-      const firstRow = rows.first();
 
-      const columnIndex = await findColumnIndex(
-        agentListTable,
-        'ID / Endpoint',
-      );
-      const specificColumn = await firstRow
-        .locator('.ant-table-cell')
-        .nth(columnIndex);
-      const columnText = await specificColumn.textContent();
+      // "ID / Endpoint" is the fixed-left first column, so its cell is
+      // always the row's first `cell`.
+      const firstAgentCell = dataRows.first().getByRole('cell').first();
+      const columnText = await firstAgentCell.textContent();
       const firstAgentId = columnText?.split('tcp://')[0];
       expect(firstAgentId).toBeTruthy();
     });

--- a/e2e/auto-scaling-rule-preset/preset-integration.spec.ts
+++ b/e2e/auto-scaling-rule-preset/preset-integration.spec.ts
@@ -107,7 +107,7 @@ async function uploadFixturesToVFolder(
 
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),
-    page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+    page.getByRole('menuitem', { name: 'Upload Files' }).click(),
   ]);
 
   const mockServerContent = fs.readFileSync(

--- a/e2e/maintenance/maintenance.spec.ts
+++ b/e2e/maintenance/maintenance.spec.ts
@@ -8,8 +8,12 @@ import { test, expect } from '@playwright/test';
 test.beforeEach(async ({ page, request }) => {
   await loginAsAdmin(page, request);
   await page.getByRole('link', { name: 'Admin Settings' }).click();
-  await page.getByRole('link', { name: 'tool Maintenance' }).click();
-  await page.waitForLoadState('networkidle');
+  // antd is gone; the sidebar icon no longer prefixes the link's accessible
+  // name with its glyph name ("tool").
+  await page.getByRole('link', { name: 'Maintenance' }).click();
+  await expect(
+    page.getByRole('button', { name: 'Recalculate Usage' }),
+  ).toBeVisible();
 });
 
 test.describe(

--- a/e2e/plugin/plugin-system.spec.ts
+++ b/e2e/plugin/plugin-system.spec.ts
@@ -192,10 +192,9 @@ test.describe.parallel(
         // 2. Login as admin
         await loginAsAdmin(page, request);
 
-        // 3. Verify the plugin menu item links to the plugin route
-        const pluginLink = page
-          .getByRole('link', { name: 'Open Backend.AI' })
-          .locator('a');
+        // 3. Verify the plugin menu item links to the plugin route. The
+        // sidebar link IS the anchor now (no nested antd `Menu.Item` <a>).
+        const pluginLink = page.getByRole('link', { name: 'Open Backend.AI' });
         await expect(pluginLink).toHaveAttribute('href', /\/test-plugin/);
 
         // 4. Verify clicking opens a new tab (externalLink type plugin)

--- a/e2e/plugin/plugin-system.spec.ts
+++ b/e2e/plugin/plugin-system.spec.ts
@@ -18,6 +18,14 @@ const ADMIN_PLUGIN_JS = readPluginFixture('admin-test-plugin.js');
 const PLUGIN_A_JS = readPluginFixture('plugin-a.js');
 const PLUGIN_B_JS = readPluginFixture('plugin-b.js');
 
+// Vite's dev server appends `?import` to dynamically imported module URLs
+// (`/dist/plugins/<name>.js?import`), which a `**/<name>.js` glob does not
+// match, so the plugin silently 404s on a dev server while the production
+// bundle requests the bare path. Match both.
+function pluginScript(name: string): RegExp {
+  return new RegExp(`/dist/plugins/${name}\\.js(\\?.*)?$`);
+}
+
 test.describe.parallel(
   'Plugin System',
   { tag: ['@plugin', '@functional', '@regression'] },
@@ -37,7 +45,7 @@ test.describe.parallel(
         });
 
         // 2. Serve the plugin JS inline
-        await page.route('**/dist/plugins/test-plugin.js', async (route) => {
+        await page.route(pluginScript('test-plugin'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -64,7 +72,7 @@ test.describe.parallel(
         });
 
         // 2. Serve the plugin JS inline
-        await page.route('**/dist/plugins/test-plugin.js', async (route) => {
+        await page.route(pluginScript('test-plugin'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -91,16 +99,13 @@ test.describe.parallel(
         });
 
         // 2. Serve the admin plugin JS inline
-        await page.route(
-          '**/dist/plugins/admin-test-plugin.js',
-          async (route) => {
-            await route.fulfill({
-              status: 200,
-              contentType: 'application/javascript',
-              body: ADMIN_PLUGIN_JS,
-            });
-          },
-        );
+        await page.route(pluginScript('admin-test-plugin'), async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: ADMIN_PLUGIN_JS,
+          });
+        });
 
         // 3. Login as admin after setting up routes
         await loginAsAdmin(page, request);
@@ -147,7 +152,7 @@ test.describe.parallel(
         });
 
         // 2. Route the plugin JS to return 404
-        await page.route('**/dist/plugins/broken-plugin.js', async (route) => {
+        await page.route(pluginScript('broken-plugin'), async (route) => {
           await route.fulfill({ status: 404 });
         });
 
@@ -181,7 +186,7 @@ test.describe.parallel(
           plugin: { page: 'test-plugin' },
         });
 
-        await page.route('**/dist/plugins/test-plugin.js', async (route) => {
+        await page.route(pluginScript('test-plugin'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -220,16 +225,13 @@ test.describe.parallel(
           plugin: { page: 'admin-test-plugin' },
         });
 
-        await page.route(
-          '**/dist/plugins/admin-test-plugin.js',
-          async (route) => {
-            await route.fulfill({
-              status: 200,
-              contentType: 'application/javascript',
-              body: ADMIN_PLUGIN_JS,
-            });
-          },
-        );
+        await page.route(pluginScript('admin-test-plugin'), async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: ADMIN_PLUGIN_JS,
+          });
+        });
 
         // 2. Login as USER (not admin)
         await loginAsUser(page, request);
@@ -256,7 +258,7 @@ test.describe.parallel(
           menu: { blocklist: 'test-plugin' },
         });
 
-        await page.route('**/dist/plugins/test-plugin.js', async (route) => {
+        await page.route(pluginScript('test-plugin'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -283,7 +285,7 @@ test.describe.parallel(
           menu: { blocklist: 'chat' },
         });
 
-        await page.route('**/dist/plugins/test-plugin.js', async (route) => {
+        await page.route(pluginScript('test-plugin'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -319,7 +321,7 @@ test.describe.parallel(
         });
 
         // 2. Route both plugin JS files
-        await page.route('**/dist/plugins/plugin-a.js', async (route) => {
+        await page.route(pluginScript('plugin-a'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -327,7 +329,7 @@ test.describe.parallel(
           });
         });
 
-        await page.route('**/dist/plugins/plugin-b.js', async (route) => {
+        await page.route(pluginScript('plugin-b'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -357,7 +359,7 @@ test.describe.parallel(
         });
 
         // 2. Route plugin-a with valid JS, broken-plugin with 404
-        await page.route('**/dist/plugins/plugin-a.js', async (route) => {
+        await page.route(pluginScript('plugin-a'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
@@ -365,7 +367,7 @@ test.describe.parallel(
           });
         });
 
-        await page.route('**/dist/plugins/broken-plugin.js', async (route) => {
+        await page.route(pluginScript('broken-plugin'), async (route) => {
           await route.fulfill({ status: 404 });
         });
 
@@ -405,7 +407,7 @@ test.describe.parallel(
           plugin: { page: 'test-plugin' },
         });
 
-        await page.route('**/dist/plugins/test-plugin.js', async (route) => {
+        await page.route(pluginScript('test-plugin'), async (route) => {
           await route.fulfill({
             status: 200,
             contentType: 'application/javascript',

--- a/e2e/serving/serving-deploy-lifecycle.spec.ts
+++ b/e2e/serving/serving-deploy-lifecycle.spec.ts
@@ -57,11 +57,12 @@ const HEALTH_CHECK_INTERVAL = 5_000; // 5 seconds
 /**
  * Locates the BAIFetchKeyButton (refresh/reload button) on the serving page.
  * The icon is lucide `RotateCw` (no antd `.anticon-reload` class since ticket
- * 12); the button carries the native `title="Refresh"` attribute instead
+ * 12); its hover text is an Astryx tooltip (not a native `title` attribute),
+ * but the button always carries `aria-label="Refresh"`
  * (`packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx`).
  */
 function getTableRefreshButton(page: Page) {
-  return page.locator('button[title="Refresh"]').first();
+  return page.getByRole('button', { name: 'Refresh', exact: true }).first();
 }
 
 /**

--- a/e2e/serving/serving-deploy-lifecycle.spec.ts
+++ b/e2e/serving/serving-deploy-lifecycle.spec.ts
@@ -87,7 +87,7 @@ async function uploadFixturesToVFolder(
 
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),
-    page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+    page.getByRole('menuitem', { name: 'Upload Files' }).click(),
   ]);
 
   const mockServerContent = fs.readFileSync(

--- a/e2e/utils/classes/AdminModelCardPage.ts
+++ b/e2e/utils/classes/AdminModelCardPage.ts
@@ -322,9 +322,14 @@ export class AdminModelCardPage {
     await expect(dropdown.getByRole('option').first()).toBeVisible({
       timeout: 15000,
     });
-    // Click the option matching the folder name
+    // Click the option matching the folder name. The option's accessible
+    // name is "<folder name> <vfolder id>" (the id is rendered as trailing
+    // copyable text), so an exact match on the bare name never matches —
+    // anchor on the name as a prefix instead.
     await dropdown
-      .getByRole('option', { name: folderName, exact: true })
+      .getByRole('option', {
+        name: new RegExp(`^${this.escapeRegExp(folderName)}\\b`),
+      })
       .click();
     // Wait for dropdown to close
     await expect(dropdown).toBeHidden({ timeout: 10000 });
@@ -375,8 +380,12 @@ export class AdminModelCardPage {
         timeout: 10000,
       });
       if (fields.vfolderTitle) {
+        // Same trailing-id accessible-name shape as createNewFolderViaPlus —
+        // anchor on the title as a prefix rather than an exact match.
         await dropdown
-          .getByRole('option', { name: fields.vfolderTitle, exact: true })
+          .getByRole('option', {
+            name: new RegExp(`^${this.escapeRegExp(fields.vfolderTitle)}\\b`),
+          })
           .click();
       } else {
         await dropdown.getByRole('option').first().click();
@@ -523,9 +532,13 @@ export class AdminModelCardPage {
     await expect(this.getCreateModal()).toBeVisible();
     await this.fillCreateModal(fields);
     await this.getCreateModalSubmitButton().click();
+    // The mutation can lag well past 15s on the shared nightly cluster (the
+    // create succeeds server-side but the toast lands later), so this window
+    // matches the other slow-mutation waits in this class (e.g.
+    // deleteModelCardByName's 30s).
     await expect(
       this.page.getByText('Model card has been created.'),
-    ).toBeVisible({ timeout: 15000 });
+    ).toBeVisible({ timeout: 30000 });
     await expect(this.getCreateModal()).toBeHidden();
   }
 

--- a/e2e/utils/classes/AdminModelCardPage.ts
+++ b/e2e/utils/classes/AdminModelCardPage.ts
@@ -531,15 +531,33 @@ export class AdminModelCardPage {
     await this.getCreateModelCardButton().click();
     await expect(this.getCreateModal()).toBeVisible();
     await this.fillCreateModal(fields);
+    // Synchronize on the mutation itself, not the success toast: the toast is
+    // transient and a leftover one from a previous create would satisfy the
+    // next call even if this mutation failed. The mutation can lag well past
+    // 15s on the shared nightly cluster, hence the 30s window.
+    const createResponsePromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/admin/gql') &&
+        (response.request().postData() ?? '').includes(
+          'AdminModelCardSettingModalCreateMutation',
+        ),
+      { timeout: 30000 },
+    );
     await this.getCreateModalSubmitButton().click();
-    // The mutation can lag well past 15s on the shared nightly cluster (the
-    // create succeeds server-side but the toast lands later), so this window
-    // matches the other slow-mutation waits in this class (e.g.
-    // deleteModelCardByName's 30s).
-    await expect(
-      this.page.getByText('Model card has been created.'),
-    ).toBeVisible({ timeout: 30000 });
-    await expect(this.getCreateModal()).toBeHidden();
+    const createResponse = await createResponsePromise;
+    if (!createResponse.ok()) {
+      throw new Error(
+        `Model card create mutation returned ${createResponse.status()}: ${await createResponse.text()}`,
+      );
+    }
+    const createBody = await createResponse.json();
+    if (createBody.errors) {
+      throw new Error(
+        `Model card create mutation returned errors: ${JSON.stringify(createBody.errors)}`,
+      );
+    }
+    // Durable success signal — the modal only closes once the mutation resolved.
+    await expect(this.getCreateModal()).toBeHidden({ timeout: 30000 });
   }
 
   async deleteModelCardByName(name: string): Promise<void> {

--- a/e2e/utils/classes/vfolder/FolderExplorerModal.ts
+++ b/e2e/utils/classes/vfolder/FolderExplorerModal.ts
@@ -49,8 +49,11 @@ export class FolderExplorerModal {
   }
 
   async getUploadButton(): Promise<Locator> {
+    // Astryx DropdownMenu trigger: accessible name is the visible label only
+    // (no antd icon-name prefix).
     const uploadButton = this.modal.getByRole('button', {
-      name: 'upload Upload',
+      name: 'Upload',
+      exact: true,
     });
     await expect(uploadButton).toBeVisible({ timeout: 10000 });
     // Give the modal toolbar a moment to settle so click() doesn't fail with

--- a/e2e/utils/cleanup-util.ts
+++ b/e2e/utils/cleanup-util.ts
@@ -11,12 +11,13 @@ import { Page } from '@playwright/test';
 
 /**
  * Locates the BAIFetchKeyButton (refresh/reload button). The icon is lucide
- * `RotateCw` (no antd `.anticon-reload` class since ticket 12); the button
- * carries the native `title="Refresh"` attribute instead
+ * `RotateCw` (no antd `.anticon-reload` class since ticket 12); its hover
+ * text is an Astryx tooltip (not a native `title` attribute), but the
+ * button always carries `aria-label="Refresh"`
  * (`packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx`).
  */
 function getTableRefreshButton(page: Page) {
-  return page.locator('button[title="Refresh"]').first();
+  return page.getByRole('button', { name: 'Refresh', exact: true }).first();
 }
 
 /**

--- a/e2e/utils/cleanup-util.ts
+++ b/e2e/utils/cleanup-util.ts
@@ -22,7 +22,7 @@ function getTableRefreshButton(page: Page) {
 
 /**
  * Deletes all services matching the given pattern from the serving page.
- * Uses the table refresh button + delete icon button + Ant Design confirm modal.
+ * Uses the table refresh button + delete icon button + the Astryx confirm dialog.
  */
 export async function sweepServices(
   page: Page,
@@ -62,15 +62,21 @@ export async function sweepServices(
     }
     await deleteBtn.click();
 
-    const confirmBtn = page
-      .locator('.ant-modal-confirm')
+    // The confirmation is an Astryx dialog — the old `.ant-modal-confirm`
+    // scope matched nothing, so the click was silently skipped while the
+    // counter still advanced, reporting progress the sweep never made.
+    const confirmDialog = page.getByRole('dialog');
+    const confirmBtn = confirmDialog
       .getByRole('button', { name: 'Delete' })
       .first();
-    if (await confirmBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await confirmBtn.click();
+    if (!(await confirmBtn.isVisible({ timeout: 5000 }).catch(() => false))) {
+      console.log('Delete confirmation dialog did not appear, stopping sweep');
+      break;
     }
-
-    await page.waitForTimeout(3000);
+    await confirmBtn.click();
+    // Only count a service as swept once the dialog closed and the row is gone.
+    await confirmDialog.waitFor({ state: 'hidden', timeout: 30000 });
+    await serviceRow.waitFor({ state: 'detached', timeout: 30000 });
     deleted++;
   }
 

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -486,6 +486,15 @@ export async function selectPropertyFilter(
     await page.getByRole('combobox', { name: 'Value' }).click();
     await page.getByRole('option', { name: searchValue, exact: true }).click();
   }
+
+  // Committing the value hands focus back to the search bar, which reopens
+  // the field typeahead (listbox "Search results") over the first table rows
+  // and intercepts clicks on their action buttons. Close it before returning.
+  const typeahead = page.getByRole('listbox', { name: 'Search results' });
+  if (await typeahead.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await searchBar.press('Escape');
+    await expect(typeahead).toBeHidden({ timeout: 5000 });
+  }
 }
 
 /**
@@ -678,11 +687,12 @@ export async function moveToTrashAndVerify(
   });
   await expect(moveToTrashButton).toBeEnabled({ timeout: 10000 });
   await moveToTrashButton.click();
-  // The "Move to trash" confirmation modal uses a standardized "Confirm"
-  // button (t('button.Confirm')) instead of "Move".
+  // The "Move to trash" confirmation is the app-shim `modal.confirm`, which
+  // renders as role="alertdialog" (not "dialog") with a "Confirm" button; the
+  // old `.ant-modal-confirm` scope matched nothing.
   const confirmButton = page
-    .locator('.ant-modal-confirm')
-    .getByRole('button', { name: 'Confirm' });
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Confirm', exact: true });
   await expect(confirmButton).toBeVisible();
   // Wait for the DELETE /folders API response so a rejected request fails
   // here with the status/body instead of surfacing as a row-gone timeout.
@@ -755,7 +765,9 @@ export async function deleteForeverAndVerifyFromTrash(
   // Wait for confirmation modal to appear before interacting with it.
   // Use fill() directly (it waits for actionability) to avoid flakiness from
   // click() on a modal still playing its open animation ("element is not stable").
-  const confirmInput = page.locator('#confirmText');
+  // `BAIDeleteConfirmModal`'s typed-confirm input carries no `#confirmText`
+  // id on the Astryx build; it is the dialog's only textbox.
+  const confirmInput = page.getByRole('dialog').getByRole('textbox');
   await expect(confirmInput).toBeVisible();
   await confirmInput.fill(folderName);
   await page.getByRole('button', { name: 'Delete forever' }).click();

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -490,13 +490,15 @@ export async function selectPropertyFilter(
 
 /**
  * Locates the table refresh button (BAIFetchKeyButton). The icon is lucide
- * `RotateCw` (no antd `.anticon-reload` class since ticket 12); the button
- * carries the native `title="Refresh"` attribute instead
- * (`packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx`).
- * Clicking it bumps the list's fetchKey, forcing a network-only refetch.
+ * `RotateCw` (no antd `.anticon-reload` class since ticket 12); its hover
+ * text is an Astryx tooltip (not a native `title` attribute), but the
+ * button always carries `aria-label="Refresh"`
+ * (`packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx`), so match
+ * on the accessible name instead. Clicking it bumps the list's fetchKey,
+ * forcing a network-only refetch.
  */
 export function getTableRefreshButton(page: Page) {
-  return page.locator('button[title="Refresh"]').first();
+  return page.getByRole('button', { name: 'Refresh', exact: true }).first();
 }
 
 /**

--- a/e2e/vfolder/file-upload-duplicate.spec.ts
+++ b/e2e/vfolder/file-upload-duplicate.spec.ts
@@ -77,7 +77,7 @@ test.describe(
         await uploadButton.click();
         const [fileChooser] = await Promise.all([
           page.waitForEvent('filechooser'),
-          page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+          page.getByRole('menuitem', { name: 'Upload Files' }).click(),
         ]);
         await fileChooser.setFiles([testFilePath]);
         await modal.verifyFileVisible(path.basename(testFilePath));
@@ -131,7 +131,7 @@ test.describe(
 
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
-        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+        page.getByRole('menuitem', { name: 'Upload Files' }).click(),
       ]);
 
       await fileChooser.setFiles([testFilePath]);
@@ -170,7 +170,7 @@ test.describe(
       // 4. Upload the same file again
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
-        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+        page.getByRole('menuitem', { name: 'Upload Files' }).click(),
       ]);
 
       await fileChooser.setFiles([testFilePath]);

--- a/e2e/vfolder/file-upload-subdirectory.spec.ts
+++ b/e2e/vfolder/file-upload-subdirectory.spec.ts
@@ -140,7 +140,7 @@ test.describe(
 
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
-        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+        page.getByRole('menuitem', { name: 'Upload Files' }).click(),
       ]);
 
       await fileChooser.setFiles([testFilePath]);

--- a/e2e/vfolder/file-upload.spec.ts
+++ b/e2e/vfolder/file-upload.spec.ts
@@ -130,7 +130,7 @@ test.describe(
       // 4. In the dropdown, click "Upload Files" button and handle file chooser
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
-        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+        page.getByRole('menuitem', { name: 'Upload Files' }).click(),
       ]);
 
       // 5. Upload a single test file
@@ -160,7 +160,7 @@ test.describe(
       // 4. In the dropdown, click "Upload Files" and handle file chooser
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
-        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+        page.getByRole('menuitem', { name: 'Upload Files' }).click(),
       ]);
 
       // 5. Upload multiple test files


### PR DESCRIPTION
Produced automatically by the **daily digest auto-heal** (2026-09-03 run). Every change here is test-side only — no file under `react/` or `packages/` is touched. Each healed test was re-run against the nightly cluster and verified passing before this PR was opened.

Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-09-03.md` (run: 714 total · 295 passed · 97 failed; triage: 16 HEAL / 81 HUMAN).

## Healed (re-run verified)

| Spec | Drift | Fix |
|---|---|---|
| `e2e/maintenance/maintenance.spec.ts` | Sidebar link locator assumed the antd icon-prefixed accessible name `"tool Maintenance"` | → `"Maintenance"`; replaced a `networkidle` wait with a concrete visibility assertion. **3 passed** |
| `e2e/agent/agent.spec.ts` | Same family (`"hdd Resources"`). Fixing it surfaced two more antd-only branches behind it: `getByRole('tab', …)` (Astryx `TabList` emits no `role="tab"`) and a body full of `.ant-layout-content` / `.ant-card` / `.ant-table*` / `.ant-tabs` selectors | Role-based locators (`nav[aria-label="Tabs"]` + button, `aria-current`, `getByRole('cell')`). **3 passed** |
| `e2e/plugin/plugin-system.spec.ts` | `getByRole('link', …).locator('a')` assumed the old antd `Menu.Item` nested anchor | Assert `toHaveAttribute` on the link itself. **14 passed** |
| `e2e/session/session-detail-drawer-transition-delay.spec.ts` (via `e2e/utils/test-util.ts`) | `getTableRefreshButton()` matched `button[title="Refresh"]`, but `BAIFetchKeyButton`'s hover text is an Astryx tooltip now — only `aria-label` is reliable | `getByRole('button', { name: 'Refresh', exact: true })`. **3 passed** |
| `e2e/admin-model-card/admin-model-card-page-load.spec.ts` — "Superadmin can view the … management page" | `columnheader` strict-mode collision: each BAITable header's accessible name is `"<label> Resize column <raw key>"`, and `domainName` ends in `Name`, so `{name:'Name'}` matched both Name and Domain | Reused `getSortableColumnHeader()` (added by #9384) for all 8 header assertions. **3 consecutive re-runs passed** |

### Silent-fallback cleanup

The `title="Refresh"` helper had been **duplicated**, not imported, into `e2e/utils/cleanup-util.ts` and `e2e/serving/serving-deploy-lifecycle.spec.ts`, where both copies were silently no-op'ing behind `.isVisible(…).catch(() => false)` guards. Both are fixed here. The shared helper's other consumer, `retryWithTableRefresh`, already tolerates click failures via `.catch()`, so no other call site regresses.

### `AdminModelCardPage.ts`

Two real drifts found while healing the spec above: the VFolder-select option locator used `exact: true` against an accessible name that now carries a trailing folder id (`"<name> <uuid>"`), so it never matched (fixed with an anchored-prefix regex in both `createNewFolderViaPlus` and `fillCreateModal`), and the "Model card has been created." toast wait was raised 15s → 30s after confirming the create mutation does succeed server-side but can lag past 15s on this cluster.

## Retry budget exhausted (1)

`admin-model-card-page-load.spec.ts` — "Superadmin can see model card rows with correct data in the table". The two locator drifts above were real and are fixed, but the test then failed on two *different* subsequent symptoms (duplicate-name toast timeout, then a plain `waitForTableLoad` 30s timeout on navigation), both consistent with nightly-cluster latency rather than a stable contract drift. Left failing rather than forced green; the next run will show whether it stabilises. A leftover model card named `e2e-test-pageload-16-1788396755651` may still exist on the nightly cluster from the debug session.

cc @nowgnuesLee (daily digest operator)


---

## Copilot review round (resolved)

Copilot raised 2 comments, both legitimate and both fixed in `62e24340e`:

1. **`e2e/utils/cleanup-util.ts`** — fixing the refresh locator alone did not make `sweepServices()` functional: the confirmation was still scoped through `.ant-modal-confirm`, which matches nothing, so the click was silently skipped while `deleted` still incremented — the teardown reported progress it never made. Now scoped via `getByRole('dialog')`, `break`s with a log when the dialog does not appear, and increments only after the dialog is hidden **and** the row is detached.

2. **`e2e/utils/classes/AdminModelCardPage.ts`** — waiting on a transient success toast (and for longer) meant a leftover toast could satisfy the next create even if that mutation failed. `createModelCard()` now synchronizes on the `AdminModelCardSettingModalCreateMutation` response (HTTP status **and** the GraphQL `errors` array) and asserts modal closure as the durable signal.

### ⚠️ That second fix surfaced a real backend failure

With the toast wait removed, the "retry budget exhausted" test above stopped timing out and started reporting the actual cause:

```
ModelCardGQL.__init__() got an unexpected keyword argument 'min_resource'
  path: ["adminCreateModelCardV2"]
  code: backendai_generic_internal-error (strawberry)
```

`adminCreateModelCardV2` is failing server-side on the nightly cluster. The original "cluster latency" diagnosis in this PR was wrong — the toast wait had been masking a manager-side error as a timeout. **`admin-model-card-page-load.spec.ts` — "Superadmin can see model card rows with correct data in the table" is therefore an app/backend issue, not test drift**, and is reclassified to needs-human in today's digest. The test now fails fast with the real error instead of a 30s toast timeout, which is the point of the change.

Re-run after both fixes: `3 passed, 2 skipped, 1 failed` — the single failure being the backend error above.


---

## Follow-up heal round (re-run of this PR against a Vite dev server, 2026-09-03)

Re-running the healed specs on a fresh `pnpm dev` server for this branch (backend `10.82.130.172:8090`, manager 26.8.0rc1) surfaced five more drifts, all test-side, that the first round did not reach. Each was reproduced with a live probe before the fix and re-run afterwards.

| Where | Drift | Fix |
|---|---|---|
| `e2e/plugin/plugin-system.spec.ts` (8 of 12 failed) | Vite's dev server appends `?import` to dynamically imported module URLs (`/dist/plugins/test-plugin.js?import`), so the `**/dist/plugins/<name>.js` route globs never matched and every plugin 404'd. The production bundle requests the bare path, which is why the earlier run passed. | `pluginScript(name)` regex helper that matches both forms; all 13 `page.route` calls use it. **12 passed** |
| `e2e/utils/classes/vfolder/FolderExplorerModal.ts` `getUploadButton()` | `'upload Upload'` was the antd icon-prefixed name; the Astryx `DropdownMenu` trigger is named `Upload`. | `{ name: 'Upload', exact: true }` |
| `serving-deploy-lifecycle.spec.ts`, `file-upload*.spec.ts`, `preset-integration.spec.ts` (8 call sites) | `getByRole('button', { name: 'file-add Upload Files' })` — same family; the dropdown entry is now a `menuitem` named `Upload Files`. | `getByRole('menuitem', { name: 'Upload Files' })` |
| `e2e/utils/test-util.ts` `moveToTrashAndVerify` | Confirm was scoped through `.ant-modal-confirm`; the app-shim `modal.confirm` renders `role="alertdialog"`. **This is why the global cleanup's admin sweep was timing out at 10 min every run** — every `Move to trash` silently failed, so the `e2e-*` backlog only ever grew. | `getByRole('alertdialog').getByRole('button', { name: 'Confirm', exact: true })` |
| `e2e/utils/test-util.ts` `selectPropertyFilter` | After committing a Name filter, focus returns to the search bar and the field typeahead (`listbox "Search results"`) reopens over the first table rows, intercepting the action-button click (`<span>Status</span> … subtree intercepts pointer events`). | Press `Escape` on the search bar and wait for the listbox to hide before returning. |
| `e2e/utils/test-util.ts` `deleteForeverAndVerifyFromTrash` | `#confirmText` id is gone from `BAIDeleteConfirmModal`'s typed-confirm input (already handled per-spec in `project-crud` / `rbac-role-detail` / `resource-policy`, not in the shared helper). | `getByRole('dialog').getByRole('textbox')`, same as those specs. |

With the three shared-helper fixes the `cleanup` project drained the backlog on the nightly cluster in one run: **removed 19 folder(s), purged 3 leftover e2e-* users, 2 passed (8.5m)** — previously 0 removed and a 10-min timeout.

Still failing, and still not test drift: `admin-model-card-page-load.spec.ts › Superadmin can see model card rows with correct data in the table` — `adminCreateModelCardV2` returns `ModelCardGQL.__init__() got an unexpected keyword argument 'min_resource'` (backend, as classified above).

One thing to know when running this suite against a dev server: do **not** bake `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD` into it — with those set the login form is skipped and every `login()` dies on `getByLabel('Email or Username')`. Endpoint only.
