### PR TITLE
fix(FR-3725): keep the assignment tab rendered while the assign modal loads

### DIFF
--- a/react/src/components/AssignRoleModal.tsx
+++ b/react/src/components/AssignRoleModal.tsx
@@ -62,6 +62,9 @@ const AssignRoleModal: React.FC<AssignRoleModalProps> = ({
   const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const deferredSearch = useDeferredValue(search);
+  // Starts false so a fresh mount (BAIUnmountAfterClose) fetches in a deferred
+  // render: the tab around the modal keeps its content instead of suspending.
+  const deferredOpen = useDeferredValue(baiModalProps.open, false);
   const [isAssigning, setIsAssigning] = useState(false);
   // One row per user the server rejected on the last save; the error modal
   // is open while non-empty.
@@ -100,7 +103,7 @@ const AssignRoleModal: React.FC<AssignRoleModalProps> = ({
       first: 50,
     },
     {
-      fetchPolicy: baiModalProps.open ? 'store-and-network' : 'store-only',
+      fetchPolicy: deferredOpen ? 'store-and-network' : 'store-only',
     },
   );
 
@@ -258,7 +261,9 @@ const AssignRoleModal: React.FC<AssignRoleModalProps> = ({
               setSelectedUserIds(value);
               setSearch('');
             }}
-            loading={deferredSearch !== search}
+            loading={
+              deferredSearch !== search || deferredOpen !== baiModalProps.open
+            }
             maxTagCount="responsive"
             allowClear
             maxTagPlaceholder={(omittedValues) => (


### PR DESCRIPTION
Resolves #9173 (FR-3725)

## Problem

In RBAC management → role detail → **Role assignment**, clicking **Add user** swapped the whole tab body (filter, buttons, assignment table) for a skeleton until the modal's user list had loaded.

`AssignRoleModal` runs `useLazyLoadQuery`, and it is mounted on click through `BAIUnmountAfterClose`. On that fresh mount the query suspended up to the nearest boundary — the tab-level `Suspense` in `RoleDetailDrawerContent` — which showed its skeleton fallback.

Reproduced on current `main` (e71cf54b6) with an 8 s delayed `AssignRoleModalQuery` response: 13 ms after the click the table header, empty-state text and the Add user button were gone and 4 skeleton elements were on screen; the tab only came back when the response arrived.

## Fix

Handled inside the modal: `useDeferredValue(open, false)`. The first render starts with `false`, so it reads the store only and commits the modal at once; the deferred re-render flips to `true` and runs the fetch, and because it is a deferred render React keeps the already-visible UI instead of showing a fallback. The user select shows `loading` until the deferred value catches up.

The plain `useDeferredValue(open)` used by the sibling modals is not sufficient for a modal that is unmounted on close: on a fresh mount it returns `true` immediately, so the first render still suspends. The `initialValue` argument is what makes the in-modal handling work.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- Live check against 10.82.0.241 (manager 26.8.0), same 8 s delayed response: the modal title appeared 59 ms after the click (before the response), skeleton count stayed at 0 for the whole wait, and the table/filter/buttons stayed rendered.

## Follow-up (not in this PR)

- `UserSettingModal` is also wrapped in `BAIUnmountAfterClose` at all four call sites but uses the plain `useDeferredValue(open)`, so it likely has the same fresh-mount behaviour.
- `AssignRoleModal` hand-rolls a user multi-select over `adminUsersV2` (`first: 50`, no pagination); `BAIUserSelect` already covers this and `ProjectAdminSettingModal` uses it for the same job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
