### PR TITLE
feat(FR-3857): draw N pins from one layer instead of one pin per overlay

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ catalogs:
       specifier: ^4.18.1
       version: 4.18.1
     lucide-react:
-      specifier: ^1.29.0
-      version: 1.29.0
+      specifier: ^1.37.0
+      version: 1.37.0
     marked:
       specifier: ^16.4.2
       version: 16.4.2
@@ -548,7 +548,7 @@ importers:
         version: 4.18.1
       lucide-react:
         specifier: 'catalog:'
-        version: 1.29.0(react@19.2.8)
+        version: 1.37.0(react@19.2.8)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -903,7 +903,7 @@ importers:
         version: 4.18.1
       lucide-react:
         specifier: 'catalog:'
-        version: 1.29.0(react@19.2.8)
+        version: 1.37.0(react@19.2.8)
       markdown-to-jsx:
         specifier: ^9.10.2
         version: 9.10.2(react@19.2.8)
@@ -8173,8 +8173,8 @@ packages:
   lru-queue@0.1.0:
     resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
 
-  lucide-react@1.29.0:
-    resolution: {integrity: sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg==}
+  lucide-react@1.37.0:
+    resolution: {integrity: sha512-LPsB4rD1TD6wZu1djKOf9vUnS1jTNaHbolXebXDgiTdb6jeA1agIJhJsIybCmjKmQClcOaal1o1OaiYahEftyQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -11253,7 +11253,7 @@ snapshots:
   '@astryxdesign/theme-neutral@0.5.2(@astryxdesign/core@0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@astryxdesign/core': 0.5.2(patch_hash=c9b0d04ba4d03f2fed56352870de082e2a58f9d92b509e247342e59c951918ed)(@stylexjs/stylex@0.19.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      lucide-react: 1.29.0(react@19.2.8)
+      lucide-react: 1.37.0(react@19.2.8)
       react: 19.2.8
 
   '@babel/code-frame@7.29.7':
@@ -19617,7 +19617,7 @@ snapshots:
     dependencies:
       es5-ext: 0.10.64
 
-  lucide-react@1.29.0(react@19.2.8):
+  lucide-react@1.37.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 
@@ -23484,7 +23484,7 @@ time:
   lint-staged@15.5.2: '2025-05-06T10:11:25.711Z'
   lodash-es@4.18.1: '2026-04-01T21:04:15.518Z'
   lodash@4.18.1: '2026-04-01T21:01:20.458Z'
-  lucide-react@1.29.0: '2026-08-06T11:51:53.703Z'
+  lucide-react@1.37.0: '2026-08-29T07:25:15.000Z'
   markdown-to-jsx@9.10.2: '2026-08-03T17:49:48.169Z'
   marked@12.0.2: '2024-04-19T05:13:06.397Z'
   marked@16.4.2: '2025-11-06T22:29:20.004Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ catalog:
   # whose hard dependency is lucide-react ^1.18.0 (to-astryx ticket 07). All
   # 78 icon names the app imports exist in both 0.552 and 1.x (measured);
   # converging up dedupes the two installed majors into one instance.
-  lucide-react: ^1.29.0
+  lucide-react: ^1.37.0
   marked: ^16.4.2
   prettier: ^3.9.6
   prettier-plugin-sort-json: ^4.2.0

--- a/react/vite-plugins/review-overlay/client/icons.test.ts
+++ b/react/vite-plugins/review-overlay/client/icons.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `icons.ts` is a COPY of lucide's node data — the overlay client is served
+ * unbundled and cannot import `lucide-react`. This is what stops the copy from
+ * drifting: every entry is diffed against the module it was copied from, so a
+ * catalog bump that redraws a glyph fails here instead of shipping two looks.
+ */
+import { ICON_NODES, icon, type IconName } from './icons.js';
+import { __iconNode as check } from 'lucide-react/dist/esm/icons/check.mjs';
+import { __iconNode as clipboard } from 'lucide-react/dist/esm/icons/clipboard.mjs';
+import { __iconNode as copy } from 'lucide-react/dist/esm/icons/copy.mjs';
+import { __iconNode as crosshair } from 'lucide-react/dist/esm/icons/crosshair.mjs';
+import { __iconNode as externalLink } from 'lucide-react/dist/esm/icons/external-link.mjs';
+import { __iconNode as eyeOff } from 'lucide-react/dist/esm/icons/eye-off.mjs';
+import { __iconNode as eye } from 'lucide-react/dist/esm/icons/eye.mjs';
+import { __iconNode as files } from 'lucide-react/dist/esm/icons/files.mjs';
+import { __iconNode as gripVertical } from 'lucide-react/dist/esm/icons/grip-vertical.mjs';
+import { __iconNode as mapPin } from 'lucide-react/dist/esm/icons/map-pin.mjs';
+import { __iconNode as trash2 } from 'lucide-react/dist/esm/icons/trash-2.mjs';
+import { __iconNode as x } from 'lucide-react/dist/esm/icons/x.mjs';
+import { describe, expect, it } from 'vitest';
+
+const UPSTREAM: Record<IconName, unknown> = {
+  check,
+  clipboard,
+  copy,
+  crosshair,
+  'external-link': externalLink,
+  eye,
+  'eye-off': eyeOff,
+  files,
+  'grip-vertical': gripVertical,
+  'map-pin': mapPin,
+  'trash-2': trash2,
+  x,
+};
+
+describe('the inlined icon data', () => {
+  it.each(Object.keys(ICON_NODES) as IconName[])(
+    'is lucide’s own for %s',
+    (name) => {
+      expect(ICON_NODES[name]).toEqual(UPSTREAM[name]);
+    },
+  );
+
+  // A name the overlay stopped drawing is dead weight the parity test still
+  // pays for; a name it draws without a copy would throw at render time.
+  it('covers exactly the names the overlay draws', () => {
+    expect(Object.keys(ICON_NODES).sort()).toEqual(
+      Object.keys(UPSTREAM).sort(),
+    );
+  });
+});
+
+describe('icon()', () => {
+  it('draws one 14px stroked svg, hidden from the accessibility tree', () => {
+    const svg = icon('trash-2');
+
+    expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(svg.getAttribute('width')).toBe('14');
+    expect(svg.getAttribute('height')).toBe('14');
+    expect(svg.getAttribute('viewBox')).toBe('0 0 24 24');
+    expect(svg.getAttribute('fill')).toBe('none');
+    expect(svg.getAttribute('stroke')).toBe('currentColor');
+    expect(svg.getAttribute('stroke-width')).toBe('2');
+    expect(svg.getAttribute('stroke-linecap')).toBe('round');
+    expect(svg.getAttribute('stroke-linejoin')).toBe('round');
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+    expect(svg.children).toHaveLength(ICON_NODES['trash-2'].length);
+  });
+
+  it('writes lucide’s attributes and drops its react key', () => {
+    const svg = icon('check');
+    const path = svg.firstElementChild as SVGPathElement;
+
+    expect(path.tagName).toBe('path');
+    expect(path.getAttribute('d')).toBe('M20 6 9 17l-5-5');
+    expect(path.hasAttribute('key')).toBe(false);
+  });
+
+  it('takes a size, for the marker’s smaller glyph', () => {
+    expect(icon('map-pin', 12).getAttribute('width')).toBe('12');
+  });
+});

--- a/react/vite-plugins/review-overlay/client/icons.ts
+++ b/react/vite-plugins/review-overlay/client/icons.ts
@@ -1,0 +1,194 @@
+/**
+ * The overlay's icon set: lucide's node data, inlined. The client is served
+ * unbundled, so it cannot import `lucide-react` (a React package) — the data
+ * below is copied verbatim from `lucide-react@1.37.0`'s
+ * `dist/esm/icons/<name>.mjs`, and `icons.test.ts` diffs every entry against
+ * that module so a bump cannot leave a stale glyph behind.
+ *
+ * lucide-react is ISC-licensed (Copyright (c) 2020, Lucide Contributors);
+ * lucide's icons are ISC too, derived from Feather (MIT).
+ */
+
+/** `[tag, attributes]`, lucide's own shape — copied, not re-derived. */
+export type IconNode = [string, Record<string, string>];
+
+export const ICON_NODES = {
+  check: [['path', { d: 'M20 6 9 17l-5-5', key: '1gmf2c' }]],
+  clipboard: [
+    [
+      'rect',
+      {
+        width: '8',
+        height: '4',
+        x: '8',
+        y: '2',
+        rx: '1',
+        ry: '1',
+        key: 'tgr4d6',
+      },
+    ],
+    [
+      'path',
+      {
+        d: 'M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2',
+        key: '116196',
+      },
+    ],
+  ],
+  copy: [
+    [
+      'rect',
+      {
+        width: '14',
+        height: '14',
+        x: '8',
+        y: '8',
+        rx: '2',
+        ry: '2',
+        key: '17jyea',
+      },
+    ],
+    [
+      'path',
+      {
+        d: 'M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2',
+        key: 'zix9uf',
+      },
+    ],
+  ],
+  crosshair: [
+    ['circle', { cx: '12', cy: '12', r: '10', key: '1mglay' }],
+    ['line', { x1: '22', x2: '18', y1: '12', y2: '12', key: 'l9bcsi' }],
+    ['line', { x1: '6', x2: '2', y1: '12', y2: '12', key: '13hhkx' }],
+    ['line', { x1: '12', x2: '12', y1: '6', y2: '2', key: '10w3f3' }],
+    ['line', { x1: '12', x2: '12', y1: '22', y2: '18', key: '15g9kq' }],
+  ],
+  'external-link': [
+    ['path', { d: 'M15 3h6v6', key: '1q9fwt' }],
+    ['path', { d: 'M10 14 21 3', key: 'gplh6r' }],
+    [
+      'path',
+      {
+        d: 'M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6',
+        key: 'a6xqqp',
+      },
+    ],
+  ],
+  eye: [
+    [
+      'path',
+      {
+        d: 'M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0',
+        key: '1nclc0',
+      },
+    ],
+    ['circle', { cx: '12', cy: '12', r: '3', key: '1v7zrd' }],
+  ],
+  'eye-off': [
+    [
+      'path',
+      {
+        d: 'M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49',
+        key: 'ct8e1f',
+      },
+    ],
+    ['path', { d: 'M14.084 14.158a3 3 0 0 1-4.242-4.242', key: '151rxh' }],
+    [
+      'path',
+      {
+        d: 'M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143',
+        key: '13bj9a',
+      },
+    ],
+    ['path', { d: 'm2 2 20 20', key: '1ooewy' }],
+  ],
+  files: [
+    [
+      'path',
+      {
+        d: 'M15 2h-4a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8',
+        key: '14sh0y',
+      },
+    ],
+    [
+      'path',
+      {
+        d: 'M16.706 2.706A2.4 2.4 0 0 0 15 2v5a1 1 0 0 0 1 1h5a2.4 2.4 0 0 0-.706-1.706z',
+        key: '1970lx',
+      },
+    ],
+    [
+      'path',
+      {
+        d: 'M5 7a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h8a2 2 0 0 0 1.732-1',
+        key: 'l4dndm',
+      },
+    ],
+  ],
+  'grip-vertical': [
+    ['circle', { cx: '9', cy: '12', r: '1', key: '1vctgf' }],
+    ['circle', { cx: '9', cy: '5', r: '1', key: 'hp0tcf' }],
+    ['circle', { cx: '9', cy: '19', r: '1', key: 'fkjjf6' }],
+    ['circle', { cx: '15', cy: '12', r: '1', key: '1tmaij' }],
+    ['circle', { cx: '15', cy: '5', r: '1', key: '19l28e' }],
+    ['circle', { cx: '15', cy: '19', r: '1', key: 'f4zoj3' }],
+  ],
+  'map-pin': [
+    [
+      'path',
+      {
+        d: 'M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0',
+        key: '1r0f0z',
+      },
+    ],
+    ['circle', { cx: '12', cy: '10', r: '3', key: 'ilqhr7' }],
+  ],
+  'trash-2': [
+    ['path', { d: 'M10 11v6', key: 'nco0om' }],
+    ['path', { d: 'M14 11v6', key: 'outv1u' }],
+    ['path', { d: 'M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6', key: 'miytrc' }],
+    ['path', { d: 'M3 6h18', key: 'd0wm0j' }],
+    ['path', { d: 'M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2', key: 'e791ji' }],
+  ],
+  x: [
+    ['path', { d: 'M18 6 6 18', key: '1bl5f8' }],
+    ['path', { d: 'm6 6 12 12', key: 'd8bk6v' }],
+  ],
+} as const satisfies Record<string, readonly IconNode[]>;
+
+export type IconName = keyof typeof ICON_NODES;
+
+/** One size for the whole chrome, so the buttons stop varying in height. */
+export const ICON_SIZE = 14;
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * `aria-hidden` on purpose: every button carrying an icon already has the
+ * `title`/`aria-label` that names its action, and a second name reads twice.
+ */
+export function icon(name: IconName, size: number = ICON_SIZE): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'icon');
+  svg.setAttribute('width', String(size));
+  svg.setAttribute('height', String(size));
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+  for (const [tag, attrs] of ICON_NODES[name] as readonly IconNode[]) {
+    const node = document.createElementNS(SVG_NS, tag);
+    for (const [attr, value] of Object.entries(attrs))
+      if (attr !== 'key') node.setAttribute(attr, value);
+    svg.append(node);
+  }
+  return svg;
+}
+
+/** Shared by every shadow root that draws icons. */
+export const ICON_STYLE = `
+  .icon { flex: none; vertical-align: -2px; }
+`;

--- a/react/vite-plugins/review-overlay/client/lucide-icon-node.d.ts
+++ b/react/vite-plugins/review-overlay/client/lucide-icon-node.d.ts
@@ -1,0 +1,8 @@
+/**
+ * lucide-react ships no `.d.ts` beside its per-icon ESM entries, and
+ * `icons.test.ts` reads exactly those to prove the overlay's inlined copies
+ * still match. Only the shape the test uses is declared.
+ */
+declare module 'lucide-react/dist/esm/icons/*.mjs' {
+  export const __iconNode: Array<[string, Record<string, string>]>;
+}

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -26,10 +26,9 @@ import {
   parseFragment,
   pathNeedsChange,
   pinUrl,
-  retryUntil,
 } from './deeplink.js';
 import { createPicker } from './picker.js';
