### PR TITLE
fix(FR-3727): suppress the press scale on disabled Astryx buttons

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ overrides:
   lodash: ^4.18.0
 
 patchedDependencies:
-  '@astryxdesign/core@0.5.2': c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed
+  '@astryxdesign/core@0.5.2': 7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16
   '@astryxdesign/lab@0.3.0-canary.12db2a1': 0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08
   '@cloudscape-design/board-components@3.0.176': 06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98
   ansi_up@6.0.6: 99856fc7fa4571c6ef4716cfd2dbf1151a025690c737775e248e8b7fe08a4459
@@ -579,16 +579,16 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 'catalog:'
-        version: 0.5.2(99e8f36cd61c267b6ec7c7832be69752)
+        version: 0.5.2(b2d589d654493f4e639846e22cde9a9c)
       '@astryxdesign/core':
         specifier: 'catalog:'
-        version: 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/lab':
         specifier: 'catalog:'
-        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/theme-neutral':
         specifier: 'catalog:'
-        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.5
@@ -762,13 +762,13 @@ importers:
         version: 2.0.230(react@19.2.8)(zod@4.4.3)
       '@astryxdesign/core':
         specifier: 'catalog:'
-        version: 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/lab':
         specifier: 'catalog:'
-        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astryxdesign/theme-neutral':
         specifier: 'catalog:'
