### PR TITLE
chore: drop the @license marker from co-located CSS headers

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAlert.css
+++ b/packages/backend.ai-ui/src/components/BAIAlert.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIAlert> — ONE rule, restoring Astryx `Banner`'s own

--- a/packages/backend.ai-ui/src/components/BAIAppShell.css
+++ b/packages/backend.ai-ui/src/components/BAIAppShell.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIAppShell> (FR-3612).

--- a/packages/backend.ai-ui/src/components/BAIBadge.css
+++ b/packages/backend.ai-ui/src/components/BAIBadge.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIBadge> (to-astryx phase 3, ticket A). Imported by

--- a/packages/backend.ai-ui/src/components/BAICard.css
+++ b/packages/backend.ai-ui/src/components/BAICard.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAICard` co-located CSS (to-astryx phase 3, wave 2 / ticket W2-D).

--- a/packages/backend.ai-ui/src/components/BAIColorPicker.css
+++ b/packages/backend.ai-ui/src/components/BAIColorPicker.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAIColorPicker` chrome. Astryx ships no colour-picking component (see the

--- a/packages/backend.ai-ui/src/components/BAICompactGroup.css
+++ b/packages/backend.ai-ui/src/components/BAICompactGroup.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAICompactGroup` — the weld antd's `Space.Compact` performed (QA-FINDINGS

--- a/packages/backend.ai-ui/src/components/BAIComplexSelect.css
+++ b/packages/backend.ai-ui/src/components/BAIComplexSelect.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAIComplexSelect`'s popup body, shaped like Astryx `Selector`'s (FR-3603).

--- a/packages/backend.ai-ui/src/components/BAICountdownBorder.css
+++ b/packages/backend.ai-ui/src/components/BAICountdownBorder.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAICountdownBorder> (to-astryx ticket 33). Replaces the

--- a/packages/backend.ai-ui/src/components/BAIDialog.css
+++ b/packages/backend.ai-ui/src/components/BAIDialog.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for `<BAIDialog>` — the mask, centering and entry

--- a/packages/backend.ai-ui/src/components/BAIDoubleTag.css
+++ b/packages/backend.ai-ui/src/components/BAIDoubleTag.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  The weld antd's `<Tag style={{ margin: 0, marginRight: -1 }}>` performed

--- a/packages/backend.ai-ui/src/components/BAIDrawer.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawer.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Header/body geometry for <BAIDrawer> (qa2-c).

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIDrawerPortal> — the scrim and stacking a scrimmed

--- a/packages/backend.ai-ui/src/components/BAILink.css
+++ b/packages/backend.ai-ui/src/components/BAILink.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAILink> (to-astryx ticket 33). Replaces the

--- a/packages/backend.ai-ui/src/components/BAIListAlert.css
+++ b/packages/backend.ai-ui/src/components/BAIListAlert.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIListAlert> (to-astryx ticket 33). Replaces the

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.css
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAIMetadataList` paint: a lightened item label and top-aligned side labels

--- a/packages/backend.ai-ui/src/components/BAIOverlayScrollbar.css
+++ b/packages/backend.ai-ui/src/components/BAIOverlayScrollbar.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIOverlayScrollbar> (FR-3612).

--- a/packages/backend.ai-ui/src/components/BAIResourceUnitGrid.css
+++ b/packages/backend.ai-ui/src/components/BAIResourceUnitGrid.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIResourceUnitGrid> (FR-3569). Imported by the

--- a/packages/backend.ai-ui/src/components/BAISelect.css
+++ b/packages/backend.ai-ui/src/components/BAISelect.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAISelect> (imported by the component itself, P17).

--- a/packages/backend.ai-ui/src/components/BAIStatistic.css
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIStatistic> (to-astryx phase 3, ticket A). Imported

--- a/packages/backend.ai-ui/src/components/BAITabCountBadge.css
+++ b/packages/backend.ai-ui/src/components/BAITabCountBadge.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `.bai-tab-count-badge` — the count pill next to a tab label (FR-3706).

--- a/packages/backend.ai-ui/src/components/BAITabList.css
+++ b/packages/backend.ai-ui/src/components/BAITabList.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `BAITabList` card-type tab strip (QA2-A / item 2).

--- a/packages/backend.ai-ui/src/components/BAIText.css
+++ b/packages/backend.ai-ui/src/components/BAIText.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIText> (FR-3726). The component renders its own

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.css
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAINameActionCell> (to-astryx ticket 33). Replaces the

--- a/packages/backend.ai-ui/src/components/Table/BAITable.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAITable>. Renamed from `BAITable.css` in

--- a/packages/backend.ai-ui/src/components/astryxNumberStepper.css
+++ b/packages/backend.ai-ui/src/components/astryxNumberStepper.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  The ladder stepper, drawn as Astryx draws its own (FR-3688).

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DragAndDrop.css
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DragAndDrop.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <DragAndDrop>, imported by the component itself (P17).

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.css
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <EditableFileName>, imported by the component itself

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAISubStepNodes> (P17). Imported by the component.

--- a/packages/backend.ai-ui/src/form-engine/FormItemVisual.css
+++ b/packages/backend.ai-ui/src/form-engine/FormItemVisual.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  The form item's entire static stylesheet (to-astryx tickets 05 + 34).
@@ -340,4 +339,3 @@
  since antd is no longer a dependency of this repo at all; CSS, unlike JS,
  carries its text into the minified bundle regardless.
 */
-

--- a/packages/backend.ai-ui/src/styles/actionAccent.css
+++ b/packages/backend.ai-ui/src/styles/actionAccent.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  `.bai-action-accent` — QA-FINDINGS **Q-37**.

--- a/react/src/components/AllocationHistoryStatistics.css
+++ b/react/src/components/AllocationHistoryStatistics.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Recharts theming for AllocationHistoryStatistics (to-astryx ticket 33).

--- a/react/src/components/AnnouncementBanner.css
+++ b/react/src/components/AnnouncementBanner.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <AnnouncementBanner> (P17). Banner's title slot wraps

--- a/react/src/components/AnnouncementEditModal.css
+++ b/react/src/components/AnnouncementEditModal.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for AnnouncementEditModal. The markdown-preview typography

--- a/react/src/components/BAIContentWithDrawerArea.css
+++ b/react/src/components/BAIContentWithDrawerArea.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIContentWithDrawerArea> (to-astryx ticket 33).

--- a/react/src/components/BAIMultiStepNotificationItem.css
+++ b/react/src/components/BAIMultiStepNotificationItem.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <BAIMultiStepNotificationItem> (to-astryx ticket 33).

--- a/react/src/components/BAINotificationButton.css
+++ b/react/src/components/BAINotificationButton.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  The trigger carries the band's inverted media scope so the bell glyph contrasts

--- a/react/src/components/BAINotificationListItem.css
+++ b/react/src/components/BAINotificationListItem.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Row shell for the notification-drawer items (to-astryx phase 3, wave 2 A).

--- a/react/src/components/Chat/ChatMessageContent.css
+++ b/react/src/components/Chat/ChatMessageContent.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Markdown-element chrome for <ChatMessageContent> (to-astryx ticket 33).

--- a/react/src/components/DeploymentRevisionDetail.css
+++ b/react/src/components/DeploymentRevisionDetail.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for DeploymentRevisionDetail (P17).

--- a/react/src/components/FairShareItems/UsageBucketChartContent.css
+++ b/react/src/components/FairShareItems/UsageBucketChartContent.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Recharts theming for UsageBucketChartContent (to-astryx ticket 33). Replaces

--- a/react/src/components/FolderCreateModal.css
+++ b/react/src/components/FolderCreateModal.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <FolderCreateModal> (to-astryx ticket 33). Replaces the

--- a/react/src/components/InputNumberWithSlider.css
+++ b/react/src/components/InputNumberWithSlider.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Two things Astryx `Slider` does not expose as props, both previously done

--- a/react/src/components/MainLayout/MainLayout.css
+++ b/react/src/components/MainLayout/MainLayout.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <MainLayout> (to-astryx ticket 33). Replaces BOTH the

--- a/react/src/components/SessionMetricGraph.css
+++ b/react/src/components/SessionMetricGraph.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Recharts theming for SessionMetricGraph (astryx ticket 17).

--- a/react/src/components/SessionResourceGrid.css
+++ b/react/src/components/SessionResourceGrid.css
@@ -1,5 +1,4 @@
 /*
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <SessionResourceGrid> (P17). The popover usage bar's

--- a/react/src/components/SourceCodeView.css
+++ b/react/src/components/SourceCodeView.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <SourceCodeView> (to-astryx ticket 33). Replaces the

--- a/react/src/components/TerminateSessionModalForProjectAdmin.css
+++ b/react/src/components/TerminateSessionModalForProjectAdmin.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Co-located styles for <TerminateSessionModalForProjectAdmin> (to-astryx

--- a/react/src/components/documentProse.css
+++ b/react/src/components/documentProse.css
@@ -1,5 +1,4 @@
 /**
- @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Block rhythm and list semantics for UN-CLASSED third-party HTML — the Terms of


### PR DESCRIPTION
## What

Removes the `@license` marker line from the 48 co-located `.css` files under
`react/src` and `packages/backend.ai-ui/src`. The copyright line and the prose
below it stay in the source — only the marker goes.

## Why

esbuild's default `legalComments: 'inline'` preserves any comment that contains
`@license`. Our co-located stylesheets carry design-rationale headers under that
marker, so they shipped verbatim in the minified bundle:

- **54,345 B** of comments in `assets/*.css` — **12.5%** of the 332,700-byte
  entry stylesheet
- up to **85.6%** of a route chunk (`ProjectAdminSessionPage.css`: 646 → 93 B)

None of it is a third-party notice. All 47 blocks that reached the bundle read
`Copyright (c) 2015-2026 Lablup Inc.`

## Measured

Three `vite build` runs of this tree at the same commit (baseline / after):

| | baseline | after | delta |
|---|---:|---:|---|
| entry `index.css` | 332,700 B | 291,165 B | −41,535 B |
| all CSS raw | 705,809 B | 651,464 B | **−54,345 B (−7.7%)** |
| all CSS gzip | 126,762 B | 103,754 B | **−23,008 B (−18.2%)** |
| all CSS brotli | 91,235 B | 72,976 B | −18,259 B (−20.0%) |
| CSS comment bytes | 54,345 B | 0 B | −100% |
| all JS raw | 20,785,860 B | 20,785,860 B | unchanged |
| JS chunks keeping `@license` | 79 | 79 | unchanged |

Strip comments from both builds' entry stylesheets and they are **byte-identical**,
so no rule changed.

## Why not the one-line config option

`esbuild: { legalComments: 'none' }` in `react/vite.config.ts` produces the same
CSS saving, but Vite forwards the option to JS minification as well
(`resolveMinifyCssEsbuildOptions`, and the JS transform path). Built and counted:
JS chunks carrying `@license` go **79 → 0**, stripping lucide-react (ISC), React,
Remix, OpenJS Foundation and ieee754 (BSD-3) notices. MIT/BSD/ISC require the
notice to be retained in distributions.

`legalComments: 'external'` is not a fix either — it emitted **zero** `.LEGAL.txt`
sidecars and produced byte-identical output to `'none'`, because Vite minifies
through esbuild's *transform* API, which does not implement `'external'`.

Editing the source headers is the surgical version: same CSS saving, JS untouched.

## Follow-ups (not in this PR)

Two larger CSS wins measured alongside this one, both structural:

- `@astryxdesign/lab`'s stylesheet re-emits 25,866 B of `@astryxdesign/core`'s
  atomic rules byte-for-byte (382 of lab's 627 rules) — needs a cross-package
  dedup step at concat time, or an upstream fix.
- ~34,166 B of atomic rules whose class names appear in no shipped JS chunk.
  `@astryxdesign/core` exports exactly one stylesheet (`./astryx.css`), the whole
  163-component catalog, so JS tree-shaking cannot reach the CSS.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
