### PR TITLE
fix(FR-3846): apply "Off" on the first auto-refresh interval pick

### DIFF
--- a/react/src/components/AutoUpdateFetchKeyButton.test.tsx
+++ b/react/src/components/AutoUpdateFetchKeyButton.test.tsx
@@ -1,0 +1,84 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-3846: picking "Off" while the consumer's `defaultAutoUpdateDelay` is still
+ * in effect must turn auto-refresh off on the first try, not only after a
+ * detour through another interval.
+ */
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture what the host wrapper actually hands the presentational button; the
+// dropdown's own rendering is not under test.
+let lastAutoUpdateDelay: number | null | undefined;
+let lastOnChangeAutoUpdateDelay: ((delayMs: number | null) => void) | undefined;
+
+vi.mock('backend.ai-ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('backend.ai-ui')>();
+  return {
+    ...actual,
+    BAIFetchKeyButton: (props: {
+      autoUpdateDelay?: number | null;
+      onChangeAutoUpdateDelay?: (delayMs: number | null) => void;
+    }) => {
+      lastAutoUpdateDelay = props.autoUpdateDelay;
+      lastOnChangeAutoUpdateDelay = props.onChangeAutoUpdateDelay;
+      return <div data-testid="fetch-key-button" />;
+    },
+  };
+});
+
+const SETTING_KEY =
+  'backendaiwebui.settings.user.fetchKeyAutoUpdateDelay.session-list';
+
+const renderButton = () =>
+  render(
+    <AutoUpdateFetchKeyButton
+      settingId="session-list"
+      defaultAutoUpdateDelay={15_000}
+      onChange={() => {}}
+    />,
+  );
+
+describe('AutoUpdateFetchKeyButton', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    lastAutoUpdateDelay = undefined;
+    lastOnChangeAutoUpdateDelay = undefined;
+  });
+
+  it('starts at the consumer default when nothing is persisted', () => {
+    renderButton();
+    expect(lastAutoUpdateDelay).toBe(15_000);
+  });
+
+  it('turns auto-refresh off on the first "Off" pick, straight from the default', () => {
+    renderButton();
+    expect(lastAutoUpdateDelay).toBe(15_000);
+
+    act(() => lastOnChangeAutoUpdateDelay?.(null));
+
+    expect(localStorage.getItem(SETTING_KEY)).toBe('null');
+    expect(lastAutoUpdateDelay).toBeNull();
+  });
+
+  it('keeps working through the interval -> off detour', () => {
+    renderButton();
+
+    act(() => lastOnChangeAutoUpdateDelay?.(30_000));
+    expect(lastAutoUpdateDelay).toBe(30_000);
+
+    act(() => lastOnChangeAutoUpdateDelay?.(null));
+    expect(lastAutoUpdateDelay).toBeNull();
+  });
+
+  it('honours a persisted "Off" over the consumer default on remount', () => {
+    localStorage.setItem(SETTING_KEY, 'null');
+    renderButton();
+    expect(lastAutoUpdateDelay).toBeNull();
+  });
+});

