### PR TITLE
fix(FR-3853): dock the pin card instead of hiding it off-screen

### DIFF
--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -399,8 +399,40 @@ describe('createDeepLinkPin', () => {
         expect(
           host.shadowRoot?.querySelector('.awaynote')?.textContent,
         ).toContain('→');
-        expect(card().style.left).toBe('684px');
+        // 1024 − 340 − 8.
+        expect(card().style.left).toBe('676px');
       });
+    });
+
+    // The element is inside the WINDOW the whole time — only its scroller took
+    // it sideways — so clamping its own `left` would leave the card mid-screen
+    // under a ← that points at nothing.
+    it('docks sideways to the viewport edge, not to the element', () => {
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<div id="scroller" style="overflow-x: auto; overflow-y: auto"></div>',
+      );
+      const scroller = document.querySelector('#scroller') as HTMLElement;
+      scroller.getBoundingClientRect = () =>
+        ({
+          left: 400,
+          right: 800,
+          width: 400,
+          top: 0,
+          bottom: 700,
+          height: 700,
+        }) as DOMRect;
+      const element = mountSized(
+        { left: 100, right: 300, top: 100, bottom: 300, height: 200 },
+        60,
+      );
+      scroller.append(element);
+      show();
+      expect(pin.locate()).toBe(true);
+      expect(
+        host.shadowRoot?.querySelector('.awaynote')?.textContent,
+      ).toContain('←');
+      expect(card().style.left).toBe('8px');
     });
 
     it('clears the docked state when the pin is dismissed', () => {

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -236,7 +236,7 @@ describe('createDeepLinkPin', () => {
 
     // `getBoundingClientRect` still reports the box of an element a scroller
     // has clipped out of sight, so the window test alone leaves an orphan pin.
-    it('drops the pin when a scroller clips the element out of sight', () => {
+    it('docks the card when a scroller clips the element out of sight', () => {
       document.body.insertAdjacentHTML(
         'beforeend',
         '<div id="scroller" style="overflow-x: auto; overflow-y: auto"></div>',
@@ -256,7 +256,9 @@ describe('createDeepLinkPin', () => {
       show();
       expect(pin.locate()).toBe(true);
       expect(marker().classList.contains('found')).toBe(false);
-      expect(card().classList.contains('found')).toBe(false);
+      expect(marked()).toBe(false);
+      expect(card().classList.contains('found')).toBe(true);
+      expect(card().classList.contains('away')).toBe(true);
     });
 
     // A resize is pure geometry: it must not wait on the mutation debounce.
@@ -280,7 +282,10 @@ describe('createDeepLinkPin', () => {
       expect(marker().style.top).toBe('406px');
     });
 
-    it('drops the marker and the card when the element scrolls away', () => {
+    // The marker and the box belong ON the element and leave with it; the card
+    // is the comment, and it carries the control that scrolls back — hiding it
+    // is what put that button out of reach exactly when it was wanted.
+    it('drops the marker but docks the card when the element scrolls away', () => {
       const element = mountSized({ top: 100, bottom: 300, height: 200 }, 60);
       show();
       expect(pin.locate()).toBe(true);
@@ -296,8 +301,60 @@ describe('createDeepLinkPin', () => {
       window.dispatchEvent(new Event('resize'));
       return new Promise((resolve) => setTimeout(resolve, 400)).then(() => {
         expect(marker().classList.contains('found')).toBe(false);
-        expect(card().classList.contains('found')).toBe(false);
+        expect(marked()).toBe(false);
+        expect(card().classList.contains('found')).toBe(true);
+        expect(card().classList.contains('away')).toBe(true);
+        // Scrolled off the top, so the card docks to the top edge.
+        expect(card().style.top).toBe('8px');
+        expect(
+          host.shadowRoot?.querySelector('.awaynote')?.textContent,
+        ).toContain('↑');
       });
+    });
+
+    it('anchors the card again once the element scrolls back', () => {
+      const element = mountSized({ top: 100, bottom: 300, height: 200 }, 60);
+      show();
+      expect(pin.locate()).toBe(true);
+      const away = {
+        left: 20,
+        right: 420,
+        width: 400,
+        top: 2000,
+        bottom: 2200,
+        height: 200,
+      } as DOMRect;
+      const back = element.getBoundingClientRect;
+      element.getBoundingClientRect = () => away;
+      window.dispatchEvent(new Event('resize'));
+      return new Promise((resolve) => setTimeout(resolve, 400))
+        .then(() => {
+          expect(card().classList.contains('away')).toBe(true);
+          expect(
+            host.shadowRoot?.querySelector('.awaynote')?.textContent,
+          ).toContain('↓');
+          element.getBoundingClientRect = back;
+          window.dispatchEvent(new Event('resize'));
+          return new Promise((resolve) => setTimeout(resolve, 400));
+        })
+        .then(() => {
+          expect(card().classList.contains('away')).toBe(false);
+          expect(marked()).toBe(true);
+          expect(host.shadowRoot?.querySelector('.awaynote')?.textContent).toBe(
+            '',
+          );
+        });
+    });
+
+    it('clears the docked state when the pin is dismissed', () => {
+      mountSized({ top: -900, bottom: -700, height: 200 }, 60);
+      show();
+      expect(pin.locate()).toBe(true);
+      expect(card().classList.contains('away')).toBe(true);
+      pin.dismiss();
+      expect(card().classList.contains('found')).toBe(false);
+      expect(card().classList.contains('away')).toBe(false);
+      expect(host.shadowRoot?.querySelector('.awaynote')?.textContent).toBe('');
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -371,6 +371,38 @@ describe('createDeepLinkPin', () => {
       expect(card().style.top).toBe('712px');
     });
 
+    // The hint is the cue for where to look, so "off to the side" is not an
+    // answer — and the card's own left clamp already points the same way.
+    it('names left and right apart, and clamps the card toward each', () => {
+      const element = mountSized(
+        { left: -500, right: -100, top: 100, bottom: 300, height: 200 },
+        60,
+      );
+      show();
+      expect(pin.locate()).toBe(true);
+      expect(
+        host.shadowRoot?.querySelector('.awaynote')?.textContent,
+      ).toContain('←');
+      expect(card().style.left).toBe('8px');
+
+      element.getBoundingClientRect = () =>
+        ({
+          left: 1500,
+          right: 1900,
+          width: 400,
+          top: 100,
+          bottom: 300,
+          height: 200,
+        }) as DOMRect;
+      window.dispatchEvent(new Event('resize'));
+      return new Promise((resolve) => setTimeout(resolve, 400)).then(() => {
+        expect(
+          host.shadowRoot?.querySelector('.awaynote')?.textContent,
+        ).toContain('→');
+        expect(card().style.left).toBe('684px');
+      });
+    });
+
     it('clears the docked state when the pin is dismissed', () => {
       mountSized({ top: -900, bottom: -700, height: 200 }, 60);
       show();

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -259,6 +259,12 @@ describe('createDeepLinkPin', () => {
       expect(marked()).toBe(false);
       expect(card().classList.contains('found')).toBe(true);
       expect(card().classList.contains('away')).toBe(true);
+      // The element sits ABOVE its scroller (100..300 vs 400..700) while still
+      // inside the window, so the direction has to come from the scroller.
+      expect(
+        host.shadowRoot?.querySelector('.awaynote')?.textContent,
+      ).toContain('↑');
+      expect(card().style.top).toBe('8px');
     });
 
     // A resize is pure geometry: it must not wait on the mutation debounce.

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -346,6 +346,25 @@ describe('createDeepLinkPin', () => {
         });
     });
 
+    // The hint is a line OF the card, so a height read before it is written
+    // docks a bottom-docked card that many pixels past the fold.
+    it('measures the docked card with its hint already in place', () => {
+      mountSized({ top: 900, bottom: 1100, height: 200 }, 60);
+      Object.defineProperty(card(), 'offsetHeight', {
+        get: () =>
+          host.shadowRoot?.querySelector('.awaynote')?.textContent ? 80 : 60,
+        configurable: true,
+      });
+      show();
+      expect(pin.locate()).toBe(true);
+      expect(card().classList.contains('away')).toBe(true);
+      expect(
+        host.shadowRoot?.querySelector('.awaynote')?.textContent,
+      ).toContain('↓');
+      // 800 − 80 − 8, not 800 − 60 − 8.
+      expect(card().style.top).toBe('712px');
+    });
+
     it('clears the docked state when the pin is dismissed', () => {
       mountSized({ top: -900, bottom: -700, height: 200 }, 60);
       show();

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -373,11 +373,18 @@ describe('createDeepLinkPin', () => {
 
     // The hint is the cue for where to look, so "off to the side" is not an
     // answer — and the card's own left clamp already points the same way.
-    it('names left and right apart, and clamps the card toward each', () => {
+    it('names left and right apart, and docks the card toward each', () => {
       const element = mountSized(
         { left: -500, right: -100, top: 100, bottom: 300, height: 200 },
         60,
       );
+      // `.card` is `width: auto`, so a right dock has to measure it — an
+      // assumed width leaves a short comment short of the edge.
+      let width = 300;
+      Object.defineProperty(card(), 'offsetWidth', {
+        get: () => width,
+        configurable: true,
+      });
       show();
       expect(pin.locate()).toBe(true);
       expect(
@@ -385,23 +392,31 @@ describe('createDeepLinkPin', () => {
       ).toContain('←');
       expect(card().style.left).toBe('8px');
 
-      element.getBoundingClientRect = () =>
-        ({
-          left: 1500,
-          right: 1900,
-          width: 400,
-          top: 100,
-          bottom: 300,
-          height: 200,
-        }) as DOMRect;
+      const rightOfTheWindow = {
+        left: 1500,
+        right: 1900,
+        width: 400,
+        top: 100,
+        bottom: 300,
+        height: 200,
+      } as DOMRect;
+      element.getBoundingClientRect = () => rightOfTheWindow;
       window.dispatchEvent(new Event('resize'));
-      return new Promise((resolve) => setTimeout(resolve, 400)).then(() => {
-        expect(
-          host.shadowRoot?.querySelector('.awaynote')?.textContent,
-        ).toContain('→');
-        // 1024 − 340 − 8.
-        expect(card().style.left).toBe('676px');
-      });
+      return new Promise((resolve) => setTimeout(resolve, 400))
+        .then(() => {
+          expect(
+            host.shadowRoot?.querySelector('.awaynote')?.textContent,
+          ).toContain('→');
+          // 1024 − 300 − 8.
+          expect(card().style.left).toBe('716px');
+          // A narrower card hugs the same edge, not a fixed offset from it.
+          width = 200;
+          window.dispatchEvent(new Event('resize'));
+          return new Promise((resolve) => setTimeout(resolve, 400));
+        })
+        .then(() => {
+          expect(card().style.left).toBe('816px');
+        });
     });
 
     // The element is inside the WINDOW the whole time — only its scroller took

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -298,9 +298,10 @@ export function createDeepLinkPin({
     markBox.classList.remove('found');
     card.classList.add('found');
     card.classList.add('away');
-    const height = card.offsetHeight;
     const up = box.bottom <= 0;
     const down = box.top >= vh;
+    // Written BEFORE the measurement: the hint is a line of the card, so a
+    // height read without it docks a bottom-docked card past the fold.
     away.textContent = up
       ? '↑ Scrolled above — 📍 goes back'
       : down
@@ -309,7 +310,7 @@ export function createDeepLinkPin({
     card.style.left = `${Math.max(8, Math.min(box.left, vw - 340))}px`;
     card.style.top = up
       ? `${VIEWPORT_PAD}px`
-      : `${Math.max(VIEWPORT_PAD, vh - height - VIEWPORT_PAD)}px`;
+      : `${Math.max(VIEWPORT_PAD, vh - card.offsetHeight - VIEWPORT_PAD)}px`;
   }
 
   function place() {

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -22,6 +22,14 @@ const PULSE_MS = 4200;
 /** Escalated text scans a lost element gets before the pin stops looking. */
 const MAX_MISSED_SCANS = 3;
 
+/** The edges of a rectangle the element may have left: viewport or scroller. */
+interface Bounds {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
 const STYLE = `
   .pinlayer {
     position: fixed; inset: 0; z-index: 2147482999; pointer-events: none;
@@ -292,14 +300,19 @@ export function createDeepLinkPin({
    * go with it, but the card is the comment — and the control that scrolls
    * back lives in it, so hiding the card is what made that button unreachable
    * exactly when it was wanted. It docks to the edge the element left by.
+   *
+   * `area` is the rectangle the element left — a clipping scroller's, not the
+   * viewport's, when a scroller is what hid it. The card still docks to the
+   * VIEWPORT edge, because it lives on a fixed layer; only the direction comes
+   * from `area`.
    */
-  function placeAway(box: DOMRect, vh: number, vw: number) {
+  function placeAway(box: DOMRect, area: Bounds, vh: number, vw: number) {
     marker.classList.remove('found');
     markBox.classList.remove('found');
     card.classList.add('found');
     card.classList.add('away');
-    const up = box.bottom <= 0;
-    const down = box.top >= vh;
+    const up = box.bottom <= area.top;
+    const down = box.top >= area.bottom;
     // Written BEFORE the measurement: the hint is a line of the card, so a
     // height read without it docks a bottom-docked card past the fold.
     away.textContent = up
@@ -321,24 +334,24 @@ export function createDeepLinkPin({
     // A rect with no size at all is jsdom (or `display: contents`), not a
     // scrolled-away element.
     const measured = box.width > 0 || box.height > 0;
-    const outside = (area: {
-      top: number;
-      bottom: number;
-      left: number;
-      right: number;
-    }) =>
+    const outside = (area: Bounds) =>
       box.bottom <= area.top ||
       box.top >= area.bottom ||
       box.right <= area.left ||
       box.left >= area.right;
-    const offscreen = outside({ top: 0, bottom: vh, left: 0, right: vw });
+    const viewport: Bounds = { top: 0, bottom: vh, left: 0, right: vw };
     // `getBoundingClientRect` reports the geometric box of an element a
-    // scroller has clipped out of sight, so the window test is not enough.
-    const clipped = clippers.some((clip) => {
+    // scroller has clipped out of sight, so the window test is not enough —
+    // and the scroller's rect, not the viewport's, is what says which way it
+    // went.
+    const clipper = clippers.find((clip) => {
       const area = clip.getBoundingClientRect();
       return (area.width > 0 || area.height > 0) && outside(area);
     });
-    if (measured && (offscreen || clipped)) return placeAway(box, vh, vw);
+    const gone = outside(viewport)
+      ? viewport
+      : clipper?.getBoundingClientRect();
+    if (measured && gone) return placeAway(box, gone, vh, vw);
     marker.classList.add('found');
     card.classList.add('found');
     card.classList.remove('away');

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -17,6 +17,8 @@ const SETTLE_MS = 1200;
 /** Card gap below/above the element, and its margin to the viewport edge. */
 const CARD_GAP = 10;
 const VIEWPORT_PAD = 8;
+/** `.card`'s `max-width` plus its border and padding — its widest rendering. */
+const CARD_WIDTH = 340;
 /** Four 1 s beats of the prototype's arrival pulse, then just the box. */
 const PULSE_MS = 4200;
 /** Escalated text scans a lost element gets before the pin stops looking. */
@@ -325,7 +327,14 @@ export function createDeepLinkPin({
         : left
           ? '← Scrolled to the left — 📍 goes back'
           : '→ Scrolled to the right — 📍 goes back';
-    card.style.left = `${Math.max(8, Math.min(box.left, vw - 340))}px`;
+    // A horizontal departure docks to a horizontal edge. Clamping `box.left`
+    // would leave the card mid-screen whenever a scroller — not the window —
+    // is what took the element sideways, with an arrow pointing nowhere.
+    const rightEdge = Math.max(VIEWPORT_PAD, vw - CARD_WIDTH - VIEWPORT_PAD);
+    card.style.left =
+      up || down
+        ? `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - CARD_WIDTH))}px`
+        : `${left ? VIEWPORT_PAD : rightEdge}px`;
     card.style.top = up
       ? `${VIEWPORT_PAD}px`
       : `${Math.max(VIEWPORT_PAD, vh - card.offsetHeight - VIEWPORT_PAD)}px`;
@@ -371,7 +380,7 @@ export function createDeepLinkPin({
     });
     marker.style.left = `${box.left + 6}px`;
     marker.style.top = `${box.top + 6}px`;
-    card.style.left = `${Math.max(8, Math.min(box.left, vw - 340))}px`;
+    card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - CARD_WIDTH))}px`;
     // `locate()` centres the element, so anything taller than half the
     // viewport puts `box.bottom` below the fold — and a fixed layer cannot be
     // scrolled to. Flip above, then clamp.

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -17,8 +17,8 @@ const SETTLE_MS = 1200;
 /** Card gap below/above the element, and its margin to the viewport edge. */
 const CARD_GAP = 10;
 const VIEWPORT_PAD = 8;
-/** `.card`'s `max-width` plus its border and padding — its widest rendering. */
-const CARD_WIDTH = 340;
+/** `.card`'s `max-width` under the shadow root's `box-sizing: border-box`. */
+const CARD_MAX_WIDTH = 320;
 /** Four 1 s beats of the prototype's arrival pulse, then just the box. */
 const PULSE_MS = 4200;
 /** Escalated text scans a lost element gets before the pin stops looking. */
@@ -289,6 +289,13 @@ export function createDeepLinkPin({
     return view?.getComputedStyle(node).borderRadius || '0px';
   }
 
+  /**
+   * The card as it will be shown. Read only after `found` is on and the text
+   * is written, or it measures a hidden box. jsdom reports 0 for every layout
+   * value, so the cap stands in and keeps the clamps meaningful there.
+   */
+  const cardWidth = () => card.offsetWidth || CARD_MAX_WIDTH;
+
   function hide() {
     marker.classList.remove('found');
     card.classList.remove('found');
@@ -330,10 +337,12 @@ export function createDeepLinkPin({
     // A horizontal departure docks to a horizontal edge. Clamping `box.left`
     // would leave the card mid-screen whenever a scroller — not the window —
     // is what took the element sideways, with an arrow pointing nowhere.
-    const rightEdge = Math.max(VIEWPORT_PAD, vw - CARD_WIDTH - VIEWPORT_PAD);
+    // Measured, not assumed: `.card` is `width: auto`, so a short comment is
+    // far narrower than the cap and an assumed width would not reach the edge.
+    const rightEdge = Math.max(VIEWPORT_PAD, vw - cardWidth() - VIEWPORT_PAD);
     card.style.left =
       up || down
-        ? `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - CARD_WIDTH))}px`
+        ? `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - cardWidth()))}px`
         : `${left ? VIEWPORT_PAD : rightEdge}px`;
     card.style.top = up
       ? `${VIEWPORT_PAD}px`
@@ -380,7 +389,7 @@ export function createDeepLinkPin({
     });
     marker.style.left = `${box.left + 6}px`;
     marker.style.top = `${box.top + 6}px`;
-    card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - CARD_WIDTH))}px`;
+    card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - cardWidth()))}px`;
     // `locate()` centres the element, so anything taller than half the
     // viewport puts `box.bottom` below the fold — and a fixed layer cannot be
     // scrolled to. Flip above, then clamp.

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -52,6 +52,13 @@ const STYLE = `
     box-shadow: 0 4px 18px var(--bai-review-shadow);
   }
   .card.found { display: block; }
+  /* The element is gone from the viewport; the card is docked, not anchored. */
+  .card.away { border-style: dashed; opacity: 0.94; }
+  .card .awaynote {
+    color: var(--bai-review-text-dim); font-size: 11px; margin-bottom: 6px;
+    padding-right: 62px;
+  }
+  .card .awaynote:empty { display: none; }
   /* The reviewer's own words lead. An anchor from before the note travelled
      carries none, and :empty leaves no gap where it would have been. */
   .card .note {
@@ -167,6 +174,8 @@ export function createDeepLinkPin({
   const truncText = run();
   truncText.textContent = 'Note truncated — the comment has the whole of it.';
   trunc.append(truncText);
+  const away = document.createElement('div');
+  away.className = 'awaynote';
   const label = document.createElement('div');
   label.className = 'label';
   const labelText = run();
@@ -198,7 +207,7 @@ export function createDeepLinkPin({
   commentCopy.textContent = '⧉';
   commentCopy.title = 'Copy the whole comment';
   commentCopy.setAttribute('aria-label', 'Copy the whole comment');
-  card.append(close, locateButton, commentCopy, note, trunc, label, sub);
+  card.append(close, locateButton, commentCopy, away, note, trunc, label, sub);
   const markBox = document.createElement('div');
   markBox.className = 'markbox';
   layer.append(markBox, marker, card);
@@ -273,7 +282,34 @@ export function createDeepLinkPin({
   function hide() {
     marker.classList.remove('found');
     card.classList.remove('found');
+    card.classList.remove('away');
     markBox.classList.remove('found');
+    away.textContent = '';
+  }
+
+  /**
+   * The element scrolled out of sight. The marker and the box belong ON it and
+   * go with it, but the card is the comment — and the control that scrolls
+   * back lives in it, so hiding the card is what made that button unreachable
+   * exactly when it was wanted. It docks to the edge the element left by.
+   */
+  function placeAway(box: DOMRect, vh: number, vw: number) {
+    marker.classList.remove('found');
+    markBox.classList.remove('found');
+    card.classList.add('found');
+    card.classList.add('away');
+    const height = card.offsetHeight;
+    const up = box.bottom <= 0;
+    const down = box.top >= vh;
+    away.textContent = up
+      ? '↑ Scrolled above — 📍 goes back'
+      : down
+        ? '↓ Scrolled below — 📍 goes back'
+        : '↔ Off to the side — 📍 goes back';
+    card.style.left = `${Math.max(8, Math.min(box.left, vw - 340))}px`;
+    card.style.top = up
+      ? `${VIEWPORT_PAD}px`
+      : `${Math.max(VIEWPORT_PAD, vh - height - VIEWPORT_PAD)}px`;
   }
 
   function place() {
@@ -281,8 +317,8 @@ export function createDeepLinkPin({
     const box = markedBox(located);
     const vw = window.innerWidth;
     const vh = window.innerHeight;
-    // A scrolled-away element must not leave a floating card behind. A rect
-    // with no size at all is jsdom (or `display: contents`), not off-screen.
+    // A rect with no size at all is jsdom (or `display: contents`), not a
+    // scrolled-away element.
     const measured = box.width > 0 || box.height > 0;
     const outside = (area: {
       top: number;
@@ -301,9 +337,11 @@ export function createDeepLinkPin({
       const area = clip.getBoundingClientRect();
       return (area.width > 0 || area.height > 0) && outside(area);
     });
-    if (measured && (offscreen || clipped)) return hide();
+    if (measured && (offscreen || clipped)) return placeAway(box, vh, vw);
     marker.classList.add('found');
     card.classList.add('found');
+    card.classList.remove('away');
+    away.textContent = '';
     markBox.classList.add('found');
     Object.assign(markBox.style, {
       left: `${box.left}px`,

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -313,13 +313,18 @@ export function createDeepLinkPin({
     card.classList.add('away');
     const up = box.bottom <= area.top;
     const down = box.top >= area.bottom;
+    // `placeAway` runs only when the element is outside `area` on one of the
+    // four sides, so failing the other three leaves exactly "past the right".
+    const left = box.right <= area.left;
     // Written BEFORE the measurement: the hint is a line of the card, so a
     // height read without it docks a bottom-docked card past the fold.
     away.textContent = up
       ? '↑ Scrolled above — 📍 goes back'
       : down
         ? '↓ Scrolled below — 📍 goes back'
-        : '↔ Off to the side — 📍 goes back';
+        : left
+          ? '← Scrolled to the left — 📍 goes back'
+          : '→ Scrolled to the right — 📍 goes back';
     card.style.left = `${Math.max(8, Math.min(box.left, vw - 340))}px`;
     card.style.top = up
       ? `${VIEWPORT_PAD}px`

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -295,6 +295,9 @@ export function createDeepLinkPin({
    * value, so the cap stands in and keeps the clamps meaningful there.
    */
   const cardWidth = () => card.offsetWidth || CARD_MAX_WIDTH;
+  /** The rightmost `left` that still leaves the card's shadow room to draw. */
+  const rightEdge = () =>
+    Math.max(VIEWPORT_PAD, window.innerWidth - cardWidth() - VIEWPORT_PAD);
 
   function hide() {
     marker.classList.remove('found');
@@ -315,7 +318,7 @@ export function createDeepLinkPin({
    * VIEWPORT edge, because it lives on a fixed layer; only the direction comes
    * from `area`.
    */
-  function placeAway(box: DOMRect, area: Bounds, vh: number, vw: number) {
+  function placeAway(box: DOMRect, area: Bounds, vh: number) {
     marker.classList.remove('found');
     markBox.classList.remove('found');
     card.classList.add('found');
@@ -339,11 +342,10 @@ export function createDeepLinkPin({
     // is what took the element sideways, with an arrow pointing nowhere.
     // Measured, not assumed: `.card` is `width: auto`, so a short comment is
     // far narrower than the cap and an assumed width would not reach the edge.
-    const rightEdge = Math.max(VIEWPORT_PAD, vw - cardWidth() - VIEWPORT_PAD);
     card.style.left =
       up || down
-        ? `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - cardWidth()))}px`
-        : `${left ? VIEWPORT_PAD : rightEdge}px`;
+        ? `${Math.max(VIEWPORT_PAD, Math.min(box.left, rightEdge()))}px`
+        : `${left ? VIEWPORT_PAD : rightEdge()}px`;
     card.style.top = up
       ? `${VIEWPORT_PAD}px`
       : `${Math.max(VIEWPORT_PAD, vh - card.offsetHeight - VIEWPORT_PAD)}px`;
@@ -374,7 +376,7 @@ export function createDeepLinkPin({
     const gone = outside(viewport)
       ? viewport
       : clipper?.getBoundingClientRect();
-    if (measured && gone) return placeAway(box, gone, vh, vw);
+    if (measured && gone) return placeAway(box, gone, vh);
     marker.classList.add('found');
     card.classList.add('found');
     card.classList.remove('away');
@@ -389,7 +391,7 @@ export function createDeepLinkPin({
     });
     marker.style.left = `${box.left + 6}px`;
     marker.style.top = `${box.top + 6}px`;
-    card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, vw - cardWidth()))}px`;
+    card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, rightEdge()))}px`;
     // `locate()` centres the element, so anything taller than half the
     // viewport puts `box.bottom` below the fold — and a fixed layer cannot be
     // scrolled to. Flip above, then clamp.


### PR DESCRIPTION
Resolves #9428 (FR-3853)

## The defect

The deep-link card carries a `📍` control whose whole job is **"scroll back to this element"** (`locate`, from FR-3813). It is the answer to *"where did my pin go?"* — and it was unreachable in exactly that situation.

`place()` hid the marker, the highlight box **and** the card the moment the element left the viewport or a scroll container clipped it out of sight. So the button existed only while the pin was already on screen, which is when nobody needs it. What was left of its usefulness was re-centring an element that happened to be half-visible.

## The fix

Split the three pieces by **what each one is anchored to**:

| piece | anchored to | when the element scrolls away |
|---|---|---|
| marker (`📍`) | the element | leaves with it (unchanged) |
| highlight box | the element | leaves with it (unchanged) |
| card | nothing — it *is* the comment | **stays**, docked to the edge the element went past |

The docked card drops its anchor, goes dashed, and names the direction: `↑ Scrolled above — 📍 goes back`. Pressing `📍` scrolls the element back and the card re-anchors, marker and box with it. A card that comes back into view on its own clears the docked state too, as does dismissing the pin — so the next link starts clean.

### Accepted trade-off

A card docked to the top overlaps the app's own header band. That is deliberate rather than overlooked: the card is dismissable (`✕`), the whole overlay is dev-only, and dodging page chrome would mean reading a layout this overlay knows nothing about on purpose (it resolves elements from an anchor payload, not from the app's structure).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm exec vitest run vite-plugins/review-overlay` → **16 files, 289 tests passed**
  - two existing tests re-stated to the new contract (window-scroll and the `clippers` path both now assert *marker hidden, card docked*),
  - three new: the direction hint and the top-edge dock, re-anchoring when the element comes back, and dismissal clearing the docked state.
- Live-checked on the dev server, on `.main-layout-content-scroll` (a scroll container, not the window):

| state | card | marker / box | hint |
|---|---|---|---|
| anchored | `card found`, `top: 170px` | shown | — |
| scrolled off | `card found away`, `top: 8px` | hidden | `↑ Scrolled above — 📍 goes back` |
| after pressing `📍` | `card found`, `top: 170px` | shown | cleared |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bp1aMFbstuURhZs7QmKLLh

---

## Review record

Copilot reviewed this as a draft **six times**; every pass landed a real finding, each fixed with a regression test and each thread replied to and resolved:

1. `placeAway` measured the card's height before writing the hint → a bottom dock landed past the fold (`bc4184a5b`).
2. The departure direction came from the viewport even when a *scroller* hid the element → `↔ Off to the side` and a bottom dock for something that went up (`351fb609c`).
3. `↔` named no direction at all → split into `←` / `→` (`099f255a1`).
4. The horizontal twin of (2): a sideways departure clamped `box.left` and left the card mid-screen under an arrow pointing nowhere (`efa8a8637`).
5. The right dock subtracted an assumed 340 — `.card` is `width: auto`, and the shadow root's `box-sizing: border-box` makes the cap 320, not 340 → measure `offsetWidth` (`3084d471a`).
6. That measurement removed 20px of accidental slack, so a far-right card sat flush against the edge, clipping its shadow → one `rightEdge()` for both clamps (`9fba8865c`).

The loop was stopped at six by choice, not by the findings drying up. Commit `9fba8865c` is the one commit no Copilot pass has itself re-read: a one-line padding restoration, `verify.sh` green, 292 overlay tests passing, and live-checked on the dev server.

### Final live check (1280×460)

| state | card | marker | hint |
|---|---|---|---|
| anchored | `card found`, `top: 170px`, measured width 320 | shown | — |
| scrolled off | `card found away`, `top: 8px` | hidden | `↑ Scrolled above — 📍 goes back` |
| after `📍` | `card found`, `top: 170px` | shown | cleared |
