### PR TITLE
fix(FR-3674): show pending state through the whole create-file flow

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx
@@ -113,11 +113,18 @@ const CreateFileModal: React.FC<CreateFileModalProps> = ({
   return (
     <BAIModal
       title={t('comp:FileExplorer.CreateANewFile')}
-      onCancel={() => onRequestClose(false)}
+      onCancel={() => {
+        if (!isCreating) {
+          onRequestClose(false);
+        }
+      }}
       okText={t('general.button.Create')}
       onOk={createFile}
       okButtonProps={{ loading: isCreating }}
       cancelButtonProps={{ disabled: isCreating }}
+      closable={!isCreating}
+      maskClosable={!isCreating}
+      keyboard={!isCreating}
       {...modalProps}
       width={400}
     >

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx
@@ -7,7 +7,7 @@ import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useCon
 import { FolderInfoContext } from './BAIFileExplorer';
 import { useMutation } from '@tanstack/react-query';
 import * as _ from 'lodash-es';
-import React, { use, useRef } from 'react';
+import React, { use, useRef, useState } from 'react';
 
 interface CreateFileModalProps extends BAIModalProps {
   onRequestClose: (success: boolean) => void;
@@ -23,6 +23,7 @@ const CreateFileModal: React.FC<CreateFileModalProps> = ({
   const { targetVFolderId, currentPath } = use(FolderInfoContext);
   const baiClient = useConnectedBAIClient();
   const formRef = useRef<FormInstance>(null);
+  const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false);
 
   const createFileMutation = useMutation({
     mutationFn: async ({
@@ -58,17 +59,22 @@ const CreateFileModal: React.FC<CreateFileModalProps> = ({
     },
   });
 
+  // Covers the duplicate-name pre-check too — `createFileMutation.isPending`
+  // alone leaves the button idle while `list_files` is in flight (FR-3674).
+  const isCreating = isCheckingDuplicate || createFileMutation.isPending;
+
   const createFile = () => {
     formRef.current
       ?.validateFields()
       .then(async (values) => {
         const filePath = [currentPath, values.fileName].join('/');
 
-        // Check for duplicate file name before creating
+        setIsCheckingDuplicate(true);
         const isDuplicate = await baiClient.vfolder
           .list_files(currentPath, targetVFolderId)
           .then((res) => _.some(res.items, (f) => f.name === values.fileName))
-          .catch(() => false);
+          .catch(() => false)
+          .finally(() => setIsCheckingDuplicate(false));
 
         if (isDuplicate) {
           modal.confirm({
@@ -110,7 +116,8 @@ const CreateFileModal: React.FC<CreateFileModalProps> = ({
       onCancel={() => onRequestClose(false)}
       okText={t('general.button.Create')}
       onOk={createFile}
-      okButtonProps={{ loading: createFileMutation.isPending }}
+      okButtonProps={{ loading: isCreating }}
+      cancelButtonProps={{ disabled: isCreating }}
       {...modalProps}
       width={400}
     >
@@ -142,6 +149,7 @@ const CreateFileModal: React.FC<CreateFileModalProps> = ({
           <AstryxFormTextInput
             label={t('comp:FileExplorer.FileName')}
             placeholder={t('comp:FileExplorer.FileNamePlaceholder')}
+            disabled={isCreating}
           />
         </Form.Item>
       </Form>


### PR DESCRIPTION
Resolves #9061 (FR-3674)

applied test server: https://fr-3674-pr9409-show-pending-state.seungwon.10-82-0-159.sslip.io/

## Problem

In the folder explorer's **Create new file** modal, clicking **Create** gave no visual feedback until the request completed. The OK button's loading was bound only to `createFileMutation.isPending` (the tus upload), but the click first runs a duplicate-name pre-check via `vfolder.list_files`, which has no pending state of its own — so the button stayed idle for the whole pre-check.

## Changes (`packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx`)

- Track the duplicate-name pre-check in an `isCheckingDuplicate` state; the OK button's `loading` is now driven by `isCheckingDuplicate || createFileMutation.isPending`, so the pending state appears immediately after the click and stays on through the upload.
- Lock the form while the flow is in flight: the file name input and the Cancel button are disabled during the combined pending state.
- The duplicate-confirm path is unchanged — while its `modal.confirm` is open the pre-check flag is already cleared, and confirming re-enters loading via the mutation's own `isPending`.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, theme build, terminology)