### PR TITLE
feat(FR-3856): carry a pin set as `&`-repeated `#bai=v3` parts

### DIFF
--- a/react/vite-plugins/review-overlay/cli.test.ts
+++ b/react/vite-plugins/review-overlay/cli.test.ts
@@ -1,8 +1,9 @@
 import { API_VERSION, main, parsePins, parseResult } from './cli.js';
-import { buildBlockFromCapture } from './client/block.js';
+import { buildBlockFromCapture, buildSetText } from './client/block.js';
 import { encodeAnchor } from './client/codec.js';
+import { pinSetUrl } from './client/deeplink.js';
 import { pinId } from './client/id.js';
-import type { AnchorV3 } from './client/types.js';
+import type { AnchorV3, SetPin } from './client/types.js';
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -126,6 +127,23 @@ describe('parse — links on their own', () => {
       const pins = await parsePins(text);
       expect(pins).toHaveLength(1);
       expect(pins[0].url).toBe(full);
+    }
+  });
+
+  // Pin count breaks a tie inside a tier; a pasted link must not outrank the
+  // matching one by carrying more parts than the tiebreak has room for.
+  it('prefers the matching link over a longer set on another page', async () => {
+    const anchorB64 = await encodeAnchor(anchor);
+    const match = `http://x/project/default/session/start?tab=general#bai=v3.c_abcdef2.${anchorB64}`;
+    const padding = Array.from(
+      { length: 200 },
+      (_, i) =>
+        `&bai=v3.c_${'abcdefghijklmnopqrstuvwxyz234567'[i % 32].repeat(7)}.QUJDREVGR0g`,
+    ).join('');
+    const longer = `http://x/elsewhere#bai=v3.c_abcdef2.${anchorB64}${padding}`;
+    for (const text of [`${match}\n\n${longer}`, `${longer}\n\n${match}`]) {
+      const pins = await parsePins(text);
+      expect(pins[0].url).toBe(match);
     }
   });
 
@@ -281,5 +299,98 @@ describe('the envelope and the exit codes', () => {
       write.mockRestore();
       errors.mockRestore();
     }
+  });
+});
+
+describe('parse — a pin set in one link', () => {
+  type PickedPin = Extract<SetPin, { origin: 'pick' }>;
+  const setPin = (over: Partial<PickedPin>): PickedPin => ({
+    id: 'c_aaaaaa2',
+    origin: 'pick',
+    anchor,
+    anchorB64: '',
+    label: 'Start › page-start › button "Create Deployment"',
+    appHash: '',
+    stack: [],
+    at: '2026-09-04T00:00:00Z',
+    pr: 9400,
+    ...over,
+  });
+
+  /** Three real anchors, each with the id its own marker would claim. */
+  const threePins = async (): Promise<SetPin[]> => {
+    const at = '2026-09-04T00:00:00Z';
+    const anchors: AnchorV3[] = [
+      { ...anchor, n: 'first' },
+      { ...anchor, s: '#second', n: 'second' },
+      { v: 3, s: '#third', p: '/start', tag: 'button', n: 'third' },
+    ];
+    const pins: SetPin[] = [];
+    for (const each of anchors) {
+      const anchorB64 = await encodeAnchor(each);
+      pins.push(
+        setPin({
+          id: pinId(9400, anchorB64, at),
+          anchor: each,
+          anchorB64,
+          stack: [],
+        }),
+      );
+    }
+    return pins;
+  };
+
+  it('reads every pin of a bare set link, and hands each the whole link', async () => {
+    const pins = await threePins();
+    const url = `https://fr-3856.localhost:1355${pinSetUrl(pins)}`;
+    const parsed = await parsePins(`please look at ${url} — all three`);
+    expect(parsed.map((pin) => pin.id)).toEqual(pins.map((pin) => pin.id));
+    expect(parsed.map((pin) => pin.url)).toEqual([url, url, url]);
+    // A bare link carries the note in the anchor and nothing to prove the id.
+    expect(parsed.map((pin) => pin.note)).toEqual(['first', 'second', 'third']);
+    expect(parsed.map((pin) => pin.idVerified)).toEqual([null, null, null]);
+  });
+
+  it('reads a set GitHub quote-escaped the `&` of', async () => {
+    const pins = await threePins();
+    const url = `http://x${pinSetUrl(pins)}`;
+    const quoted = `&gt; [Open on dev server](${url
+      .replace('#', '%23')
+      .replace(/&/g, '%26')
+      .replace(/=v3/g, '%3Dv3')})`;
+    const parsed = await parsePins(quoted);
+    expect(parsed.map((pin) => pin.id)).toEqual(pins.map((pin) => pin.id));
+  });
+
+  it('reads a set whose `&` arrived as an HTML entity', async () => {
+    const pins = await threePins();
+    const url = `http://x${pinSetUrl(pins)}`;
+    const parsed = await parsePins(url.replace(/&/g, '&amp;'));
+    expect(parsed.map((pin) => pin.id)).toEqual(pins.map((pin) => pin.id));
+    // The escaped copy carries only the first pin, so the whole set wins.
+    expect(parsed.map((pin) => pin.url)).toEqual([url, url, url]);
+  });
+
+  it('reads back the blocks the set producer wrote', async () => {
+    const pins = await threePins();
+    // Off a link: `at`/`pr` never travelled, so no marker may be written.
+    const linkOnly: SetPin = {
+      ...pins[2],
+      origin: 'link',
+      at: undefined,
+      pr: undefined,
+    };
+    const text = buildSetText([pins[0], pins[1], linkOnly], {
+      origin: 'https://fr-3856.localhost:1355',
+    });
+    const parsed = await parsePins(text);
+    expect(parsed.map((pin) => pin.id)).toEqual(pins.map((pin) => pin.id));
+    expect(parsed.map((pin) => pin.note)).toEqual(['first', 'second', 'third']);
+    expect(parsed[0].label).toBe(
+      'Start › page-start › button "Create Deployment"',
+    );
+    // The two picked pins carry markers; the link's pin has none to be proved
+    // by, and its whole block still reads.
+    expect(parsed.map((pin) => pin.idVerified)).toEqual([true, true, null]);
   });
 });

--- a/react/vite-plugins/review-overlay/cli.ts
+++ b/react/vite-plugins/review-overlay/cli.ts
@@ -89,13 +89,16 @@ export function htmlUnescape(text: string): string {
 }
 
 /**
- * GitHub's "Quote reply" percent-encodes the link's `#` and `=`; that one
- * sequence is decoded and nothing else (see the commit body).
+ * GitHub's "Quote reply" percent-encodes the link's `#`, `&` and `=`; those
+ * sequences are decoded and nothing else (see the commit body). `&amp;` is a
+ * plain `&` by the time this runs — `htmlUnescape` goes first.
  */