-import { createDeepLinkPin, type DeepLinkPinTarget } from './pin.js';
+import { createPinLayer, type DeepLinkPinTarget } from './pin.js';
 import type {
   AnchorComponent,
   AnchorV3,
@@ -40,9 +39,6 @@ import { createOverlayUI } from './ui.js';
 
 /** The SPA's own `<Navigate replace>` redirects drop the fragment on login. */
 const BOOT_HASH = location.hash;
-/** 10 s of SPA boot at 500 ms — the login form is lazy behind the splash. */
-const ANCHOR_TRIES = 20;
-const ANCHOR_EVERY_MS = 500;
 
 if (!window.__baiReviewOverlay) {
   window.__baiReviewOverlay = true;
@@ -72,6 +68,13 @@ function boot() {
     null;
   /** Typing faster than `encodeAnchor` resolves; only the last one counts. */
   let encodeSeq = 0;
+  let pickActive = false;
+  /**
+   * Drawn cards sit over the app, so the next pick would land on one. The
+   * markers are click-through already; only the cards have to fold away.
+   */
+  const syncCollapse = () =>
+    pins.setCollapsed(pickActive || ui.getComposeTarget() !== null);
 
   const ui = createOverlayUI({
     onBuildBlock: (text) => {
@@ -90,6 +93,7 @@ function boot() {
       capture = null;
       pick = null;
       picker.stop();
+      syncCollapse();
     },
     onEscape: () => picker.stop(),
   });
@@ -99,6 +103,7 @@ function boot() {
       capture = null;
       pick = null;
       ui.openCompose(element, x, y, region);
+      syncCollapse();
       // One capture per pick: the label, the anchor payload and the rect all
       // come from this single walk, measured while the page still looks the
       // way the reviewer saw it.
@@ -106,7 +111,11 @@ function boot() {
       ui.setComposeLabel(landmarkLabel(currentRouteLabel(), anchor));
       void prepare(element, anchor);
     },
-    onModeChange: (active) => ui.setPickActive(active),
+    onModeChange: (active) => {
+      pickActive = active;
+      ui.setPickActive(active);
+      syncCollapse();
+    },
     onHover: (rect, borderRadius) => ui.setHoverRect(rect, borderRadius),
     isOwnEvent: (evt) => ui.isOwnEvent(evt),
     showHint: (message) => ui.showToast(message),
@@ -173,8 +182,6 @@ function boot() {
   const currentRouteLabel = () =>
     resolveRouteLabel(location.pathname, window.__BAI_REVIEW__?.routeLabel);
 
-  picker.watchForReactGrab();
-
   // ------------------------------------------------- deep link (FR-3813)
 
   /** A pin that locates before react-grab registers, retried into a stack. */
@@ -234,7 +241,7 @@ function boot() {
     return { text: buildBlockText(input), html: buildBlockHtml(input) };
   }
 
-  const pin = createDeepLinkPin({
+  const pins = createPinLayer({
     root: ui.root,
     host: ui.host,
     copyText: ui.copyText,
@@ -242,8 +249,10 @@ function boot() {
     buildComment,
     onLocated: (element) => void readPinStack(element),
   });
+  // After the layer: registering the plugin can activate react-grab straight
+  // away, and `syncCollapse` reaches `pins`.
+  picker.watchForReactGrab();
   const guard = createNavigationGuard();
-  let cancelRetry = () => undefined as void;
 
   /** The route the pin was made on, not the one the reader happens to be on. */
   const anchorRouteLabel = (anchor: AnchorV3) =>
@@ -279,18 +288,16 @@ function boot() {
     } else {
       guard.landed();
     }
-    cancelRetry();
-    pin.show({
-      id: fragment.id,
-      anchor,
-      anchorB64: fragment.anchorB64,
-      label: landmarkLabel(anchorRouteLabel(anchor), anchor),
-    });
-    cancelRetry = retryUntil(() => pin.locate(), {
-      tries: ANCHOR_TRIES,
-      everyMs: ANCHOR_EVERY_MS,
-      onGiveUp: () => ui.showToast('Could not find that element on this page'),
-    });
+    // The layer owns the retry ladder: one driver for however many pins the
+    // link carried, and one give-up sentence for all of them.
+    pins.show([
+      {
+        id: fragment.id,
+        anchor,
+        anchorB64: fragment.anchorB64,
+        label: landmarkLabel(anchorRouteLabel(anchor), anchor),
+      },
+    ]);
   }
 
   window.addEventListener('hashchange', () => {

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -1,0 +1,433 @@
+/**
+ * The layer side of `pin.ts` (FR-3857): one `<style>`, one observer, one retry
+ * driver and one docked column over N pin views. `pin.test.ts` covers what a
+ * single view does; this covers what only a set can show.
+ */
+import {
+  createPinLayer,
+  type DeepLinkPinTarget,
+  type PinLayer,
+} from './pin.js';
+import type { AnchorV3 } from './types.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let host: HTMLElement;
+let layer: PinLayer;
+let toasts: string[];
+let dismissed: string[];
+let scrolled: string[];
+
+const shadow = () => host.shadowRoot as ShadowRoot;
+const cards = () => Array.from(shadow().querySelectorAll<HTMLElement>('.card'));
+const cardOf = (id: string) =>
+  shadow().querySelector<HTMLElement>(
+    `.card[data-pin-id="${id}"]`,
+  ) as HTMLElement;
+const markerOf = (id: string) =>
+  shadow().querySelector<HTMLElement>(
+    `.pin[data-pin-id="${id}"]`,
+  ) as HTMLElement;
+const countOf = (id: string) =>
+  cardOf(id).querySelector<HTMLElement>('.count')?.textContent;
+
+/** The layer places on a rAF; give it one frame to land. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 60));
+
+const target = (
+  id: string,
+  testid: string,
+  over: Partial<AnchorV3> = {},
+): DeepLinkPinTarget => ({
+  id,
+  anchor: {
+    v: 3,
+    s: `[data-testid="${testid}"]`,
+    p: '/',
+    tag: 'button',
+    txt: testid,
+    ...over,
+  },
+  anchorB64: `PAYLOAD_${id}`,
+  label: `Start › ${testid}`,
+});
+
+/** jsdom has no layout, so every element the layer measures is given a box. */
+const mount = (testid: string, box: Partial<DOMRect> = {}): HTMLElement => {
+  document.body.insertAdjacentHTML(
+    'beforeend',
+    `<button data-testid="${testid}">${testid}</button>`,
+  );
+  const element = document.querySelector<HTMLElement>(
+    `[data-testid="${testid}"]`,
+  ) as HTMLElement;
+  element.getBoundingClientRect = () =>
+    ({
+      left: 20,
+      right: 420,
+      width: 400,
+      top: 100,
+      bottom: 300,
+      height: 200,
+      ...box,
+    }) as DOMRect;
+  element.scrollIntoView = () => {
+    scrolled.push(testid);
+  };
+  return element;
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  toasts = [];
+  dismissed = [];
+  scrolled = [];
+  host = document.createElement('div');
+  host.setAttribute('data-bai-review-overlay', '');
+  document.body.append(host);
+  Object.defineProperty(window, 'innerHeight', {
+    value: 800,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'innerWidth', {
+    value: 1024,
+    configurable: true,
+  });
+  layer = createPinLayer({
+    root: host.attachShadow({ mode: 'open' }),
+    host,
+    copyText: () => true,
+    showToast: (message) => toasts.push(message),
+    buildComment: () => ({ text: 'block', html: '<p>block</p>' }),
+    onDismiss: (pin) => dismissed.push(pin.id),
+  });
+});
+
+afterEach(() => {
+  layer.dispose();
+});
+
+describe('createPinLayer', () => {
+  it('draws one view per pin, tagged with its own id', () => {
+    mount('one');
+    mount('two');
+    layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+
+    expect(layer.locate()).toBe(true);
+    expect(cards().map((card) => card.dataset.pinId)).toEqual(['c_a', 'c_b']);
+    expect(cardOf('c_b').textContent).toContain('Start › two');
+    expect(layer.locatedElement('c_b')).toBe(
+      document.querySelector('[data-testid="two"]'),
+    );
+  });
+
+  // One layer means one stylesheet and one fixed plane, however many pins.
+  it('keeps a single style and a single plane for the whole set', () => {
+    mount('one');
+    mount('two');
+    mount('three');
+    layer.show([
+      target('c_a', 'one'),
+      target('c_b', 'two'),
+      target('c_c', 'three'),
+    ]);
+
+    expect(shadow().querySelectorAll('style')).toHaveLength(1);
+    expect(shadow().querySelectorAll('.pinlayer')).toHaveLength(1);
+    expect(shadow().querySelectorAll('.card')).toHaveLength(3);
+    expect(shadow().querySelectorAll('.markbox')).toHaveLength(3);
+  });
+
+  it('numbers the markers and heads each card with its place in the set', () => {
+    mount('one');
+    mount('two');
+    layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+
+    expect(markerOf('c_a').textContent).toBe('1');
+    expect(markerOf('c_b').textContent).toBe('2');
+    expect(countOf('c_a')).toBe('1 / 2');
+    expect(countOf('c_b')).toBe('2 / 2');
+  });
+
+  // A set of one is what a single pin has always been.
+  it('leaves a set of one unnumbered', () => {
+    mount('one');
+    layer.show([target('c_a', 'one')]);
+
+    expect(markerOf('c_a').textContent).toBe('📍');
+    expect(countOf('c_a')).toBe('');
+  });
+
+  it('shrinks back to one view when the set does', () => {
+    mount('one');
+    mount('two');
+    layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+    layer.show([target('c_a', 'one')]);
+
+    expect(shadow().querySelectorAll('.card')).toHaveLength(1);
+    expect(markerOf('c_a').textContent).toBe('📍');
+  });
+
+  describe('the focus pin', () => {
+    it('is the only one that scrolls the page and pulses', () => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+
+      expect(scrolled).toEqual(['one']);
+      expect(markerOf('c_a').classList.contains('pulse')).toBe(true);
+      expect(markerOf('c_b').classList.contains('pulse')).toBe(false);
+    });
+
+    // A stored focus id outlives the pin it named; the set still scrolls.
+    it('falls back to the first pin when the named one is not in the set', () => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')], {
+        focusId: 'c_gone',
+      });
+
+      expect(scrolled).toEqual(['one']);
+      expect(markerOf('c_a').classList.contains('pulse')).toBe(true);
+    });
+
+    it('is whichever pin the caller names', () => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')], {
+        focusId: 'c_b',
+      });
+
+      expect(scrolled).toEqual(['two']);
+      expect(markerOf('c_b').classList.contains('pulse')).toBe(true);
+    });
+  });
+
+  describe('dismissing one pin of a set', () => {
+    beforeEach(() => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+      layer.locate();
+    });
+
+    it('takes that one down and leaves the rest drawn', () => {
+      layer.dismiss('c_a');
+
+      expect(layer.ids()).toEqual(['c_b']);
+      expect(layer.isShowing('c_a')).toBe(false);
+      expect(cardOf('c_a').classList.contains('found')).toBe(false);
+      expect(markerOf('c_a').classList.contains('found')).toBe(false);
+      expect(cardOf('c_b').classList.contains('found')).toBe(true);
+      expect(markerOf('c_b').classList.contains('found')).toBe(true);
+    });
+
+    // ✕ is a set edit, and only the set's owner knows what that costs.
+    it('hands the pin back to the owner when ✕ is what did it', () => {
+      cardOf('c_b').querySelector<HTMLButtonElement>('.close')?.click();
+
+      expect(dismissed).toEqual(['c_b']);
+      expect(layer.ids()).toEqual(['c_a']);
+    });
+
+    it('renumbers what is left, so the heads still count the set', () => {
+      mount('three');
+      layer.show([
+        target('c_a', 'one'),
+        target('c_b', 'two'),
+        target('c_c', 'three'),
+      ]);
+
+      layer.dismiss('c_a');
+
+      expect(markerOf('c_b').textContent).toBe('1');
+      expect(countOf('c_b')).toBe('1 / 2');
+      expect(countOf('c_c')).toBe('2 / 2');
+    });
+
+    // Two pins minus one is a set of one, which never numbered itself.
+    it('drops back to a lone 📍 when ✕ leaves one pin', () => {
+      cardOf('c_a').querySelector<HTMLButtonElement>('.close')?.click();
+
+      expect(markerOf('c_b').textContent).toBe('📍');
+      expect(countOf('c_b')).toBe('');
+    });
+
+    it('takes the whole set down when no pin is named', () => {
+      layer.dismiss();
+
+      expect(layer.ids()).toEqual([]);
+      expect(layer.isShowing()).toBe(false);
+    });
+  });
+
+  describe('the retry driver', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // One driver, one sentence: a pin per toast would bury the page in them.
+    it('gives up once for the whole set, counting what is missing', () => {
+      mount('one');
+      layer.show([
+        target('c_a', 'one'),
+        target('c_b', 'two'),
+        target('c_c', 'three'),
+      ]);
+
+      vi.advanceTimersByTime(20 * 500);
+
+      expect(toasts).toEqual(['2 of 3 pins are not on this page']);
+    });
+
+    // The sentence a single pin has always given up with.
+    it('says what it always said for a set of one', () => {
+      layer.show([target('c_a', 'one')]);
+
+      vi.advanceTimersByTime(20 * 500);
+
+      expect(toasts).toEqual(['Could not find that element on this page']);
+    });
+
+    it('says nothing at all once every pin has landed', () => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+
+      vi.advanceTimersByTime(20 * 500);
+
+      expect(toasts).toEqual([]);
+    });
+  });
+
+  // Mid-pick a card would swallow the click meant for the element under it.
+  describe('folding away for a pick', () => {
+    it('collapses every card and leaves the markers', () => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+      layer.locate();
+
+      layer.setCollapsed(true);
+      expect(
+        cards().every((card) => card.classList.contains('collapsed')),
+      ).toBe(true);
+      expect(markerOf('c_a').classList.contains('found')).toBe(true);
+
+      layer.setCollapsed(false);
+      expect(cards().some((card) => card.classList.contains('collapsed'))).toBe(
+        false,
+      );
+    });
+
+    // Only the card folds: the marker is what still says where the pin is.
+    it('keeps the marker on the element while the card is folded', async () => {
+      const element = mount('one');
+      layer.show([target('c_a', 'one')]);
+      layer.locate();
+      layer.setCollapsed(true);
+
+      element.getBoundingClientRect = () =>
+        ({
+          left: 40,
+          right: 440,
+          width: 400,
+          top: 200,
+          bottom: 400,
+          height: 200,
+        }) as DOMRect;
+      window.dispatchEvent(new Event('resize'));
+      await settle();
+
+      expect(markerOf('c_a').classList.contains('found')).toBe(true);
+      expect(markerOf('c_a').style.left).toBe('46px');
+    });
+
+    // A folded card measures 0 high, and a card placed on that lands off-screen.
+    it('leaves the folded card where it was and re-places it on the way out', async () => {
+      mount('one', { top: 900, bottom: 1100 });
+      layer.show([target('c_a', 'one')]);
+      layer.locate();
+      Object.defineProperty(cardOf('c_a'), 'offsetHeight', {
+        value: 60,
+        configurable: true,
+      });
+      await settle();
+      expect(cardOf('c_a').style.top).toBe('732px');
+
+      layer.setCollapsed(true);
+      Object.defineProperty(window, 'innerHeight', {
+        value: 600,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('resize'));
+      await settle();
+      expect(cardOf('c_a').style.top).toBe('732px');
+
+      layer.setCollapsed(false);
+      await settle();
+      expect(cardOf('c_a').style.top).toBe('532px');
+    });
+
+    it('reaches a pin drawn after the pick began', () => {
+      mount('one');
+      layer.setCollapsed(true);
+      layer.show([target('c_a', 'one')]);
+
+      expect(cardOf('c_a').classList.contains('collapsed')).toBe(true);
+    });
+  });
+
+  // FR-3853 docks an away card to the edge the element left by. Two of them
+  // at the same edge would sit on top of each other.
+  it('stacks away cards into a column, the first where it always was', async () => {
+    const gone = { top: -300, bottom: -100 };
+    mount('one', gone);
+    mount('two', gone);
+    layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+    layer.locate();
+    for (const card of cards()) {
+      Object.defineProperty(card, 'offsetHeight', {
+        value: 60,
+        configurable: true,
+      });
+    }
+    // No resize, no mutation: locating the set is what lays the column out.
+    await settle();
+
+    expect(cardOf('c_a').classList.contains('away')).toBe(true);
+    expect(cardOf('c_b').classList.contains('away')).toBe(true);
+    // The head of the column keeps FR-3853's own geometry; the next clears it.
+    expect(cardOf('c_a').style.top).toBe('8px');
+    expect(cardOf('c_b').style.top).toBe('74px');
+  });
+
+  // A pin that lands on a later retry tick has no scroll to follow and no
+  // draw of the set to ride on: locating it is what must lay the column out.
+  it('stacks the column for a pin that lands after the set was drawn', async () => {
+    const gone = { top: -300, bottom: -100 };
+    mount('one', gone);
+    layer.show(
+      [target('c_x', 'missing'), target('c_a', 'one'), target('c_b', 'two')],
+      { focusId: 'c_x' },
+    );
+    layer.locate();
+    for (const card of cards()) {
+      Object.defineProperty(card, 'offsetHeight', {
+        value: 60,
+        configurable: true,
+      });
+    }
+    await settle();
+    expect(cardOf('c_a').style.top).toBe('8px');
+
+    mount('two', gone);
+    layer.locate();
+    await settle();
+
+    expect(cardOf('c_b').style.top).toBe('74px');
+  });
+});

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -29,6 +29,9 @@ const markerOf = (id: string) =>
   ) as HTMLElement;
 const countOf = (id: string) =>
   cardOf(id).querySelector<HTMLElement>('.count')?.textContent;
