### PR TITLE
feat(FR-3849): copy the pin id from the deep-link card, and let overlay text be selected

### DIFF
--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -169,7 +169,12 @@ function boot() {
 
   // ------------------------------------------------- deep link (FR-3813)
 
-  const pin = createDeepLinkPin({ root: ui.root, host: ui.host });
+  const pin = createDeepLinkPin({
+    root: ui.root,
+    host: ui.host,
+    copyText: ui.copyText,
+    showToast: ui.showToast,
+  });
   const guard = createNavigationGuard();
   let cancelRetry = () => undefined as void;
 

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -13,6 +13,9 @@ const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
 
 let host: HTMLElement;
 let pin: DeepLinkPin;
+let copied: string[];
+let toasts: string[];
+let copyResult: boolean | Promise<boolean>;
 
 const show = (over: Partial<AnchorV3> = {}) =>
   pin.show({ id: 'c_zdv3rhz', anchor: anchor(over), label: 'Start › button' });
@@ -55,7 +58,18 @@ beforeEach(() => {
   host = document.createElement('div');
   host.setAttribute('data-bai-review-overlay', '');
   document.body.append(host);
-  pin = createDeepLinkPin({ root: host.attachShadow({ mode: 'open' }), host });
+  copied = [];
+  toasts = [];
+  copyResult = true;
+  pin = createDeepLinkPin({
+    root: host.attachShadow({ mode: 'open' }),
+    host,
+    copyText: (text) => {
+      copied.push(text);
+      return copyResult;
+    },
+    showToast: (message) => toasts.push(message),
+  });
 });
 
 afterEach(() => {
@@ -509,6 +523,83 @@ describe('createDeepLinkPin', () => {
       show();
       expect(pin.locate()).toBe(true);
       expect(markbox().style.borderRadius).toBe('6px');
+    });
+  });
+
+  // FR-3849. The id is what names this comment in the PR thread, a Teams
+  // message or a Claude prompt — reading it off the card and retyping it was
+  // the only way to get it.
+  describe('the id copy control', () => {
+    const idCopy = () =>
+      host.shadowRoot?.querySelector('.idcopy') as HTMLButtonElement;
+    const subText = () =>
+      (host.shadowRoot?.querySelector('.sub') as HTMLElement).textContent;
+
+    it('writes the bare id — no #bai prefix, no URL', () => {
+      show({
+        c: { name: 'CreateButton', src: 'react/src/Create.tsx:12' },
+      } as Partial<AnchorV3>);
+      idCopy().click();
+      expect(copied).toEqual(['c_zdv3rhz']);
+    });
+
+    it('says which id it copied', () => {
+      show();
+      idCopy().click();
+      expect(toasts).toEqual(['Copied c_zdv3rhz 📋']);
+    });
+
+    it('waits for an async clipboard before it claims success', async () => {
+      copyResult = Promise.resolve(false);
+      show();
+      idCopy().click();
+      await copyResult;
+      expect(toasts[0]).toContain('Could not reach the clipboard');
+    });
+
+    it('copies nothing once the pin is dismissed', () => {
+      show();
+      pin.dismiss();
+      idCopy().click();
+      expect(copied).toEqual([]);
+    });
+
+    it('keeps the component line beside the id, not inside the button', () => {
+      show({
+        c: { name: 'CreateButton', src: 'react/src/Create.tsx:12' },
+      } as Partial<AnchorV3>);
+      expect(idCopy().textContent).toBe('📋');
+      expect(subText()).toBe(
+        'c_zdv3rhz📋 · CreateButton (react/src/Create.tsx:12)',
+      );
+    });
+  });
+
+  // FR-3849. G4 made the whole card click-through so it would not swallow
+  // clicks meant for the app; that also made its text unselectable.
+  describe('selectable text on a click-through card', () => {
+    const runs = () =>
+      Array.from(host.shadowRoot?.querySelectorAll('.card .txt') ?? []);
+
+    it('carries every text run in an inline span of its own', () => {
+      show({ n: 'Misaligned.' });
+      expect(runs().map((span) => span.parentElement?.className)).toEqual([
+        'note',
+        'trunc',
+        'label',
+        'sub',
+        'sub',
+      ]);
+    });
+
+    it('gives those spans pointer events and selection, not the card', () => {
+      const css = host.shadowRoot?.querySelector('style')?.textContent ?? '';
+      expect(css).toContain(
+        'padding: 8px 10px; font-size: 14px; pointer-events: none;',
+      );
+      expect(css).toContain(
+        'pointer-events: auto; -webkit-user-select: text; user-select: text;',
+      );
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -543,6 +543,18 @@ describe('createDeepLinkPin', () => {
       expect(copied).toEqual(['c_zdv3rhz']);
     });
 
+    it('names every icon-only control for a screen reader', () => {
+      show();
+      const named = ['.idcopy', '.close', '.locate'].map((sel) =>
+        host.shadowRoot?.querySelector(sel)?.getAttribute('aria-label'),
+      );
+      expect(named).toEqual([
+        'Copy this comment id',
+        'Dismiss this pin',
+        'Scroll back to this element',
+      ]);
+    });
+
     it('says which id it copied', () => {
       show();
       idCopy().click();

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -71,6 +71,18 @@ const STYLE = `
     color: var(--bai-review-text-dim); font-size: 13px; margin-top: 3px;
     word-break: break-all;
   }
+  /* The card stays click-through (G4), so its padding and the space beside a
+     short line still reach the app. Each text run takes pointer events back:
+     an inline box hugs its own lines, so only the words are covered. */
+  .card .txt {
+    pointer-events: auto; -webkit-user-select: text; user-select: text;
+  }
+  .card .idcopy {
+    pointer-events: auto; cursor: pointer; border: 0; background: none;
+    padding: 0 2px; font: inherit; font-size: 11px; line-height: 1;
+    color: var(--bai-review-text-dim);
+  }
+  .card .idcopy:hover { color: var(--bai-review-text); }
   .card .close, .card .locate {
     position: absolute; top: 2px; cursor: pointer; border: 0;
     background: none; color: var(--bai-review-text-dim); font-size: 14px;
@@ -92,6 +104,12 @@ export interface DeepLinkPinOptions {
   root: ShadowRoot;
   /** The overlay's own shadow host — never a valid answer for the anchor. */
   host: Element;
+  /**
+   * The overlay's own clipboard, not `navigator.clipboard`: the gateway origin
+   * is plain http, where `execCommand` is the only path that writes.
+   */
+  copyText: (text: string) => boolean | Promise<boolean>;
+  showToast: (message: string) => void;
 }
 
 export interface DeepLinkPinTarget {
@@ -101,7 +119,12 @@ export interface DeepLinkPinTarget {
   label: string;
 }
 
-export function createDeepLinkPin({ root, host }: DeepLinkPinOptions) {
+export function createDeepLinkPin({
+  root,
+  host,
+  copyText,
+  showToast,
+}: DeepLinkPinOptions) {
   const style = document.createElement('style');
   style.textContent = STYLE;
   const layer = document.createElement('div');
@@ -113,15 +136,34 @@ export function createDeepLinkPin({ root, host }: DeepLinkPinOptions) {
   marker.append(head);
   const card = document.createElement('div');
   card.className = 'card';
+  /** A text run: the line stays click-through, the words do not. */
+  const run = (): HTMLSpanElement => {
+    const span = document.createElement('span');
+    span.className = 'txt';
+    return span;
+  };
   const note = document.createElement('div');
   note.className = 'note';
+  // Appended only when there IS a note, so `.note:empty` still collapses it.
+  const noteText = run();
   const trunc = document.createElement('div');
   trunc.className = 'trunc';
-  trunc.textContent = 'Note truncated — the comment has the whole of it.';
+  const truncText = run();
+  truncText.textContent = 'Note truncated — the comment has the whole of it.';
+  trunc.append(truncText);
   const label = document.createElement('div');
   label.className = 'label';
+  const labelText = run();
+  label.append(labelText);
   const sub = document.createElement('div');
   sub.className = 'sub';
+  const idText = run();
+  const idCopy = document.createElement('button');
+  idCopy.className = 'idcopy';
+  idCopy.textContent = '📋';
+  idCopy.title = 'Copy this comment id';
+  const componentText = run();
+  sub.append(idText, idCopy, componentText);
   const close = document.createElement('button');
   close.className = 'close';
   close.textContent = '✕';
@@ -345,6 +387,23 @@ export function createDeepLinkPin({ root, host }: DeepLinkPinOptions) {
   );
   close.addEventListener('click', () => dismiss());
 
+  /**
+   * The bare id, not the `#bai=v3.` link: what the reader pastes into the PR
+   * thread or a Claude prompt to name this comment. The whole link is already
+   * one ⌘L away in the address bar.
+   */
+  idCopy.addEventListener('click', () => {
+    const id = target?.id;
+    if (!id) return;
+    const done = (ok: boolean) =>
+      showToast(
+        ok ? `Copied ${id} 📋` : 'Could not reach the clipboard — try again',
+      );
+    const copied = copyText(id);
+    if (typeof copied === 'boolean') done(copied);
+    else void copied.then(done);
+  });
+
   function dismiss() {
     target = null;
     setLocated(null);
@@ -362,13 +421,15 @@ export function createDeepLinkPin({ root, host }: DeepLinkPinOptions) {
       target = next;
       marker.dataset.pinId = next.id;
       card.dataset.pinId = next.id;
-      note.textContent = next.anchor.n ?? '';
+      noteText.textContent = next.anchor.n ?? '';
+      note.replaceChildren(...(next.anchor.n ? [noteText] : []));
       trunc.classList.toggle('shown', next.anchor.nt === 1 && !!next.anchor.n);
-      label.textContent = next.label;
+      labelText.textContent = next.label;
+      idText.textContent = next.id;
       const component = next.anchor.c;
-      sub.textContent = component
-        ? `${next.id} · ${component.name}${component.src ? ` (${component.src})` : ''}`
-        : next.id;
+      componentText.textContent = component
+        ? ` · ${component.name}${component.src ? ` (${component.src})` : ''}`
+        : '';
     },
 
     /**

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -161,17 +161,22 @@ export function createDeepLinkPin({
   const idCopy = document.createElement('button');
   idCopy.className = 'idcopy';
   idCopy.textContent = '📋';
+  // The glyph is the accessible name unless one is given, and "clipboard" is
+  // not the action; `title` stays the visual tooltip.
   idCopy.title = 'Copy this comment id';
+  idCopy.setAttribute('aria-label', 'Copy this comment id');
   const componentText = run();
   sub.append(idText, idCopy, componentText);
   const close = document.createElement('button');
   close.className = 'close';
   close.textContent = '✕';
   close.title = 'Dismiss this pin';
+  close.setAttribute('aria-label', 'Dismiss this pin');
   const locateButton = document.createElement('button');
   locateButton.className = 'locate';
   locateButton.textContent = '📍';
   locateButton.title = 'Scroll back to this element';
+  locateButton.setAttribute('aria-label', 'Scroll back to this element');
   card.append(close, locateButton, note, trunc, label, sub);
   const markBox = document.createElement('div');
   markBox.className = 'markbox';

--- a/react/vite-plugins/review-overlay/client/ui.test.ts
+++ b/react/vite-plugins/review-overlay/client/ui.test.ts
@@ -70,6 +70,42 @@ describe('the dock is gone', () => {
   });
 });
 
+// FR-3849. The guard exists to beat react-grab's async focus restore; taking
+// focus back also collapsed a selection the reviewer was dragging in our chrome.
+describe('the focus guard on the composer', () => {
+  const textarea = () => compose().querySelector('textarea') as HTMLElement;
+
+  it('holds focus against a blur from outside the overlay', async () => {
+    const target = mountSized({ top: 100, bottom: 300 }, 160);
+    ui.openCompose(target, 40, 306);
+    const focus = vi.spyOn(textarea(), 'focus');
+    textarea().dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('lets go the moment the reviewer presses on our own chrome', async () => {
+    const target = mountSized({ top: 100, bottom: 300 }, 160);
+    ui.openCompose(target, 40, 306);
+    const label = compose().querySelector('.pathlabel') as HTMLElement;
+    label.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    const focus = vi.spyOn(textarea(), 'focus');
+    textarea().dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('keeps holding when the press was on the textarea itself', async () => {
+    const target = mountSized({ top: 100, bottom: 300 }, 160);
+    ui.openCompose(target, 40, 306);
+    textarea().dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    const focus = vi.spyOn(textarea(), 'focus');
+    textarea().dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(focus).toHaveBeenCalled();
+  });
+});
+
 describe('placing the composer', () => {
   it('hangs it under an element that leaves room', () => {
     const target = mountSized({ top: 100, bottom: 300 }, 160);

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -328,6 +328,18 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
     }, 0);
   });
 
+  // A deliberate press on our own chrome ends the guard: dragging across the
+  // path label to select it moves focus off the textarea, and taking it back
+  // collapses the selection the reviewer was making. react-grab's restore —
+  // the only thing the guard exists to beat — lands before any of this.
+  root.addEventListener(
+    'mousedown',
+    (evt) => {
+      if (evt.target !== composeText) focusGuardUntil = 0;
+    },
+    true,
+  );
+
   function closeCompose() {
     if (!isComposeOpen()) return;
     clearTimeout(noteTimer);


### PR DESCRIPTION
Resolves #9420 (FR-3849)

## What

Two things the deep-link overlay was missing, both from driver feedback on the merged FR-3813:

- **The pin id can be copied.** The card's sub line now carries a small 📋 beside the id; clicking it puts the **bare** id (`c_ppz7vuh` — no `#bai=v3.` prefix, no URL) on the clipboard and the overlay's existing toast says which one went.
- **The overlay's text can be selected.** The card's note, label and component line are drag-selectable, and a click on the card where there is *no* text still reaches the app element underneath — the FR-3813 G4 behaviour survives.

The composer's path label and the toast were already selectable; one real bug there is fixed (below).

## How

**The affordance — a separate 📋, not a clickable id.** The id stays a plain text run and gets a one-glyph button next to it. Making the id itself the button would have cost the other half of this ticket: a `<button>`'s label cannot be dragged across, so the id would have become the one thing on the card you still could not select. One glyph on a line that already exists keeps the card as tight as it was.

**No second control for the whole link.** The driver asked only for the id, and the full deep link is already in the address bar one ⌘L away — a second button would be chrome for nothing.

**Selectable text on a click-through card.** `.card` keeps `pointer-events: none`, so its padding and the empty space beside a short line stay click-through. Each text run moved into an inline `<span class="txt">` that takes `pointer-events: auto; user-select: text` back. An inline box hugs its own line boxes, so a drag across the words selects them while a click beside a short line falls through to the app. `.note` appends its span only when the link carries a note, so `.note:empty { display: none }` still collapses the row for a note-less link.

**The clipboard path is the overlay's own.** `createDeepLinkPin` now takes `copyText` / `showToast` from `createOverlayUI` rather than reaching for `navigator.clipboard`: the gateway origin is plain http and has none, so `execCommand` is the only thing that writes there, and that fallback already exists in `ui.ts`.

**The composer focus-guard fix.** FR-3811's guard re-focuses the textarea for 1 s after a pick, to outlast react-grab's asynchronous focus restore. Pressing on the path label blurs the textarea, the guard takes focus back, and the browser collapses the selection the mousedown had just started — so for that first second the label was *not* selectable. A mousedown anywhere in our own chrome other than the textarea now ends the guard: that press is the reviewer's intent, and nothing the guard defends against looks like one.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`.

`pnpm --filter ./react exec vitest run vite-plugins` → **272 passed** (262 on `main`; +7 for the card, +3 for the focus guard).

`E2E_WEBUI_ENDPOINT=http://127.0.0.1:4143 E2E_REVIEW_OVERLAY_SMOKE=1 pnpm exec playwright test e2e/review-overlay-deeplink.spec.ts --project chromium` → **1 passed**; the two `[cleanup]` teardown failures are pre-existing and unrelated.

### Live, against a dev server booted from this branch

A real `#bai=v3` link, built with the overlay's own `anchor` / `codec` / `id` modules and opened in a fresh browser context at `/project/a한국어가능_cde/start`.

**Clipboard read-back** — real `navigator.clipboard.readText()` with `clipboard-read` granted, after seeding the clipboard with `SENTINEL-BEFORE`; no hooking or stubbing was needed:

```
clipboard          : "c_ppz7vuh"
matches the pin id : true
toast              : "Copied c_ppz7vuh 📋"
```

**Selection** — mouse drags, then `getSelection().toString()` (identical from `document` and from the shadow root):

| run | line boxes | selected |
|---|---|---|
| note | 4 | `The button is misaligned.\nIt should sit flush with the row above it.` |
| label | 2 | `/project/a한국어가능_cde/start › page-start › button "See Details"` |
| component line | 2 | ` · StartPageCard (react/src/pages/StartPage.tsx:42)` |
| toast | 1 | `Copied c_ppz7vuh 📋` |
| composer path label | — | `Start › page-start › span "Create Folder"\n⚛️ in ActionItemContent (at /src/components/ActionItemContent.tsx)\nin Button (@astryxdesign/core)\nin StartPage (at /src/pages/StartPage.tsx)` |

The multi-line note and the wrapped label both select cleanly, which is the inline-box behaviour the design depends on.

**G4 click-through survives.** The card was 320×159 at (849, 52). Searched every pixel inside it for the point *furthest* from every text run and button — (1142, 103), 26 px of clearance, not a corner artefact — and clicked it. A capture-phase listener recorded the composed path:

```
composedPath()[0] : DIV.bai-webui-header  ("Project  Select Project  a한국어가능_cde …")
overlay in path   : false
```

The app got the click; the card did not.

**The focus-guard bug, measured.** Drag on the composer's path label:

| when | before | after |
|---|---|---|
| 250 ms after the composer opens | `""` (textarea had taken focus back) | full label |
| 4 s after | full label | full label |

Screenshots were taken for each step and md5-verified distinct; they live under `/tmp` and nothing was left in the repository (`git ls-files --others --exclude-standard` is empty).

## Not in this PR

- **No control for the whole deep link.** The address bar already holds it.
- **The toast is still not click-through.** It has been `pointer-events: auto` since FR-3811 and blocks clicks under it for its 3.5 s; making it click-through would make it unselectable, which is the opposite of what this ticket asks.
- **The 📋 / 📍 / ✕ glyphs render as monochrome fallbacks on this headless box** (no colour emoji font installed). That is the screenshot environment, not the overlay — the existing FR-3813 chrome renders the same way there.
- **The overlay's `⌘⌃C` chord could not be exercised through synthetic key events** in headless Chromium once react-grab owns it; the composer was opened via `__REACT_GRAB__.activate()` plus a real mouse click, which drives the same `onPick` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165N2Y5PnF5AnzvuTx96k64