-const PIN_MARKER_ESCAPE_RE = /(?:%23|#)bai(?:%3[Dd]|=)v3/g;
+const PIN_MARKER_ESCAPE_RE = /(%23|%26|[#&])bai(?:%3[Dd]|=)v3/g;
 
 export const decodeBody = (text: string): string =>
-  htmlUnescape(text).replace(PIN_MARKER_ESCAPE_RE, '#bai=v3');
+  htmlUnescape(text).replace(PIN_MARKER_ESCAPE_RE, (_whole, lead: string) =>
+    lead === '#' || lead === '%23' ? '#bai=v3' : '&bai=v3',
+  );
 
 /**
  * The body as written, then its unescaped copies. A link is taken from the
@@ -120,11 +123,24 @@ interface PinRef {
   url: string;
 }
 
-/** The link is whatever runs up to the match, back to the nearest delimiter. */
+/** Sticky, so a set's later parts are read off the end of the earlier one. */
+const SET_TAIL_RE = new RegExp(`&bai=v3\\.${PIN_BODY_SRC}`, 'y');
+
+/**
+ * The link is whatever runs up to the match, back to the nearest delimiter —
+ * then on past it through the rest of the set, so every pin of a set link is
+ * handed the whole set's URL rather than a prefix of it.
+ */
 function expandUrl(text: string, start: number, end: number): string {
   let left = start;
   while (left > 0 && !' \t\n\r"\'<>()[]`'.includes(text[left - 1])) left -= 1;
-  return text.slice(left, end);
+  let right = end;
+  for (;;) {
+    SET_TAIL_RE.lastIndex = right;
+    if (!SET_TAIL_RE.exec(text)) break;
+    right = SET_TAIL_RE.lastIndex;
+  }
+  return text.slice(left, right);
 }
 
 /**
@@ -287,23 +303,42 @@ function verifyId(ref: PinRef, block: ParsedBlock | null): boolean | null {
 
 const beforeHash = (link: string) => link.split('#')[0];
 
+/** Its own instance: `findPinRefs` is mid-scan over the shared one. */
+const COUNT_PIN_RE = new RegExp(`[#&]bai=v3\\.${PIN_BODY_SRC}`, 'g');
+
+const countPins = (link: string): number => {
+  COUNT_PIN_RE.lastIndex = 0;
+  let pins = 0;
+  while (COUNT_PIN_RE.exec(link)) pins += 1;
+  return pins;
+};
+
 /**
- * How much a link deserves to be handed back: 2 the overlay's own — path and
- * query still match the anchor it carries; 1 any other `#bai=v3` link; 0 none.
+ * How much a link deserves to be handed back: the overlay's own — path and
+ * query still match the anchor it carries — outranks any other `#bai=v3` link,
+ * which outranks no link at all. Pins carried breaks the tie WITHIN a tier, so
+ * a set beats the prefix of itself an escaped copy leaves behind — and a
+ * pasted link cannot buy its way up a tier by carrying more parts.
  */
-async function linkRank(link: string): Promise<number> {
-  if (!link) return 0;
+async function linkRank(link: string): Promise<[tier: number, pins: number]> {
+  if (!link) return [0, 0];
   const match = ONE_PIN_RE.exec(link);
-  if (!match) return 0;
+  if (!match) return [0, 0];
   const anchor = await decodeAnchor(match[2]);
-  if (!anchor) return 1;
+  const pins = countPins(link);
+  if (!anchor) return [1, pins];
   const [path, query = ''] = beforeHash(link).split('?');
   const pathname = path.replace(/^[a-zA-Z][\w+.-]*:\/\/[^/]*/, '');
-  return pathname === anchor.p && query === (anchor.q ?? '') ? 2 : 1;
+  const same = pathname === anchor.p && query === (anchor.q ?? '');
+  return [same ? 2 : 1, pins];
 }
 
-const betterLink = async (first: string, second: string): Promise<string> =>
-  (await linkRank(second)) > (await linkRank(first)) ? second : first;
+const betterLink = async (first: string, second: string): Promise<string> => {
+  const [tier, pins] = await linkRank(first);
+  const [otherTier, otherPins] = await linkRank(second);
+  const better = otherTier !== tier ? otherTier > tier : otherPins > pins;
+  return better ? second : first;
+};
 
 /** One pin per id: first non-empty value wins, best-ranked link wins. */
 async function mergePins(pins: CliPin[]): Promise<CliPin[]> {

--- a/react/vite-plugins/review-overlay/client/block.test.ts
+++ b/react/vite-plugins/review-overlay/client/block.test.ts
@@ -4,6 +4,8 @@ import {
   buildBlockFromCapture,
   buildBlockHtml,
   buildBlockText,
+  buildSetHtml,
+  buildSetText,
   captureForBlock,
   landmarkLabel,
   LINK_LABEL,
@@ -11,7 +13,7 @@ import {
   resolveRouteLabel,
 } from './block.js';
 import { decodeAnchor } from './codec.js';
-import type { AnchorV3 } from './types.js';
+import type { AnchorV3, SetPin } from './types.js';
 import { describe, expect, it } from 'vitest';
 
 const anchor: AnchorV3 = {
@@ -427,5 +429,226 @@ describe('a block whose anchor carries the note', () => {
     expect(decoded?.n).toHaveLength(280);
     expect(decoded?.nt).toBe(1);
     expect(built.block).toContain(long);
+  });
+});
+
+/**
+ * The set format. A pin set of one has to stay byte-identical to what the
+ * overlay has been copying, or every link and block already in the wild reads
+ * differently from the ones written next.
+ */
+describe('a pin set', () => {
+  const ORIGIN = 'https://fr-3856.localhost:1355';
+
+  const first = (): SetPin => ({
+    id: 'c_aaaaaa2',
+    origin: 'pick',
+    anchor: {
+      v: 3,
+      s: '#login',
+      p: '/session/start',
+      q: 'tab=general',
+      n: 'The label is cut off.',
+    },
+    anchorB64: 'PAYLOAD1',
+    label: 'Sessions › login-button › button "Login"',
+    appHash: '',
+    stack: ['in LoginButton (at LoginView.tsx:12)'],
+    at: '2026-08-31T09:00:00Z',
+    pr: 9330,
+  });
+
+  const second = (): SetPin => ({
+    id: 'c_bbbbbb3',
+    origin: 'pick',
+    anchor: {
+      v: 3,
+      s: '#search',
+      p: '/session/start',
+      q: 'tab=general',
+      n: 'Placeholder is stale.',
+    },
+    anchorB64: 'PAYLOAD2',
+    label: 'Sessions › filter-row › input "Search"',
+    appHash: '',
+    stack: [],
+    at: '2026-08-31T09:01:00Z',
+    pr: 9330,
+  });
+
+  /** Off a link: no `at`/`pr` ever travelled, so no marker may be emitted. */
+  const third = (): SetPin => ({
+    id: 'c_cccccc4',
+    origin: 'link',
+    anchor: { v: 3, s: '#create', p: '/start' },
+    anchorB64: 'PAYLOAD3',
+    label: 'Start › page-start › button',
+    appHash: '',
+    stack: ['in StartPage'],
+  });
+
+  describe('of one', () => {
+    it('is the block the overlay copies today', () => {
+      expect(buildSetText([first()], { origin: ORIGIN })).toBe(
+        [
+          'The label is cut off.',
+          '',
+          '> 📍 **Sessions › login-button › button "Login"** · `c_aaaaaa2`',
+          '> ⚛️ in LoginButton (at LoginView.tsx:12)',
+          `> [Open on dev server](${ORIGIN}/session/start?tab=general#bai=v3.c_aaaaaa2.PAYLOAD1)`,
+          '<!-- bai-review v3 id=c_aaaaaa2 pr=9330 at=2026-08-31T09:00:00Z -->',
+        ].join('\n'),
+      );
+    });
+
+    it('keeps the app fragment the pin was made under', () => {
+      expect(
+        buildSetText([{ ...first(), appHash: 'tab=logs' }], { origin: ORIGIN }),
+      ).toContain(
+        `> [Open on dev server](${ORIGIN}/session/start?tab=general#tab=logs&bai=v3.c_aaaaaa2.PAYLOAD1)`,
+      );
+    });
+
+    it('is one blockquote, with nothing separating it from itself', () => {
+      const html = buildSetHtml([first()], { origin: ORIGIN });
+      expect(html).not.toContain('<p></p>');
+      expect(html).toBe(
+        [
+          '<p>The label is cut off.</p>',
+          '<blockquote>📍 <b>Sessions › login-button › button &quot;Login&quot;</b> · <code>c_aaaaaa2</code>' +
+            '<br>⚛️ in LoginButton (at LoginView.tsx:12)' +
+            `<br><a href="${ORIGIN}/session/start?tab=general#bai=v3.c_aaaaaa2.PAYLOAD1">Open on dev server ↗</a>` +
+            '</blockquote>',
+          '<!-- bai-review v3 id=c_aaaaaa2 pr=9330 at=2026-08-31T09:00:00Z -->',
+        ].join('\n'),
+      );
+    });
+  });
+
+  describe('of three', () => {
+    const pins = () => [first(), second(), third()];
+    const HASH =
+      '#bai=v3.c_aaaaaa2.PAYLOAD1&bai=v3.c_bbbbbb3.PAYLOAD2&bai=v3.c_cccccc4.PAYLOAD3';
+    const URL = `${ORIGIN}/session/start?tab=general${HASH}`;
+
+    // Every block is pasted on its own as often as the set is, and a block
+    // without the link carries no anchor at all.
+    it('gives every block the same one link', () => {
+      const text = buildSetText(pins(), { origin: ORIGIN });
+      expect(text.split(`[Open on dev server](${URL})`)).toHaveLength(4);
+    });
+
+    it('separates the markdown blocks with one blank line', () => {
+      const text = buildSetText(pins(), { origin: ORIGIN });
+      expect(text).toContain(
+        '<!-- bai-review v3 id=c_aaaaaa2 pr=9330 at=2026-08-31T09:00:00Z -->\n\nPlaceholder is stale.',
+      );
+      // A link's pin has no marker to close its block with.
+      expect(text).not.toContain('id=c_cccccc4');
+      expect(text.trimEnd().endsWith(')')).toBe(true);
+    });
+
+    it('renders the rich flavour verbatim', () => {
+      const href = URL.replace(/&/g, '&amp;');
+      expect(buildSetHtml(pins(), { origin: ORIGIN })).toBe(
+        [
+          '<p>The label is cut off.</p>',
+          '<blockquote>📍 <b>Sessions › login-button › button &quot;Login&quot;</b> · <code>c_aaaaaa2</code>' +
+            '<br>⚛️ in LoginButton (at LoginView.tsx:12)' +
+            `<br><a href="${href}">Open on dev server ↗</a>` +
+            '</blockquote>',
+          '<!-- bai-review v3 id=c_aaaaaa2 pr=9330 at=2026-08-31T09:00:00Z -->',
+          '<p></p>',
+          '<p>Placeholder is stale.</p>',
+          '<blockquote>📍 <b>Sessions › filter-row › input &quot;Search&quot;</b> · <code>c_bbbbbb3</code>' +
+            `<br><a href="${href}">Open on dev server ↗</a>` +
+            '</blockquote>',
+          '<!-- bai-review v3 id=c_bbbbbb3 pr=9330 at=2026-08-31T09:01:00Z -->',
+          '<p></p>',
+          '<blockquote>📍 <b>Start › page-start › button</b> · <code>c_cccccc4</code>' +
+            '<br>⚛️ in StartPage' +
+            `<br><a href="${href}">Open on dev server ↗</a>` +
+            '</blockquote>',
+        ].join('\n'),
+      );
+    });
+
+    // The link de-duplicates by id, so the blocks must too — two blocks for
+    // one link part is two markers claiming one pin.
+    it('emits a pin once, however often it was added', () => {
+      const text = buildSetText([first(), second(), first()], {
+        origin: ORIGIN,
+      });
+      expect(text.split('📍')).toHaveLength(3);
+      expect(text.match(/id=c_aaaaaa2 /g)).toHaveLength(1);
+      expect(text.split('bai=v3.c_aaaaaa2.PAYLOAD1')).toHaveLength(3);
+      expect(
+        buildSetHtml([first(), second(), first()], { origin: ORIGIN }).split(
+          '<p></p>',
+        ),
+      ).toHaveLength(2);
+    });
+  });
+});
+
+describe('the marker a block may not claim', () => {
+  const base = {
+    label: 'Sessions › login-button › button "Login"',
+    id: 'c_abcdefg',
+    stack: [],
+    text: '',
+    url: 'https://dev.test/#bai=v3.c_abcdefg.PAYLOAD1',
+    pr: 0,
+    at: '',
+    marker: false,
+  };
+
+  // The id hashes from `pr` + anchor + `at`; a fabricated marker would name
+  // an id that does not verify against itself.
+  it('is left off both flavours when the pin has no pr/at of its own', () => {
+    expect(buildBlockText(base)).not.toContain('<!-- bai-review');
+    expect(buildBlockHtml(base)).not.toContain('<!-- bai-review');
+  });
+});
+
+/**
+ * The write side used to drop the app's own fragment while the read side kept
+ * it, so a copy made on `#tab=logs` reopened on the wrong tab. One builder now,
+ * and it is the read side's behaviour that survived.
+ */
+describe('the link a fresh pick copies', () => {
+  const build = async (appHash?: string) => {
+    document.body.innerHTML = '<button id="go">Login</button>';
+    const capture = await captureForBlock(
+      captureAnchorSignals(document.querySelector('#go') as Element),
+      [],
+    );
+    return buildBlockFromCapture(capture, {
+      text: '',
+      pr: 9330,
+      routeLabel: 'Sessions',
+      at: '2026-08-31T09:00:00Z',
+      origin: 'https://dev.test',
+      appHash,
+    });
+  };
+
+  it('keeps the fragment it was handed', async () => {
+    const built = await build('#tab=logs');
+    expect(built.url).toBe(
+      `https://dev.test/#tab=logs&bai=v3.${built.id}.${built.anchorB64}`,
+    );
+  });
+
+  it('reads the live fragment otherwise, without the pin already in it', async () => {
+    history.replaceState({}, '', '/#tab=logs&bai=v3.c_zdv3rhz.QUJDREVGR0g');
+    try {
+      const built = await build();
+      expect(built.url).toBe(
+        `https://dev.test/#tab=logs&bai=v3.${built.id}.${built.anchorB64}`,
+      );
+    } finally {
+      history.replaceState({}, '', '/');
+    }
   });
 });

--- a/react/vite-plugins/review-overlay/client/block.test.ts
+++ b/react/vite-plugins/review-overlay/client/block.test.ts
@@ -13,6 +13,7 @@ import {
   resolveRouteLabel,
 } from './block.js';
 import { decodeAnchor } from './codec.js';
+import { MAX_SET_PINS } from './deeplink.js';
 import type { AnchorV3, SetPin } from './types.js';
 import { describe, expect, it } from 'vitest';
 
@@ -530,12 +531,21 @@ describe('a pin set', () => {
     const HASH =
       '#bai=v3.c_aaaaaa2.PAYLOAD1&bai=v3.c_bbbbbb3.PAYLOAD2&bai=v3.c_cccccc4.PAYLOAD3';
     const URL = `${ORIGIN}/session/start?tab=general${HASH}`;
+    const OWN1 = `${ORIGIN}/session/start?tab=general#bai=v3.c_aaaaaa2.PAYLOAD1`;
+    const OWN2 = `${ORIGIN}/session/start?tab=general#bai=v3.c_bbbbbb3.PAYLOAD2`;
+    const OWN3 = `${ORIGIN}/start#bai=v3.c_cccccc4.PAYLOAD3`;
 
-    // Every block is pasted on its own as often as the set is, and a block
-    // without the link carries no anchor at all.
-    it('gives every block the same one link', () => {
+    // A block is pasted on its own as often as the set is, and a block without
+    // a link carries no anchor at all — but the SET's link in every block is
+    // what made the comment grow as N².
+    it('gives every block its own link, and the set link once', () => {
       const text = buildSetText(pins(), { origin: ORIGIN });
-      expect(text.split(`[Open on dev server](${URL})`)).toHaveLength(4);
+      for (const own of [OWN1, OWN2, OWN3]) {
+        expect(text.split(`[Open on dev server](${own})`)).toHaveLength(2);
+      }
+      expect(
+        text.split(`[Open all 3 pins on dev server](${URL})`),
+      ).toHaveLength(2);
     });
 
     it('separates the markdown blocks with one blank line', () => {
@@ -555,22 +565,30 @@ describe('a pin set', () => {
           '<p>The label is cut off.</p>',
           '<blockquote>📍 <b>Sessions › login-button › button &quot;Login&quot;</b> · <code>c_aaaaaa2</code>' +
             '<br>⚛️ in LoginButton (at LoginView.tsx:12)' +
-            `<br><a href="${href}">Open on dev server ↗</a>` +
+            `<br><a href="${OWN1}">Open on dev server ↗</a>` +
             '</blockquote>',
           '<!-- bai-review v3 id=c_aaaaaa2 pr=9330 at=2026-08-31T09:00:00Z -->',
           '<p></p>',
           '<p>Placeholder is stale.</p>',
           '<blockquote>📍 <b>Sessions › filter-row › input &quot;Search&quot;</b> · <code>c_bbbbbb3</code>' +
-            `<br><a href="${href}">Open on dev server ↗</a>` +
+            `<br><a href="${OWN2}">Open on dev server ↗</a>` +
             '</blockquote>',
           '<!-- bai-review v3 id=c_bbbbbb3 pr=9330 at=2026-08-31T09:01:00Z -->',
           '<p></p>',
           '<blockquote>📍 <b>Start › page-start › button</b> · <code>c_cccccc4</code>' +
             '<br>⚛️ in StartPage' +
-            `<br><a href="${href}">Open on dev server ↗</a>` +
+            `<br><a href="${OWN3}">Open on dev server ↗</a>` +
             '</blockquote>',
+          `<p><a href="${href}">Open all 3 pins on dev server ↗</a></p>`,
         ].join('\n'),
       );
+    });
+
+    // `@github/paste-markdown` rewrites an HTML anchor whose text it finds in
+    // the plain flavour; the ↗ keeps the set link out of its reach too.
+    it('keeps the rich set label out of the markdown flavour', () => {
+      const text = buildSetText(pins(), { origin: ORIGIN });
+      expect(text).not.toContain('Open all 3 pins on dev server ↗');
     });
 
     // The link de-duplicates by id, so the blocks must too — two blocks for
@@ -581,12 +599,46 @@ describe('a pin set', () => {
       });
       expect(text.split('📍')).toHaveLength(3);
       expect(text.match(/id=c_aaaaaa2 /g)).toHaveLength(1);
+      // Once in its own block's link, once in the set link at the end.
       expect(text.split('bai=v3.c_aaaaaa2.PAYLOAD1')).toHaveLength(3);
       expect(
         buildSetHtml([first(), second(), first()], { origin: ORIGIN }).split(
           '<p></p>',
         ),
       ).toHaveLength(2);
+    });
+  });
+
+  /**
+   * Repeating the set's own URL — which grows with N — in each of the N blocks
+   * made the comment quadratic: 30 pins came to 371 KB, and GitHub refuses a
+   * body over 65,536 characters from about 12 pins on. One link per block plus
+   * one set link is linear, so the D9 cap of 30 is a size the reviewer can
+   * actually paste.
+   */
+  describe('grows linearly with the number of pins', () => {
+    const B64 = 'P'.repeat(380);
+    const many = (count: number): SetPin[] =>
+      Array.from({ length: count }, (_unused, i) => ({
+        ...first(),
+        id: `c_${'abcdefg'.slice(0, 6)}${i.toString(36)}`,
+        anchorB64: `${B64}${i}`,
+      }));
+    const size = (count: number) =>
+      buildSetText(many(count), { origin: ORIGIN }).length;
+
+    it('fits a full set in a GitHub comment body', () => {
+      expect(many(MAX_SET_PINS)).toHaveLength(30);
+      expect(size(MAX_SET_PINS)).toBeLessThan(65536);
+      expect(
+        buildSetHtml(many(MAX_SET_PINS), { origin: ORIGIN }).length,
+      ).toBeLessThan(65536);
+    });
+
+    it('doubles, not quadruples, when the set doubles', () => {
+      // Quadratic growth put this ratio near 4; the constant term keeps it
+      // just under 2 here, and the bound catches any return to N².
+      expect(size(20) / size(10)).toBeLessThan(2.2);
     });
   });
 });

--- a/react/vite-plugins/review-overlay/client/block.ts
+++ b/react/vite-plugins/review-overlay/client/block.ts
@@ -181,9 +181,12 @@ export interface SetBlockOptions {
 }
 
 /**
- * Every block of a pin set carries the SAME link — the set's one URL — because
- * a block is pasted on its own as often as the whole set is, and a block
- * without a link carries no anchor at all.
+ * Every block carries a link — a block is pasted on its own as often as the
+ * whole set is, and a block without one carries no anchor at all — but its
+ * OWN link, not the set's: the set URL grows with N, so repeating it in all N
+ * blocks grew the comment as N² and crossed GitHub's 65,536-character body
+ * limit around 12 pins. The set's one URL is emitted once, after the last
+ * block, so the whole set stays one click away.
  */
 const setBlockInput = (pin: SetPin, url: string): BlockInput => {
   const input = {
@@ -202,14 +205,34 @@ const setBlockInput = (pin: SetPin, url: string): BlockInput => {
 const setUrl = (pins: SetPin[], options: SetBlockOptions): string =>
   `${options.origin ?? location.origin}${pinSetUrl(pins)}`;
 
-/** The set as markdown: one block per pin, a blank line between them. */
+/** A pin's own link: the set of one it would be on its own. */
+const ownUrl = (pin: SetPin, options: SetBlockOptions): string =>
+  setUrl([pin], options);
+
+/** The whole set in one URL, emitted once after the last block. */
+export const setLinkLabel = (count: number): string =>
+  `Open all ${count} pins on dev server`;
+/** Distinct from the markdown label, for `LINK_LABEL_HTML`'s reason. */
+export const setLinkLabelHtml = (count: number): string =>
+  `${setLinkLabel(count)} ↗`;
+
+/**
+ * The set as markdown: one block per pin, a blank line between them, then the
+ * set's one link. A set of one IS its pin's link, so it gets no extra line and
+ * stays byte-identical to what the overlay has always copied.
+ */
 export function buildSetText(
   pins: SetPin[],
   options: SetBlockOptions = {},
 ): string {
   const set = dedupeById(pins);
-  const url = setUrl(set, options);
-  return set.map((pin) => buildBlockText(setBlockInput(pin, url))).join('\n\n');
+  const parts = set.map((pin) =>
+    buildBlockText(setBlockInput(pin, ownUrl(pin, options))),
+  );
+  if (set.length > 1) {
+    parts.push(`[${setLinkLabel(set.length)}](${setUrl(set, options)})`);
+  }
+  return parts.join('\n\n');
 }
 
 /** The same set for a rich editor. */
@@ -218,12 +241,14 @@ export function buildSetHtml(
   options: SetBlockOptions = {},
 ): string {
   const set = dedupeById(pins);
-  const url = setUrl(set, options);
   // Adjacent `<blockquote>`s merge into one in a rich editor; an empty
   // paragraph between them is the separator Teams keeps.
-  return set
-    .map((pin) => buildBlockHtml(setBlockInput(pin, url)))
+  const html = set
+    .map((pin) => buildBlockHtml(setBlockInput(pin, ownUrl(pin, options))))
     .join('\n<p></p>\n');
+  if (set.length < 2) return html;
+  const href = esc(setUrl(set, options));
+  return `${html}\n<p><a href="${href}">${setLinkLabelHtml(set.length)}</a></p>`;
 }
 
 /**

--- a/react/vite-plugins/review-overlay/client/block.ts
+++ b/react/vite-plugins/review-overlay/client/block.ts
@@ -10,9 +10,9 @@
  */
 import { captureAnchorSignals, withNote } from './anchor.js';
 import { encodeAnchor } from './codec.js';
-import { readablePath } from './deeplink.js';
+import { dedupeById, pinSetUrl, pinUrl, readablePath } from './deeplink.js';
 import { pinId } from './id.js';
-import type { AnchorComponent, AnchorV3 } from './types.js';
+import type { AnchorComponent, AnchorV3, SetPin } from './types.js';
 
 /**
  * The app publishes the current route's ENGLISH i18n label on
@@ -58,6 +58,11 @@ export interface BlockInput {
    * lands it drops in here without changing the block's shape.
    */
   imageUrl?: string;
+  /**
+   * Emit the `<!-- bai-review … -->` marker. False for a pin that came off a
+   * link: its `pr`/`at` never travelled, so a marker would disown its own id.
+   */
+  marker?: boolean;
 }
 
 /** The markdown flavour's link label. */
@@ -125,7 +130,7 @@ export function buildBlockText(input: BlockInput): string {
         break;
     }
   }
-  out.push(marker(input));
+  if (input.marker !== false) out.push(marker(input));
   return out.join('\n');
 }
 
@@ -166,8 +171,59 @@ export function buildBlockHtml(input: BlockInput): string {
     }
   });
   out.push(`<blockquote>${quoted.join('<br>')}</blockquote>`);
-  out.push(marker(input));
+  if (input.marker !== false) out.push(marker(input));
   return out.join('\n');
+}
+
+export interface SetBlockOptions {
+  /** Prepended to the set link; defaults to this document's origin. */
+  origin?: string;
+}
+
+/**
+ * Every block of a pin set carries the SAME link — the set's one URL — because
+ * a block is pasted on its own as often as the whole set is, and a block
+ * without a link carries no anchor at all.
+ */
+const setBlockInput = (pin: SetPin, url: string): BlockInput => {
+  const input = {
+    label: pin.label,
+    id: pin.id,
+    stack: pin.stack,
+    text: pin.anchor.n ?? '',
+    url,
+  };
+  // No marker to write, so the fields only a marker reads stay blank.
+  return pin.origin === 'pick'
+    ? { ...input, pr: pin.pr, at: pin.at }
+    : { ...input, pr: 0, at: '', marker: false };
+};
+
+const setUrl = (pins: SetPin[], options: SetBlockOptions): string =>
+  `${options.origin ?? location.origin}${pinSetUrl(pins)}`;
+
+/** The set as markdown: one block per pin, a blank line between them. */
+export function buildSetText(
+  pins: SetPin[],
+  options: SetBlockOptions = {},
+): string {
+  const set = dedupeById(pins);
+  const url = setUrl(set, options);
+  return set.map((pin) => buildBlockText(setBlockInput(pin, url))).join('\n\n');
+}
+
+/** The same set for a rich editor. */
+export function buildSetHtml(
+  pins: SetPin[],
+  options: SetBlockOptions = {},
+): string {
+  const set = dedupeById(pins);
+  const url = setUrl(set, options);
+  // Adjacent `<blockquote>`s merge into one in a rich editor; an empty
+  // paragraph between them is the separator Teams keeps.
+  return set
+    .map((pin) => buildBlockHtml(setBlockInput(pin, url)))
+    .join('\n<p></p>\n');
 }
 
 /**
@@ -210,6 +266,11 @@ export interface BlockRenderOptions {
   /** Injected in tests; defaults to now, truncated to whole seconds. */
   at?: string;
   origin?: string;
