### PR TITLE
style(FR-3854): align the Bulk Create Users from CSV modal with the other modals

### DIFF
--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -979,8 +979,8 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
       centered
       destroyOnHidden
       title={
-        <BAIFlex align="center" gap="xs">
-          <Heading level={5}>{t('credential.BulkCreateUserFromCSV')}</Heading>
+        <BAIFlex align="center" gap="xxs">
+          {t('credential.BulkCreateUserFromCSV')}
           <BAIQuestionIconWithTooltip
             title={t('credential.BulkCreateUserFromCSVSubtitle')}
           />
@@ -1038,10 +1038,9 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           flexShrink: 0,
           borderRight: `1px solid ${token.colorBorderSecondary}`,
           overflowY: 'auto',
-          // The modal body already supplies vertical padding (BAIModal sets
-          // paddingTop/Bottom to paddingMD); only add the matching horizontal
-          // padding here so the content sits evenly inset on all sides.
-          padding: token.paddingMD,
+          // The modal body is already inset on all four sides by Astryx
+          // `LayoutContent`; only the gutter before the divider is ours.
+          paddingRight: token.paddingMD,
         }}
       >
         {/* ── Source file section ── */}
@@ -1322,7 +1321,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           flex: 1,
           minWidth: 0,
           overflowY: 'auto',
-          padding: token.paddingMD,
+          paddingLeft: token.paddingMD,
         }}
       >
         <BAIFlex align="center" gap="xs">

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -1001,7 +1001,6 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           minHeight: 0,
           overflow: 'hidden',
         },
-        header: { paddingBottom: token.paddingSM },
       }}
       footer={
         <BAIFlex justify="end" gap="sm">


### PR DESCRIPTION
Resolves #9430 (FR-3854)

The **Bulk Create Users from CSV** modal drifted from every other modal in the app: its title did not sit on the header's centre line, and its content was inset noticeably further from the left edge than the title above it. Three separate antd-era leftovers in the call site, all measured in the running app.

## What was wrong

**1. The title sat 6px above the header's centre line.** The call site passed `styles={{ header: { paddingBottom: token.paddingSM } }}`, which adds 12px to the **bottom** of the Astryx `LayoutHeader` only. The title row inside it is already padded symmetrically (16px/16px), so the band ran 125→185 while its content centred at 149 — a visible gap under the title. No other modal pads the header slot on one side; the ones that touch it only remove the border.

**2. The title's line box overflowed the header row.** It was passed as a `Heading level={5}` nested inside `BAIModal`'s `title` prop, which `DialogHeader` already wraps in its own `Heading level={2}`. Both render at 16px, so the size looked right, but the inner `h5` carries a **26.67px** line-height against the header's **24px**. Every other modal (e.g. `SchedulerSettingModal`) passes plain text next to `BAIQuestionIconWithTooltip`; this one now does too.

**3. The body was inset twice.** Astryx `LayoutContent`, which `BAIModal` renders around the body, already pads all four sides — it is only edge-to-edge with `padding={0}`, which `BAIModal` does not pass. Each of the two panels added another `token.paddingMD` on top, so the content sat 20px further in than the title. Each panel now keeps only the gutter it owns around the divider. (`styles.body: { padding: 0 }` does not undo the `LayoutContent` inset — it only reaches the inner div.)

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9431/20260904-065330-before.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9431/20260904-071129-after-v2.png) |

In the "before" shot the panel content starts to the right of the modal title and the title floats above the header's centre; in the "after" shot both are flush and centred.

## Dev server

Test server: `10.82.130.172:8090`

A dev server for this branch is running on box `sujin` and reachable from the team network:

http://fr-3854-pr9431-align-bulk-create.sujin.10-82-0-159.sslip.io

Open it and go to **Admin → Users → ⋯ → Bulk Create Users from CSV**. The login form is pre-filled with the endpoint and the shared test account.

## Verification

Measured in the running app against a live manager, before and after:

| | before | after |
|---|---|---|
| header band vs title centre | 155 vs 149 (6px high) | 149.5 vs 149 |
| title line box | 26.66px | 24px, matching the header row |
| panel headings | x = 124 | x = 104 — flush with the modal title |

`bash scripts/verify.sh` → `=== ALL PASS ===`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqdtyamjPMoWuwj1g2KNub

<!-- fw-dev-server-url -->
🔗 **Dev server**: http://fr-3854-pr9431-align-bulk-create.sujin.10-82-0-159.sslip.io
<!-- /fw-dev-server-url -->