### PR TITLE
style(FR-3707): restore the antd-era bulleted overflow list in BAITagList

### DIFF
--- a/packages/backend.ai-ui/src/components/BAITagList.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAITagList.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Renders a list of short values with a bounded footprint: the first `maxInline` entries show inline and the remainder collapse into a `+N` affordance that reveals only the overflowed values. The overflow opens on hover in both variants — it is a read-only peek, so it appears on hover and leaves with the pointer. `variant="chip"` draws the inline entries as Astryx `Badge` chips and the `+N` as a keyboard-reachable `Link`; `variant="text"` draws them as nowrap plain text and puts the `+N` in a compact `Badge`. Use the chip variant in modals and detail panels and the text variant in dense table cells. With no items it renders `emptyText` and nothing else.',
+      'Renders a list of short values with a bounded footprint: the first `maxInline` entries show inline and the remainder collapse into a `+N` affordance that reveals only the overflowed values. The overflow opens on hover in both variants — it is a read-only peek, so it appears on hover and leaves with the pointer. `variant="chip"` draws the inline entries as Astryx `Badge` chips and the `+N` as a keyboard-reachable `Link` whose card lists the overflow as a disc-bulleted list; `variant="text"` draws them as nowrap plain text and puts the `+N` in a compact `Badge`. Use the chip variant in modals and detail panels and the text variant in dense table cells. With no items it renders `emptyText` and nothing else.',
     bestPractices: [
       {
         guidance: true,

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -79,17 +79,35 @@ const BAITagList: React.FC<BAITagListProps> = ({
     return <>{emptyText}</>;
   }
 
-  const restItemsList = (
-    <BAIFlex
-      direction="column"
-      align="start"
-      style={{ maxHeight: 240, overflowY: 'auto' }}
-    >
-      {_.map(restItems, (item, index) => (
-        <Text key={`${item}-${index}`}>{item}</Text>
-      ))}
-    </BAIFlex>
-  );
+  // The chip variant's overflow renders as a disc-bulleted list — the design
+  // FR-3707 asks to keep; the text variant keeps plain lines for dense cells.
+  const restItemsList =
+    variant === 'text' ? (
+      <BAIFlex
+        direction="column"
+        align="start"
+        style={{ maxHeight: 240, overflowY: 'auto' }}
+      >
+        {_.map(restItems, (item, index) => (
+          <Text key={`${item}-${index}`}>{item}</Text>
+        ))}
+      </BAIFlex>
+    ) : (
+      <ul
+        style={{
+          paddingInlineStart: 'var(--spacing-4)',
+          margin: 0,
+          maxHeight: 240,
+          overflow: 'auto',
+        }}
+      >
+        {_.map(restItems, (item, index) => (
+          <li key={`${item}-${index}`} style={{ listStyle: 'disc' }}>
+            <Text>{item}</Text>
+          </li>
+        ))}
+      </ul>
+    );
 
   // Astryx `Popover` wires its handlers onto a `<button>` in the trigger
   // subtree, and `Link` without `href` renders exactly that — so the click


### PR DESCRIPTION
Resolves #9125 (FR-3707)

Follow-up to #9147, which fixed the interaction (the `+N` overflow now opens on hover and no longer surfaces the Popover's dismiss control). What remained of FR-3707's "show it as the antd-era design" is the **content** of the overflow card: the antd-era chip variant rendered the hidden items as a disc-bulleted `<ul>`, while the migrated component rendered a plain left-aligned column.

## Mechanism

`BAITagList` shared one `restItemsList` between both variants. The antd implementation branched: the chip variant's Popover held `<ul style={{ paddingLeft: token.padding }}>` with `listStyle: 'disc'` items; the text variant's Tooltip held plain lines. This change restores that branch — chip gets the bulleted `<ul>` back (`paddingInlineStart: var(--spacing-4)` = 16px, the same value as antd `token.padding`), text keeps plain nowrap lines for dense table cells. The hover/click trigger model from #9147 is untouched.

## Measured before/after (Storybook `Tag/BAITagList` Default story, hover on `+2`)

| | before | after |
|---|---|---|
| `li` count in card | 0 (plain `Text` column) | 2 |
| `list-style-type` | – | `disc` / `disc` |
| `ul` `padding-inline-start` | – | `16px` (`--spacing-4`, = antd `token.padding`) |
| visible button in card | none | none |
| card bg (light / dark) | `rgb(255,255,255)` / `rgb(20,20,20)` | same |
| `pageerror` | 0 | 0 |

## Screenshots

| | light | dark |
|---|---|---|
| **before** | ![before-light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9410/20260903-024016-before-light.png) | ![before-dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9410/20260903-024022-before-dark.png) |
| **after** | ![after-light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9410/20260903-024028-after-light.png) | ![after-dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9410/20260903-024034-after-dark.png) |

## Verification

```
bash scripts/verify.sh                                  → === ALL PASS ===
pnpm --filter backend.ai-ui build                       → ok
pnpm --filter backend.ai-ui exec vitest run             → all passed (BAITagList: 7 passed)
pnpm --prefix ./react exec vitest run                   → all passed
node scripts/migration-gates/astryx-token-gate.mjs --strict → pass (only pre-existing dynamic var() constructions reported)
```

## Residue

- The Fair Share modals themselves were not exercised live — same limitation #9147 recorded: no project on the shared dev cluster has more than `maxInline` users, so no `+N` renders there. The Storybook Default story exercises the identical chip/hover/HoverCard path.
- The click branch (`trigger="click"`, no current caller) shares the same per-variant content, so a chip-variant click popover also shows the bulleted list, as antd's did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