+/** A set of one draws lucide's map-pin where a set draws its index. */
+const markerGlyph = (id: string) =>
+  markerOf(id).querySelector('svg') ? 'map-pin' : markerOf(id).textContent;
 
 /** The layer places on a rAF; give it one frame to land. */
 const settle = () => new Promise((resolve) => setTimeout(resolve, 60));
@@ -153,7 +156,7 @@ describe('createPinLayer', () => {
     mount('one');
     layer.show([target('c_a', 'one')]);
 
-    expect(markerOf('c_a').textContent).toBe('📍');
+    expect(markerGlyph('c_a')).toBe('map-pin');
     expect(countOf('c_a')).toBe('');
   });
 
@@ -164,7 +167,7 @@ describe('createPinLayer', () => {
     layer.show([target('c_a', 'one')]);
 
     expect(shadow().querySelectorAll('.card')).toHaveLength(1);
-    expect(markerOf('c_a').textContent).toBe('📍');
+    expect(markerGlyph('c_a')).toBe('map-pin');
   });
 
   describe('the focus pin', () => {
@@ -245,10 +248,10 @@ describe('createPinLayer', () => {
     });
 
     // Two pins minus one is a set of one, which never numbered itself.
-    it('drops back to a lone 📍 when ✕ leaves one pin', () => {
+    it('drops back to a lone map-pin when ✕ leaves one pin', () => {
       cardOf('c_a').querySelector<HTMLButtonElement>('.close')?.click();
 
-      expect(markerOf('c_b').textContent).toBe('📍');
+      expect(markerGlyph('c_b')).toBe('map-pin');
       expect(countOf('c_b')).toBe('');
     });
 
@@ -343,7 +346,7 @@ describe('createPinLayer', () => {
       await settle();
 
       expect(markerOf('c_a').classList.contains('found')).toBe(true);
-      expect(markerOf('c_a').style.left).toBe('46px');
+      expect(markerOf('c_a').style.left).toBe('40px');
     });
 
     // A folded card measures 0 high, and a card placed on that lands off-screen.

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -16,6 +16,7 @@ let layer: PinLayer;
 let toasts: string[];
 let dismissed: string[];
 let scrolled: string[];
+let pending: string[][];
 
 const shadow = () => host.shadowRoot as ShadowRoot;
 const cards = () => Array.from(shadow().querySelectorAll<HTMLElement>('.card'));
@@ -84,6 +85,7 @@ beforeEach(() => {
   toasts = [];
   dismissed = [];
   scrolled = [];
+  pending = [];
   host = document.createElement('div');
   host.setAttribute('data-bai-review-overlay', '');
   document.body.append(host);
@@ -303,6 +305,104 @@ describe('createPinLayer', () => {
       vi.advanceTimersByTime(20 * 500);
 
       expect(toasts).toEqual([]);
+    });
+
+    // The owner knows whether a pending pin is on another page or waiting for
+    // its element; the layer only knows which ids are still unresolved.
+    it('hands the still-pending ids to an owner that wants them', () => {
+      layer.dispose();
+      layer = createPinLayer({
+        root: shadow(),
+        host,
+        copyText: () => true,
+        showToast: (message) => toasts.push(message),
+        buildComment: () => ({ text: 'block', html: '<p>block</p>' }),
+        onGiveUp: (ids) => pending.push(ids),
+      });
+      mount('one');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+
+      vi.advanceTimersByTime(20 * 500);
+
+      expect(pending).toEqual([['c_b']]);
+      expect(toasts).toEqual([]);
+    });
+  });
+
+  /**
+   * R7.2: the ladder is 10 s of SPA boot, not the pin's whole life. A pin
+   * whose element is inside a closed modal has to appear the moment the
+   * reviewer opens it again, however long after that is.
+   */
+  describe('a pin still waiting for its element', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** One mutation batch, through the layer's own debounce. */
+    const churn = async (times = 1) => {
+      for (let i = 0; i < times; i++) {
+        document.body.insertAdjacentHTML('beforeend', '<i>churn</i>');
+        await Promise.resolve();
+        vi.advanceTimersByTime(400);
+      }
+    };
+
+    it('draws it when the element arrives after the ladder gave up', async () => {
+      layer.show([target('c_a', 'late')]);
+      vi.advanceTimersByTime(20 * 500);
+      expect(toasts).toEqual(['Could not find that element on this page']);
+
+      mount('late');
+      await churn();
+
+      expect(markerOf('c_a').classList.contains('found')).toBe(true);
+      expect(layer.locatedElement('c_a')).toBe(
+        document.querySelector('[data-testid="late"]'),
+      );
+    });
+
+    // The escalated scan's budget is spent by the page's own churn long before
+    // the modal opens; the landmark coming back is what buys it a new one.
+    it('escalates again when the landmark it lived in comes back', async () => {
+      layer.show([
+        target('c_a', 'unused', {
+          s: '#never-matches',
+          tid: 'panel',
+          rect: { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+          txt: 'Deploy',
+        }),
+      ]);
+      vi.advanceTimersByTime(20 * 500);
+      await churn(5);
+
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<div data-testid="panel"><button>Deploy</button></div>',
+      );
+      await churn();
+
+      expect(layer.locatedElement('c_a')).toBe(
+        document.querySelector('[data-testid="panel"] button'),
+      );
+    });
+
+    // One `querySelector` per waiting pin per batch is the budget; the
+    // document-wide text scan keeps the cap it has always had.
+    it('does not re-run the document-wide scan on every mutation', async () => {
+      layer.show([target('c_a', 'gone')]);
+      vi.advanceTimersByTime(20 * 500);
+      const wide = vi.spyOn(document, 'querySelectorAll');
+
+      await churn(6);
+
+      const scans = wide.mock.calls.filter(([sel]) => sel === 'button').length;
+      expect(scans).toBeLessThanOrEqual(3);
+      wide.mockRestore();
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -381,6 +381,106 @@ describe('createPinLayer', () => {
     });
   });
 
+  // ✕ on a card, and the dock's own switch, both take the card off the page —
+  // the marker and the box are what say where the pin is, and they stay.
+  describe('cards taken off screen', () => {
+    beforeEach(() => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+      layer.locate();
+    });
+
+    it('hides one card and leaves its pin drawn', () => {
+      layer.setCardHidden('c_a', true);
+
+      expect(cardOf('c_a').classList.contains('hidden')).toBe(true);
+      expect(markerOf('c_a').classList.contains('found')).toBe(true);
+      expect(cardOf('c_b').classList.contains('hidden')).toBe(false);
+
+      layer.setCardHidden('c_a', false);
+      expect(cardOf('c_a').classList.contains('hidden')).toBe(false);
+    });
+
+    it('hides every card at once, and the markers stay', () => {
+      layer.setCardsHidden(true);
+
+      expect(cards().every((card) => card.classList.contains('hidden'))).toBe(
+        true,
+      );
+      expect(markerOf('c_b').classList.contains('found')).toBe(true);
+
+      layer.setCardsHidden(false);
+      expect(cards().some((card) => card.classList.contains('hidden'))).toBe(
+        false,
+      );
+    });
+
+    // The switch outlives the set it was thrown on.
+    it('reaches a pin drawn after the switch was thrown', () => {
+      layer.setCardsHidden(true);
+      mount('three');
+      layer.show([
+        target('c_a', 'one'),
+        target('c_b', 'two'),
+        target('c_c', 'three'),
+      ]);
+
+      expect(cardOf('c_c').classList.contains('hidden')).toBe(true);
+    });
+
+    // Adopting a pin is a fresh card: the last pin's ✕ is not this one's.
+    it('shows the card again when the view takes a new pin', () => {
+      layer.setCardHidden('c_b', true);
+
+      layer.show([target('c_a', 'one'), target('c_c', 'two')]);
+
+      expect(cardOf('c_c').classList.contains('hidden')).toBe(false);
+    });
+  });
+
+  // A hidden card is `display: none`, so it measures 0 high — counting it into
+  // the column would leave a gap where nothing is drawn.
+  it('leaves a hidden away card out of the docked column', async () => {
+    const gone = { top: -300, bottom: -100 };
+    mount('one', gone);
+    mount('two', gone);
+    layer.show([target('c_a', 'one'), target('c_b', 'two')]);
+    layer.locate();
+    for (const card of cards()) {
+      Object.defineProperty(card, 'offsetHeight', {
+        value: 60,
+        configurable: true,
+      });
+    }
+    layer.setCardHidden('c_a', true);
+    await settle();
+
+    expect(cardOf('c_b').style.top).toBe('8px');
+  });
+
+  // The arrival pulse is spent once; a deliberate "this one" — the set dock's
+  // row click — has to beat the marker again.
+  describe('beating a marker again', () => {
+    it('re-pulses a pin that already had its arrival beat', () => {
+      mount('one');
+      layer.show([target('c_a', 'one')]);
+      expect(markerOf('c_a').classList.contains('pulse')).toBe(true);
+      markerOf('c_a').classList.remove('pulse');
+
+      layer.pulse('c_a');
+
+      expect(markerOf('c_a').classList.contains('pulse')).toBe(true);
+    });
+
+    it('says nothing about a pin the layer does not draw', () => {
+      mount('one');
+      layer.show([target('c_a', 'one')]);
+
+      expect(() => layer.pulse('c_gone')).not.toThrow();
+    });
+  });
+
   // FR-3853 docks an away card to the edge the element left by. Two of them
   // at the same edge would sit on top of each other.
   it('stacks away cards into a column, the first where it always was', async () => {

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -265,6 +265,35 @@ describe('createPinLayer', () => {
     });
   });
 
+  // A row asking about ITS pin must not move the page to the focus pin, which
+  // is exactly where a link's arrival leaves the layer (R7.3).
+  describe('resolving one named pin', () => {
+    beforeEach(() => {
+      mount('one');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')], {
+        focusId: 'c_a',
+      });
+      scrolled = [];
+    });
+
+    it('draws the pin that arrived late and scrolls nothing', () => {
+      const two = mount('two');
+
+      expect(layer.locate('c_b')).toBe(true);
+      expect(layer.locatedElement('c_b')).toBe(two);
+      expect(scrolled).toEqual([]);
+    });
+
+    it('is the difference from re-running the whole ladder', () => {
+      layer.locate('c_b');
+      expect(scrolled).toEqual([]);
+
+      layer.locate();
+
+      expect(scrolled).toEqual(['one']);
+    });
+  });
+
   describe('the retry driver', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -232,7 +232,8 @@ describe('createDeepLinkPin', () => {
       mountSized({ top: -50, bottom: 900, height: 950 }, 60);
       show();
       expect(pin.locate()).toBe(true);
-      expect(card().style.top).toBe('8px');
+      // 8 pad + the 34px marker clamped to the same edge + its 10px gap.
+      expect(card().style.top).toBe('52px');
     });
 
     // `getBoundingClientRect` still reports the box of an element a scroller
@@ -308,6 +309,19 @@ describe('createDeepLinkPin', () => {
         expect(pin.locate()).toBe(true);
 
         expect(card().style.top).toBe('266px');
+      });
+
+      // A region taller than the window has no outside left: flipping would put
+      // the marker in the middle of the content it points at.
+      it('keeps the marker at the leading edge of a region taller than the window', () => {
+        mountSized({ left: 40, right: 440, top: -100, bottom: 900 }, 60);
+        show();
+        expect(pin.locate()).toBe(true);
+
+        expect(marker().classList.contains('flip')).toBe(false);
+        // Clamped to the top edge, not to `vh - 25` down at the fold.
+        expect(marker().style.top).toBe('25px');
+        expect(marker().style.left).toBe('40px');
       });
 
       it('slides along the top edge instead of off the left of the window', () => {

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -224,7 +224,8 @@ describe('createDeepLinkPin', () => {
       mountSized({ top: 160, bottom: 760, height: 600 }, 60);
       show();
       expect(pin.locate()).toBe(true);
-      expect(card().style.top).toBe('90px');
+      // 160 - 10 gap - 60 card - 36 the marker took above the element.
+      expect(card().style.top).toBe('54px');
     });
 
     it('clamps into the viewport when the card fits neither way', () => {
@@ -267,12 +268,63 @@ describe('createDeepLinkPin', () => {
       expect(card().style.top).toBe('8px');
     });
 
+    // R5.4. The marker used to sit INSIDE the box at +6/+6, covering the very
+    // content the region points at. `style.left`/`top` are its centre, and the
+    // teardrop's tip is 17px from that on the axis it points along.
+    describe('the marker outside the marked region', () => {
+      it('hangs above the region, tip on its top-left corner', () => {
+        mountSized(
+          { left: 100, right: 500, top: 100, bottom: 300, height: 200 },
+          60,
+        );
+        show();
+        expect(pin.locate()).toBe(true);
+
+        expect(marker().classList.contains('flip')).toBe(false);
+        expect(marker().style.left).toBe('100px');
+        expect(marker().style.top).toBe('81px');
+        // Tip at 81 + 17 = 98, two pixels clear of the region's top at 100.
+        expect(Number.parseInt(marker().style.top, 10) + 17).toBeLessThan(100);
+      });
+
+      it('flips below when the region is too near the top to fit above', () => {
+        mountSized({ top: 20, bottom: 220, height: 200 }, 60);
+        show();
+        expect(pin.locate()).toBe(true);
+
+        expect(marker().classList.contains('flip')).toBe(true);
+        // Tip at 239 - 17 = 222, below the region's bottom at 220.
+        expect(marker().style.top).toBe('239px');
+        expect(Number.parseInt(marker().style.top, 10) - 17).toBeGreaterThan(
+          220,
+        );
+      });
+
+      // Flipped, the marker takes the space under the region — which is where
+      // the card goes by default.
+      it('starts the card past the flipped marker, not under it', () => {
+        mountSized({ top: 20, bottom: 220, height: 200 }, 60);
+        show();
+        expect(pin.locate()).toBe(true);
+
+        expect(card().style.top).toBe('266px');
+      });
+
+      it('slides along the top edge instead of off the left of the window', () => {
+        mountSized({ left: 2, right: 402, top: 100, bottom: 300 }, 60);
+        show();
+        expect(pin.locate()).toBe(true);
+
+        expect(marker().style.left).toBe('25px');
+      });
+    });
+
     // A resize is pure geometry: it must not wait on the mutation debounce.
     it('re-places on resize within a frame', async () => {
       show();
       const element = mountSized({ top: 100, bottom: 300, height: 200 }, 60);
       await new Promise((resolve) => setTimeout(resolve, 400));
-      expect(marker().style.top).toBe('106px');
+      expect(marker().style.top).toBe('81px');
 
       element.getBoundingClientRect = () =>
         ({
@@ -285,7 +337,7 @@ describe('createDeepLinkPin', () => {
         }) as DOMRect;
       window.dispatchEvent(new Event('resize'));
       await new Promise((resolve) => setTimeout(resolve, 60));
-      expect(marker().style.top).toBe('406px');
+      expect(marker().style.top).toBe('381px');
     });
 
     // The marker and the box belong ON the element and leave with it; the card
@@ -649,8 +701,8 @@ describe('createDeepLinkPin', () => {
       expect(region().style.height).toBe('100px');
       // A region has no corners of its own; react-grab's drag box has none either.
       expect(region().style.borderRadius).toBe('0px');
-      // The marker sits on the region, not on the frame's corner.
-      expect(marker().style.left).toBe('126px');
+      // The marker points at the region's corner, not the frame's.
+      expect(marker().style.left).toBe('120px');
     });
 
     it('takes the region down with the pin', () => {
@@ -745,7 +797,7 @@ describe('createDeepLinkPin', () => {
     it('says which id it copied', () => {
       show();
       idCopy().click();
-      expect(toasts).toEqual(['Copied c_zdv3rhz 📋']);
+      expect(toasts).toEqual(['Copied c_zdv3rhz']);
     });
 
     it('waits for an async clipboard before it claims success', async () => {
@@ -767,9 +819,9 @@ describe('createDeepLinkPin', () => {
       show({
         c: { name: 'CreateButton', src: 'react/src/Create.tsx:12' },
       } as Partial<AnchorV3>);
-      expect(idCopy().textContent).toBe('📋');
+      expect(idCopy().querySelector('svg')).not.toBeNull();
       expect(subText()).toBe(
-        'c_zdv3rhz📋 · CreateButton (react/src/Create.tsx:12)',
+        'c_zdv3rhz · CreateButton (react/src/Create.tsx:12)',
       );
     });
   });
@@ -784,7 +836,7 @@ describe('createDeepLinkPin', () => {
       commentCopy().click();
       expect(copied).toEqual(['the whole comment']);
       expect(copiedHtml).toEqual(['<p>the whole comment</p>']);
-      expect(toasts).toEqual(['Copied the whole comment 📋']);
+      expect(toasts).toEqual(['Copied the whole comment']);
     });
 
     it('hands the owner the pin it is showing, payload included', () => {
@@ -803,7 +855,7 @@ describe('createDeepLinkPin', () => {
       show({ n: 'A very long note…', nt: 1 });
       commentCopy().click();
       expect(toasts).toEqual([
-        'Copied — the note is the shortened one the link carries 📋',
+        'Copied — the note is the shortened one the link carries',
       ]);
     });
 
@@ -885,6 +937,50 @@ describe('createDeepLinkPin', () => {
       expect(css).toContain(
         'pointer-events: auto; -webkit-user-select: text; user-select: text;',
       );
+    });
+  });
+
+  // R5.2. The chrome was a row of emoji at whatever height each font drew
+  // them; every one of them is a lucide svg now, at one size.
+  describe('the card’s chrome', () => {
+    const EMOJI = /\p{Extended_Pictographic}/u;
+
+    it('draws an icon in every button and no emoji anywhere', () => {
+      mountSized({ top: 100, bottom: 300, height: 200 }, 60);
+      show({ n: 'Misaligned.' });
+      expect(pin.locate()).toBe(true);
+
+      const buttons = Array.from(card().querySelectorAll('button'));
+      expect(buttons.length).toBeGreaterThan(0);
+      for (const button of buttons) {
+        expect(button.querySelector('svg')).not.toBeNull();
+        // The icon is aria-hidden, so the button still has to name itself.
+        expect(button.getAttribute('aria-label')).toBeTruthy();
+      }
+      expect(card().textContent).not.toMatch(EMOJI);
+      expect(marker().querySelector('svg')).not.toBeNull();
+      expect(marker().textContent).not.toMatch(EMOJI);
+    });
+
+    it('keeps the docked card’s hint free of them too', async () => {
+      const element = mountSized({ top: 100, bottom: 300, height: 200 }, 60);
+      show();
+      pin.locate();
+      element.getBoundingClientRect = () =>
+        ({
+          left: 20,
+          right: 420,
+          width: 400,
+          top: -400,
+          bottom: -200,
+          height: 200,
+        }) as DOMRect;
+      window.dispatchEvent(new Event('resize'));
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      const hint = host.shadowRoot?.querySelector('.awaynote')?.textContent;
+      expect(hint).toContain('↑');
+      expect(hint).not.toMatch(EMOJI);
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -1,12 +1,16 @@
 /**
- * The pin a `#bai=v3` link drops on its element: one marker, one card leading
- * with the note the reviewer typed, and a translucent box over the element.
+ * The pins a `#bai=v3` link drops on their elements. One LAYER owns the
+ * `<style>`, the mutation observer, the scroll/resize listeners, the placement
+ * batch, the retry driver and the docked column; one VIEW per pin owns its
+ * marker, its card leading with the note the reviewer typed, and the
+ * translucent box over the element.
  *
  * The card text comes off a link anyone can write, so it goes in through
  * `textContent` — never `innerHTML`. The box is state, not a one-shot effect:
  * a React re-render that replaces the anchored node re-draws it over the new
  * one rather than leaving it on a detached element.
  */
+import { retryUntil } from './deeplink.js';
 import { findAnchorTarget, quickFindTarget, textMatches } from './resolve.js';
 import { projectFraction } from './selection.js';
 import type { AnchorV3, CopyPayload } from './types.js';
@@ -17,12 +21,17 @@ const SETTLE_MS = 1200;
 /** Card gap below/above the element, and its margin to the viewport edge. */
 const CARD_GAP = 10;
 const VIEWPORT_PAD = 8;
+/** Between two cards of the docked column. */
+const DOCK_GAP = 6;
 /** `.card`'s `max-width` under the shadow root's `box-sizing: border-box`. */
 const CARD_MAX_WIDTH = 320;
 /** Four 1 s beats of the prototype's arrival pulse, then just the box. */
 const PULSE_MS = 4200;
 /** Escalated text scans a lost element gets before the pin stops looking. */
 const MAX_MISSED_SCANS = 3;
+/** 10 s of SPA boot at 500 ms — the login form is lazy behind the splash. */
+const ANCHOR_TRIES = 20;
+const ANCHOR_EVERY_MS = 500;
 
 /** The edges of a rectangle the element may have left: viewport or scroller. */
 interface Bounds {
@@ -31,6 +40,9 @@ interface Bounds {
   left: number;
   right: number;
 }
+
+/** Which viewport edge a card docked to, so the layer can stack the column. */
+type DockEdge = 'top' | 'bottom';
 
 const STYLE = `
   .pinlayer {
@@ -64,6 +76,13 @@ const STYLE = `
   .card.found { display: block; }
   /* The element is gone from the viewport; the card is docked, not anchored. */
   .card.away { border-style: dashed; opacity: 0.94; }
+  /* Mid-pick the cards fold away; the markers are click-through already. */
+  .card.collapsed { display: none; }
+  .card .count {
+    color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
+    margin-bottom: 4px; padding-right: 62px;
+  }
+  .card .count:empty { display: none; }
   .card .awaynote {
     color: var(--bai-review-text-dim); font-size: 11px; margin-bottom: 6px;
     padding-right: 62px;
@@ -119,7 +138,7 @@ const STYLE = `
   .markbox.found { display: block; }
 `;
 
-export interface DeepLinkPinOptions {
+export interface PinLayerOptions {
   root: ShadowRoot;
   /** The overlay's own shadow host — never a valid answer for the anchor. */
   host: Element;
@@ -138,8 +157,16 @@ export interface DeepLinkPinOptions {
    */
   buildComment: (target: DeepLinkPinTarget) => CopyPayload | null;
   /** The pin settled on a different element — or on none. */
-  onLocated?: (element: Element | null) => void;
+  onLocated?: (
+    element: Element | null,
+    target: DeepLinkPinTarget | null,
+  ) => void;
+  /** The reviewer pressed ✕; whoever owns the set decides what that means. */
+  onDismiss?: (target: DeepLinkPinTarget) => void;
 }
+
+/** The one-view layer `main.ts` opened a link with before pin sets. */
+export type DeepLinkPinOptions = PinLayerOptions;
 
 export interface DeepLinkPinTarget {
   id: string;
@@ -150,18 +177,42 @@ export interface DeepLinkPinTarget {
   label: string;
 }
 
-export function createDeepLinkPin({
-  root,
-  host,
-  copyText,
-  showToast,
-  buildComment,
-  onLocated,
-}: DeepLinkPinOptions) {
-  const style = document.createElement('style');
-  style.textContent = STYLE;
-  const layer = document.createElement('div');
-  layer.className = 'pinlayer';
+interface ViewDeps {
+  host: Element;
+  copyText: PinLayerOptions['copyText'];
+  showToast: PinLayerOptions['showToast'];
+  buildComment: PinLayerOptions['buildComment'];
+  onLocated?: PinLayerOptions['onLocated'];
+  onDismiss?: PinLayerOptions['onDismiss'];
+  /** One layout read per frame, however many views ask for one. */
+  placeSoon: () => void;
+  /** A smooth scroll ends after `locate()` returns; follow it to its stop. */
+  followScroll: () => void;
+}
+
+interface PinView {
+  /** Marker, box and card, for the layer to mount and unmount. */
+  readonly nodes: Element[];
+  /** The card itself, so the layer can stack the docked column. */
+  readonly card: HTMLElement;
+  id(): string;
+  show(next: DeepLinkPinTarget): void;
+  /** Set order, for the marker glyph and the `3 / 5` header. */
+  setOrdinal(index: number, total: number): void;
+  setCollapsed(collapsed: boolean): void;
+  /** The edge the card docked to, or null while it is anchored or hidden. */
+  place(): DockEdge | null;
+  locate(focus: boolean): boolean;
+  reposition(): void;
+  dismiss(): void;
+  isShowing(): boolean;
+  isLocated(): boolean;
+  locatedElement(): Element | null;
+  dispose(): void;
+}
+
+function createPinView(deps: ViewDeps): PinView {
+  const { host } = deps;
   const marker = document.createElement('div');
   marker.className = 'pin';
   const head = document.createElement('span');
@@ -175,6 +226,8 @@ export function createDeepLinkPin({
     span.className = 'txt';
     return span;
   };
+  const count = document.createElement('div');
+  count.className = 'count';
   const note = document.createElement('div');
   note.className = 'note';
   // Appended only when there IS a note, so `.note:empty` still collapses it.
@@ -217,11 +270,19 @@ export function createDeepLinkPin({
   commentCopy.textContent = '⧉';
   commentCopy.title = 'Copy the whole comment';
   commentCopy.setAttribute('aria-label', 'Copy the whole comment');
-  card.append(close, locateButton, commentCopy, away, note, trunc, label, sub);
+  card.append(
+    close,
+    locateButton,
+    commentCopy,
+    count,
+    away,
+    note,
+    trunc,
+    label,
+    sub,
+  );
   const markBox = document.createElement('div');
   markBox.className = 'markbox';
-  layer.append(markBox, marker, card);
-  root.append(style, layer);
 
   let target: DeepLinkPinTarget | null = null;
   let located: Element | null = null;
@@ -232,6 +293,8 @@ export function createDeepLinkPin({
   /** One arrival pulse per link — the box is what stays. */
   let pulsed = false;
   let pulseTimer = 0;
+  /** Folded away for a pick: a hidden card measures 0 high, so it is not moved. */
+  let collapsed = false;
 
   function pulse() {
     if (pulsed) return;
@@ -266,7 +329,7 @@ export function createDeepLinkPin({
     clippers = node ? collectClippers(node) : [];
     // The ⚛️ stack a copy quotes belongs to the element the pin is on now, and
     // a re-render moves it — so this fires on every change, not just the first.
-    if (moved) onLocated?.(node);
+    if (moved) deps.onLocated?.(node, target);
   }
 
   /**
@@ -299,12 +362,13 @@ export function createDeepLinkPin({
   const rightEdge = () =>
     Math.max(VIEWPORT_PAD, window.innerWidth - cardWidth() - VIEWPORT_PAD);
 
-  function hide() {
+  function hide(): null {
     marker.classList.remove('found');
     card.classList.remove('found');
     card.classList.remove('away');
     markBox.classList.remove('found');
     away.textContent = '';
+    return null;
   }
 
   /**
@@ -318,7 +382,7 @@ export function createDeepLinkPin({
    * VIEWPORT edge, because it lives on a fixed layer; only the direction comes
    * from `area`.
    */
-  function placeAway(box: DOMRect, area: Bounds, vh: number) {
+  function placeAway(box: DOMRect, area: Bounds, vh: number): DockEdge {
     marker.classList.remove('found');
     markBox.classList.remove('found');
     card.classList.add('found');
@@ -337,6 +401,7 @@ export function createDeepLinkPin({
         : left
           ? '← Scrolled to the left — 📍 goes back'
           : '→ Scrolled to the right — 📍 goes back';
+    if (collapsed) return up ? 'top' : 'bottom';
     // A horizontal departure docks to a horizontal edge. Clamping `box.left`
     // would leave the card mid-screen whenever a scroller — not the window —
     // is what took the element sideways, with an arrow pointing nowhere.
@@ -349,9 +414,10 @@ export function createDeepLinkPin({
     card.style.top = up
       ? `${VIEWPORT_PAD}px`
       : `${Math.max(VIEWPORT_PAD, vh - card.offsetHeight - VIEWPORT_PAD)}px`;
+    return up ? 'top' : 'bottom';
   }
 
-  function place() {
+  function place(): DockEdge | null {
     if (!located) return hide();
     const box = markedBox(located);
     const vw = window.innerWidth;
@@ -391,6 +457,9 @@ export function createDeepLinkPin({
     });
     marker.style.left = `${box.left + 6}px`;
     marker.style.top = `${box.top + 6}px`;
+    // A folded card measures 0 high, which would place it past the fold;
+    // `setCollapsed(false)` re-places it with a height to read.
+    if (collapsed) return null;
     card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, rightEdge()))}px`;
     // `locate()` centres the element, so anything taller than half the
     // viewport puts `box.bottom` below the fold — and a fixed layer cannot be
@@ -400,39 +469,7 @@ export function createDeepLinkPin({
     const top =
       below + height <= vh - VIEWPORT_PAD ? below : box.top - CARD_GAP - height;
     card.style.top = `${Math.max(VIEWPORT_PAD, Math.min(top, vh - height - VIEWPORT_PAD))}px`;
-  }
-
-  let frame = 0;
-  /** Called, never aliased: a detached `requestAnimationFrame` throws. */
-  const raf = (callback: FrameRequestCallback): number =>
-    typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame(callback)
-      : window.setTimeout(() => callback(0), 16);
-
-  /** One layout read per frame, however many scrollers report a scroll. */
-  function placeSoon() {
-    if (frame) return;
-    frame = raf(() => {
-      frame = 0;
-      place();
-    });
-  }
-
-  let settleUntil = 0;
-  /** A smooth scroll ends after `locate()` returns; follow it to its stop. */
-  function placeUntilSettled() {
-    const first = settleUntil === 0;
-    settleUntil = Date.now() + SETTLE_MS;
-    if (!first) return;
-    const step = () => {
-      place();
-      if (Date.now() >= settleUntil) {
-        settleUntil = 0;
-        return;
-      }
-      raf(step);
-    };
-    raf(step);
+    return null;
   }
 
   /** The cheap ladder settled for the container of the element it wants. */
@@ -444,9 +481,9 @@ export function createDeepLinkPin({
   /**
    * Cheap first — it runs on every mutation batch — but a target the text scan
    * resolved cannot be re-found by the selector/landmark step, and a re-render
-   * would either lose the pin or slide it onto the landmark. Debounced, so the
-   * expensive scan runs at most once per settle, and budgeted, so a page the
-   * reviewer has navigated away from stops paying for it entirely.
+   * would either lose the pin or slide it onto the landmark. Debounced by the
+   * layer, so the expensive scan runs at most once per settle, and budgeted,
+   * so a page the reviewer has navigated away from stops paying for it.
    */
   function reposition() {
     if (!target) return;
@@ -466,38 +503,23 @@ export function createDeepLinkPin({
       next = full ?? next;
     }
     setLocated(next);
-    place();
   }
-
-  let timer = 0;
-  const schedule = () => {
-    clearTimeout(timer);
-    timer = window.setTimeout(reposition, REPOSITION_DEBOUNCE_MS);
-  };
-
-  const observer = new MutationObserver((records) => {
-    if (!target) return;
-    if (records.every((record) => host.contains(record.target as Node))) return;
-    schedule();
-  });
-  observer.observe(document.body, { childList: true, subtree: true });
-  window.addEventListener('resize', placeSoon);
-  // Viewport coordinates, so a scroll moves the pin — including a scroll in an
-  // overflow ancestor, which a document-coordinate layer would miss.
-  window.addEventListener('scroll', placeSoon, {
-    capture: true,
-    passive: true,
-  });
 
   locateButton.addEventListener('click', () =>
     located?.scrollIntoView?.({ block: 'center', behavior: 'smooth' }),
   );
-  close.addEventListener('click', () => dismiss());
+  close.addEventListener('click', () => {
+    const dismissed = target;
+    dismiss();
+    if (dismissed) deps.onDismiss?.(dismissed);
+  });
 
   function write(text: string, html: string | undefined, ok: string) {
     const done = (written: boolean) =>
-      showToast(written ? ok : 'Could not reach the clipboard — try again');
-    const copied = copyText(text, html);
+      deps.showToast(
+        written ? ok : 'Could not reach the clipboard — try again',
+      );
+    const copied = deps.copyText(text, html);
     if (typeof copied === 'boolean') done(copied);
     else void copied.then(done);
   }
@@ -519,9 +541,9 @@ export function createDeepLinkPin({
    */
   commentCopy.addEventListener('click', () => {
     if (!target) return;
-    const payload = buildComment(target);
+    const payload = deps.buildComment(target);
     if (!payload) {
-      showToast('Still reading this element — try again');
+      deps.showToast('Still reading this element — try again');
       return;
     }
     write(
@@ -540,9 +562,15 @@ export function createDeepLinkPin({
     setLocated(null);
     missedScans = 0;
     place();
+    // The docked column is one pin shorter now.
+    deps.placeSoon();
   }
 
   return {
+    nodes: [markBox, marker, card],
+    card,
+    id: () => target?.id ?? '',
+
     /** Adopt a link's anchor. Nothing is drawn until `locate()` finds it. */
     show(next: DeepLinkPinTarget) {
       dismiss();
@@ -552,6 +580,7 @@ export function createDeepLinkPin({
       target = next;
       marker.dataset.pinId = next.id;
       card.dataset.pinId = next.id;
+      markBox.dataset.pinId = next.id;
       noteText.textContent = next.anchor.n ?? '';
       note.replaceChildren(...(next.anchor.n ? [noteText] : []));
       trunc.classList.toggle('shown', next.anchor.nt === 1 && !!next.anchor.n);
@@ -563,11 +592,27 @@ export function createDeepLinkPin({
         : '';
     },
 
+    // A set of one is what a single pin has always been — the 📍 glyph and no
+    // header. Only a real set numbers itself.
+    setOrdinal(index: number, total: number) {
+      head.textContent = total > 1 ? String(index + 1) : '📍';
+      count.textContent = total > 1 ? `${index + 1} / ${total}` : '';
+    },
+
+    setCollapsed(next: boolean) {
+      collapsed = next;
+      card.classList.toggle('collapsed', next);
+    },
+
+    place,
+    reposition,
+
     /**
      * One attempt at the full resolution ladder. True once the element is on
-     * the page — which is when the pin and its box appear.
+     * the page — which is when the pin and its box appear. Only the focus pin
+     * scrolls the page to itself and pulses; the rest are drawn quietly.
      */
-    locate(): boolean {
+    locate(focus: boolean): boolean {
       if (!target) return false;
       // The debounced observer runs the cheap ladder and can land first; a pin
       // already drawn must not also report "could not find that element".
@@ -578,28 +623,291 @@ export function createDeepLinkPin({
       setLocated(found);
       missedScans = 0;
       place();
+      if (!focus) return true;
       found.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
-      placeUntilSettled();
+      deps.followScroll();
       pulse();
       return true;
     },
 
     dismiss,
     isShowing: () => !!target,
+    isLocated: () => !!located,
     locatedElement: () => located,
 
-    /** One pin lives as long as the page; tests make one per case. */
+    dispose() {
+      clearTimeout(pulseTimer);
+      dismiss();
+      for (const node of [markBox, marker, card]) node.remove();
+    },
+  };
+}
+
+export function createPinLayer(options: PinLayerOptions) {
+  const { root, host, showToast } = options;
+  const style = document.createElement('style');
+  style.textContent = STYLE;
+  const layer = document.createElement('div');
+  layer.className = 'pinlayer';
+  root.append(style, layer);
+
+  const views: PinView[] = [];
+  let collapsed = false;
+  let focusId: string | null = null;
+  let frame = 0;
+  let settleUntil = 0;
+  let timer = 0;
+  let cancelRetry: () => void = () => undefined;
+
+  /** Called, never aliased: a detached `requestAnimationFrame` throws. */
+  const raf = (callback: FrameRequestCallback): number =>
+    typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame(callback)
+      : window.setTimeout(() => callback(0), 16);
+
+  /**
+   * Away cards form a column at the edge they left by, in set order. The head
+   * of the column keeps the geometry it placed itself at, so a set of one —
+   * and the first card of any set — docks exactly where it always has.
+   */
+  function layoutDocked(docked: Array<{ card: HTMLElement; edge: DockEdge }>) {
+    if (docked.length < 2) return;
+    const vh = window.innerHeight;
+    const run: Record<DockEdge, number> = { top: 0, bottom: 0 };
+    for (const { card, edge } of docked) {
+      const height = card.offsetHeight;
+      if (run[edge])
+        card.style.top =
+          edge === 'top'
+            ? `${VIEWPORT_PAD + run[edge]}px`
+            : `${Math.max(VIEWPORT_PAD, vh - height - VIEWPORT_PAD - run[edge])}px`;
+      run[edge] += height + DOCK_GAP;
+    }
+  }
+
+  function placeAll() {
+    const docked: Array<{ card: HTMLElement; edge: DockEdge }> = [];
+    for (const view of views) {
+      const edge = view.place();
+      if (edge) docked.push({ card: view.card, edge });
+    }
+    // A folded column measures 0 high; it is stacked again on the way out.
+    if (!collapsed) layoutDocked(docked);
+  }
+
+  /** One layout read per frame, however many scrollers report a scroll. */
+  function placeSoon() {
+    if (frame) return;
+    frame = raf(() => {
+      frame = 0;
+      placeAll();
+    });
+  }
+
+  /** A smooth scroll ends after `locate()` returns; follow it to its stop. */
+  function followScroll() {
+    const first = settleUntil === 0;
+    settleUntil = Date.now() + SETTLE_MS;
+    if (!first) return;
+    const step = () => {
+      placeAll();
+      if (Date.now() >= settleUntil) {
+        settleUntil = 0;
+        return;
+      }
+      raf(step);
+    };
+    raf(step);
+  }
+
+  const deps: ViewDeps = {
+    host,
+    copyText: options.copyText,
+    showToast,
+    buildComment: options.buildComment,
+    onLocated: options.onLocated,
+    onDismiss: (target) => {
+      renumber();
+      options.onDismiss?.(target);
+    },
+    placeSoon,
+    followScroll,
+  };
+
+  /** Views are reused BY POSITION, so a card the set keeps keeps its node. */
+  function resize(count: number) {
+    while (views.length > count) views.pop()?.dispose();
+    while (views.length < count) {
+      const view = createPinView(deps);
+      view.setCollapsed(collapsed);
+      layer.append(...view.nodes);
+      views.push(view);
+    }
+  }
+
+  const showingViews = () => views.filter((view) => view.isShowing());
+
+  /** A set one pin shorter says so: the glyphs and the `n / N` heads move up. */
+  function renumber() {
+    const shown = showingViews();
+    for (const [index, view] of shown.entries())
+      view.setOrdinal(index, shown.length);
+  }
+
+  function locateAll(skipLocated: boolean): boolean {
+    const shown = showingViews();
+    // A stored focus id can name a pin this set does not have; the set still
+    // has to scroll somewhere.
+    const focus =
+      shown.find((view) => view.id() === focusId)?.id() ??
+      shown[0]?.id() ??
+      null;
+    let missing = 0;
+    let landed = false;
+    for (const view of shown) {
+      if (skipLocated && view.isLocated()) continue;
+      if (view.locate(view.id() === focus)) landed = true;
+      else missing++;
+    }
+    // Each view placed itself; the column between them is the layer's to lay.
+    if (landed) placeSoon();
+    return missing === 0;
+  }
+
+  function stopRetry() {
+    cancelRetry();
+    cancelRetry = () => undefined;
+  }
+
+  /** N=1 says what the overlay has always said; a set counts itself instead. */
+  function giveUp() {
+    const shown = showingViews();
+    const missing = shown.filter((view) => !view.isLocated()).length;
+    if (!missing) return;
+    showToast(
+      shown.length === 1
+        ? 'Could not find that element on this page'
+        : `${missing} of ${shown.length} pins are not on this page`,
+    );
+  }
+
+  /** One driver for the whole layer: every unlocated view, once per tick. */
+  function startRetry() {
+    stopRetry();
+    if (!showingViews().length) return;
+    cancelRetry = retryUntil(() => locateAll(true), {
+      tries: ANCHOR_TRIES,
+      everyMs: ANCHOR_EVERY_MS,
+      onGiveUp: giveUp,
+    });
+  }
+
+  function schedule() {
+    clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      for (const view of views) view.reposition();
+      placeAll();
+    }, REPOSITION_DEBOUNCE_MS);
+  }
+
+  const observer = new MutationObserver((records) => {
+    if (!showingViews().length) return;
+    if (records.every((record) => host.contains(record.target as Node))) return;
+    schedule();
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+  window.addEventListener('resize', placeSoon);
+  // Viewport coordinates, so a scroll moves the pin — including a scroll in an
+  // overflow ancestor, which a document-coordinate layer would miss.
+  window.addEventListener('scroll', placeSoon, {
+    capture: true,
+    passive: true,
+  });
+
+  return {
+    /** Build this many cards up front, before any pin is adopted. */
+    reserve: (count: number) => resize(Math.max(views.length, count)),
+
+    /**
+     * Draw exactly these pins, in set order, and start the one retry driver
+     * that resolves whatever is not on the page yet. `focusId` names the pin
+     * that scrolls and pulses; the first pin is the default.
+     */
+    show(targets: DeepLinkPinTarget[], opts: { focusId?: string } = {}) {
+      resize(targets.length);
+      focusId = opts.focusId ?? targets[0]?.id ?? null;
+      targets.forEach((target, index) => {
+        views[index].show(target);
+        views[index].setOrdinal(index, targets.length);
+      });
+      startRetry();
+    },
+
+    /** One pass of the full ladder over every drawn pin. */
+    locate: () => locateAll(false),
+
+    /** No id dismisses every pin; the cards stay for the next set. */
+    dismiss(id?: string) {
+      for (const view of views)
+        if (id === undefined || view.id() === id) view.dismiss();
+      if (id === undefined || id === focusId) focusId = null;
+      renumber();
+      if (!showingViews().length) stopRetry();
+    },
+
+    /**
+     * Mid-pick the cards are in the way of the next pick — the markers are
+     * click-through already, so they stay and the cards fold away.
+     */
+    setCollapsed(next: boolean) {
+      if (collapsed === next) return;
+      collapsed = next;
+      for (const view of views) view.setCollapsed(next);
+      placeSoon();
+    },
+
+    ids: () => showingViews().map((view) => view.id()),
+    isShowing: (id?: string) =>
+      id === undefined
+        ? showingViews().length > 0
+        : showingViews().some((view) => view.id() === id),
+    locatedElement: (id?: string) =>
+      (id === undefined
+        ? showingViews()[0]
+        : views.find((view) => view.id() === id)
+      )?.locatedElement() ?? null,
+
+    /** One layer lives as long as the page; tests make one per case. */
     dispose() {
       observer.disconnect();
       window.removeEventListener('resize', placeSoon);
       window.removeEventListener('scroll', placeSoon, { capture: true });
+      stopRetry();
       settleUntil = 0;
       clearTimeout(timer);
-      clearTimeout(pulseTimer);
-      dismiss();
+      resize(0);
       layer.remove();
       style.remove();
     },
+  };
+}
+
+export type PinLayer = ReturnType<typeof createPinLayer>;
+
+/**
+ * A pin set of one, with the surface `pin.test.ts` has always called: the card
+ * exists from construction and `show` re-targets it in place.
+ */
+export function createDeepLinkPin(options: DeepLinkPinOptions) {
+  const layer = createPinLayer(options);
+  layer.reserve(1);
+  return {
+    show: (next: DeepLinkPinTarget) => layer.show([next]),
+    locate: () => layer.locate(),
+    dismiss: () => layer.dismiss(),
+    isShowing: () => layer.isShowing(),
+    locatedElement: () => layer.locatedElement(),
+    dispose: () => layer.dispose(),
   };
 }
 

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -190,9 +190,8 @@ export interface PinLayerOptions {
   /** The reviewer pressed ✕; whoever owns the set decides what that means. */
   onDismiss?: (target: DeepLinkPinTarget) => void;
   /**
-   * The ladder ran out with these pins still unresolved. They stay pending —
-   * the observer keeps re-resolving them — so the owner can say where each one
-   * was rather than that it is gone. Without it the layer keeps its own line.
+   * The ladder ran out with these still unresolved; they stay pending (R7.2).
+   * Without it the layer keeps its own line.
    */
   onGiveUp?: (pendingIds: string[]) => void;
 }
@@ -883,10 +882,8 @@ export function createPinLayer(options: PinLayerOptions) {
   }
 
   /**
-   * The ladder ends; the pin does not (R7.2) — the observer keeps re-resolving
-   * every pending view. Whoever owns the set knows whether a pending pin is on
-   * another page or waiting for its element, so it gets the ids; a layer built
-   * without that keeps the overlay's own sentence.
+   * The ladder ends; the pin does not (R7.2). Only the owner knows why a pin
+   * is pending — another page, or a closed modal — so it gets the ids.
    */
   function giveUp() {
     const shown = showingViews();

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -953,8 +953,18 @@ export function createPinLayer(options: PinLayerOptions) {
       startRetry();
     },
 
-    /** One pass of the full ladder over every drawn pin. */
-    locate: () => locateAll(false),
+    /**
+     * One pass of the full ladder: over every drawn pin, or — given an id —
+     * over that ONE, which never scrolls; asking about a pin is not arriving.
+     */
+    locate(id?: string): boolean {
+      if (id === undefined) return locateAll(false);
+      const view = views.find((held) => held.id() === id);
+      if (!view?.isShowing()) return false;
+      const found = view.locate(false);
+      if (found) placeSoon();
+      return found;
+    },
 
     /** No id dismisses every pin; the cards stay for the next set. */
     dismiss(id?: string) {

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -11,6 +11,7 @@
  * one rather than leaving it on a detached element.
  */
 import { retryUntil } from './deeplink.js';
+import { icon, ICON_STYLE } from './icons.js';
 import { findAnchorTarget, quickFindTarget, textMatches } from './resolve.js';
 import { projectFraction } from './selection.js';
 import type { AnchorV3, CopyPayload } from './types.js';
@@ -32,6 +33,16 @@ const MAX_MISSED_SCANS = 3;
 /** 10 s of SPA boot at 500 ms — the login form is lazy behind the splash. */
 const ANCHOR_TRIES = 20;
 const ANCHOR_EVERY_MS = 500;
+/**
+ * The teardrop is a 24px square rotated -45°, so its point is 12·√2 below its
+ * centre and the whole glyph fits in a 34px diamond. `MARKER_SPAN` is what it
+ * needs OUTSIDE the marked region: the tip's gap plus the glyph itself.
+ */
+const MARKER_TIP = 17;
+const MARKER_GAP = 2;
+const MARKER_SPAN = MARKER_GAP + MARKER_TIP * 2;
+/** The marker's own glyph, smaller than the chrome's — it sits in 24px. */
+const MARKER_ICON_SIZE = 12;
 
 /** The edges of a rectangle the element may have left: viewport or scroller. */
 interface Bounds {
@@ -57,7 +68,11 @@ const STYLE = `
     box-shadow: 0 1px 4px var(--bai-review-shadow);
   }
   .pin.found { display: flex; }
-  .pin > span { transform: rotate(45deg); }
+  .pin > span { transform: rotate(45deg); display: flex; }
+  /* No room above the region: the point goes to the top and the body hangs
+     below it, so the glyph still leaves the marked rectangle alone. */
+  .pin.flip { transform: rotate(135deg); }
+  .pin.flip > span { transform: rotate(-135deg); }
   .pin.pulse { animation: baipulse 1s ease-in-out 4; }
   @keyframes baipulse {
     0%,100% { box-shadow: 0 1px 4px var(--bai-review-shadow); }
@@ -117,19 +132,23 @@ const STYLE = `
   }
   .card .idcopy {
     pointer-events: auto; cursor: pointer; border: 0; background: none;
-    padding: 0 2px; font: inherit; font-size: 11px; line-height: 1;
-    color: var(--bai-review-text-dim);
+    padding: 0 3px; font: inherit; line-height: 1; display: inline-flex;
+    color: var(--bai-review-text-dim); vertical-align: -3px;
   }
   .card .idcopy:hover { color: var(--bai-review-text); }
   .card .close, .card .locate, .card .copyall {
-    position: absolute; top: 2px; cursor: pointer; border: 0;
-    background: none; color: var(--bai-review-text-dim); font-size: 14px;
-    pointer-events: auto;
+    position: absolute; top: 4px; cursor: pointer; border: 0; padding: 0;
+    background: none; color: var(--bai-review-text-dim);
+    display: flex; align-items: center; justify-content: center;
+    width: 16px; height: 16px; pointer-events: auto;
   }
   .card .close { right: 4px; }
   .card .locate { right: 24px; }
   .card .copyall { right: 44px; }
-  .card .copyall:hover { color: var(--bai-review-text); }
+  .card .close:hover, .card .locate:hover, .card .copyall:hover {
+    color: var(--bai-review-text);
+  }
+${ICON_STYLE}
   /* The pick box's own style, so arriving on a link looks like the pick that
      made it: a thin stroke over a light fill, on our layer — never the app's. */
   .markbox {
@@ -224,7 +243,7 @@ function createPinView(deps: ViewDeps): PinView {
   const marker = document.createElement('div');
   marker.className = 'pin';
   const head = document.createElement('span');
-  head.textContent = '📍';
+  head.append(icon('map-pin', MARKER_ICON_SIZE));
   marker.append(head);
   const card = document.createElement('div');
   card.className = 'card';
@@ -256,26 +275,26 @@ function createPinView(deps: ViewDeps): PinView {
   const idText = run();
   const idCopy = document.createElement('button');
   idCopy.className = 'idcopy';
-  idCopy.textContent = '📋';
-  // The glyph is the accessible name unless one is given, and "clipboard" is
-  // not the action; `title` stays the visual tooltip.
+  idCopy.append(icon('clipboard'));
+  // The icon is `aria-hidden`, so the label below is the accessible name;
+  // `title` stays the visual tooltip.
   idCopy.title = 'Copy this comment id';
   idCopy.setAttribute('aria-label', 'Copy this comment id');
   const componentText = run();
   sub.append(idText, idCopy, componentText);
   const close = document.createElement('button');
   close.className = 'close';
-  close.textContent = '✕';
+  close.append(icon('x'));
   close.title = 'Dismiss this pin';
   close.setAttribute('aria-label', 'Dismiss this pin');
   const locateButton = document.createElement('button');
   locateButton.className = 'locate';
-  locateButton.textContent = '📍';
+  locateButton.append(icon('crosshair'));
   locateButton.title = 'Scroll back to this element';
   locateButton.setAttribute('aria-label', 'Scroll back to this element');
   const commentCopy = document.createElement('button');
   commentCopy.className = 'copyall';
-  commentCopy.textContent = '⧉';
+  commentCopy.append(icon('copy'));
   commentCopy.title = 'Copy the whole comment';
   commentCopy.setAttribute('aria-label', 'Copy the whole comment');
   card.append(
@@ -414,12 +433,12 @@ function createPinView(deps: ViewDeps): PinView {
     // Written BEFORE the measurement: the hint is a line of the card, so a
     // height read without it docks a bottom-docked card past the fold.
     away.textContent = up
-      ? '↑ Scrolled above — 📍 goes back'
+      ? '↑ Scrolled above — the crosshair goes back'
       : down
-        ? '↓ Scrolled below — 📍 goes back'
+        ? '↓ Scrolled below — the crosshair goes back'
         : left
-          ? '← Scrolled to the left — 📍 goes back'
-          : '→ Scrolled to the right — 📍 goes back';
+          ? '← Scrolled to the left — the crosshair goes back'
+          : '→ Scrolled to the right — the crosshair goes back';
     if (cardOff()) return null;
     // A horizontal departure docks to a horizontal edge. Clamping `box.left`
     // would leave the card mid-screen whenever a scroller — not the window —
@@ -474,19 +493,36 @@ function createPinView(deps: ViewDeps): PinView {
       height: `${box.height}px`,
       borderRadius: cornerRadius(located),
     });
-    marker.style.left = `${box.left + 6}px`;
-    marker.style.top = `${box.top + 6}px`;
+    // The marker points AT the region from outside it: the teardrop's tip
+    // touches the top-left corner and the glyph sits above, clear of the very
+    // content the box is pointing at. With no room above it flips under.
+    const flip = box.top - MARKER_SPAN < VIEWPORT_PAD;
+    marker.classList.toggle('flip', flip);
+    // Against the left edge it slides along the region's top rather than
+    // off-screen; `style.left`/`top` are the glyph's CENTRE (negative margins).
+    const markerRight = Math.max(
+      VIEWPORT_PAD + MARKER_TIP,
+      vw - VIEWPORT_PAD - MARKER_TIP,
+    );
+    const markerTop = flip
+      ? box.bottom + MARKER_GAP + MARKER_TIP
+      : box.top - MARKER_GAP - MARKER_TIP;
+    marker.style.left = `${Math.min(Math.max(box.left, VIEWPORT_PAD + MARKER_TIP), markerRight)}px`;
+    marker.style.top = `${Math.min(Math.max(markerTop, VIEWPORT_PAD + MARKER_TIP), Math.max(VIEWPORT_PAD + MARKER_TIP, vh - VIEWPORT_PAD - MARKER_TIP))}px`;
     // A card that is off measures 0 high, which would place it past the fold;
     // showing it again re-places it with a height to read.
     if (cardOff()) return null;
     card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, rightEdge()))}px`;
     // `locate()` centres the element, so anything taller than half the
     // viewport puts `box.bottom` below the fold — and a fixed layer cannot be
-    // scrolled to. Flip above, then clamp.
+    // scrolled to. Flip above, then clamp. Whichever side the marker took, the
+    // card starts past it: they share the region's left edge.
     const height = card.offsetHeight;
-    const below = box.bottom + CARD_GAP;
+    const below = box.bottom + CARD_GAP + (flip ? MARKER_SPAN : 0);
     const top =
-      below + height <= vh - VIEWPORT_PAD ? below : box.top - CARD_GAP - height;
+      below + height <= vh - VIEWPORT_PAD
+        ? below
+        : box.top - CARD_GAP - height - (flip ? 0 : MARKER_SPAN);
     card.style.top = `${Math.max(VIEWPORT_PAD, Math.min(top, vh - height - VIEWPORT_PAD))}px`;
     return null;
   }
@@ -551,7 +587,7 @@ function createPinView(deps: ViewDeps): PinView {
   idCopy.addEventListener('click', () => {
     const id = target?.id;
     if (!id) return;
-    write(id, undefined, `Copied ${id} 📋`);
+    write(id, undefined, `Copied ${id}`);
   });
 
   /**
@@ -571,8 +607,8 @@ function createPinView(deps: ViewDeps): PinView {
       // The link caps the note it carries, and a copy that quietly loses the
       // rest is worse than one that says so.
       target.anchor.nt === 1
-        ? 'Copied — the note is the shortened one the link carries 📋'
-        : 'Copied the whole comment 📋',
+        ? 'Copied — the note is the shortened one the link carries'
+        : 'Copied the whole comment',
     );
   });
 
@@ -613,10 +649,11 @@ function createPinView(deps: ViewDeps): PinView {
         : '';
     },
 
-    // A set of one is what a single pin has always been — the 📍 glyph and no
-    // header. Only a real set numbers itself.
+    // A set of one is what a single pin has always been — the map-pin glyph
+    // and no header. Only a real set numbers itself.
     setOrdinal(index: number, total: number) {
-      head.textContent = total > 1 ? String(index + 1) : '📍';
+      if (total > 1) head.textContent = String(index + 1);
+      else head.replaceChildren(icon('map-pin', MARKER_ICON_SIZE));
       count.textContent = total > 1 ? `${index + 1} / ${total}` : '';
     },
 

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -303,7 +303,6 @@ function createPinView(deps: ViewDeps): PinView {
   let pulseTimer = 0;
   /** Folded away for a pick: a hidden card measures 0 high, so it is not moved. */
   let collapsed = false;
-  /** ✕ on this card. */
   let hidden = false;
   /** The dock's switch — every card at once. */
   let allHidden = false;
@@ -919,10 +918,7 @@ export function createPinLayer(options: PinLayerOptions) {
       placeSoon();
     },
 
-    /**
-     * Beat the marker again on purpose — the set dock's way of saying "this
-     * one", after the arrival pulse a pin gets once has already been spent.
-     */
+    /** Beat the marker again on purpose, once its arrival pulse is spent. */
     pulse(id: string) {
       views.find((view) => view.id() === id)?.pulse(true);
     },

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -496,7 +496,13 @@ function createPinView(deps: ViewDeps): PinView {
     // The marker points AT the region from outside it: the teardrop's tip
     // touches the top-left corner and the glyph sits above, clear of the very
     // content the box is pointing at. With no room above it flips under.
-    const flip = box.top - MARKER_SPAN < VIEWPORT_PAD;
+    const roomAbove = box.top - MARKER_SPAN >= VIEWPORT_PAD;
+    const roomBelow = box.bottom + MARKER_SPAN <= vh - VIEWPORT_PAD;
+    const flip = !roomAbove && roomBelow;
+    // A region taller than the viewport has no outside on screen. Unflipped it
+    // clamps to the top edge, by the region's leading corner; flipped it would
+    // clamp onto the middle of the content.
+    const crowded = !roomAbove && !roomBelow;
     marker.classList.toggle('flip', flip);
     // Against the left edge it slides along the region's top rather than
     // off-screen; `style.left`/`top` are the glyph's CENTRE (negative margins).
@@ -523,7 +529,11 @@ function createPinView(deps: ViewDeps): PinView {
       below + height <= vh - VIEWPORT_PAD
         ? below
         : box.top - CARD_GAP - height - (flip ? 0 : MARKER_SPAN);
-    card.style.top = `${Math.max(VIEWPORT_PAD, Math.min(top, vh - height - VIEWPORT_PAD))}px`;
+    // Crowded, both land at the top: the card starts under the clamped marker.
+    const topFloor = crowded
+      ? VIEWPORT_PAD + MARKER_TIP * 2 + CARD_GAP
+      : VIEWPORT_PAD;
+    card.style.top = `${Math.max(topFloor, Math.min(top, vh - height - VIEWPORT_PAD))}px`;
     return null;
   }
 

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -78,6 +78,8 @@ const STYLE = `
   .card.away { border-style: dashed; opacity: 0.94; }
   /* Mid-pick the cards fold away; the markers are click-through already. */
   .card.collapsed { display: none; }
+  /* ✕ or the dock's switch: the card is off, the marker and the box stay. */
+  .card.hidden { display: none; }
   .card .count {
     color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
     margin-bottom: 4px; padding-right: 62px;
@@ -200,6 +202,12 @@ interface PinView {
   /** Set order, for the marker glyph and the `3 / 5` header. */
   setOrdinal(index: number, total: number): void;
   setCollapsed(collapsed: boolean): void;
+  /** ✕ on this card alone; the pin keeps its marker and its box. */
+  setHidden(hidden: boolean): void;
+  /** The dock's switch, applied to every card at once. */
+  setCardsHidden(hidden: boolean): void;
+  /** `force` replays the arrival beat on a pin that already had one. */
+  pulse(force?: boolean): void;
   /** The edge the card docked to, or null while it is anchored or hidden. */
   place(): DockEdge | null;
   locate(focus: boolean): boolean;
@@ -295,10 +303,22 @@ function createPinView(deps: ViewDeps): PinView {
   let pulseTimer = 0;
   /** Folded away for a pick: a hidden card measures 0 high, so it is not moved. */
   let collapsed = false;
+  /** ✕ on this card. */
+  let hidden = false;
+  /** The dock's switch — every card at once. */
+  let allHidden = false;
+  /** No card on screen, so none is measured and none joins the column. */
+  const cardOff = () => collapsed || hidden || allHidden;
+  const syncHidden = () => card.classList.toggle('hidden', hidden || allHidden);
 
-  function pulse() {
-    if (pulsed) return;
+  function pulse(force = false) {
+    if (pulsed && !force) return;
     pulsed = true;
+    clearTimeout(pulseTimer);
+    // Re-adding the class in the same frame restarts nothing; the removal has
+    // to be committed to layout first.
+    marker.classList.remove('pulse');
+    void marker.offsetWidth;
     marker.classList.add('pulse');
     pulseTimer = window.setTimeout(
       () => marker.classList.remove('pulse'),
@@ -382,7 +402,7 @@ function createPinView(deps: ViewDeps): PinView {
    * VIEWPORT edge, because it lives on a fixed layer; only the direction comes
    * from `area`.
    */
-  function placeAway(box: DOMRect, area: Bounds, vh: number): DockEdge {
+  function placeAway(box: DOMRect, area: Bounds, vh: number): DockEdge | null {
     marker.classList.remove('found');
     markBox.classList.remove('found');
     card.classList.add('found');
@@ -401,7 +421,7 @@ function createPinView(deps: ViewDeps): PinView {
         : left
           ? '← Scrolled to the left — 📍 goes back'
           : '→ Scrolled to the right — 📍 goes back';
-    if (collapsed) return up ? 'top' : 'bottom';
+    if (cardOff()) return null;
     // A horizontal departure docks to a horizontal edge. Clamping `box.left`
     // would leave the card mid-screen whenever a scroller — not the window —
     // is what took the element sideways, with an arrow pointing nowhere.
@@ -457,9 +477,9 @@ function createPinView(deps: ViewDeps): PinView {
     });
     marker.style.left = `${box.left + 6}px`;
     marker.style.top = `${box.top + 6}px`;
-    // A folded card measures 0 high, which would place it past the fold;
-    // `setCollapsed(false)` re-places it with a height to read.
-    if (collapsed) return null;
+    // A card that is off measures 0 high, which would place it past the fold;
+    // showing it again re-places it with a height to read.
+    if (cardOff()) return null;
     card.style.left = `${Math.max(VIEWPORT_PAD, Math.min(box.left, rightEdge()))}px`;
     // `locate()` centres the element, so anything taller than half the
     // viewport puts `box.bottom` below the fold — and a fixed layer cannot be
@@ -574,6 +594,8 @@ function createPinView(deps: ViewDeps): PinView {
     /** Adopt a link's anchor. Nothing is drawn until `locate()` finds it. */
     show(next: DeepLinkPinTarget) {
       dismiss();
+      hidden = false;
+      syncHidden();
       pulsed = false;
       clearTimeout(pulseTimer);
       marker.classList.remove('pulse');
@@ -603,6 +625,18 @@ function createPinView(deps: ViewDeps): PinView {
       collapsed = next;
       card.classList.toggle('collapsed', next);
     },
+
+    setHidden(next: boolean) {
+      hidden = next;
+      syncHidden();
+    },
+
+    setCardsHidden(next: boolean) {
+      allHidden = next;
+      syncHidden();
+    },
+
+    pulse,
 
     place,
     reposition,
@@ -653,6 +687,8 @@ export function createPinLayer(options: PinLayerOptions) {
 
   const views: PinView[] = [];
   let collapsed = false;
+  /** The dock's switch: every card off, markers and boxes still on the page. */
+  let cardsHidden = false;
   let focusId: string | null = null;
   let frame = 0;
   let settleUntil = 0;
@@ -740,6 +776,7 @@ export function createPinLayer(options: PinLayerOptions) {
     while (views.length < count) {
       const view = createPinView(deps);
       view.setCollapsed(collapsed);
+      view.setCardsHidden(cardsHidden);
       layer.append(...view.nodes);
       views.push(view);
     }
@@ -864,6 +901,30 @@ export function createPinLayer(options: PinLayerOptions) {
       collapsed = next;
       for (const view of views) view.setCollapsed(next);
       placeSoon();
+    },
+
+    /** One card off, by the reviewer's own ✕: the pin itself stays drawn. */
+    setCardHidden(id: string, hidden: boolean) {
+      const view = views.find((held) => held.id() === id);
+      if (!view) return;
+      view.setHidden(hidden);
+      placeSoon();
+    },
+
+    /** Every card off at once, and the ones drawn after it stay off too. */
+    setCardsHidden(next: boolean) {
+      if (cardsHidden === next) return;
+      cardsHidden = next;
+      for (const view of views) view.setCardsHidden(next);
+      placeSoon();
+    },
+
+    /**
+     * Beat the marker again on purpose — the set dock's way of saying "this
+     * one", after the arrival pulse a pin gets once has already been spent.
+     */
+    pulse(id: string) {
+      views.find((view) => view.id() === id)?.pulse(true);
     },
 
     ids: () => showingViews().map((view) => view.id()),

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -12,7 +12,12 @@
  */
 import { retryUntil } from './deeplink.js';
 import { icon, ICON_STYLE } from './icons.js';
-import { findAnchorTarget, quickFindTarget, textMatches } from './resolve.js';
+import {
+  findAnchorTarget,
+  hasLandmark,
+  quickFindTarget,
+  textMatches,
+} from './resolve.js';
 import { projectFraction } from './selection.js';
 import type { AnchorV3, CopyPayload } from './types.js';
 
@@ -184,6 +189,12 @@ export interface PinLayerOptions {
   ) => void;
   /** The reviewer pressed ✕; whoever owns the set decides what that means. */
   onDismiss?: (target: DeepLinkPinTarget) => void;
+  /**
+   * The ladder ran out with these pins still unresolved. They stay pending —
+   * the observer keeps re-resolving them — so the owner can say where each one
+   * was rather than that it is gone. Without it the layer keeps its own line.
+   */
+  onGiveUp?: (pendingIds: string[]) => void;
 }
 
 /** The one-view layer `main.ts` opened a link with before pin sets. */
@@ -317,6 +328,8 @@ function createPinView(deps: ViewDeps): PinView {
   let clippers: Element[] = [];
   /** Escalated scans in a row that found nothing — the page moved on. */
   let missedScans = 0;
+  /** The landmark at the last batch; its return re-arms the escalated scan. */
+  let hadLandmark = false;
   /** One arrival pulse per link — the box is what stays. */
   let pulsed = false;
   let pulseTimer = 0;
@@ -552,6 +565,12 @@ function createPinView(deps: ViewDeps): PinView {
    */
   function reposition() {
     if (!target) return;
+    // The frame the pin lived in is back — a modal reopened, a section
+    // expanded. The escalated scan gets its budget again, or the SPA's own
+    // boot churn would have spent it long before the reviewer opened anything.
+    const landmark = hasLandmark(target.anchor);
+    if (landmark && !hadLandmark) missedScans = 0;
+    hadLandmark = landmark;
     const held =
       located?.isConnected && textMatches(located, target.anchor.txt)
         ? located
@@ -639,6 +658,7 @@ function createPinView(deps: ViewDeps): PinView {
     /** Adopt a link's anchor. Nothing is drawn until `locate()` finds it. */
     show(next: DeepLinkPinTarget) {
       dismiss();
+      hadLandmark = false;
       hidden = false;
       syncHidden();
       pulsed = false;
@@ -862,15 +882,22 @@ export function createPinLayer(options: PinLayerOptions) {
     cancelRetry = () => undefined;
   }
 
-  /** N=1 says what the overlay has always said; a set counts itself instead. */
+  /**
+   * The ladder ends; the pin does not (R7.2) — the observer keeps re-resolving
+   * every pending view. Whoever owns the set knows whether a pending pin is on
+   * another page or waiting for its element, so it gets the ids; a layer built
+   * without that keeps the overlay's own sentence.
+   */
   function giveUp() {
     const shown = showingViews();
-    const missing = shown.filter((view) => !view.isLocated()).length;
-    if (!missing) return;
+    const pending = shown.filter((view) => !view.isLocated());
+    if (!pending.length) return;
+    if (options.onGiveUp)
+      return options.onGiveUp(pending.map((view) => view.id()));
     showToast(
       shown.length === 1
         ? 'Could not find that element on this page'
-        : `${missing} of ${shown.length} pins are not on this page`,
+        : `${pending.length} of ${shown.length} pins are not on this page`,
     );
   }
 

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -93,7 +93,7 @@ const STYLE = `
   .card.away { border-style: dashed; opacity: 0.94; }
   /* Mid-pick the cards fold away; the markers are click-through already. */
   .card.collapsed { display: none; }
-  /* ✕ or the dock's switch: the card is off, the marker and the box stay. */
+  /* Hidden by its own button or the dock's switch: marker and box stay. */
   .card.hidden { display: none; }
   .card .count {
     color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
@@ -221,7 +221,7 @@ interface PinView {
   /** Set order, for the marker glyph and the `3 / 5` header. */
   setOrdinal(index: number, total: number): void;
   setCollapsed(collapsed: boolean): void;
-  /** ✕ on this card alone; the pin keeps its marker and its box. */
+  /** This card alone; the pin keeps its marker and its box. */
   setHidden(hidden: boolean): void;
   /** The dock's switch, applied to every card at once. */
   setCardsHidden(hidden: boolean): void;
@@ -949,7 +949,7 @@ export function createPinLayer(options: PinLayerOptions) {
       placeSoon();
     },
 
-    /** One card off, by the reviewer's own ✕: the pin itself stays drawn. */
+    /** One card off, by its own hide button: the pin itself stays drawn. */
     setCardHidden(id: string, hidden: boolean) {
       const view = views.find((held) => held.id() === id);
       if (!view) return;

--- a/react/vite-plugins/review-overlay/client/resolve.ts
+++ b/react/vite-plugins/review-overlay/client/resolve.ts
@@ -122,6 +122,22 @@ function uniqueLandmark(
   return isOurs(found[0], ignore) ? null : found[0];
 }
 
+/**
+ * Is the anchor's landmark on the page at all? One selector, so the retry loop
+ * can tell "the frame it lived in is back" from "still nothing".
+ */
+export function hasLandmark(
+  anchor: AnchorV3 | null,
+  doc: Document = document,
+): boolean {
+  if (!anchor?.tid) return false;
+  try {
+    return !!doc.querySelector(`[data-testid="${esc(anchor.tid)}"]`);
+  } catch {
+    return false;
+  }
+}
+
 /** Cheap enough to run on every reposition: no text scan, no projection. */
 export function quickFindTarget(
   anchor: AnchorV3 | null,

--- a/react/vite-plugins/review-overlay/client/ui.test.ts
+++ b/react/vite-plugins/review-overlay/client/ui.test.ts
@@ -290,6 +290,13 @@ describe('gating the copy on the note', () => {
     ui.openCompose(target, 40, 306);
   });
 
+  // R5.2: the whole chrome is lucide at one size, emoji nowhere.
+  it('labels the copy button with a lucide icon, not an emoji', () => {
+    expect(copyButton().querySelector('svg')).not.toBeNull();
+    expect(copyButton().textContent).toBe('Copy block');
+    expect(compose().textContent).not.toMatch(/\p{Extended_Pictographic}/u);
+  });
+
   it('re-disables the button the moment the note leaves the capture', () => {
     expect(copyButton().disabled).toBe(true);
     ui.setComposeReady(true, '');

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -13,6 +13,7 @@
  * `data-react-grab-ignore-events` makes react-grab skip our own chrome while
  * its select mode is on, so the composer stays clickable mid-pick.
  */
+import { icon, ICON_STYLE } from './icons.js';
 import { fractionWithin, projectFraction, type Box } from './selection.js';
 import type { AnchorRect, CopyPayload } from './types.js';
 
@@ -124,6 +125,9 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
     .compose .actions {
       display: flex; justify-content: flex-end; gap: 6px; margin-top: 6px;
     }
+    .compose .btn.primary {
+      display: inline-flex; align-items: center; gap: 5px;
+    }
     .compose .err {
       color: var(--bai-review-error); font-size: 11px; margin-top: 4px;
       display: none;
@@ -134,6 +138,7 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
       color: var(--bai-review-on-inverted); font-size: 14px; padding: 8px 14px;
       border-radius: 16px; display: none; max-width: 70vw;
     }
+${ICON_STYLE}
   `;
   root.appendChild(style);
 
@@ -145,7 +150,7 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
     <div class="err"></div>
     <div class="actions">
       <button class="btn" data-act="cancel">Cancel</button>
-      <button class="btn primary" data-act="copy">📋 Copy block</button>
+      <button class="btn primary" data-act="copy"><span class="lbl"></span></button>
     </div>
   `;
   const toast = el('div', 'toast');
@@ -157,6 +162,9 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
   const copyButton = compose.querySelector(
     '[data-act="copy"]',
   ) as HTMLButtonElement;
+  const copyLabel = copyButton.querySelector('.lbl') as HTMLElement;
+  copyButton.prepend(icon('copy'));
+  copyLabel.textContent = 'Copy block';
 
   let pickActive = false;
   let pickTarget: Element | null = null;
@@ -461,7 +469,7 @@ export function createOverlayUI(callbacks: OverlayUICallbacks) {
     const done = (ok: boolean) => {
       showToast(
         ok
-          ? 'Copied — paste it into the PR comment, the Teams thread, or Claude 📋'
+          ? 'Copied — paste it into the PR comment, the Teams thread, or Claude'
           : 'Could not reach the clipboard — press ⌘⏎ again',
       );
       if (ok) closeCompose();


### PR DESCRIPTION
Resolves #9434 (FR-3857)

Part of the pin-set stack (#9442): #9437 → #9438 → #9439 → #9440 → #9441. Design record: `docs/adr/0002-pin-set-link-grammar-and-single-codec.md`; vocabulary: `react/vite-plugins/review-overlay/CONTEXT.md`.

`pin.ts` was one closure holding one pin: its `<style>`, its MutationObserver,
its scroll/resize listeners, its rAF placement batch and its marker, card and
box, all in the same scope. A pin set needs many of the second group and
exactly one of the first, so the file splits along that seam. The LAYER owns
the stylesheet, the single observer, the listeners, the placement batch, the
retry driver and the docked column; a VIEW owns one pin's marker, card, box,
target, located element, clippers, missed-scan budget and arrival pulse, and is
handed `place()` and the settle-follow by the layer. Views are reused by
position, so a card the set keeps keeps its node — and its measured height —
across a re-show.

The retry ladder moves out of `main.ts` and into the layer, because a set needs
one driver rather than one per pin: each tick runs the full resolution ladder
over every view that has not landed yet and stops as soon as they all have.
Give-up is one sentence for the whole set, and for a set of one it is still the
sentence the overlay has always said.

Three things a set makes visible arrive with it. The marker glyph becomes the
pin's place in the set and the card gets a `3 / 5` header, but only for N > 1 —
a set of one keeps a single pin glyph and no header, which is what a single pin
has always looked like. Away cards stack into a column at the edge they left
by, in set order, with the head of the column keeping the geometry FR-3853 gave
it, so a lone docked card lands on the same pixels as before. And the layer can
fold every card away while a pick or the composer is in flight: the markers are
click-through already, so a drawn pin no longer sits between the reviewer and
the element they are trying to pick next. Two anchored cards can still overlap
each other; the later one is on top, and the set dock (#9440) is what will
reach every pin regardless.

`createDeepLinkPin` stays exported as a one-view layer with today's option
shape, so `pin.test.ts` compiles and passes — its card exists from
construction, which is what the place tests measure before they show anything.
Nothing yet asks the layer for more than one pin: `main.ts` opens a link as a
set of one, and the draft set that will feed it real sets lands in #9440.

## What else this branch carries

The layer is the primitive every later feedback round needed, so five of the
rounds put their layer-side half here. Read this branch as "the pin layer,
finished", not as the first round alone.

**R4 primitives.** A view carries its own hide flag and the layer carries the
dock switch's, both folded into the same "no card" test the pick-collapse
already used, so a card can go away without its pin going with it (a hidden
card measures 0 high and leaves the docked column rather than opening a gap in
it). `pulse(id)` can replay a marker's arrival animation on demand, so the dock
row that scrolls to a pin can also make it findable. Both are unused on this
branch and driven from #9440.

**R5.2 / R5.3 — lucide icons.** The overlay chrome was a row of emoji whose
glyphs come from whatever emoji font the OS picked, at whatever size it draws
them, so the card's buttons were visibly different heights. `client/icons.ts`
inlines lucide's icon node data — the overlay client is served unbundled and
cannot import `lucide-react`, which is a React package — plus one helper that
builds a 14px `currentColor` svg. Every button keeps its `title` / `aria-label`
and the svg is `aria-hidden`, so nothing changes for a screen reader.
`icons.test.ts` diffs every entry against
`lucide-react/dist/esm/icons/<name>.mjs`, so a catalog bump that redraws a
glyph fails here instead of shipping two looks (`lucide-icon-node.d.ts` types
those deep entries). The 📍 and ⚛️ INSIDE the copied block are untouched — they
are wire format, matched by `BLOCK_HEAD_RE`, by the CLI and by the Claude-side
skill. On screen the marker keeps its CSS teardrop and swaps its emoji for a
12px lucide `map-pin`.

**The lucide bump to 1.37.0 (`pnpm-workspace.yaml`, `pnpm-lock.yaml`)** is the
only change on this stack outside the overlay, and it is here because the
inlined data has to be generated from the version the workspace actually
installs or the parity test guards nothing. 1.41.0 is newer but under
`minimumReleaseAge`'s 7-day quarantine and would need an exclude entry, which
is not worth spending on a devtool's icon set. All 177 icon names the app
imports still export from 1.37.0; of the 37 icons whose shape changed between
the versions, three are imported here — `circle-check`, `badge-check` and
`square-check` had their inner tick redrawn slightly larger and better centred
(40 call sites, `CircleCheck` and `BadgeCheck`). That redraw is the one visible
effect this stack has on the product UI.

**R5.4 — the marker moves off the region.** It used to sit at
`box.left + 6 / box.top + 6`, inside the highlighted box, covering the content
the box exists to point at (and covering more once an index went in it). The
teardrop's point is at the bottom, so it now hangs above the region with its
tip on the top-left corner; with no room above it flips (`rotate(135deg)` puts
the point up) and hangs below. A follow-up fixes the case the first cut got
wrong: a region taller than the viewport has room on neither side, and the
flipped marker was being clamped back up into the middle of the rectangle it
points at — it now flips only when there is no room above AND room below, and
otherwise clamps to the top edge beside the leading corner. Against the left
edge it slides along the top rather than off-screen; the card starts past the
marker whenever both land on the same side. `pin.test.ts`'s marker-geometry
assertions moved with the behaviour and the flip has a case of its own.

**R7.2 — a waiting pin never gives up.** The 10-second retry ladder and
`MAX_MISSED_SCANS` between them retired a pin picked inside a modal before the
reviewer could reopen it: the escalated text scan's budget was spent by the
page's own boot churn, so the pin settled on its landmark and never moved off
it. A `hasLandmark` check — one `querySelector` per waiting pin per already
debounced observer batch — gives the escalated scan its budget back when the
frame the pin lived in comes back, and only then; the document-wide scan keeps
its cap. `onGiveUp` also stops being a verdict and hands the owner the ids
still pending, because only the owner knows whether a pin is on another page or
waiting for its element (R7.3 / R7.4, driven from #9440 and #9441).

**R7.3 — `locate(id)`.** `locate()` was the whole layer or nothing: it ran the
ladder over every drawn view and, with `autoFocus` on (the state a link's
arrival leaves the layer in), scrolled and pulsed the focus pin. A caller that
only wants to know whether ONE pin's element has appeared therefore scrolled
the reviewer to a different pin and paid N document-wide scans for the answer.
`locate(id)` resolves that view alone, never focuses, and costs one ladder run.

Two seams were widened for the branches above. `onLocated` also reports which
pin moved. `onDismiss` reported the pin whose hide control was pressed — but
R6.2 later took every destructive control off the card, so **#9440 deletes
`onDismiss` and its `ViewDeps` plumbing from this file**. Read #9439 and #9440
together: on its own, this branch still shows a card with a remove button.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (run on the stack top, `feat/FR-3859-pin-set-read`)
- `pnpm vitest run vite-plugins/review-overlay` (from `react/`) → 23 files, 557 tests, all passing on the stack top
- New here: `pin-layer.test.ts` (two-pin identity and numbering, per-pin dismiss, focus-only scroll and pulse, the aggregate give-up and its N=1 wording, the collapse hook, the docked column, the waiting-pin re-resolve, per-pin `locate`) and `icons.test.ts` (every inlined icon diffed against `lucide-react` 1.37.0).
- Each branch was reviewed by two independent review agents (correctness, design conformance) and their blocker/major findings were fixed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhEbqZ9DDe2HFJF43rAVP1
