### PR TITLE
feat(FR-3855): read #bai=v3 pins with the overlay's own codec from a CLI

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,17 @@
+# Context Map
+
+The Web UI is one application with several bounded contexts. Only the ones that
+have been modeled explicitly are listed; add a context here when its glossary is
+written.
+
+## Contexts
+
+- [Dev review overlay](./react/vite-plugins/review-overlay/CONTEXT.md) — the
+  dev-server-only tool a reviewer uses to pin an element, write a note about
+  it, and hand the result to a PR comment, a Teams thread or a Claude prompt.
+
+## Relationships
+
+- **Dev review overlay → PR review loop**: the overlay writes blocks and links;
+  the `fw` plugin's `pr-review-thread-resolver` skill (claude-mp) reads them
+  through the overlay's own codec, run from a Web UI checkout.

--- a/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
+++ b/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
@@ -1,0 +1,54 @@
+# ADR-0002: A pin set is `&`-repeated `#bai=v3` parts, read by one codec
+
+- Status: Accepted
+- Date: 2026-09-04
+- Issues: FR-3313 (epic), the pin-set tickets under it
+
+## Context
+
+The dev review overlay copies one pin as `<path>?<query>#bai=v3.<id>.<anchor>`
+plus a markdown block. Reviewers want to make several pins in one sitting and
+hand them over as one comment with one link that shows every pin at once. The
+fragment is a wire format: it is pasted into PR comments, Teams threads and
+Claude prompts, and it is read back by this overlay and by the Claude-side
+review skill, so its grammar is hard to change once links exist in the wild.
+
+## Decision
+
+A pin set is carried as **`&`-separated repetitions of the existing part**:
+`#bai=v3.<id1>.<anchor1>&bai=v3.<id2>.<anchor2>…`, in set order, with the
+link's path and query taken from the first pin. A single pin is the N=1 case
+and is byte-identical to today's link and block. There is no version bump.
+
+The format has **one reader**: the overlay's own codec
+(`react/vite-plugins/review-overlay/client/codec.ts`, `deeplink.ts`,
+`block.ts`, `id.ts`), exposed as a Node CLI (`pnpm run review-pins`). The
+Claude-side skill runs that CLI from a Web UI checkout instead of keeping its
+own reimplementation.
+
+What stays in claude-mp is the **transport** in front of the format: Teams
+renders a pasted block to HTML and its reader flattens it back to text with
+the quote markers gone and the link moved to a separate `hrefs[]`, so that
+reconstruction is Teams-shaped, not pin-shaped, and it feeds the CLI rather
+than duplicating it.
+
+## Considered options
+
+- **`v4` set envelope** — every anchor in one compressed blob. Shorter URLs
+  (deflate shares the repeated route and landmark) and a natural place for
+  set-level metadata, but a second grammar, a permanent legacy path for `v3`
+  links, all-or-nothing decoding of a truncated link, and every reader has to
+  be revised. Rejected until set-level metadata is actually wanted; `&`
+  repetition remains valid alongside it if that day comes.
+- **Keeping the Python reimplementation** (`pin_parser.py` in claude-mp)
+  in step with the TypeScript codec by hand. Rejected: the multi-pin change
+  would have to land twice, and the two had already drifted in comments.
+
+## Consequences
+
+- `deeplink.ts` parses a list; the app's own fragment parts still ride along
+  and are preserved.
+- A pin's `at` (hence its id) is fixed when it joins the set, not when the
+  set is copied, so re-copying a growing set re-emits stable ids.
+- Fragment length grows linearly (≈300–500 chars per pin); a soft cap of 30
+  pins keeps a link pasteable everywhere.

--- a/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
+++ b/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
@@ -52,3 +52,7 @@ than duplicating it.
   set is copied, so re-copying a growing set re-emits stable ids.
 - Fragment length grows linearly (≈300–500 chars per pin); a soft cap of 30
   pins keeps a link pasteable everywhere.
+- Each block carries its own pin's link and the set link is emitted once after
+  the last block, because repeating the set link in every block made the
+  comment O(N²) — 371 KB at 30 pins, past GitHub's 65,536-character comment
+  limit from 13 pins on.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prepare": "husky",
     "theme-schema:update": "node scripts/gen-theme-schema.cjs",
     "astryx": "pnpm --prefix ./react exec astryx",
-    "bai-agent": "node packages/backend.ai-agent-cli/dist/cli.js"
+    "bai-agent": "node packages/backend.ai-agent-cli/dist/cli.js",
+    "review-pins": "node --import ./react/vite-plugins/review-overlay/register.mjs react/vite-plugins/review-overlay/cli.ts"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",

--- a/react/vite-plugins/review-overlay/CONTEXT.md
+++ b/react/vite-plugins/review-overlay/CONTEXT.md
@@ -38,15 +38,15 @@ selector, landmark, text, and the note. Travels compressed inside the link.
 _Avoid_: payload, target, locator
 
 **Link**:
-The dev-server URL that carries a pin set in its fragment. A pin set has
-exactly one link, whatever its size.
+The dev-server URL that carries pins in its fragment. Every pin has its own
+one-pin link, and a set also has a set link that carries all of its pins.
 _Avoid_: deep link (the act of opening it), permalink, share URL
 
 **Block**:
 The markdown a pin is rendered as for pasting: the reviewer's note, a quoted
 label, the ⚛️ component stack, the link, and the marker comment. One block per
-pin; every block of a pin set carries the set's one link, so a block pasted on
-its own still opens.
+pin; every block carries its own pin's link, so a block pasted on its own still
+opens, and the set's link follows the last block once.
 _Avoid_: snippet, template, card (the on-screen thing)
 
 **Label**:

