### PR TITLE
feat(FR-3851): copy the whole comment from the deep-link card

### DIFF
--- a/react/vite-plugins/review-overlay/client/block.ts
+++ b/react/vite-plugins/review-overlay/client/block.ts
@@ -223,13 +223,17 @@ export interface BuiltBlock {
   at: string;
 }
 
+/** The block's `at`: an ISO instant, truncated to whole seconds. */
+export const blockStamp = (): string =>
+  new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+
 /** The sync half: safe to call inside the keydown/click that copies. */
 export function buildBlockFromCapture(
   capture: AnchorCapture,
   options: BlockRenderOptions,
 ): BuiltBlock {
   const { anchor, anchorB64 } = capture;
-  const at = options.at ?? new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const at = options.at ?? blockStamp();
   const id = pinId(options.pr, anchorB64, at);
   const q = anchor.q ? `?${anchor.q}` : '';
   const origin = options.origin ?? location.origin;

--- a/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
@@ -31,8 +31,22 @@ function stubExecCommand(): Record<string, string> {
   return written;
 }
 
+interface OpenPinOptions {
+  /** Extra fragment parts the pin rides alongside, e.g. `tab=logs`. */
+  otherHash?: string;
+  /** Withhold react-grab, the way a pin that beats the app's boot sees it. */
+  withoutReactGrab?: boolean;
+  /** Hold `/__review/state` open, so the pin locates before `pr` is known. */
+  slowState?: boolean;
+  /** Boot ticks to run; short enough to catch the pin mid-read. */
+  ticks?: number;
+}
+
 /** Boot the overlay on a `#bai=v3` link to `[data-testid="create"]`. */
-async function openPin(over: Partial<AnchorV3> = {}): Promise<string> {
+async function openPin(
+  over: Partial<AnchorV3> = {},
+  options: OpenPinOptions = {},
+): Promise<string> {
   const anchor: AnchorV3 = {
     v: 3,
     s: '[data-testid="create"]',
@@ -44,29 +58,40 @@ async function openPin(over: Partial<AnchorV3> = {}): Promise<string> {
   };
   const anchorB64 = await encodeAnchor(anchor);
   document.body.innerHTML = '<button data-testid="create">Create</button>';
-  history.replaceState({}, '', `/#bai=v3.${ID}.${anchorB64}`);
-  window.__REACT_GRAB__ = {
-    activate: () => undefined,
-    deactivate: () => undefined,
-    isActive: () => false,
-    registerPlugin: (_plugin: Plugin) => undefined,
-    getStackContext: () =>
-      Promise.resolve(`  in CreateButton (at ${ROOT}/${FILE})`),
-    getSource: () => Promise.resolve(null),
-  } as unknown as ReactGrabAPI;
+  const rest = options.otherHash ? `${options.otherHash}&` : '';
+  history.replaceState({}, '', `/#${rest}bai=v3.${ID}.${anchorB64}`);
+  if (options.withoutReactGrab) delete window.__REACT_GRAB__;
+  else
+    window.__REACT_GRAB__ = {
+      activate: () => undefined,
+      deactivate: () => undefined,
+      isActive: () => false,
+      registerPlugin: (_plugin: Plugin) => undefined,
+      getStackContext: () =>
+        Promise.resolve(`  in CreateButton (at ${ROOT}/${FILE})`),
+      getSource: () => Promise.resolve(null),
+    } as unknown as ReactGrabAPI;
+  const state = { json: () => Promise.resolve({ pr: 42, root: ROOT }) };
   vi.stubGlobal('fetch', () =>
-    Promise.resolve({ json: () => Promise.resolve({ pr: 42, root: ROOT }) }),
+    options.slowState
+      ? new Promise((resolve) => setTimeout(() => resolve(state), 5000))
+      : Promise.resolve(state),
   );
 
   vi.resetModules();
   delete window.__baiReviewOverlay;
   await import('./main.js');
   // The state gate, the anchor inflate, the locate ladder and the stack read.
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < (options.ticks ?? 12); i++) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   return anchorB64;
 }
+
+const toast = () =>
+  document
+    .querySelector('[data-bai-review-overlay]')
+    ?.shadowRoot?.querySelector('.toast')?.textContent ?? '';
 
 const click = (selector: string) =>
   document
@@ -129,5 +154,60 @@ describe('copying the whole comment off a deep link', () => {
     click('.copyall');
 
     expect(written['text/plain'].startsWith('> 📍 ')).toBe(true);
+  });
+
+  // The pin can ride inside a fragment the app already uses; a link that
+  // reopens on the wrong tab is not the link that was shared.
+  it('keeps the app fragment the pin rides alongside', async () => {
+    const anchorB64 = await openPin({}, { otherHash: 'tab=logs' });
+    const written = stubExecCommand();
+
+    click('.copyall');
+
+    expect(written['text/plain']).toContain(
+      `(${location.origin}/#tab=logs&bai=v3.${ID}.${anchorB64})`,
+    );
+  });
+
+  // `pr` and the ⚛️ stack are read per element; a block written before they
+  // land would claim `pr=0` and quietly drop the frames.
+  it('refuses to write until this element has been read', async () => {
+    await openPin({}, { slowState: true });
+    const card = document
+      .querySelector('[data-bai-review-overlay]')
+      ?.shadowRoot?.querySelector('.card');
+    // The pin is drawn — it is only `pr` and the stack that have not landed.
+    expect(card?.classList.contains('found')).toBe(true);
+    const written = stubExecCommand();
+
+    click('.copyall');
+
+    expect(written['text/plain']).toBeUndefined();
+    expect(toast()).toBe('Still reading this element — try again');
+  });
+
+  // react-grab arrives with the app, so a pin that locates first sees an
+  // empty stack — and `onLocated` will not fire again for the same element.
+  it('retries the stack for a pin that beat react-grab to the page', async () => {
+    await openPin({}, { withoutReactGrab: true, ticks: 4 });
+    window.__REACT_GRAB__ = {
+      activate: () => undefined,
+      deactivate: () => undefined,
+      isActive: () => false,
+      registerPlugin: (_plugin: Plugin) => undefined,
+      getStackContext: () =>
+        Promise.resolve(`  in CreateButton (at ${ROOT}/${FILE})`),
+      getSource: () => Promise.resolve(null),
+    } as unknown as ReactGrabAPI;
+    for (let i = 0; i < 8; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    const written = stubExecCommand();
+
+    click('.copyall');
+
+    expect(written['text/plain']).toContain(
+      `> ⚛️ in CreateButton (at ${FILE})`,
+    );
   });
 });

--- a/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * What the deep-link card's copy control actually writes (FR-3851). `pin.ts`
+ * owns the button and `block.ts` the rendering, but only `main.ts` composes
+ * them — the note off the fragment, the ⚛️ stack re-read from the element the
+ * pin landed on, and the pin's own link on this origin.
+ */
+import { encodeAnchor } from './codec.js';
+import type { AnchorV3 } from './types.js';
+import type { Plugin, ReactGrabAPI } from 'react-grab';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ID = 'c_zdv3rhz';
+const ROOT = '/home/driver/Workspace/backend.ai-webui';
+const FILE = 'react/src/components/CreateButton.tsx';
+
+/** jsdom has no editing host: `execCommand` never fires its own copy event. */
+function stubExecCommand(): Record<string, string> {
+  const written: Record<string, string> = {};
+  document.execCommand = vi.fn(() => {
+    const evt = new Event('copy', { bubbles: true, cancelable: true });
+    Object.defineProperty(evt, 'clipboardData', {
+      value: {
+        setData: (type: string, value: string) => {
+          written[type] = value;
+        },
+      },
+    });
+    document.dispatchEvent(evt);
+    return true;
+  });
+  return written;
+}
+
+/** Boot the overlay on a `#bai=v3` link to `[data-testid="create"]`. */
+async function openPin(over: Partial<AnchorV3> = {}): Promise<string> {
+  const anchor: AnchorV3 = {
+    v: 3,
+    s: '[data-testid="create"]',
+    p: '/',
+    tag: 'button',
+    txt: 'Create',
+    n: 'The label is cut off.',
+    ...over,
+  };
+  const anchorB64 = await encodeAnchor(anchor);
+  document.body.innerHTML = '<button data-testid="create">Create</button>';
+  history.replaceState({}, '', `/#bai=v3.${ID}.${anchorB64}`);
+  window.__REACT_GRAB__ = {
+    activate: () => undefined,
+    deactivate: () => undefined,
+    isActive: () => false,
+    registerPlugin: (_plugin: Plugin) => undefined,
+    getStackContext: () =>
+      Promise.resolve(`  in CreateButton (at ${ROOT}/${FILE})`),
+    getSource: () => Promise.resolve(null),
+  } as unknown as ReactGrabAPI;
+  vi.stubGlobal('fetch', () =>
+    Promise.resolve({ json: () => Promise.resolve({ pr: 42, root: ROOT }) }),
+  );
+
+  vi.resetModules();
+  delete window.__baiReviewOverlay;
+  await import('./main.js');
+  // The state gate, the anchor inflate, the locate ladder and the stack read.
+  for (let i = 0; i < 12; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return anchorB64;
+}
+
+const click = (selector: string) =>
+  document
+    .querySelector('[data-bai-review-overlay]')
+    ?.shadowRoot?.querySelector<HTMLButtonElement>(selector)
+    ?.click();
+
+beforeEach(() => {
+  sessionStorage.clear();
+  history.replaceState({}, '', '/');
+});
+
+afterEach(() => {
+  // The pin outlives the module and keeps a MutationObserver on `body`; with
+  // no target it schedules nothing, so dismissing it first keeps the observer
+  // from firing into a torn-down jsdom.
+  click('.close');
+  vi.unstubAllGlobals();
+  document.querySelector('[data-bai-review-overlay]')?.remove();
+  document.body.innerHTML = '';
+  delete window.__REACT_GRAB__;
+});
+
+describe('copying the whole comment off a deep link', () => {
+  it('rebuilds the block the composer wrote, link and stack included', async () => {
+    const anchorB64 = await openPin();
+    const written = stubExecCommand();
+
+    click('.copyall');
+
+    const lines = written['text/plain'].split('\n');
+    expect(lines.slice(0, 5)).toEqual([
+      'The label is cut off.',
+      '',
+      `> 📍 **/ › button "Create"** · \`${ID}\``,
+      `> ⚛️ in CreateButton (at ${FILE})`,
+      `> [Open on dev server](${location.origin}/#bai=v3.${ID}.${anchorB64})`,
+    ]);
+    // `at` is this copy's own instant; the id is what carries the identity.
+    expect(lines[5]).toMatch(
+      new RegExp(`^<!-- bai-review v3 id=${ID} pr=42 at=\\S+ -->$`),
+    );
+  });
+
+  it('writes the rich flavour too, so a Teams paste stays a quote', async () => {
+    await openPin();
+    const written = stubExecCommand();
+
+    click('.copyall');
+
+    expect(written['text/html']).toContain('<p>The label is cut off.</p>');
+    expect(written['text/html']).toContain('<blockquote>📍 <b>');
+  });
+
+  // A link written before the note travelled in the anchor still copies.
+  it('drops the note and keeps the block when the link carries none', async () => {
+    await openPin({ n: undefined });
+    const written = stubExecCommand();
+
+    click('.copyall');
+
+    expect(written['text/plain'].startsWith('> 📍 ')).toBe(true);
+  });
+});

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -177,6 +177,9 @@ function boot() {
 
   // ------------------------------------------------- deep link (FR-3813)
 
+  /** A pin that locates before react-grab registers, retried into a stack. */
+  const STACK_TRIES = 8;
+  const STACK_RETRY_MS = 500;
   /**
    * The ⚛️ stack the copied comment quotes. The anchor does not carry it — it
    * is re-read here, from the element this pin landed on, the same way the
@@ -184,29 +187,47 @@ function boot() {
    */
   let pinStack: string[] = [];
   let stackOf: Element | null = null;
+  /** False until `pr` and the stack are both this element's — see `buildComment`. */
+  let pinReady = false;
 
   async function readPinStack(element: Element | null) {
     stackOf = element;
     pinStack = [];
+    pinReady = false;
     if (!element) return;
+    // `pr` is part of the block, so the copy waits for the same gate the
+    // composer waits for rather than writing `pr=0`.
     await stateReady;
-    const stack = await picker.getStack(element);
-    if (stackOf !== element) return;
-    pinStack = stack;
+    for (let left = STACK_TRIES; ; left--) {
+      const stack = await picker.getStack(element);
+      if (stackOf !== element) return;
+      pinStack = stack;
+      pinReady = true;
+      // An empty stack is the answer once react-grab is there; before that it
+      // only means the app has not finished booting.
+      if (stack.length || left <= 0 || picker.hasReactGrab()) return;
+      await new Promise((resolve) => setTimeout(resolve, STACK_RETRY_MS));
+      if (stackOf !== element) return;
+    }
   }
 
   /**
    * The comment this pin was written as, re-rendered here. The note, the label
    * and the link all come off the fragment, so they are the reviewer's own;
    * `pr` and `at` describe this copy, and the id is what carries the identity.
+   * `null` while the element's own reads are still in flight — a block missing
+   * its stack, or claiming `pr=0`, is not the comment that was written.
    */
-  function buildComment(target: DeepLinkPinTarget): CopyPayload {
+  function buildComment(target: DeepLinkPinTarget): CopyPayload | null {
+    if (!pinReady) return null;
     const input = {
       label: target.label,
       id: target.id,
       stack: pinStack,
       text: target.anchor.n ?? '',
-      url: `${location.origin}${pinUrl(target.anchor, target.id, target.anchorB64)}`,
+      // The app's own fragment rides alongside the pin (`#tab=logs&bai=v3.…`),
+      // and dropping it would reopen the page on a different tab.
+      url: `${location.origin}${pinUrl(target.anchor, target.id, target.anchorB64, location.hash)}`,
       pr: serverState?.pr ?? 0,
       at: blockStamp(),
     };

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -11,7 +11,10 @@
 import { isAnchorV3 } from './anchor-guard.js';
 import { captureAnchorSignals, withNote } from './anchor.js';
 import {
+  blockStamp,
   buildBlockFromCapture,
+  buildBlockHtml,
+  buildBlockText,
   captureForBlock,
   landmarkLabel,
   resolveRouteLabel,
@@ -26,8 +29,13 @@ import {
   retryUntil,
 } from './deeplink.js';
 import { createPicker } from './picker.js';
-import { createDeepLinkPin } from './pin.js';
-import type { AnchorComponent, AnchorV3, ReviewServerState } from './types.js';
+import { createDeepLinkPin, type DeepLinkPinTarget } from './pin.js';
+import type {
+  AnchorComponent,
+  AnchorV3,
+  CopyPayload,
+  ReviewServerState,
+} from './types.js';
 import { createOverlayUI } from './ui.js';
 
 /** The SPA's own `<Navigate replace>` redirects drop the fragment on login. */
@@ -169,11 +177,49 @@ function boot() {
 
   // ------------------------------------------------- deep link (FR-3813)
 
+  /**
+   * The ⚛️ stack the copied comment quotes. The anchor does not carry it — it
+   * is re-read here, from the element this pin landed on, the same way the
+   * composer read it when the comment was written.
+   */
+  let pinStack: string[] = [];
+  let stackOf: Element | null = null;
+
+  async function readPinStack(element: Element | null) {
+    stackOf = element;
+    pinStack = [];
+    if (!element) return;
+    await stateReady;
+    const stack = await picker.getStack(element);
+    if (stackOf !== element) return;
+    pinStack = stack;
+  }
+
+  /**
+   * The comment this pin was written as, re-rendered here. The note, the label
+   * and the link all come off the fragment, so they are the reviewer's own;
+   * `pr` and `at` describe this copy, and the id is what carries the identity.
+   */
+  function buildComment(target: DeepLinkPinTarget): CopyPayload {
+    const input = {
+      label: target.label,
+      id: target.id,
+      stack: pinStack,
+      text: target.anchor.n ?? '',
+      url: `${location.origin}${pinUrl(target.anchor, target.id, target.anchorB64)}`,
+      pr: serverState?.pr ?? 0,
+      at: blockStamp(),
+    };
+    return { text: buildBlockText(input), html: buildBlockHtml(input) };
+  }
+
   const pin = createDeepLinkPin({
     root: ui.root,
     host: ui.host,
     copyText: ui.copyText,
     showToast: ui.showToast,
+    buildComment,
+    onLocated: (element) => void readPinStack(element),
   });
   const guard = createNavigationGuard();
   let cancelRetry = () => undefined as void;
@@ -216,6 +262,7 @@ function boot() {
     pin.show({
       id: fragment.id,
       anchor,
+      anchorB64: fragment.anchorB64,
       label: landmarkLabel(anchorRouteLabel(anchor), anchor),
     });
     cancelRetry = retryUntil(() => pin.locate(), {

--- a/react/vite-plugins/review-overlay/client/picker.ts
+++ b/react/vite-plugins/review-overlay/client/picker.ts
@@ -328,6 +328,8 @@ export function createPicker(callbacks: PickerCallbacks) {
     stop,
     dispose,
     isActive: () => grabActive || fallbackPicking,
+    /** react-grab loads with the app: before it does, `getStack` is empty. */
+    hasReactGrab: () => !!api(),
     watchForReactGrab,
     isHotkeyArmed: () => hotkeyArmed,
     getStack,

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -1,5 +1,9 @@
-import { createDeepLinkPin, type DeepLinkPin } from './pin.js';
-import type { AnchorV3 } from './types.js';
+import {
+  createDeepLinkPin,
+  type DeepLinkPin,
+  type DeepLinkPinTarget,
+} from './pin.js';
+import type { AnchorV3, CopyPayload } from './types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
@@ -14,11 +18,21 @@ const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
 let host: HTMLElement;
 let pin: DeepLinkPin;
 let copied: string[];
+let copiedHtml: (string | undefined)[];
 let toasts: string[];
 let copyResult: boolean | Promise<boolean>;
+let located: (Element | null)[];
+/** What `main.ts` would render for this pin; null stands for "cannot". */
+let comment: CopyPayload | null;
+let commentFor: DeepLinkPinTarget | null;
 
 const show = (over: Partial<AnchorV3> = {}) =>
-  pin.show({ id: 'c_zdv3rhz', anchor: anchor(over), label: 'Start › button' });
+  pin.show({
+    id: 'c_zdv3rhz',
+    anchor: anchor(over),
+    anchorB64: 'PAYLOAD',
+    label: 'Start › button',
+  });
 
 const marker = () => host.shadowRoot?.querySelector('.pin') as HTMLElement;
 const card = () => host.shadowRoot?.querySelector('.card') as HTMLElement;
@@ -59,16 +73,26 @@ beforeEach(() => {
   host.setAttribute('data-bai-review-overlay', '');
   document.body.append(host);
   copied = [];
+  copiedHtml = [];
   toasts = [];
+  located = [];
   copyResult = true;
+  comment = { text: 'the whole comment', html: '<p>the whole comment</p>' };
+  commentFor = null;
   pin = createDeepLinkPin({
     root: host.attachShadow({ mode: 'open' }),
     host,
-    copyText: (text) => {
+    copyText: (text, html) => {
       copied.push(text);
+      copiedHtml.push(html);
       return copyResult;
     },
     showToast: (message) => toasts.push(message),
+    buildComment: (target) => {
+      commentFor = target;
+      return comment;
+    },
+    onLocated: (element) => located.push(element),
   });
 });
 
@@ -100,6 +124,7 @@ describe('createDeepLinkPin', () => {
   it('names the component the block carried under the label', () => {
     pin.show({
       id: 'c_zdv3rhz',
+      anchorB64: 'PAYLOAD',
       anchor: anchor({ c: { name: 'StartPage', src: 'src/StartPage.tsx:4' } }),
       label: 'Start › button',
     });
@@ -545,13 +570,14 @@ describe('createDeepLinkPin', () => {
 
     it('names every icon-only control for a screen reader', () => {
       show();
-      const named = ['.idcopy', '.close', '.locate'].map((sel) =>
+      const named = ['.idcopy', '.close', '.locate', '.copyall'].map((sel) =>
         host.shadowRoot?.querySelector(sel)?.getAttribute('aria-label'),
       );
       expect(named).toEqual([
         'Copy this comment id',
         'Dismiss this pin',
         'Scroll back to this element',
+        'Copy the whole comment',
       ]);
     });
 
@@ -584,6 +610,92 @@ describe('createDeepLinkPin', () => {
       expect(subText()).toBe(
         'c_zdv3rhz📋 · CreateButton (react/src/Create.tsx:12)',
       );
+    });
+  });
+
+  // FR-3851. The id names the comment; the comment is what gets forwarded.
+  describe('the whole-comment copy control', () => {
+    const commentCopy = () =>
+      host.shadowRoot?.querySelector('.copyall') as HTMLButtonElement;
+
+    it('writes both flavours of the block the owner rendered', () => {
+      show({ n: 'The label is cut off.' });
+      commentCopy().click();
+      expect(copied).toEqual(['the whole comment']);
+      expect(copiedHtml).toEqual(['<p>the whole comment</p>']);
+      expect(toasts).toEqual(['Copied the whole comment 📋']);
+    });
+
+    it('hands the owner the pin it is showing, payload included', () => {
+      show({ n: 'Misaligned.' });
+      commentCopy().click();
+      expect(commentFor).toMatchObject({
+        id: 'c_zdv3rhz',
+        anchorB64: 'PAYLOAD',
+        label: 'Start › button',
+      });
+      expect(commentFor?.anchor.n).toBe('Misaligned.');
+    });
+
+    // The link caps the note it carries, so a copy off a capped link is short.
+    it('says so when the link only carries a shortened note', () => {
+      show({ n: 'A very long note…', nt: 1 });
+      commentCopy().click();
+      expect(toasts).toEqual([
+        'Copied — the note is the shortened one the link carries 📋',
+      ]);
+    });
+
+    it('copies nothing once the pin is dismissed', () => {
+      show();
+      pin.dismiss();
+      commentCopy().click();
+      expect(copied).toEqual([]);
+      expect(toasts).toEqual([]);
+    });
+
+    it('says so rather than writing nothing when the block cannot be built', () => {
+      comment = null;
+      show();
+      commentCopy().click();
+      expect(copied).toEqual([]);
+      expect(toasts).toEqual(['Could not rebuild that comment']);
+    });
+
+    it('waits for an async clipboard before it claims success', async () => {
+      copyResult = Promise.resolve(false);
+      show();
+      commentCopy().click();
+      await copyResult;
+      expect(toasts[0]).toContain('Could not reach the clipboard');
+    });
+  });
+
+  // The ⚛️ stack is not in the anchor: the owner re-reads it from whatever
+  // element the pin is on, so it has to hear about every move.
+  describe('the located-element handoff', () => {
+    it('reports the element it settled on, and the loss of it', () => {
+      show();
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<button data-testid="create">Create</button>',
+      );
+      const element = document.querySelector('[data-testid="create"]');
+      expect(pin.locate()).toBe(true);
+      expect(located).toEqual([element]);
+      pin.dismiss();
+      expect(located).toEqual([element, null]);
+    });
+
+    it('stays quiet while the pin holds the same element', () => {
+      show();
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<button data-testid="create">Create</button>',
+      );
+      expect(pin.locate()).toBe(true);
+      expect(pin.locate()).toBe(true);
+      expect(located).toHaveLength(1);
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -654,12 +654,12 @@ describe('createDeepLinkPin', () => {
       expect(toasts).toEqual([]);
     });
 
-    it('says so rather than writing nothing when the block cannot be built', () => {
+    it('says so rather than writing a half-read block', () => {
       comment = null;
       show();
       commentCopy().click();
       expect(copied).toEqual([]);
-      expect(toasts).toEqual(['Could not rebuild that comment']);
+      expect(toasts).toEqual(['Still reading this element — try again']);
     });
 
     it('waits for an async clipboard before it claims success', async () => {

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -116,7 +116,8 @@ export interface DeepLinkPinOptions {
   /**
    * Re-render this pin's whole comment, SYNCHRONOUSLY — the copy runs through
    * `execCommand` on the gateway origin, so nothing may be awaited inside the
-   * gesture. `main.ts` owns it: the server state and the stack live there.
+   * gesture. `main.ts` owns it: the server state and the stack live there, and
+   * `null` means those reads have not landed for this element yet.
    */
   buildComment: (target: DeepLinkPinTarget) => CopyPayload | null;
   /** The pin settled on a different element — or on none. */
@@ -443,7 +444,7 @@ export function createDeepLinkPin({
     if (!target) return;
     const payload = buildComment(target);
     if (!payload) {
-      showToast('Could not rebuild that comment');
+      showToast('Still reading this element — try again');
       return;
     }
     write(

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -9,7 +9,7 @@
  */
 import { findAnchorTarget, quickFindTarget, textMatches } from './resolve.js';
 import { projectFraction } from './selection.js';
-import type { AnchorV3 } from './types.js';
+import type { AnchorV3, CopyPayload } from './types.js';
 
 const REPOSITION_DEBOUNCE_MS = 300;
 /** Long enough for a `behavior: 'smooth'` scroll and its momentum to stop. */
@@ -55,7 +55,7 @@ const STYLE = `
   /* The reviewer's own words lead. An anchor from before the note travelled
      carries none, and :empty leaves no gap where it would have been. */
   .card .note {
-    white-space: pre-wrap; word-break: break-word; padding-right: 42px;
+    white-space: pre-wrap; word-break: break-word; padding-right: 62px;
     margin-bottom: 6px;
   }
   .card .note:empty { display: none; }
@@ -65,7 +65,7 @@ const STYLE = `
   }
   .card .trunc.shown { display: block; }
   .card .label {
-    font-weight: 600; word-break: break-word; padding-right: 42px;
+    font-weight: 600; word-break: break-word; padding-right: 62px;
   }
   .card .sub {
     color: var(--bai-review-text-dim); font-size: 13px; margin-top: 3px;
@@ -83,13 +83,15 @@ const STYLE = `
     color: var(--bai-review-text-dim);
   }
   .card .idcopy:hover { color: var(--bai-review-text); }
-  .card .close, .card .locate {
+  .card .close, .card .locate, .card .copyall {
     position: absolute; top: 2px; cursor: pointer; border: 0;
     background: none; color: var(--bai-review-text-dim); font-size: 14px;
     pointer-events: auto;
   }
   .card .close { right: 4px; }
   .card .locate { right: 24px; }
+  .card .copyall { right: 44px; }
+  .card .copyall:hover { color: var(--bai-review-text); }
   /* The pick box's own style, so arriving on a link looks like the pick that
      made it: a thin stroke over a light fill, on our layer — never the app's. */
   .markbox {
@@ -106,15 +108,26 @@ export interface DeepLinkPinOptions {
   host: Element;
   /**
    * The overlay's own clipboard, not `navigator.clipboard`: the gateway origin
-   * is plain http, where `execCommand` is the only path that writes.
+   * is plain http, where `execCommand` is the only path that writes. The HTML
+   * flavour is what makes a paste into Teams a quote instead of raw markdown.
    */
-  copyText: (text: string) => boolean | Promise<boolean>;
+  copyText: (text: string, html?: string) => boolean | Promise<boolean>;
   showToast: (message: string) => void;
+  /**
+   * Re-render this pin's whole comment, SYNCHRONOUSLY — the copy runs through
+   * `execCommand` on the gateway origin, so nothing may be awaited inside the
+   * gesture. `main.ts` owns it: the server state and the stack live there.
+   */
+  buildComment: (target: DeepLinkPinTarget) => CopyPayload | null;
+  /** The pin settled on a different element — or on none. */
+  onLocated?: (element: Element | null) => void;
 }
 
 export interface DeepLinkPinTarget {
   id: string;
   anchor: AnchorV3;
+  /** The link's own anchor payload, so a copy can rebuild the link itself. */
+  anchorB64: string;
   /** `<route> › <landmark> › <tag "quoted text">` from the block. */
   label: string;
 }
@@ -124,6 +137,8 @@ export function createDeepLinkPin({
   host,
   copyText,
   showToast,
+  buildComment,
+  onLocated,
 }: DeepLinkPinOptions) {
   const style = document.createElement('style');
   style.textContent = STYLE;
@@ -177,7 +192,12 @@ export function createDeepLinkPin({
   locateButton.textContent = '📍';
   locateButton.title = 'Scroll back to this element';
   locateButton.setAttribute('aria-label', 'Scroll back to this element');
-  card.append(close, locateButton, note, trunc, label, sub);
+  const commentCopy = document.createElement('button');
+  commentCopy.className = 'copyall';
+  commentCopy.textContent = '⧉';
+  commentCopy.title = 'Copy the whole comment';
+  commentCopy.setAttribute('aria-label', 'Copy the whole comment');
+  card.append(close, locateButton, commentCopy, note, trunc, label, sub);
   const markBox = document.createElement('div');
   markBox.className = 'markbox';
   layer.append(markBox, marker, card);
@@ -221,8 +241,12 @@ export function createDeepLinkPin({
   }
 
   function setLocated(node: Element | null) {
+    const moved = node !== located;
     located = node;
     clippers = node ? collectClippers(node) : [];
+    // The ⚛️ stack a copy quotes belongs to the element the pin is on now, and
+    // a re-render moves it — so this fires on every change, not just the first.
+    if (moved) onLocated?.(node);
   }
 
   /**
@@ -392,6 +416,14 @@ export function createDeepLinkPin({
   );
   close.addEventListener('click', () => dismiss());
 
+  function write(text: string, html: string | undefined, ok: string) {
+    const done = (written: boolean) =>
+      showToast(written ? ok : 'Could not reach the clipboard — try again');
+    const copied = copyText(text, html);
+    if (typeof copied === 'boolean') done(copied);
+    else void copied.then(done);
+  }
+
   /**
    * The bare id, not the `#bai=v3.` link: what the reader pastes into the PR
    * thread or a Claude prompt to name this comment. The whole link is already
@@ -400,13 +432,29 @@ export function createDeepLinkPin({
   idCopy.addEventListener('click', () => {
     const id = target?.id;
     if (!id) return;
-    const done = (ok: boolean) =>
-      showToast(
-        ok ? `Copied ${id} 📋` : 'Could not reach the clipboard — try again',
-      );
-    const copied = copyText(id);
-    if (typeof copied === 'boolean') done(copied);
-    else void copied.then(done);
+    write(id, undefined, `Copied ${id} 📋`);
+  });
+
+  /**
+   * The comment itself, in the shape the composer wrote it — so opening a pin
+   * and forwarding it costs one click instead of retyping the note.
+   */
+  commentCopy.addEventListener('click', () => {
+    if (!target) return;
+    const payload = buildComment(target);
+    if (!payload) {
+      showToast('Could not rebuild that comment');
+      return;
+    }
+    write(
+      payload.text,
+      payload.html,
+      // The link caps the note it carries, and a copy that quietly loses the
+      // rest is worse than one that says so.
+      target.anchor.nt === 1
+        ? 'Copied — the note is the shortened one the link carries 📋'
+        : 'Copied the whole comment 📋',
+    );
   });
 
   function dismiss() {

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -77,6 +77,12 @@ declare global {
   }
 }
 
+/** One copy, two flavours: a markdown textarea and a rich editor. */
+export interface CopyPayload {
+  text: string;
+  html: string;
+}
+
 /** `/__review/state` — the write side needs the PR number and the repo root. */
 export interface ReviewServerState {
   pr: number | null;

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -14,7 +14,7 @@
  * its select mode is on, so the composer stays clickable mid-pick.
  */
 import { fractionWithin, projectFraction, type Box } from './selection.js';
-import type { AnchorRect } from './types.js';
+import type { AnchorRect, CopyPayload } from './types.js';
 
 /** Everything the outline needs; a `DOMRect` and a projected region both fit. */
 type RectLike = { left: number; top: number; width: number; height: number };
@@ -26,12 +26,6 @@ const COMPOSE_WIDTH = 300;
 const NOTE_DEBOUNCE_MS = 250;
 const COMPOSE_GAP = 10;
 const VIEWPORT_PAD = 8;
-
-/** One copy, two flavours: a markdown textarea and a rich editor. */
-export interface CopyPayload {
-  text: string;
-  html: string;
-}
 
 export interface OverlayUICallbacks {
   /**


### PR DESCRIPTION
Resolves #9424 (FR-3851)

## What

The card a `#bai=v3` link draws could copy its **pin id** (FR-3849). The id *names* the comment — it is not the comment. A reader who opens a pin and wants to forward it (another PR thread, a Teams reply, a Claude prompt) had to retype the note off the card.

This adds a second control to the card, `⧉` **Copy the whole comment**, that puts the comment on the clipboard in the shape the composer wrote it:

```
The label is cut off.

> 📍 **/ › button "Create"** · `c_zdv3rhz`
> ⚛️ in CreateButton (at react/src/components/CreateButton.tsx)
> [Open on dev server](https://fr-3851.localhost:1355/#bai=v3.c_zdv3rhz.<payload>)
<!-- bai-review v3 id=c_zdv3rhz pr=9426 at=2026-09-04T04:12:00Z -->
```

Both flavours, `text/plain` and `text/html`, exactly as the composer's ⌘⏎ writes them — so it pastes into a GitHub textarea as markdown and into Teams as a quote.

## How faithful it is

Most of the block rebuilds from the fragment alone, so it is the reviewer's own text, not a paraphrase:

| piece | source |
|---|---|
| note | `anchor.n` — the card already shows it |
| `📍` label | the label the card already renders |
| id | the fragment's |
| link | `pinUrl` on this origin — the very link that was opened |

Two pieces are **not** in the payload, and are re-derived here rather than invented:

- the `⚛️` **stack** — re-read through react-grab from the element the pin landed on, the same call the composer made. `pin.ts` therefore reports every move of its located element (`onLocated`), not just the first: a re-render can slide the pin, and the stack has to follow.
- **`pr`** off `/__review/state`, and **`at`** stamped at copy time. The copy re-emits the comment here and now; the *id* is what carries its identity, and that one is the original.

Two edges are handled rather than papered over:

- a note the link had to truncate (`nt`) copies short, and the toast says **"the note is the shortened one the link carries"**;
- a link written before the note travelled in the anchor, or made with no note, still copies — label, stack and link, exactly as an empty-note block from the composer.

## Also

`CopyPayload` moves from `ui.ts` to `types.ts`, which is where a shape two client modules share belongs.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm exec vitest run vite-plugins/review-overlay` → **16 files, 287 tests passed**
  - `pin.test.ts` — the new control writes both flavours, hands the owner the pin it is showing, names the truncation, stays silent once dismissed, reports "could not rebuild" instead of writing nothing, and waits for an async clipboard; plus the located-element handoff (fires on a move, silent on a hold).
  - `main-comment-copy.test.ts` (new) — boots the overlay on a real `#bai=v3` link and asserts the clipboard, line by line: the verbatim note, the `📍` label line, the `⚛️` frame with the source path relativized, the pin's own URL, and the marker.
- Dev server for a live look: the dev-server comment on this PR.

### Live check on this PR's dev server (after the review fixes)

Opened a hand-built `#bai=v3` link — deliberately riding alongside an app fragment, `#tab=logs&bai=v3.…` — pressed `⧉`, and read the clipboard back. Toast: **Copied the whole comment 📋**. Clipboard:

```
The button label is cut off on narrow screens.

> 📍 **Start › button-about-backend-ai › a "About Backend.AI"** · `c_probeaa`
> ⚛️ in WebUISiderFooter (at /src/components/MainLayout/WebUISiderFooter.tsx)
>   in Link (@astryxdesign/core)
>   in WebUISider (at /src/components/MainLayout/WebUISider.tsx)
>   in WebUISiderWithCustomTheme (at /src/components/MainLayout/WebUISider.tsx)
> [Open on dev server](https://…/project/…/start#tab=logs&bai=v3.c_probeaa.<payload>)
<!-- bai-review v3 id=c_probeaa pr=9426 at=2026-09-04T04:42:36Z -->
```

`tab=logs` survives the round trip, the `⚛️` frames are the ones react-grab resolved **here** for the element the pin landed on (the anchor carried none), and `pr=9426` came off `/__review/state`.

---

Copilot reviewed this draft twice: pass 1 raised three findings (all fixed in `6646a884a`, each thread replied to and resolved), pass 2 came back 🟢 with no new comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bp1aMFbstuURhZs7QmKLLh

<!-- fw-dev-server-url -->
🔗 **Dev server**: http://fr-3851-pr9426-copy-whole-comment.jongeun.10-82-0-159.sslip.io
<!-- /fw-dev-server-url -->