-        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.5.2(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@cloudscape-design/board-components':
         specifier: 3.0.176
         version: 3.0.176(patch_hash=06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98)(@cloudscape-design/components@3.0.1341(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -1006,7 +1006,7 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 'catalog:'
-        version: 0.5.2(99e8f36cd61c267b6ec7c7832be69752)
+        version: 0.5.2(b2d589d654493f4e639846e22cde9a9c)
       '@babel/core':
         specifier: 'catalog:'
         version: 7.29.7(supports-color@8.1.1)
@@ -11206,7 +11206,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astryxdesign/cli@0.5.2(99e8f36cd61c267b6ec7c7832be69752)':
+  '@astryxdesign/cli@0.5.2(b2d589d654493f4e639846e22cde9a9c)':
     dependencies:
       commander: 12.1.0
       gpt-tokenizer: 3.4.0
@@ -11214,23 +11214,23 @@ snapshots:
       jscodeshift: 17.4.0(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       zod: 4.4.3
     optionalDependencies:
-      '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@astryxdesign/theme-neutral': 0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/theme-neutral': 0.5.2(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@stylexjs/stylex': 0.19.0
       intl-messageformat: 11.2.13
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@stylexjs/stylex': 0.19.0
       d3-array: 3.2.4
       d3-scale: 4.0.2
@@ -11250,9 +11250,9 @@ snapshots:
       '@lexical/utils': 0.46.0(typescript@6.0.3)
       lexical: 0.46.0(typescript@6.0.3)
 
-  '@astryxdesign/theme-neutral@0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@astryxdesign/theme-neutral@0.5.2(@astryxdesign/core@0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@astryxdesign/core': 0.5.2(patch_hash=7d72b4f11e736ec0ea6d4cfdf57e4bbe68baecee56c489f24fcc11db29684c16)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react: 1.29.0(react@19.2.8)
       react: 19.2.8
 

--- a/react/patches/@astryxdesign__core@0.5.2.patch
+++ b/react/patches/@astryxdesign__core@0.5.2.patch
@@ -1,3 +1,24 @@
+diff --git a/dist/Button/Button.js b/dist/Button/Button.js
+index 083184d76032a0a6ba3cdb87d7fd6ff7294f863f..647cc56a29e984695e83db633d9085bdc7f11f46 100644
+--- a/dist/Button/Button.js
++++ b/dist/Button/Button.js
+@@ -78,6 +78,7 @@ const styles = {
+   },
+   ariaDisabled: {
+     kKwaWg: "x18o3ruo xuqm82a",
++    k3aq6I: "x1c071of x1pdlv7q",
+     $$css: true
+   },
+   iconOnly: {
+@@ -434,7 +435,7 @@ export function Button({
+   } : null;
+ 
+   // Shared StyleX props for both button and link rendering
+-  const sharedStylexProps = focusOutlineProps.focusVisible(styles.base, sizeStyles[size], isIconOnly && styles.iconOnly, interactionOverlayStyles.backgroundImage, buttonDisabled && styles.disabled, useAriaDisabled && styles.ariaDisabled, renderAsLink && styles.link, !buttonGroup && styles.pressable, buttonGroup && (buttonGroup.orientation === 'horizontal' ? groupStyles.horizontal : groupStyles.vertical), buttonGroup && (variant === 'primary' || variant === 'destructive') && (buttonGroup.orientation === 'horizontal' ? groupStyles.onSolidHorizontal : groupStyles.onSolidVertical),
++  const sharedStylexProps = focusOutlineProps.focusVisible(styles.base, sizeStyles[size], isIconOnly && styles.iconOnly, interactionOverlayStyles.backgroundImage, !buttonGroup && styles.pressable, buttonDisabled && styles.disabled, useAriaDisabled && styles.ariaDisabled, renderAsLink && styles.link, buttonGroup && (buttonGroup.orientation === 'horizontal' ? groupStyles.horizontal : groupStyles.vertical), buttonGroup && (variant === 'primary' || variant === 'destructive') && (buttonGroup.orientation === 'horizontal' ? groupStyles.onSolidHorizontal : groupStyles.onSolidVertical),
+   // Standalone floating buttons only — a grouped button's elevation is owned
+   // by the ButtonGroup so the shared surface lifts as one unit.
+   !buttonGroup && elevationStyles[elevation], width != null && dynamicStyles.width(width),
 diff --git a/dist/hooks/useFocusTrap.js b/dist/hooks/useFocusTrap.js
 index ead7e0af25144043c863026cfe48bcfdaf10f6cf..f3f192ad226e80cffad26e02b2e1c696cd808100 100644
 --- a/dist/hooks/useFocusTrap.js
@@ -28,6 +49,35 @@ index ead7e0af25144043c863026cfe48bcfdaf10f6cf..f3f192ad226e80cffad26e02b2e1c696
        const active = document.activeElement;
        const focusWasLost = active == null || active === document.body || active === document.documentElement || container != null && container.contains(active);
        if (!focusWasLost) {
+diff --git a/src/Button/Button.tsx b/src/Button/Button.tsx
+index f982254829ad1254eda72dbca4bac3333a7f86e0..c1d30075084e6e5d0f7973c5cd83fcd7107633ff 100644
+--- a/src/Button/Button.tsx
++++ b/src/Button/Button.tsx
+@@ -119,6 +119,10 @@ const styles = stylex.create({
+       default: 'none',
+       ':active': 'none',
+     },
++    transform: {
++      default: 'none',
++      ':active': 'none',
++    },
+   },
+   iconOnly: {
+     '--button-icon-only-aspect': '1 / 1',
+@@ -639,10 +643,12 @@ export function Button({
+     sizeStyles[size],
+     isIconOnly && styles.iconOnly,
+     interactionOverlayStyles.backgroundImage,
++    // Before `disabled` / `ariaDisabled`: StyleX is last-wins per property,
++    // so their `transform: none` must come after the press scale.
++    !buttonGroup && styles.pressable,
+     buttonDisabled && styles.disabled,
+     useAriaDisabled && styles.ariaDisabled,
+     renderAsLink && styles.link,
+-    !buttonGroup && styles.pressable,
+     buttonGroup &&
+       (buttonGroup.orientation === 'horizontal'
+         ? groupStyles.horizontal
 diff --git a/src/hooks/useFocusTrap.ts b/src/hooks/useFocusTrap.ts
 index c05638a06c1e35345b33d9b13ecda5578821a82f..525c410546c39477b787f9cc787ba0341bf3c21d 100644
 --- a/src/hooks/useFocusTrap.ts


### PR DESCRIPTION
Resolves #9179 (FR-3727)

## Mechanism

Astryx `Button` builds its class list with `stylex.props(...)`, which is last-wins per property. `styles.pressable` (`transform: scale(1)` / `:active → scale(0.98)`) was passed **after** `styles.disabled`, so the disabled style's `transform: none` never reached the DOM and a disabled button still shrank on mouse-down. `styles.ariaDisabled` (the path a disabled button with a tooltip takes) had no transform suppression at all.

The fix is a `pnpm patch` on `@astryxdesign/core@0.5.2` (`react/patches/@astryxdesign__core@0.5.2.patch`, extending the existing `useFocusTrap` patch):

- pass `styles.pressable` before `styles.disabled` / `styles.ariaDisabled`, so their `transform: none` wins;
- give `styles.ariaDisabled` the same `transform: { default: 'none', ':active': 'none' }`.

The `dist/Button/Button.js` edit reuses the classes StyleX already emits for `styles.disabled` (`x1c071of` = `transform:none`, `x1pdlv7q` = `:active{transform:none}`), so `dist/astryx.css` is unchanged. `src/Button/Button.tsx` carries the same change for reference.

The 15% darkening overlay from the original report is already gone in 0.5.2 — `interactionOverlayStyles` guards both `:hover` and `:active` with `:where(:not(:disabled,[aria-disabled="true"]))` — so only the scale remained.

## Measured (dev server, Chromium, real `mouse.down()` held 500 ms)

Disabled ghost `IconButton` on `/summary`. "Before" is the same element with the pre-patch class output (`x3oybdh xk4oym4`, no `x1c071of x1pdlv7q`) re-applied; "after" is what the patched build renders.

| Mode | State | transform (before) | transform (after) |
|---|---|---|---|
| light | at rest | `matrix(1,0,0,1,0,0)` | `none` |
| light | pressed | **`matrix(0.98,0,0,0.98,0,0)`** | `none` |
| dark (`data-theme="dark"` via the header toggle) | at rest | `matrix(1,0,0,1,0,0)` | `none` |
| dark | pressed | **`matrix(0.98,0,0,0.98,0,0)`** | `none` |

`backgroundImage` stayed `none` in every cell. Enabled control (`/serving`, primary button): rest `scale(1)` → pressed `scale(0.98)`, overlay `0.16 → 0.18`, i.e. the press feedback on enabled buttons is untouched. Zero `pageerror` in both modes.

SSR class check on the patched dist (`react-dom/server`), all three paths of `Button`:

| Props | `aria-disabled` | scale class | `transform:none` classes |
|---|---|---|---|
| `{}` | no | yes | no |
| `isDisabled` | no (native `disabled`) | no | yes |
| `isDisabled` + `tooltip` | **yes** | no | yes |

No screenshot: the effect exists only while the mouse is held, and a 0.98 scale on a 24 px icon button is not legible in a static PNG. The computed-style tables above are the evidence.

## Verification

- `bash scripts/verify.sh`: Relay / Lint / TypeScript / Vite warmup / StyleX / Astryx theme build / Astryx integration / z-index / Agent mappings / Terminology all PASS. **Format FAIL is pre-existing and not from this branch**: it flags an untracked `src/lib/backend.ai-client-node.js` in my working tree (not part of this PR).
- `pnpm --prefix ./react exec vitest run`: 111 files, 1764 tests passed.
- `pnpm --filter backend.ai-ui exec vitest run`: 1965 passed, 1 skipped, **1 failed** — `BAIComplexSelect.popup.test.tsx › clears the query and reports the clear upstream` (`user.type` yields `b` instead of `br`). Not touched by this PR, and it passes when the file is re-run alone (10/10), so it is a timing flake.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict`: exit 1 on two **pre-existing** undeclared `var(--bai-dialog-z)` usages in `BAIDialog.css` / `BAIDrawerPortal.css` (from FR-3578). This PR adds no CSS.

## Residue

- This is a vendored patch; the same change should go upstream to Astryx (`Button.tsx`: order `pressable` before `disabled`, add `transform` to `ariaDisabled`). Until then, bumping `@astryxdesign/core` means re-applying the patch.
- Grouped buttons (`ButtonGroup`) never receive `styles.pressable`, so they were not affected and are not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