--- a/react/vite-plugins/review-overlay/CONTEXT.md
+++ b/react/vite-plugins/review-overlay/CONTEXT.md
@@ -1,0 +1,66 @@
+# Dev review overlay
+
+The dev-server-only tool a reviewer uses to point at an element on a served PR,
+say something about it, and hand that to a PR comment, a Teams thread or a
+Claude prompt — without the receiving side needing any lookup to find the
+element again.
+
+## Language
+
+**Pin**:
+One reviewer remark tied to one element: an anchor, an optional note, and an
+id. A pin is self-contained — its link alone is enough to show it again.
+_Avoid_: comment (the channel's word), marker (the drawn glyph only), pick
+
+**Pin set**:
+The ordered list of pins a reviewer makes in one sitting and hands over
+together, as one comment and one link. A single pin is a pin set of one.
+_Avoid_: batch, session, group, thread
+
+**Draft set**:
+The pin set a tab is building right now — what is drawn on screen. It is the
+single source of truth for the screen; a link opened in the tab merges into it.
+_Avoid_: session, buffer, clipboard set
+
+**Focus pin**:
+The one pin in a set that owns navigation, scroll-into-view and the arrival
+pulse when a link is opened; the others are drawn quietly.
+_Avoid_: primary pin, first pin (it is not always the first), target
+
+**Set dock**:
+The overlay's list of the draft set's pins with the set-wide actions (copy
+all, clear all). Off-page pins live only here.
+_Avoid_: panel, sidebar, tray
+
+**Anchor**:
+The self-describing payload that locates a pin's element: page (path and query),
+selector, landmark, text, and the note. Travels compressed inside the link.
+_Avoid_: payload, target, locator
+
+**Link**:
+The dev-server URL that carries a pin set in its fragment. A pin set has
+exactly one link, whatever its size.
+_Avoid_: deep link (the act of opening it), permalink, share URL
+
+**Block**:
+The markdown a pin is rendered as for pasting: the reviewer's note, a quoted
+label, the ⚛️ component stack, the link, and the marker comment. One block per
+pin; every block of a pin set carries the set's one link, so a block pasted on
+its own still opens.
+_Avoid_: snippet, template, card (the on-screen thing)
+
+**Label**:
+The human-readable path to a pin's element: route › landmark › element with its
+on-screen text. Always English for the route part.
+_Avoid_: path (ambiguous with the URL path), breadcrumb
+
+**Landmark**:
+The nearest `data-testid` ancestor of a pinned element; the stable frame the
+anchor measures against.
+_Avoid_: container, parent, testid (the attribute, not the concept)
+
+**Codec**:
+The one implementation, owned by this overlay, that encodes and decodes anchors
+and parses links and blocks. Every reader of the format — the overlay itself and
+the Claude-side skill — runs this codec rather than its own copy.
+_Avoid_: parser (a reimplementation elsewhere), pin_parser

--- a/react/vite-plugins/review-overlay/cli.test.ts
+++ b/react/vite-plugins/review-overlay/cli.test.ts
@@ -1,0 +1,277 @@
+import { API_VERSION, main, parsePins, parseResult } from './cli.js';
+import { buildBlockFromCapture } from './client/block.js';
+import { encodeAnchor } from './client/codec.js';
+import { pinId } from './client/id.js';
+import type { AnchorV3 } from './client/types.js';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+// `new URL(..., import.meta.url)` is Vite's asset-reference pattern and gets
+// rewritten in this file, so the sample paths are joined by hand.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const samplePath = (name: string) => join(HERE, 'testdata', name);
+const sample = (name: string) => readFileSync(samplePath(name), 'utf8');
+
+const anchor: AnchorV3 = {
+  v: 3,
+  s: '[data-testid="page-start"] > button:nth-of-type(2)',
+  p: '/project/default/session/start',
+  q: 'tab=general',
+  tag: 'button',
+  txt: 'Create Deployment',
+  tid: 'page-start',
+};
+
+describe('parse — the block samples the review skill reads today', () => {
+  it('lifts both pins out of a two-block comment', async () => {
+    const pins = await parsePins(sample('pin-block-sample.md'));
+    expect(pins.map((pin) => pin.id)).toEqual(['c_ew7rxz4', 'c_6jcddj5']);
+    expect(pins[0]).toMatchObject({
+      label: 'Start › webui-header › button "Create Deployment"',
+      note: 'Pin is 8px off and the tooltip is clipped.',
+      pr: 9330,
+      at: '2026-08-31T09:00:00Z',
+      idVerified: true,
+      stack: [
+        'in ActionItemContent (at /src/components/ActionItemContent.tsx:47)',
+        '  in Button (@astryxdesign/core)',
+        '  in StartPage (at /src/pages/StartPage.tsx)',
+      ],
+    });
+    expect(pins[0].anchor?.tid).toBe('webui-header');
+    expect(pins[0].url).toContain('?tab=general#bai=v3.c_ew7rxz4.');
+    // Two blocks in one comment must not steal each other's prose.
+    expect(pins[1].note).toBe(
+      'Placeholder still says "Search" after the filter is applied.',
+    );
+  });
+
+  it('reads a block and a bare link from the same comment', async () => {
+    const pins = await parsePins(sample('pin-block-noted-sample.md'));
+    expect(pins.map((pin) => pin.id)).toEqual(['c_obk74wj', 'c_mlphw3p']);
+    expect(pins[0].note).toBe(
+      'The primary action drifts right of the filter row.\n' +
+        'It should stay flush at 1280px and below.',
+    );
+    // The bare link has no block, so nothing proves its id and its note is
+    // the capped copy the anchor carries.
+    const bare = pins[1];
+    expect(bare.idVerified).toBeNull();
+    expect(bare.label).toBe('');
+    expect(bare.stack).toEqual([]);
+    expect(bare.note).toBe(bare.anchor?.n);
+    expect(bare.anchor?.nt).toBe(1);
+    expect(bare.url).toMatch(/^http:\/\/.+#bai=v3\.c_mlphw3p\./);
+  });
+});
+
+describe('parse — links on their own', () => {
+  it('finds a bare link with no block around it', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const pins = await parsePins(
+      `have a look at https://fr-3855.localhost:1355/project/default/session/start?tab=general#bai=v3.c_abcdef2.${anchorB64} please`,
+    );
+    expect(pins).toHaveLength(1);
+    expect(pins[0]).toMatchObject({
+      id: 'c_abcdef2',
+      label: '',
+      note: '',
+      pr: null,
+      at: null,
+      idVerified: null,
+    });
+    expect(pins[0].anchor).toEqual(anchor);
+    expect(pins[0].url).toBe(
+      `https://fr-3855.localhost:1355/project/default/session/start?tab=general#bai=v3.c_abcdef2.${anchorB64}`,
+    );
+  });
+
+  it("decodes GitHub's quote-reply escaping of the link", async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const quoted = `&gt; [Open on dev server](http://x/y%23bai%3Dv3.c_abcdef2.${anchorB64})`;
+    const pins = await parsePins(quoted);
+    expect(pins).toHaveLength(1);
+    expect(pins[0].id).toBe('c_abcdef2');
+    expect(pins[0].anchor).toEqual(anchor);
+  });
+
+  it('leaves a query the browser percent-encoded byte-identical', async () => {
+    const encoded: AnchorV3 = { ...anchor, q: 'filter=a%20b' };
+    const anchorB64 = await encodeAnchor(encoded);
+    const url = `http://x/project/default/session/start?filter=a%20b#bai=v3.c_abcdef2.${anchorB64}`;
+    const pins = await parsePins(url);
+    expect(pins[0].url).toBe(url);
+  });
+
+  it('unescapes a query that arrived as HTML entities', async () => {
+    const multi: AnchorV3 = { ...anchor, q: 'tab=general&status=RUNNING' };
+    const anchorB64 = await encodeAnchor(multi);
+    const pins = await parsePins(
+      `look at http://x/project/default/session/start?tab=general&amp;status=RUNNING#bai=v3.c_abcdef2.${anchorB64} please`,
+    );
+    expect(pins[0].url).toContain('?tab=general&status=RUNNING#');
+    expect(pins[0].url).not.toContain('&amp;');
+  });
+
+  it('prefers the link whose query matches, whichever came first', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const full = `http://x/project/default/session/start?tab=general#bai=v3.c_abcdef2.${anchorB64}`;
+    // What "Quote reply" leaves: the anchor without the query it was made on.
+    const degraded = `http://x/project/default/session/start#bai=v3.c_abcdef2.${anchorB64}`;
+    for (const text of [`${degraded}\n\n${full}`, `${full}\n\n${degraded}`]) {
+      const pins = await parsePins(text);
+      expect(pins).toHaveLength(1);
+      expect(pins[0].url).toBe(full);
+    }
+  });
+
+  it('is not a pin without an anchor', async () => {
+    expect(await parsePins('see #bai=v3.c_abcdef2 for the details')).toEqual(
+      [],
+    );
+  });
+});
+
+describe('parse — bounds on untrusted input', () => {
+  it('refuses an anchor longer than the codec allows', async () => {
+    const oversize = 'A'.repeat(2100);
+    expect(await parsePins(`http://x/y#bai=v3.c_abcdef2.${oversize}`)).toEqual(
+      [],
+    );
+  });
+
+  it('keeps the pin but not the payload when the anchor inflates past the cap', async () => {
+    // A few dozen base64 chars that inflate to 40 KB: within the link
+    // grammar's bounds, past the decoder's.
+    const bomb = await encodeAnchor({ ...anchor, s: 'x'.repeat(40_000) });
+    expect(bomb.length).toBeLessThan(2048);
+    const pins = await parsePins(`http://x/y#bai=v3.c_abcdef2.${bomb}`);
+    expect(pins).toHaveLength(1);
+    expect(pins[0].anchor).toBeNull();
+    expect(pins[0].url).toBe(`http://x/y#bai=v3.c_abcdef2.${bomb}`);
+  });
+});
+
+describe('parse — id verification', () => {
+  const block = async (id: string, pr: number, at: string, anchorB64: string) =>
+    [
+      'the note',
+      '',
+      `> 📍 **Start › page-start › button "Create Deployment"** · \`${id}\``,
+      '> ⚛️ in StartPage (at /src/pages/StartPage.tsx:120)',
+      `> [Open on dev server](http://x/project/default/session/start?tab=general#bai=v3.${id}.${anchorB64})`,
+      `<!-- bai-review v3 id=${id} pr=${pr} at=${at} -->`,
+    ].join('\n');
+
+  it('proves an id against the marker that claims it', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const at = '2026-09-04T00:00:00Z';
+    const id = pinId(9400, anchorB64, at);
+    const pins = await parsePins(await block(id, 9400, at, anchorB64));
+    expect(pins).toHaveLength(1);
+    expect(pins[0]).toMatchObject({ id, pr: 9400, at, idVerified: true });
+    expect(pins[0].note).toBe('the note');
+  });
+
+  it('drops a pin whose marker disowns its anchor', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const at = '2026-09-04T00:00:00Z';
+    const id = pinId(9400, anchorB64, at);
+    // The same marker over a different payload: this id does not hash from it.
+    const other = await encodeAnchor({ ...anchor, txt: 'Cancel' });
+    expect(await parsePins(await block(id, 9400, at, other))).toEqual([]);
+  });
+});
+
+describe('parse — round trip with the block producer', () => {
+  it('reads back what buildBlockFromCapture wrote', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const built = buildBlockFromCapture(
+      {
+        anchor,
+        anchorB64,
+        stack: ['in StartPage (at /src/pages/StartPage.tsx:120)'],
+      },
+      {
+        text: 'the primary action drifts right',
+        pr: 9400,
+        routeLabel: 'Start',
+        at: '2026-09-04T00:00:00Z',
+        origin: 'https://fr-3855.localhost:1355',
+      },
+    );
+    const pins = await parsePins(built.block);
+    expect(pins).toHaveLength(1);
+    expect(pins[0]).toMatchObject({
+      id: built.id,
+      url: built.url,
+      label: 'Start › page-start › button "Create Deployment"',
+      note: 'the primary action drifts right',
+      stack: ['in StartPage (at /src/pages/StartPage.tsx:120)'],
+      pr: 9400,
+      at: '2026-09-04T00:00:00Z',
+      idVerified: true,
+    });
+  });
+
+  it('merges the same pin quoted twice into one', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const built = buildBlockFromCapture(
+      { anchor, anchorB64, stack: [] },
+      { text: '', pr: 9400, routeLabel: 'Start', at: '2026-09-04T00:00:00Z' },
+    );
+    const pins = await parsePins(`${built.block}\n\nand again: ${built.url}`);
+    expect(pins).toHaveLength(1);
+    expect(pins[0].idVerified).toBe(true);
+  });
+});
+
+describe('the envelope and the exit codes', () => {
+  it('names its api version', async () => {
+    const result = await parseResult(sample('pin-block-sample.md'));
+    expect(result.apiVersion).toBe(API_VERSION);
+    expect(result.pins).toHaveLength(2);
+  });
+
+  it('parses through the loader the package script runs', () => {
+    const out = execFileSync(
+      process.execPath,
+      [
+        '--import',
+        join(HERE, 'register.mjs'),
+        join(HERE, 'cli.ts'),
+        'parse',
+        '--json',
+        samplePath('pin-block-sample.md'),
+      ],
+      { encoding: 'utf8' },
+    );
+    const result = JSON.parse(out);
+    expect(result.apiVersion).toBe(API_VERSION);
+    expect(result.pins).toHaveLength(2);
+  });
+
+  it('exits 0 with pins, 5 without, 2 on a bad invocation', async () => {
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    const errors = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    const file = samplePath('pin-block-sample.md');
+    try {
+      await expect(main(['parse', '--json', file])).resolves.toBe(0);
+      expect(JSON.parse(String(write.mock.calls[0][0])).pins).toHaveLength(2);
+      await expect(main(['parse', '/dev/null'])).resolves.toBe(5);
+      await expect(main(['pins', file])).resolves.toBe(2);
+      await expect(main(['parse', `${file}.missing`])).resolves.toBe(2);
+    } finally {
+      write.mockRestore();
+      errors.mockRestore();
+    }
+  });
+});