--- a/react/src/components/AutoUpdateFetchKeyButton.tsx
+++ b/react/src/components/AutoUpdateFetchKeyButton.tsx
@@ -3,7 +3,7 @@ import {
   useBAISettingUserState,
 } from '../hooks/useBAISetting';
 import { BAIFetchKeyButton } from 'backend.ai-ui';
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useState } from 'react';
 
 /**
  * Closed set of stable ids used to persist each consumer's auto-refresh
@@ -104,18 +104,25 @@ const AutoUpdateFetchKeyButton: React.FC<AutoUpdateFetchKeyButtonProps> = ({
   const settingName = `fetchKeyAutoUpdateDelay.${settingId}` as const;
   const [autoUpdateDelay, setAutoUpdateDelay] =
     useBAISettingUserState(settingName);
-  // Only fall back to `defaultAutoUpdateDelay` before the user has ever
-  // touched the dropdown for this consumer. Once they have (including
-  // explicitly choosing "Off"), the persisted value is `null` too, but it
-  // must not be re-overridden by the default on every subsequent render.
-  const resolvedAutoUpdateDelay = hasStoredUserSetting(settingName)
-    ? (autoUpdateDelay ?? null)
-    : defaultAutoUpdateDelay;
+  // Fall back to `defaultAutoUpdateDelay` only until the user picks something
+  // for this consumer. `hasStoredUserSetting` alone cannot carry that: it reads
+  // localStorage outside React, and picking "Off" straight from the default is
+  // a null -> null atom write jotai bails out of, so nothing re-renders and the
+  // default keeps winning (FR-3846). This flag makes that first pick observable.
+  const [hasPickedThisSession, setHasPickedThisSession] = useState(false);
+  const resolvedAutoUpdateDelay =
+    hasPickedThisSession || hasStoredUserSetting(settingName)
+      ? (autoUpdateDelay ?? null)
+      : defaultAutoUpdateDelay;
+  const handleChangeAutoUpdateDelay = (delayMs: number | null) => {
+    setHasPickedThisSession(true);
+    setAutoUpdateDelay(delayMs);
+  };
   return (
     <BAIFetchKeyButton
       {...props}
       autoUpdateDelay={resolvedAutoUpdateDelay}
-      onChangeAutoUpdateDelay={setAutoUpdateDelay}
+      onChangeAutoUpdateDelay={handleChangeAutoUpdateDelay}
     />
   );
 };


### PR DESCRIPTION
Resolves #9414 (FR-3846)

Selecting **Off** in the auto-refresh interval dropdown did nothing when it was the user's *first* pick on a page. Picking any other interval first and *then* Off worked — the workaround the report describes.

**Dev server (dev VPN):** http://fr-3846.jongeun.10-82-0-159.sslip.io — Sessions page, open the refresh button's interval menu and pick **Off** as the very first choice.

## Mechanism

Not the Astryx dropdown. `AutoUpdateFetchKeyButton` (the host wrapper) decided *"has the user chosen an interval yet?"* with `hasStoredUserSetting`, a plain `localStorage` read outside React, while `useBAISettingUserState` reads **"never set"** and **"explicitly Off"** as the same `null`:

```
default in effect (nothing persisted)  →  atom value null
user picks "Off"                       →  writes null   →  atom value null
```

Jotai bails out of a derived value that is `Object.is`-equal, so the write notified nobody. No re-render → `hasStoredUserSetting` never re-evaluated → `defaultAutoUpdateDelay` (15 s on the Sessions page) kept winning, and auto-refresh kept running. Picking `30s` first moves the atom `null → 30000`, which *does* re-render — hence the workaround.

The write itself was never broken: `localStorage` held `"null"` the whole time. Only the render was stale.

**Fix:** track the pick in local state so the first Off is a real state change. The `localStorage` read stays as the cross-reload source of truth.

## Measured, live on a dev server

Fresh browser profile (nothing persisted), Sessions page, **Off clicked as the first pick**:

| | `localStorage` before | trigger label before | `localStorage` after | trigger label after |
|---|---|---|---|---|
| **Before fix** | `null` | `15s` | `"null"` | **`15s`** ← unchanged |
| **After fix** | `null` | `15s` | `"null"` | `""` (auto-refresh off) |

Both rows measured in light **and** dark (`data-theme="dark"` asserted on `<html>`); identical in both. Zero `pageerror` in every pass.

| Before fix — after clicking "Off" | After fix — after clicking "Off" |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9417/before-fix-off-clicked.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9417/after-fix-off-clicked.png) |

The interval chip and its orange countdown border persist on the left; on the right the control falls back to a bare chevron, which is the off state.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (required `pnpm --filter backend.ai-ui build` first — this worktree had no BUI `dist`, the documented stale-dist trap)
- `pnpm --prefix ./react exec vitest run` → 112 files / 1768 tests passed
- `pnpm --filter backend.ai-ui exec vitest run` → 75 files / 1966 tests passed, 1 skipped
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on 2 **pre-existing** undeclared `var(--bai-dialog-z)` uses in `BAIDialog.css` / `BAIDrawerPortal.css`. Neither file is in this diff (2 files, no CSS).

New regression test `AutoUpdateFetchKeyButton.test.tsx` (4 cases) drives the real jotai atom and real `localStorage`, mocking only the presentational button. It fails on `main` with `expected 15000 to be null`.

## Residue

- The leg where the Astryx `DropdownMenu` emits `null` for the Off item is **not** unit-tested: jsdom has no Popover API, no BUI test currently exercises `DropdownMenu`, and adding the first one means polyfilling that API — out of scope here. It is covered by the live probe above and by the reporter's own workaround.
- Every other `settingId` consumer with a non-null `defaultAutoUpdateDelay` had the same bug and is fixed by the same change; consumers defaulting to `null` were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9aDnUBNjx7zE8aNvAGsmN