+  /**
+   * The fragment the app itself is using, kept on the link so the pin reopens
+   * on the tab it was made on. Defaults to this document's own.
+   */
+  appHash?: string;
 }
 
 export interface BuiltBlock {
@@ -235,9 +296,9 @@ export function buildBlockFromCapture(
   const { anchor, anchorB64 } = capture;
   const at = options.at ?? blockStamp();
   const id = pinId(options.pr, anchorB64, at);
-  const q = anchor.q ? `?${anchor.q}` : '';
   const origin = options.origin ?? location.origin;
-  const url = `${origin}${anchor.p}${q}#bai=v3.${id}.${anchorB64}`;
+  const hash = options.appHash ?? location.hash;
+  const url = `${origin}${pinUrl(anchor, id, anchorB64, hash)}`;
   const input = {
     label: landmarkLabel(options.routeLabel, anchor),
     id,

--- a/react/vite-plugins/review-overlay/client/deeplink.test.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.test.ts
@@ -1,12 +1,17 @@
 import {
   createNavigationGuard,
+  hasLegacyFragment,
+  MAX_SET_PINS,
   parseFragment,
+  parseFragments,
   pathNeedsChange,
+  pinSetFragment,
+  pinSetUrl,
   pinUrl,
   readablePath,
   retryUntil,
 } from './deeplink.js';
-import type { AnchorV3 } from './types.js';
+import type { AnchorV3, SetPin } from './types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
@@ -226,5 +231,152 @@ describe('createNavigationGuard', () => {
     expect(guard.shouldNavigate('c_zdv3rhz', target)).toBe(true);
     guard.reset();
     expect(guard.shouldNavigate('c_zdv3rhz', target)).toBe(true);
+  });
+});
+
+describe('parseFragments', () => {
+  const A = 'QUJDREVGR0g';
+  const B = 'SUpLTU5PUFE';
+
+  it('reads a set as its parts, in link order', () => {
+    expect(
+      parseFragments(`#bai=v3.c_zdv3rhz.${A}&bai=v3.c_abcdef2.${B}`),
+    ).toEqual([
+      { id: 'c_zdv3rhz', anchorB64: A },
+      { id: 'c_abcdef2', anchorB64: B },
+    ]);
+  });
+
+  it('keeps the app’s own fragment out of the list', () => {
+    expect(parseFragments(`#tab=logs&bai=v3.c_zdv3rhz.${A}`)).toEqual([
+      { id: 'c_zdv3rhz', anchorB64: A },
+    ]);
+  });
+
+  it('is the one part `parseFragment` reports for a single pin', () => {
+    expect(parseFragment(`#bai=v3.c_zdv3rhz.${A}`)).toEqual({
+      kind: 'v3',
+      ...parseFragments(`#bai=v3.c_zdv3rhz.${A}`)[0],
+    });
+  });
+
+  it('has no state to carry between calls', () => {
+    const hash = `#bai=v3.c_zdv3rhz.${A}&bai=v3.c_abcdef2.${B}`;
+    expect(parseFragments(hash)).toEqual(parseFragments(hash));
+  });
+
+  // A pasted hash is untrusted: one unreadable part must not cost the others.
+  it('skips a part the grammar refuses and keeps the rest', () => {
+    expect(
+      parseFragments(
+        `#bai=v3.c_zdv3rhz.${'A'.repeat(4000)}&bai=v3.c_abcdef2.${B}`,
+      ),
+    ).toEqual([{ id: 'c_abcdef2', anchorB64: B }]);
+    expect(parseFragments(`#bai=v3.nope.${A}&bai=v3.c_abcdef2.${B}`)).toEqual([
+      { id: 'c_abcdef2', anchorB64: B },
+    ]);
+  });
+
+  // Every part costs a decode and a drawn view, and the set cap is what a
+  // producer may write — the reader may be handed anything.
+  it('stops at the set cap, however many parts were pasted', () => {
+    const ids = 'abcdefghijklmnopqrstuvwxyz234567'.split('');
+    const hash = `#${ids
+      .flatMap((c) => [
+        `bai=v3.c_${c.repeat(7)}.${A}`,
+        `bai=v3.c_${c}zzzzzz.${B}`,
+      ])
+      .join('&')}`;
+    expect(parseFragments(hash)).toHaveLength(MAX_SET_PINS);
+    expect(parseFragments(hash)[0]).toEqual({ id: 'c_aaaaaaa', anchorB64: A });
+  });
+
+  it('is empty for a fragment with no pin in it', () => {
+    expect(parseFragments('#section-2')).toEqual([]);
+    expect(parseFragments('')).toEqual([]);
+  });
+});
+
+describe('hasLegacyFragment', () => {
+  it('recognises a v1 link, and nothing else', () => {
+    expect(hasLegacyFragment('#bai-review=eJyrVkrLz1eyUlAqSS0uUaoFAB')).toBe(
+      true,
+    );
+    expect(hasLegacyFragment('#bai=v3.c_zdv3rhz.QUJDREVGR0g')).toBe(false);
+    expect(hasLegacyFragment('')).toBe(false);
+  });
+});
+
+describe('pinSetFragment', () => {
+  it('repeats the part after `&`, in set order', () => {
+    expect(
+      pinSetFragment([
+        { id: 'c_zdv3rhz', anchorB64: 'QUJD' },
+        { id: 'c_abcdef2', anchorB64: 'WkhH' },
+      ]),
+    ).toBe('bai=v3.c_zdv3rhz.QUJD&bai=v3.c_abcdef2.WkhH');
+  });
+
+  it('emits a pin once, at its first place in the set', () => {
+    expect(
+      pinSetFragment([
+        { id: 'c_zdv3rhz', anchorB64: 'QUJD' },
+        { id: 'c_abcdef2', anchorB64: 'WkhH' },
+        { id: 'c_zdv3rhz', anchorB64: 'QUJD' },
+      ]),
+    ).toBe('bai=v3.c_zdv3rhz.QUJD&bai=v3.c_abcdef2.WkhH');
+  });
+
+  it('is empty for an empty set', () => {
+    expect(pinSetFragment([])).toBe('');
+  });
+});
+
+describe('pinSetUrl', () => {
+  type PickedPin = Extract<SetPin, { origin: 'pick' }>;
+  const setPin = (over: Partial<PickedPin> = {}): PickedPin => ({
+    id: 'c_zdv3rhz',
+    origin: 'pick',
+    anchor: anchor(),
+    anchorB64: 'QUJDREVGR0g',
+    label: '',
+    appHash: '',
+    stack: [],
+    at: '2026-09-04T00:00:00Z',
+    pr: 9400,
+    ...over,
+  });
+
+  // A set may span pages; the link opens on the first pin's page, whatever
+  // the others say.
+  it('takes path, query and the app fragment from the first pin', () => {
+    expect(
+      pinSetUrl([
+        setPin({
+          anchor: anchor({ q: 'status=RUNNING' }),
+          appHash: 'tab=logs',
+        }),
+        setPin({
+          id: 'c_abcdef2',
+          anchorB64: 'WkhHSUpLTA',
+          anchor: anchor({ p: '/start', q: 'x=1' }),
+          appHash: 'tab=other',
+        }),
+      ]),
+    ).toBe(
+      '/session?status=RUNNING#tab=logs&bai=v3.c_zdv3rhz.QUJDREVGR0g&bai=v3.c_abcdef2.WkhHSUpLTA',
+    );
+  });
+
+  it('is byte-identical to the single-pin link for a set of one', () => {
+    for (const hash of ['', '#tab=logs&x=1']) {
+      expect(pinSetUrl([setPin({ appHash: hash.replace(/^#/, '') })])).toBe(
+        pinUrl(anchor(), 'c_zdv3rhz', 'QUJDREVGR0g', hash),
+      );
+    }
+  });
+
+  it('has no link to build for an empty set', () => {
+    expect(pinSetUrl([])).toBe('');
   });
 });

--- a/react/vite-plugins/review-overlay/client/deeplink.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.ts
@@ -7,20 +7,46 @@
  * a link without an anchor is plain text now — never an error.
  */
 import { isSafePath, PIN_BODY_SRC } from './codec.js';
-import type { AnchorV3 } from './types.js';
+import type { AnchorV3, SetPin } from './types.js';
 
 /** `[#&]` because the pin can ride inside a fragment the app already uses. */
-const HASH_RE = new RegExp(`[#&]bai=v3\\.${PIN_BODY_SRC}`);
+const HASH_RE_SRC = `[#&]bai=v3\\.${PIN_BODY_SRC}`;
 /** v1/v2 links are not carried forward — recognised only to say so. */
 const LEGACY_RE = /[#&]bai-review=/;
 
 export type Fragment =
   { kind: 'v3'; id: string; anchorB64: string } | { kind: 'legacy' } | null;
 
+/** How many pins a set may hold; the reader bounds a pasted hash by it too. */
+export const MAX_SET_PINS = 30;
+
+/**
+ * Every pin the fragment carries, in link order — a set is the same part
+ * repeated after `&`, which the anchor alphabet excludes. Fresh regex per
+ * call: a `g` regex carries `lastIndex` between them.
+ */
+export function parseFragments(hash: string): Array<{
+  id: string;
+  anchorB64: string;
+}> {
+  const re = new RegExp(HASH_RE_SRC, 'g');
+  const text = hash || '';
+  const parts: Array<{ id: string; anchorB64: string }> = [];
+  for (let m = re.exec(text); m; m = re.exec(text)) {
+    // Each part costs a decode and a drawn view, and a hash is untrusted.
+    if (parts.length >= MAX_SET_PINS) break;
+    parts.push({ id: m[1], anchorB64: m[2] });
+  }
+  return parts;
+}
+
+export const hasLegacyFragment = (hash: string): boolean =>
+  LEGACY_RE.test(hash || '');
+
 export function parseFragment(hash: string): Fragment {
-  const match = HASH_RE.exec(hash || '');
-  if (match) return { kind: 'v3', id: match[1], anchorB64: match[2] };
-  return LEGACY_RE.test(hash || '') ? { kind: 'legacy' } : null;
+  const [first] = parseFragments(hash);
+  if (first) return { kind: 'v3', ...first };
+  return hasLegacyFragment(hash) ? { kind: 'legacy' } : null;
 }
 
 /** Path AND query, so a filtered list or a tab reproduces (R3.3). */
@@ -44,15 +70,52 @@ export function otherFragment(hash: string): string {
     .join('&');
 }
 
+/**
+ * First-seen wins, in set order. The link and the blocks render off the same
+ * list, or a pin added twice would be one part and two blocks.
+ */
+export function dedupeById<T extends { id: string }>(pins: T[]): T[] {
+  const seen = new Set<string>();
+  return pins.filter((pin) => {
+    if (seen.has(pin.id)) return false;
+    seen.add(pin.id);
+    return true;
+  });
+}
+
+/** The pin parts of a set's fragment, de-duplicated by id, in set order. */
+export function pinSetFragment(
+  pins: Array<{ id: string; anchorB64: string }>,
+): string {
+  return dedupeById(pins)
+    .map((pin) => `bai=v3.${pin.id}.${pin.anchorB64}`)
+    .join('&');
+}
+
+/** Everything of a pin a URL reads; the rest of `SetPin` never reaches one. */
+type UrlPin = Pick<SetPin, 'id' | 'anchorB64' | 'anchor' | 'appHash'>;
+
+/**
+ * The one link a pin set has, origin-relative. Path, query and the app's own
+ * fragment come from the FIRST pin — the set may span pages, and that is the
+ * page the link opens on.
+ */
+export function pinSetUrl(pins: UrlPin[]): string {
+  const first = pins[0];
+  if (!first) return '';
+  const query = first.anchor.q ? `?${first.anchor.q}` : '';
+  const app = first.appHash;
+  return `${first.anchor.p}${query}#${app ? `${app}&` : ''}${pinSetFragment(pins)}`;
+}
+
+/** A pin set of one. */
 export function pinUrl(
   anchor: AnchorV3,
   id: string,
   anchorB64: string,
   hash = '',
 ): string {
-  const query = anchor.q ? `?${anchor.q}` : '';
-  const rest = otherFragment(hash);
-  return `${anchor.p}${query}#${rest ? `${rest}&` : ''}bai=v3.${id}.${anchorB64}`;
+  return pinSetUrl([{ id, anchor, anchorB64, appHash: otherFragment(hash) }]);
 }
 
 /** A path is shown to a human here, so `%ED%95%9C` is not the answer. */

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -63,6 +63,40 @@ export interface AnchorV3 {
   nt?: 1;
 }
 
+/**
+ * One member of a pin set, as the draft set holds it. `label` and `appHash`
+ * are stamped when the pin joins the set, so a set copied later reproduces
+ * the link and the block the reviewer saw at the time.
+ */
+interface SetPinBase {
+  id: string;
+  /** Includes the note `n`. */
+  anchor: AnchorV3;
+  anchorB64: string;
+  /** `landmarkLabel(...)` output. */
+  label: string;
+  /** `otherFragment(location.hash)` at add time; `''` for a link's pins. */
+  appHash: string;
+  /** `getStackContext()` output, split into lines. */
+  stack: string[];
+}
+
+/** The id hashes from `pr` + anchor + `at`, so a block may claim it. */
+interface PickedSetPin extends SetPinBase {
+  origin: 'pick';
+  at: string;
+  pr: number;
+}
+
+/** A link's pins carry no `at`/`pr`, so their blocks carry no marker. */
+interface LinkedSetPin extends SetPinBase {
+  origin: 'link';
+  at?: never;
+  pr?: never;
+}
+
+export type SetPin = PickedSetPin | LinkedSetPin;
+
 declare global {
   interface Window {
     /** Set by `main.ts` so a second `/__review/*.js` entry is a no-op. */


### PR DESCRIPTION
Resolves #9433 (FR-3856)

Part of the pin-set stack (#9442): #9437 → #9438 → #9439 → #9440 → #9441. Design record: `docs/adr/0002-pin-set-link-grammar-and-single-codec.md`; vocabulary: `react/vite-plugins/review-overlay/CONTEXT.md`.

A pin set is now expressible in the wire format: the link repeats the
existing part after `&` — `#bai=v3.<id1>.<a1>&bai=v3.<id2>.<a2>…`, in set
order, path and query taken from the first pin — and the clipboard carries
one block per pin. The anchor alphabet already excludes `&`, so the parts are
unambiguous and there is no version bump (ADR-0002). This branch lands the
format only; nothing yet produces or draws more than one pin.

`deeplink.ts` grows the list reader and the one URL builder. `parseFragments`
returns every v3 part in link order and skips a part the grammar refuses —
an oversize anchor or a malformed id costs that part, not the ones around it.
`parseFragment` is now `parseFragments(hash)[0] ?? legacy ?? null`, identical
to what it was by construction, and `hasLegacyFragment` is the v1 test on its
own. `pinSetFragment` joins the parts, de-duplicated by id at first-seen
position; `pinSetUrl` puts the first pin's path, query and app fragment in
front of it. `pinUrl` becomes the N=1 wrapper over `pinSetUrl`, so the write
side and the read side cannot drift apart again.

That merge fixes one asymmetry deliberately. The write side used to build its
URL inline and drop the app's own fragment, while the read side kept it, so a
block copied on `#tab=logs` reopened on the default tab. `buildBlockFromCapture`
now goes through `pinUrl` with `appHash` — the fragment it is handed, or the
live one with any pin parts stripped — and the read side's behaviour is the
only one. For an empty app fragment the URL, the markdown block and the HTML
block are byte-identical to what the overlay has been copying, which is what
the N=1 golden tests assert.

`buildSetText` / `buildSetHtml` render the set. Markdown blocks are separated
by a blank line; HTML blocks by `<p></p>`, and only for N>1, because two
adjacent `<blockquote>`s merge into one in a rich editor. Every block carries
a link, since a block is pasted on its own as often as the whole set is and a
block without one carries no anchor at all. `BlockInput.marker` (default true)
is what a link-origin pin turns off: its `pr`/`at` never travelled the wire,
and the id hashes from them, so a fabricated marker would name an id that does
not verify against itself.

The CLI reads sets from the shapes a comment arrives in. `decodeBody` now
un-escapes `%26bai%3Dv3` alongside `%23bai%3Dv3` (`&amp;` is already a plain
`&` by then — `htmlUnescape` runs first), and a matched link expands rightward
through the rest of the set, so each pin of a set link is handed the whole
set's URL instead of a prefix. Link ranking gained pin count as a tiebreak
under the existing path/query rank: where an escaped copy of a set survives
only as its first part, the intact copy wins.

## What else this branch carries — the O(N²) fix (R3)

The second commit is the reason the paragraph above says "its OWN link".
D6's original form repeated the set's one URL in all N blocks, and that URL
itself grows with N, so the copy grew as N². A browser smoke test on a 30-pin
set put 371 KB on the clipboard; GitHub refuses an issue/PR comment body over
65,536 characters, which the text crossed at about 12 pins — so the D9 cap of
30 was ~2.5× larger than the largest set that could be pasted where the design
says the copy is meant to go, and the copy succeeded silently while the paste
failed.

Each block now carries its own pin's link (constant size) and the set link is
emitted once, after the last block, as `[Open all N pins on dev server](…)`.
Both terms are linear. Measured on a fixture with 382-character anchors:

| pins | 1 | 2 | 6 | 12 | 20 | 30 |
|---|---|---|---|---|---|---|
| text, before | 677 | 2,530 | 15,024 | 60,946 | 168,140 | 368,368 |
| text, after | 677 | 2,247 | 6,563 | 13,038 | 21,670 | 32,460 |
| html, after | 745 | 2,413 | 7,045 | 13,994 | 23,258 | 34,838 |

A set of one is unchanged to the byte — its own link IS the set link, and no
extra line is emitted — so the N=1 goldens still pass verbatim for both
app-fragment cases. The trade: a block pasted on its own now resolves to its
own pin rather than to the whole set, which is what quoting a single block
means anyway. The CLI needs no change — `findPinRefs` scans the whole body, so
both a block's own link and the trailing set link contribute, and `betterLink`
prefers a pin's own same-page link over a set link whose page differs.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (run on the stack top, `feat/FR-3859-pin-set-read`)
- `pnpm vitest run vite-plugins/review-overlay` (from `react/`) → 23 files, 557 tests, all passing on the stack top
- Each branch was reviewed by two independent review agents (correctness, design conformance) and their blocker/major findings were fixed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhEbqZ9DDe2HFJF43rAVP1