--- a/react/vite-plugins/review-overlay/cli.test.ts
+++ b/react/vite-plugins/review-overlay/cli.test.ts
@@ -269,6 +269,14 @@ describe('the envelope and the exit codes', () => {
       await expect(main(['parse', '/dev/null'])).resolves.toBe(5);
       await expect(main(['pins', file])).resolves.toBe(2);
       await expect(main(['parse', `${file}.missing`])).resolves.toBe(2);
+      // A second operand is refused rather than dropped, so the pins in the
+      // file the shell added are never silently missing from the answer.
+      const before = write.mock.calls.length;
+      await expect(main(['parse', file, file])).resolves.toBe(2);
+      expect(write.mock.calls.length).toBe(before);
+      expect(String(errors.mock.calls.at(-1)?.[0])).toContain(
+        'parse takes one file at most',
+      );
     } finally {
       write.mockRestore();
       errors.mockRestore();

--- a/react/vite-plugins/review-overlay/cli.ts
+++ b/react/vite-plugins/review-overlay/cli.ts
@@ -1,0 +1,457 @@
+/**
+ * `pnpm run review-pins parse [--json] [file|-]` — the overlay's codec, run
+ * from a terminal, so every reader of a `#bai=v3` link or 📍 block (the
+ * Claude-side review skill included) shares this one implementation instead of
+ * keeping a reimplementation in step by hand. See ADR-0002.
+ *
+ * Exit codes: 0 pins found · 2 usage / unreadable input · 5 no pin found.
+ */
+import { LINK_LABEL } from './client/block.js';
+import { PIN_BODY_SRC, decodeAnchor } from './client/codec.js';
+import { pinId } from './client/id.js';
+import type { AnchorV3 } from './client/types.js';
+import { readFileSync, realpathSync } from 'node:fs';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const API_VERSION = 'bai-review/v1';
+
+/** One pin as the CLI hands it over: the link's half plus the block's half. */
+export interface CliPin {
+  id: string;
+  /** `null` when the payload did not decode — the id and link still stand. */
+  anchor: AnchorV3 | null;
+  url: string;
+  label: string;
+  note: string;
+  stack: string[];
+  pr: number | null;
+  at: string | null;
+  /** `null` when no marker claimed this id, so nothing proved or disproved it. */
+  idVerified: boolean | null;
+}
+
+export interface ParseResult {
+  apiVersion: string;
+  pins: CliPin[];
+}
+
+/**
+ * `[#&]` mirrors `deeplink.ts`'s reader; the body's bounds come from the codec
+ * itself, so an over-long anchor is no match here either.
+ */
+const PIN_RE = new RegExp(`[#&]bai=v3\\.${PIN_BODY_SRC}`, 'g');
+/** The same grammar without `g`, for the callers that match exactly one link. */
+const ONE_PIN_RE = new RegExp(`[#&]bai=v3\\.${PIN_BODY_SRC}`);
+const BLOCK_HEAD_RE =
+  /^\s*(?:>\s?)+📍\s*\*\*(.*?)\*\*\s*·\s*`(c_[a-z2-7]{7})`\s*$/;
+const QUOTE_PREFIX_RE = /^\s*(?:>\s?)+/;
+const QUOTED_RE = /^\s*>/;
+const MARKER_RE =
+  /<!--\s*bai-review\s+v3\s+id=(c_[a-z2-7]{7})\s+pr=(\d+)\s+at=(\S+?)\s*-->/;
+const LINK_RE = new RegExp(`\\[${LINK_LABEL}\\]\\(([^)\\s]+)\\)`);
+const STACK_HEAD_RE = /^⚛️?\s*(.+)$/;
+const STACK_CONT_RE = /^\s+in \S/;
+
+// --------------------------------------------------------------------------
+// input normalisation
+// --------------------------------------------------------------------------
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+/**
+ * The entities a comment body actually arrives with. `&nbsp;` becomes a plain
+ * space — the stack indentation `STACK_CONT_RE` expects.
+ */
+export function htmlUnescape(text: string): string {
+  return (text || '').replace(
+    /&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g,
+    (whole, ref: string) => {
+      if (ref[0] === '#') {
+        const code =
+          ref[1] === 'x' || ref[1] === 'X'
+            ? Number.parseInt(ref.slice(2), 16)
+            : Number.parseInt(ref.slice(1), 10);
+        return Number.isFinite(code) && code > 0 && code <= 0x10ffff
+          ? String.fromCodePoint(code)
+          : whole;
+      }
+      return NAMED_ENTITIES[ref.toLowerCase()] ?? whole;
+    },
+  );
+}
+
+/**
+ * GitHub's "Quote reply" percent-encodes the link's `#` and `=`; that one
+ * sequence is decoded and nothing else (see the commit body).
+ */
+const PIN_MARKER_ESCAPE_RE = /(?:%23|#)bai(?:%3[Dd]|=)v3/g;
+
+export const decodeBody = (text: string): string =>
+  htmlUnescape(text).replace(PIN_MARKER_ESCAPE_RE, '#bai=v3');
+
+/**
+ * The body as written, then its unescaped copies. A link is taken from the
+ * variant it matched in, so `?filter=a%20b` survives byte-identical.
+ */
+export function textVariants(text: string): string[] {
+  const raw = text || '';
+  const variants = [raw];
+  for (const candidate of [htmlUnescape(raw), decodeBody(raw)]) {
+    if (!variants.includes(candidate)) variants.push(candidate);
+  }
+  return variants;
+}
+
+// --------------------------------------------------------------------------
+// links
+// --------------------------------------------------------------------------
+
+interface PinRef {
+  id: string;
+  anchorB64: string;
+  url: string;
+}
+
+/** The link is whatever runs up to the match, back to the nearest delimiter. */
+function expandUrl(text: string, start: number, end: number): string {
+  let left = start;
+  while (left > 0 && !' \t\n\r"\'<>()[]`'.includes(text[left - 1])) left -= 1;
+  return text.slice(left, end);
+}
+
+/**
+ * Every distinct `#bai=v3.<id>.<anchor>` link in `text`, in order — one anchor
+ * under two URLs is two refs, so `betterLink` gets to rank them.
+ */
+export function findPinRefs(text: string): PinRef[] {
+  const refs: PinRef[] = [];
+  const seen = new Set<string>();
+  for (const variant of textVariants(text)) {
+    PIN_RE.lastIndex = 0;
+    for (let m = PIN_RE.exec(variant); m; m = PIN_RE.exec(variant)) {
+      const url = expandUrl(variant, m.index, m.index + m[0].length);
+      const key = `${m[1]}.${m[2]}.${url}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      refs.push({ id: m[1], anchorB64: m[2], url });
+    }
+  }
+  return refs;
+}
+
+// --------------------------------------------------------------------------
+// blocks
+// --------------------------------------------------------------------------
+
+interface ParsedBlock {
+  id: string;
+  label: string;
+  stack: string[];
+  note: string;
+  link: string;
+  pr: number | null;
+  at: string | null;
+}
+
+const stripQuote = (line: string) => line.replace(QUOTE_PREFIX_RE, '');
+
+/** A generated block closes on its link line, so an upward note scan stops there. */
+const endsABlock = (line: string) =>
+  BLOCK_HEAD_RE.test(line) || LINK_RE.test(line);
+
+const closesABlock = (line: string) =>
+  QUOTED_RE.test(line) || MARKER_RE.test(line) || endsABlock(line);
+
+/**
+ * The reviewer's words are the comment's own prose, above the quote. The run
+ * stops at the previous block's end, so two blocks cannot steal each other's.
+ */
+function precedingNote(
+  lines: string[],
+  head: number,
+  floor: number,
+): [number, number] {
+  let j = head - 1;
+  while (j >= floor && !lines[j].trim()) j -= 1;
+  const end = j + 1;
+  while (j >= floor && lines[j].trim() && !closesABlock(lines[j])) j -= 1;
+  return [j + 1, end];
+}
+
+function fillBlockBody(block: ParsedBlock, body: string[]): void {
+  const notes: string[] = [];
+  let inStack = false;
+  for (const line of body) {
+    if (MARKER_RE.test(line)) continue;
+    const head = STACK_HEAD_RE.exec(line.trim());
+    if (head) {
+      block.stack.push(head[1].trim());
+      inStack = true;
+      continue;
+    }
+    if (inStack && STACK_CONT_RE.test(line)) {
+      block.stack.push(line.replace(/\s+$/, ''));
+      continue;
+    }
+    inStack = false;
+    const link = LINK_RE.exec(line);
+    if (link) {
+      block.link = link[1];
+      continue;
+    }
+    notes.push(line);
+  }
+  block.note = notes.join('\n').trim();
+}
+
+function parseBlocksIn(text: string): ParsedBlock[] {
+  const lines = text.split('\n');
+  const blocks: ParsedBlock[] = [];
+  let i = 0;
+  let floor = 0;
+  while (i < lines.length) {
+    const head = BLOCK_HEAD_RE.exec(lines[i]);
+    if (!head) {
+      i += 1;
+      continue;
+    }
+    const block: ParsedBlock = {
+      id: head[2],
+      label: head[1].trim(),
+      stack: [],
+      note: '',
+      link: '',
+      pr: null,
+      at: null,
+    };
+    const [noteStart, noteEnd] = precedingNote(lines, i, floor);
+    const body = lines.slice(noteStart, noteEnd);
+    const start = (i += 1);
+    // A second 📍 closes this block even with nothing between the two: a chat
+    // client that ate the markers leaves two pasted blocks as one quote run.
+    while (
+      i < lines.length &&
+      QUOTED_RE.test(lines[i]) &&
+      !BLOCK_HEAD_RE.test(lines[i])
+    ) {
+      i += 1;
+    }
+    const end = i;
+    body.push(...lines.slice(start, end).map(stripQuote));
+    // The marker sits outside the quote, on the line after it.
+    const tail = i < lines.length ? lines[i] : '';
+    for (const candidate of [...body, tail]) {
+      const marker = MARKER_RE.exec(candidate);
+      if (marker && marker[1] === block.id) {
+        block.pr = Number.parseInt(marker[2], 10);
+        block.at = marker[3];
+        break;
+      }
+    }
+    fillBlockBody(block, body);
+    blocks.push(block);
+    floor = end;
+  }
+  return blocks;
+}
+
+/** Every 📍 block in `text` — label, stack, note, link, marker. */
+export function parseBlocks(text: string): ParsedBlock[] {
+  for (const variant of textVariants(text)) {
+    const blocks = parseBlocksIn(variant);
+    if (blocks.length) return blocks;
+  }
+  return [];
+}
+
+// --------------------------------------------------------------------------
+// pins
+// --------------------------------------------------------------------------
+
+/**
+ * Does this id really hash from this anchor? The id is
+ * `sha256(pr + anchor + at)`, so only a marker's `pr` and `at` can say.
+ */
+function verifyId(ref: PinRef, block: ParsedBlock | null): boolean | null {
+  if (!block || block.pr === null || !block.at) return null;
+  return pinId(block.pr, ref.anchorB64, block.at) === ref.id;
+}
+
+const beforeHash = (link: string) => link.split('#')[0];
+
+/**
+ * How much a link deserves to be handed back: 2 the overlay's own — path and
+ * query still match the anchor it carries; 1 any other `#bai=v3` link; 0 none.
+ */
+async function linkRank(link: string): Promise<number> {
+  if (!link) return 0;
+  const match = ONE_PIN_RE.exec(link);
+  if (!match) return 0;
+  const anchor = await decodeAnchor(match[2]);
+  if (!anchor) return 1;
+  const [path, query = ''] = beforeHash(link).split('?');
+  const pathname = path.replace(/^[a-zA-Z][\w+.-]*:\/\/[^/]*/, '');
+  return pathname === anchor.p && query === (anchor.q ?? '') ? 2 : 1;
+}
+
+const betterLink = async (first: string, second: string): Promise<string> =>
+  (await linkRank(second)) > (await linkRank(first)) ? second : first;
+
+/** One pin per id: first non-empty value wins, best-ranked link wins. */
+async function mergePins(pins: CliPin[]): Promise<CliPin[]> {
+  const merged = new Map<string, CliPin>();
+  for (const pin of pins) {
+    const existing = merged.get(pin.id);
+    if (!existing) {
+      merged.set(pin.id, { ...pin });
+      continue;
+    }
+    if (!existing.label) existing.label = pin.label;
+    if (!existing.note) existing.note = pin.note;
+    if (!existing.anchor) existing.anchor = pin.anchor;
+    if (existing.pr === null) existing.pr = pin.pr;
+    if (!existing.at) existing.at = pin.at;
+    if (existing.idVerified === null) existing.idVerified = pin.idVerified;
+    if (!existing.stack.length) existing.stack = pin.stack;
+    existing.url = await betterLink(existing.url, pin.url);
+  }
+  return [...merged.values()];
+}
+
+/** Every pin `text` carries, from its links and its blocks, merged by id. */
+export async function parsePins(text: string): Promise<CliPin[]> {
+  const blocks = new Map<string, ParsedBlock>();
+  for (const block of parseBlocks(text)) {
+    if (!blocks.has(block.id)) blocks.set(block.id, block);
+  }
+  const pins: CliPin[] = [];
+  for (const ref of findPinRefs(text)) {
+    const block = blocks.get(ref.id) ?? null;
+    const idVerified = verifyId(ref, block);
+    if (idVerified === false) continue;
+    const anchor = await decodeAnchor(ref.anchorB64);
+    pins.push({
+      id: ref.id,
+      anchor,
+      // The block's prose is the whole note; the anchor's `n` is the capped
+      // copy that travels with a bare link.
+      note: block?.note || anchor?.n || '',
+      label: block?.label ?? '',
+      stack: block?.stack ?? [],
+      pr: block?.pr ?? null,
+      at: block?.at ?? null,
+      idVerified,
+      url: await betterLink(block?.link ?? '', ref.url),
+    });
+  }
+  return mergePins(pins);
+}
+
+export const parseResult = async (text: string): Promise<ParseResult> => ({
+  apiVersion: API_VERSION,
+  pins: await parsePins(text),
+});
+
+// --------------------------------------------------------------------------
+// command line
+// --------------------------------------------------------------------------
+
+const USAGE = `usage: review-pins parse [--json] [file|-]
+
+  Read every 📍 \`#bai=v3\` pin out of a prompt, a PR comment or a chat paste.
+  Reads stdin when no file is given, or when the file is \`-\`.`;
+
+const record = (pin: CliPin): string => {
+  const rows: Array<[string, string]> = [
+    ['id', pin.id],
+    ['label', pin.label],
+    ['note', pin.note.split('\n').join(' ⏎ ')],
+    ['url', pin.url],
+    [
+      'path',
+      pin.anchor ? pin.anchor.p + (pin.anchor.q ? `?${pin.anchor.q}` : '') : '',
+    ],
+    ['selector', pin.anchor?.s ?? ''],
+    ['testid', pin.anchor?.tid ?? ''],
+    [
+      'component',
+      pin.anchor?.c
+        ? [pin.anchor.c.name, pin.anchor.c.src].filter(Boolean).join(' ')
+        : '',
+    ],
+    ['pr', pin.pr === null ? '' : String(pin.pr)],
+    ['at', pin.at ?? ''],
+    [
+      'idVerified',
+      pin.idVerified === null ? 'unproven' : String(pin.idVerified),
+    ],
+  ];
+  const width = Math.max(...rows.map(([key]) => key.length));
+  const out = rows
+    .filter(([, value]) => value !== '')
+    .map(([key, value]) => `${key.padEnd(width)} : ${value}`);
+  for (const line of pin.stack) out.push(`${'stack'.padEnd(width)} : ${line}`);
+  return out.join('\n');
+};
+
+export const renderText = (result: ParseResult): string =>
+  result.pins.length ? result.pins.map(record).join('\n\n') : 'no pins found';
+
+export async function main(argv: string[]): Promise<number> {
+  const args = argv.filter((a) => a !== '--json');
+  const json = argv.includes('--json');
+  if (args.length === 0) {
+    process.stderr.write(`${USAGE}\n`);
+    return 2;
+  }
+  if (args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  if (args[0] !== 'parse') {
+    process.stderr.write(`unknown command: ${args[0]}\n${USAGE}\n`);
+    return 2;
+  }
+  const source = args[1] ?? '-';
+  let text: string;
+  try {
+    text = readFileSync(source === '-' ? 0 : source, 'utf8');
+  } catch (error) {
+    process.stderr.write(
+      `cannot read ${source}: ${(error as Error).message}\n`,
+    );
+    return 2;
+  }
+  const result = await parseResult(text);
+  process.stdout.write(
+    json ? `${JSON.stringify(result, null, 2)}\n` : `${renderText(result)}\n`,
+  );
+  return result.pins.length ? 0 : 5;
+}
+
+/** `argv[1]` is the test runner under vitest, so importing this file runs nothing. */
+const isEntry = (): boolean => {
+  try {
+    return (
+      !!process.argv[1] &&
+      realpathSync(process.argv[1]) ===
+        realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+};
+
+if (isEntry()) {
+  void main(process.argv.slice(2)).then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/react/vite-plugins/review-overlay/cli.ts
+++ b/react/vite-plugins/review-overlay/cli.ts
@@ -420,6 +420,14 @@ export async function main(argv: string[]): Promise<number> {
     process.stderr.write(`unknown command: ${args[0]}\n${USAGE}\n`);
     return 2;
   }
+  // One file, or stdin: reading only the first of several operands would drop
+  // the rest of the reviewer's pins without saying so.
+  if (args.length > 2) {
+    process.stderr.write(
+      `parse takes one file at most; got ${args.length - 1}\n${USAGE}\n`,
+    );
+    return 2;
+  }
   const source = args[1] ?? '-';
   let text: string;
   try {

--- a/react/vite-plugins/review-overlay/register.mjs
+++ b/react/vite-plugins/review-overlay/register.mjs
@@ -1,0 +1,20 @@
+/**
+ * Node loader for `cli.ts`. The browser modules under `client/` import each
+ * other as `./x.js` — what the dev server serves — so a `resolve` hook maps
+ * those onto the `.ts` sources Node 24 strips types from natively.
+ */
+import { existsSync } from 'node:fs';
+import { registerHooks } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (/^\.{1,2}\//.test(specifier) && specifier.endsWith('.js')) {
+      const url = new URL(`${specifier.slice(0, -3)}.ts`, context.parentURL);
+      if (existsSync(fileURLToPath(url))) {
+        return { url: url.href, shortCircuit: true };
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+});

--- a/react/vite-plugins/review-overlay/testdata/pin-block-noted-sample.md
+++ b/react/vite-plugins/review-overlay/testdata/pin-block-noted-sample.md
@@ -1,0 +1,14 @@
+The reviewer's note now travels inside the anchor too, so a bare link
+carries it even where the block's prose was stripped.
+
+The primary action drifts right of the filter row.
+It should stay flush at 1280px and below.
+
+> 📍 **Start › page-start › button "Create Deployment"** · `c_obk74wj`
+> ⚛️ in StartPage (at /src/pages/StartPage.tsx:120)
+> [Open on dev server](http://fr-3813.jongeun.10-82-0-159.sslip.io/project/default/session/start?tab=general#bai=v3.c_obk74wj.VY5NS8QwEIb_yjAnhXa7Wy9LYb3oxZugN-th2kw_JE1iMtWWZf-7UwXFS2Ce93nDe8YPrG4yTFjhiyGhXDjJaE41Buo5T0JRanyFW2hmEe8qJ0Puu1zWwFflNWYYtFqE6N-4lcJwR7OVInFKo3fFd1-ld5WEmlPPjiNZJUK9sp9Pt3MRPe8ikzDcc7B-ndhtVV2jyd8aRS1WZ3Q0sQZPG3vUVHmKmmxvsemp-M12kpbqUO6ro1rG_atdMtzA88AQ4jhRXIFa0fFg4thJgjj2g4DvQFTpRiscIfrPXe0eBNLgZ2tAl63Q2TkNQAKH8rgPC5Az0LBVFS9f)
+<!-- bai-review v3 id=c_obk74wj pr=9330 at=2026-09-03T04:10:00Z -->
+
+And one pasted as a bare link, with no block and no prose around it:
+
+http://fr-3813.jongeun.10-82-0-159.sslip.io/project/default/session#bai=v3.c_mlphw3p.TVBBTsNADPyKtSeQEkrhgirBEzhxoxzcrJNdul2v1k7TCCHxGh7GS3BKD9xG4xnP2B_u6Db3jRO3ca8eFVsl0egft05IJHJuUxTdujd4Ah-Pm6yh5b7VudDV-to1rphzVSq_U6crTz2OSVcXr40VBxOYc8EnNfzMcBkLzKQLH73x__OMzEa9BAI6FJ1BFJVgzJ4qqLF9TGowCiD0Y0pQsOJQsQTgHjouM0yBqtmPVGdg81TTDAQBBTgTpJipAcweUGF993BbThAVJtshoAw9j_UskrOojBIMLtmKu0Swo8TTXxdOvrG42AU44P6iOocl5j3sKu8pW6h1TViUC0hXySgrl03M4xAgW8eYh-WkqbKBKWpYGlk9TOnm5-t7-Yp9cP35Cw

--- a/react/vite-plugins/review-overlay/testdata/pin-block-sample.md
+++ b/react/vite-plugins/review-overlay/testdata/pin-block-sample.md
@@ -1,0 +1,19 @@
+Two things I noticed on the dev server, both on the deployments work:
+
+Pin is 8px off and the tooltip is clipped.
+
+> 📍 **Start › webui-header › button "Create Deployment"** · `c_ew7rxz4`
+> ⚛️ in ActionItemContent (at /src/components/ActionItemContent.tsx:47)
+>   in Button (@astryxdesign/core)
+>   in StartPage (at /src/pages/StartPage.tsx)
+> [Open on dev server](http://fr-3811.jongeun.10-82-0-159.sslip.io/project/default/session/start?tab=general#bai=v3.c_ew7rxz4.ZY5BTsMwEEWvEv0VlZwaSlTQSEWqyoYzUBaOM22MEjvYE5qoyt2R6QqxGb2R3p_5V3yDHhUSCO-NEVMKJ3HN7ogL16MrWzYNxyM-ipeiHkWCJy9tGU6lzAPfbVZQGEDQQwyfbEU3fDJjJzpxSi54ncREgcIXCGLq3Zk9R9NBQcwZhNvRvE4CwiGyES5eeejC3LPPUXEN6E8fKES2ArpiAt2vnzcKc4aHSuHyC1uFNkNVLQo2m970DMLeigv-Tbg_BC-3DylaUJ7ahn4Inr0k_U9cS5qoeqItluUH)
+<!-- bai-review v3 id=c_ew7rxz4 pr=9330 at=2026-08-31T09:00:00Z -->
+
+Placeholder still says "Search" after the filter is applied.
+
+> 📍 **Sessions › vfolder-filter › input "Search"** · `c_6jcddj5`
+> ⚛️ in BAIPropertyFilter (at /src/components/BAIPropertyFilter.tsx:118)
+> [Open on dev server](http://fr-3811.jongeun.10-82-0-159.sslip.io/project/default/session?status=RUNNING#bai=v3.c_6jcddj5.ZY2xigIxFEV_RW4djcM28sBit1ixGRbFSrcIyZs1MiYx740o4r8vFjZaHu7hnhvOoA8DAWEbnLqxsmgM8x3OXe4D13EXe-W6w-8opjIoDAoIttR8YK82cOeGXq2wSMwJBicQRJ0OMl9t2nbZLmCg7g-E54NeFIQ1u-r3D4wB9BKEgQfdkNyRQfj6XP7UXLjq9fu5S_WPVPXW52PJiZOKfRMnKhdqmhk1U9zv_w)
+<!-- bai-review v3 id=c_6jcddj5 pr=9330 at=2026-08-31T09:04:00Z -->
+
+Can you fix both? The second one is the one that bugs me most.


### PR DESCRIPTION
Resolves #9432 (FR-3855)

Part of the pin-set stack (#9442): #9437 → #9438 → #9439 → #9440 → #9441. Design record: `docs/adr/0002-pin-set-link-grammar-and-single-codec.md`; vocabulary: `react/vite-plugins/review-overlay/CONTEXT.md`.

The `#bai=v3` link and the 📍 block are a wire format: reviewers paste them
into PR comments, Teams threads and Claude prompts, and something on the other
side has to read them back. Until now that reader was a second implementation —
`pin_parser.py` in claude-mp — reimplementing the anchor codec, the pin id and
the block grammar on Python's standard library. Two implementations of one
format drift, and the pin-set work about to land would have to be written twice.

This adds `pnpm run review-pins parse [--json] [file|-]`, a Node entry point
over the overlay's own browser modules. `register.mjs` is a `resolve` hook
mapping the `./x.js` specifiers those modules use — what the dev server serves —
onto the `.ts` sources Node 24 strips types from natively, so `codec.ts`,
`id.ts` and `block.ts` run unchanged outside a browser and there is exactly one
implementation of the format. `parse` returns
`{ apiVersion: 'bai-review/v1', pins: [...] }`: every pin the text carries, from
bare links and from blocks, merged by id, each with the link it came from and
`idVerified` — true/false when a marker's `pr` and `at` prove or disprove that
the id hashes from the anchor beside it, null when no marker claimed it. A pin
whose marker disowns its anchor is dropped rather than handed on.

Input is normalised the way `pin_parser.py` does it and no further: HTML
entities, then GitHub's quote-reply escaping of the link marker alone
(`%23bai%3Dv3` → `#bai=v3`). Decoding the whole body would undo the escapes the
browser itself wrote into the URL, truncating a link at its first `%20` and
turning a `%2F` into a path separator. The hash stays untrusted input: the link
grammar's bounds are `PIN_BODY_SRC`'s, so an over-long anchor never becomes a
match, and a payload that inflates past the decoder's cap yields a pin with no
anchor rather than a bomb.

No format change — this reads what the overlay writes today. The two sample
comments the review skill is tested against are copied into `testdata/` and
parse here to the same pins, and a round-trip test parses back what
`buildBlockFromCapture` produced, so the block grammar cannot drift between
producer and reader without a red test.

ADR-0002 (the `&`-repeated set grammar and the single-codec decision), the
repository context map (`CONTEXT-MAP.md`) and the overlay's glossary
(`CONTEXT.md`) land with this first layer, because every branch above it is
written in their words.

## What else this branch carries

Beyond the round the title names, one documentation commit. The R3 browser
smoke run on #9438 measured the set copy growing as N² and changed D6: each
block now carries its OWN pin's link, and the set's single link is emitted once
after the last block. ADR-0002 and `CONTEXT.md` describe that grammar rather
than the superseded one, so the two documents this branch introduces are not
stale the moment the branch above it lands. No code moves here.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (run on the stack top, `feat/FR-3859-pin-set-read`)
- `pnpm vitest run vite-plugins/review-overlay` (from `react/`) → 23 files, 557 tests, all passing on the stack top
- A two-pin set generated through `buildSetText` round-trips through `pnpm run review-pins parse` with both ids verified against their markers.
- Each branch was reviewed by two independent review agents (correctness, design conformance) and their blocker/major findings were fixed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhEbqZ9DDe2HFJF43rAVP1
