### PR TITLE
feat(FR-3858): keep every pin the reviewer makes in a draft set

### DIFF
--- a/react/vite-plugins/review-overlay/client/block.test.ts
+++ b/react/vite-plugins/review-overlay/client/block.test.ts
@@ -641,6 +641,45 @@ describe('a pin set', () => {
       expect(size(20) / size(10)).toBeLessThan(2.2);
     });
   });
+
+  describe('with a note longer than the link carries', () => {
+    const long = `${'x'.repeat(300)} and the rest of what was typed`;
+    const short = `${long.slice(0, 279)}…`;
+
+    /** `withNote` caps `anchor.n` at `NOTE_MAX` and flags it with `nt`. */
+    const capped = (): SetPin => {
+      const pin = first();
+      return { ...pin, anchor: { ...pin.anchor, n: short, nt: 1 }, note: long };
+    };
+
+    it('leads the block with the whole note, not the shortened one', () => {
+      const text = buildSetText([capped()], { origin: ORIGIN });
+
+      expect(text.split('\n')[0]).toBe(long);
+      expect(text).toContain(
+        `> [Open on dev server](${ORIGIN}/session/start?tab=general#bai=v3.c_aaaaaa2.PAYLOAD1)`,
+      );
+    });
+
+    // A link's pin never travelled with the note the reviewer typed; the
+    // shortened one the anchor carries is all there is.
+    it('falls back to the anchor for a pin that came off a link', () => {
+      const pin = capped();
+      const fromLink: SetPin = {
+        id: pin.id,
+        origin: 'link',
+        anchor: pin.anchor,
+        anchorB64: pin.anchorB64,
+        label: pin.label,
+        appHash: '',
+        stack: [],
+      };
+
+      expect(buildSetText([fromLink], { origin: ORIGIN }).split('\n')[0]).toBe(
+        short,
+      );
+    });
+  });
 });
 
 describe('the marker a block may not claim', () => {

--- a/react/vite-plugins/review-overlay/client/block.ts
+++ b/react/vite-plugins/review-overlay/client/block.ts
@@ -193,7 +193,8 @@ const setBlockInput = (pin: SetPin, url: string): BlockInput => {
     label: pin.label,
     id: pin.id,
     stack: pin.stack,
-    text: pin.anchor.n ?? '',
+    // The link carries the shortened note; the block is what keeps the rest.
+    text: pin.note ?? pin.anchor.n ?? '',
     url,
   };
   // No marker to write, so the fields only a marker reads stay blank.

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The set dock (FR-3858): the list that reaches every pin of the draft set,
+ * whatever the layer managed to draw, plus the two set-wide actions.
+ */
+import { createSetDock, type SetDock } from './dock.js';
+import type { SetPin } from './types.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let dock: SetDock;
+let root: ShadowRoot;
+let copied: number;
+let cleared: number;
+let located: string[];
+
+const pin = (id: string, label: string): SetPin => ({
+  id,
+  origin: 'pick',
+  anchor: { v: 3, s: `[data-testid="${id}"]`, p: '/session/start' },
+  anchorB64: `PAYLOAD_${id}`,
+  label,
+  appHash: '',
+  stack: [],
+  at: '2026-08-31T09:00:00Z',
+  pr: 9330,
+});
+
+const node = <T extends HTMLElement>(selector: string) =>
+  root.querySelector<T>(selector) as T;
+const rows = () => Array.from(root.querySelectorAll<HTMLElement>('.row'));
+const shown = () => node('.setdock').classList.contains('shown');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  copied = 0;
+  cleared = 0;
+  located = [];
+  const host = document.createElement('div');
+  document.body.append(host);
+  root = host.attachShadow({ mode: 'open' });
+  dock = createSetDock({
+    root,
+    onCopyAll: () => copied++,
+    onClear: () => cleared++,
+    onLocate: (id) => located.push(id),
+  });
+});
+
+afterEach(() => {
+  dock.dispose();
+});
+
+describe('createSetDock', () => {
+  it('stays out of the way while there is no set', () => {
+    dock.render([]);
+
+    expect(shown()).toBe(false);
+    expect(rows()).toHaveLength(0);
+  });
+
+  it('lists the set in order, numbered, with each pin its own label', () => {
+    dock.render([pin('c_a', 'Sessions › start'), pin('c_b', 'Sessions › end')]);
+
+    expect(shown()).toBe(true);
+    expect(node('.title').textContent).toBe('📍 2 pins');
+    expect(rows().map((row) => row.dataset.pinId)).toEqual(['c_a', 'c_b']);
+    expect(rows().map((row) => row.querySelector('.idx')?.textContent)).toEqual(
+      ['1', '2'],
+    );
+    expect(rows()[1].querySelector('.rowlabel')?.textContent).toBe(
+      'Sessions › end',
+    );
+  });
+
+  it('counts one pin as a pin', () => {
+    dock.render([pin('c_a', 'Sessions › start')]);
+
+    expect(node('.title').textContent).toBe('📍 1 pin');
+  });
+
+  it('hands back the id of the row whose 📍 was pressed', () => {
+    dock.render([pin('c_a', 'a'), pin('c_b', 'b')]);
+
+    rows()[1].querySelector<HTMLButtonElement>('.locate')?.click();
+
+    expect(located).toEqual(['c_b']);
+  });
+
+  // The copy runs inside this click — `execCommand` is the only clipboard on
+  // the gateway origin, and it needs the activation still to be live.
+  it('asks for the whole set on one click, with nothing awaited', () => {
+    dock.render([pin('c_a', 'a')]);
+
+    node<HTMLButtonElement>('.copyall').click();
+
+    expect(copied).toBe(1);
+  });
+
+  describe('clearing the set', () => {
+    beforeEach(() => {
+      dock.render([pin('c_a', 'a'), pin('c_b', 'b'), pin('c_c', 'c')]);
+    });
+
+    // Clear is the one action with no undo, so one click only asks.
+    it('asks before it clears, naming how many it would take', () => {
+      expect(node('.clear').textContent).toBe('🗑 Clear all (3)');
+
+      node<HTMLButtonElement>('.clear').click();
+
+      expect(cleared).toBe(0);
+      expect(node('.setdock').classList.contains('confirming')).toBe(true);
+      expect(node('.confirm').textContent).toContain('Clear all 3?');
+    });
+
+    it('clears once the ✓ confirms it', () => {
+      node<HTMLButtonElement>('.clear').click();
+
+      node<HTMLButtonElement>('.yes').click();
+
+      expect(cleared).toBe(1);
+      expect(node('.setdock').classList.contains('confirming')).toBe(false);
+    });
+
+    it('keeps the set when the ✕ takes the question back', () => {
+      node<HTMLButtonElement>('.clear').click();
+
+      node<HTMLButtonElement>('.no').click();
+
+      expect(cleared).toBe(0);
+      expect(node('.setdock').classList.contains('confirming')).toBe(false);
+    });
+
+    // A pin added or dismissed while the question is up changes the answer.
+    it('takes the question back when the set changes under it', () => {
+      node<HTMLButtonElement>('.clear').click();
+
+      dock.render([pin('c_a', 'a')]);
+
+      expect(node('.setdock').classList.contains('confirming')).toBe(false);
+      expect(node('.clear').textContent).toBe('🗑 Clear all (1)');
+    });
+  });
+
+  // Labels come off links a stranger may have written.
+  it('writes a label as text, never as markup', () => {
+    dock.render([pin('c_a', '<img src=x onerror=alert(1)>')]);
+
+    expect(rows()[0].querySelector('img')).toBeNull();
+    expect(rows()[0].querySelector('.rowlabel')?.textContent).toBe(
+      '<img src=x onerror=alert(1)>',
+    );
+  });
+});

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -2,7 +2,7 @@
  * The set dock (FR-3858): the list that reaches every pin of the draft set,
  * whatever the layer managed to draw, plus the two set-wide actions.
  */
-import { createSetDock, type SetDock } from './dock.js';
+import { CARDS_CHORD, createSetDock, type SetDock } from './dock.js';
 import type { SetPin } from './types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -10,7 +10,10 @@ let dock: SetDock;
 let root: ShadowRoot;
 let copied: number;
 let cleared: number;
+let toggled: number;
 let located: string[];
+let removed: string[];
+let unhidden: string[];
 
 const pin = (id: string, label: string): SetPin => ({
   id,
@@ -33,7 +36,10 @@ beforeEach(() => {
   document.body.innerHTML = '';
   copied = 0;
   cleared = 0;
+  toggled = 0;
   located = [];
+  removed = [];
+  unhidden = [];
   const host = document.createElement('div');
   document.body.append(host);
   root = host.attachShadow({ mode: 'open' });
@@ -42,6 +48,9 @@ beforeEach(() => {
     onCopyAll: () => copied++,
     onClear: () => cleared++,
     onLocate: (id) => located.push(id),
+    onRemove: (id) => removed.push(id),
+    onUnhide: (id) => unhidden.push(id),
+    onToggleCards: () => toggled++,
   });
 });
 
@@ -77,12 +86,80 @@ describe('createSetDock', () => {
     expect(node('.title').textContent).toBe('📍 1 pin');
   });
 
-  it('hands back the id of the row whose 📍 was pressed', () => {
+  // The row IS the control: one click goes to the pin it names.
+  it('hands back the id of the row that was clicked', () => {
     dock.render([pin('c_a', 'a'), pin('c_b', 'b')]);
 
-    rows()[1].querySelector<HTMLButtonElement>('.locate')?.click();
+    rows()[1].querySelector<HTMLButtonElement>('.rowlabel')?.click();
 
     expect(located).toEqual(['c_b']);
+  });
+
+  it('hands back the id of the row whose 🗑 was pressed', () => {
+    dock.render([pin('c_a', 'a'), pin('c_b', 'b')]);
+
+    rows()[0].querySelector<HTMLButtonElement>('.remove')?.click();
+
+    expect(removed).toEqual(['c_a']);
+    expect(located).toEqual([]);
+  });
+
+  // ✕ on a card is not ✕ on the pin: the row is what still reaches it.
+  describe('a pin whose card is hidden', () => {
+    const withHidden = () =>
+      dock.render([
+        pin('c_a', 'a'),
+        { ...pin('c_b', 'b'), hidden: true } as SetPin,
+      ]);
+
+    it('dims the row and offers to show the card again', () => {
+      withHidden();
+
+      expect(rows()[0].classList.contains('off')).toBe(false);
+      expect(rows()[1].classList.contains('off')).toBe(true);
+      expect(rows()[1].querySelector('.unhide')).not.toBeNull();
+      expect(rows()[0].querySelector('.unhide')).toBeNull();
+    });
+
+    it('shows it again from the row’s own button', () => {
+      withHidden();
+
+      rows()[1].querySelector<HTMLButtonElement>('.unhide')?.click();
+
+      expect(unhidden).toEqual(['c_b']);
+    });
+
+    // Asking to go to a pin means wanting to see it.
+    it('brings the card back when the row itself is clicked', () => {
+      withHidden();
+
+      rows()[1].querySelector<HTMLButtonElement>('.rowlabel')?.click();
+
+      expect(unhidden).toEqual(['c_b']);
+      expect(located).toEqual(['c_b']);
+    });
+  });
+
+  describe('the cards switch', () => {
+    it('asks the owner to flip it, and shows the chord that does too', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      expect(node('.cards').textContent).toBe('👁 Cards');
+      expect(node('.chord').textContent).toBe(CARDS_CHORD);
+      expect(node('.cards').getAttribute('aria-label')).toContain(CARDS_CHORD);
+
+      node<HTMLButtonElement>('.cards').click();
+
+      expect(toggled).toBe(1);
+    });
+
+    // The dock is the switch's home, so it says which way it is thrown.
+    it('says the cards are off once the owner says so', () => {
+      dock.render([pin('c_a', 'a')], true);
+
+      expect(node('.cards').textContent).toBe('🙈 Cards');
+      expect(node('.cards').getAttribute('aria-pressed')).toBe('true');
+    });
   });
 
   // The copy runs inside this click — `execCommand` is the only clipboard on

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -411,6 +411,19 @@ describe('createSetDock', () => {
       expect(node('.setdock').classList.contains('confirming')).toBe(false);
     });
 
+    // The rows re-render whenever a pin lands or loses its element; the ✓/✕
+    // must not vanish from under the cursor because the app re-rendered.
+    it('keeps the question through a re-render of the same set', () => {
+      node<HTMLButtonElement>('.clear').click();
+
+      dock.render(
+        [pin('c_a', 'a'), pin('c_b', 'b'), pin('c_c', 'c')],
+        new Map([['c_b', { kind: 'waiting' }]]),
+      );
+
+      expect(node('.setdock').classList.contains('confirming')).toBe(true);
+    });
+
     // A pin added or dismissed while the question is up changes the answer.
     it('takes the question back when the set changes under it', () => {
       node<HTMLButtonElement>('.clear').click();

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -601,6 +601,21 @@ describe('createSetDock', () => {
       expect(node('.setdock').style.top).toBe('132px');
     });
 
+    // Shrinking used to overwrite the dragged position with the clamped one,
+    // so the reviewer's spot was gone the moment the window came back.
+    it('puts the dock back where it was dragged when the window grows again', () => {
+      dock.render([pin('c_a', 'a')]);
+      dragTo(700, 500);
+
+      viewport(400, 300);
+      window.dispatchEvent(new Event('resize'));
+      viewport(1024, 768);
+      window.dispatchEvent(new Event('resize'));
+
+      expect(node('.setdock').style.left).toBe('700px');
+      expect(node('.setdock').style.top).toBe('500px');
+    });
+
     it('leaves the default corner alone until something moves it', () => {
       dock.render([pin('c_a', 'a')]);
 

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -52,7 +52,8 @@ const viewport = (width: number, height: number) => {
 
 /**
  * jsdom lays nothing out, so every `offsetHeight` is 0 — including the one a
- * real browser reports for a shown dock. Returns its own undo.
+ * real browser reports for a shown dock. A folded one is `display: none` and
+ * really does measure 0. Returns its own undo.
  */
 const measureShownDockAs = (height: number) => {
   const proto = HTMLElement.prototype;
@@ -60,7 +61,8 @@ const measureShownDockAs = (height: number) => {
   Object.defineProperty(proto, 'offsetHeight', {
     configurable: true,
     get(this: HTMLElement) {
-      return this.classList.contains('shown') ? height : 0;
+      const list = this.classList;
+      return list.contains('shown') && !list.contains('folded') ? height : 0;
     },
   });
   return () => {
@@ -584,6 +586,32 @@ describe('createSetDock', () => {
 
         // 480 - 300 - 8: the whole dock, not the eight pixels of its top
         // border that the stand-in height alone would have left on screen.
+        expect(node('.setdock').style.top).toBe('172px');
+      } finally {
+        measured();
+      }
+    });
+
+    // Committing a pin re-renders the dock while the composer still has it
+    // folded, where it is `display: none` and measures the stand-in box. The
+    // clamp that follows would let a 300px dock sit at 312px of a 480px window.
+    it('waits for the unfold to clamp a dock the composer folded', () => {
+      const measured = measureShownDockAs(300);
+      try {
+        dock.render([pin('c_a', 'a')]);
+        dragTo(400, 400);
+        expect(node('.setdock').style.top).toBe('400px');
+
+        dock.setCollapsed(true);
+        viewport(1280, 480);
+        dock.render([pin('c_a', 'a'), pin('c_b', 'b')]);
+
+        // 480 - 160 stand-in - 8 is what a measurement of the folded dock buys.
+        expect(node('.setdock').style.top).not.toBe('312px');
+
+        dock.setCollapsed(false);
+
+        // 480 - 300 - 8: the whole dock, clamped against the box it really has.
         expect(node('.setdock').style.top).toBe('172px');
       } finally {
         measured();

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -119,6 +119,8 @@ describe('createSetDock', () => {
       expect(rows()[1].classList.contains('off')).toBe(true);
       expect(rows()[1].querySelector('.unhide')).not.toBeNull();
       expect(rows()[0].querySelector('.unhide')).toBeNull();
+      // 🙈 says "hidden" in the header; the row's button is what reveals.
+      expect(rows()[1].querySelector('.unhide')?.textContent).toBe('👁');
     });
 
     it('shows it again from the row’s own button', () => {
@@ -159,6 +161,29 @@ describe('createSetDock', () => {
 
       expect(node('.cards').textContent).toBe('🙈 Cards');
       expect(node('.cards').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    // A pressed toggle named after the action that un-presses it announces
+    // the opposite of its own state.
+    it('keeps one name whichever way it is thrown', () => {
+      dock.render([pin('c_a', 'a')]);
+      const named = node('.cards').getAttribute('aria-label');
+
+      dock.render([pin('c_a', 'a')], true);
+
+      expect(node('.cards').getAttribute('aria-label')).toBe(named);
+      expect(node('.cards').title).toBe(named);
+    });
+
+    // A 260px header wraps; a hint stranded on the title's line reads as part
+    // of it, so it travels with the button it names.
+    it('puts the chord after the button it names', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      const head = Array.from(node('.head').children).map(
+        (child) => child.className,
+      );
+      expect(head.indexOf('chord')).toBe(head.indexOf('act cards') + 1);
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -2,7 +2,12 @@
  * The set dock (FR-3858): the list that reaches every pin of the draft set,
  * whatever the layer managed to draw, plus the two set-wide actions.
  */
-import { CARDS_CHORD, createSetDock, type SetDock } from './dock.js';
+import {
+  CARDS_CHORD,
+  createSetDock,
+  DOCK_POS_KEY,
+  type SetDock,
+} from './dock.js';
 import type { SetPin } from './types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -32,8 +37,21 @@ const node = <T extends HTMLElement>(selector: string) =>
 const rows = () => Array.from(root.querySelectorAll<HTMLElement>('.row'));
 const shown = () => node('.setdock').classList.contains('shown');
 
+const viewport = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    value: height,
+    configurable: true,
+  });
+};
+
 beforeEach(() => {
   document.body.innerHTML = '';
+  sessionStorage.clear();
+  viewport(1024, 768);
   copied = 0;
   cleared = 0;
   toggled = 0;
@@ -70,7 +88,7 @@ describe('createSetDock', () => {
     dock.render([pin('c_a', 'Sessions › start'), pin('c_b', 'Sessions › end')]);
 
     expect(shown()).toBe(true);
-    expect(node('.title').textContent).toBe('📍 2 pins');
+    expect(node('.title').textContent).toBe('2 pins');
     expect(rows().map((row) => row.dataset.pinId)).toEqual(['c_a', 'c_b']);
     expect(rows().map((row) => row.querySelector('.idx')?.textContent)).toEqual(
       ['1', '2'],
@@ -83,7 +101,7 @@ describe('createSetDock', () => {
   it('counts one pin as a pin', () => {
     dock.render([pin('c_a', 'Sessions › start')]);
 
-    expect(node('.title').textContent).toBe('📍 1 pin');
+    expect(node('.title').textContent).toBe('1 pin');
   });
 
   // The row IS the control: one click goes to the pin it names.
@@ -119,8 +137,10 @@ describe('createSetDock', () => {
       expect(rows()[1].classList.contains('off')).toBe(true);
       expect(rows()[1].querySelector('.unhide')).not.toBeNull();
       expect(rows()[0].querySelector('.unhide')).toBeNull();
-      // 🙈 says "hidden" in the header; the row's button is what reveals.
-      expect(rows()[1].querySelector('.unhide')?.textContent).toBe('👁');
+      // The header's own icon says "hidden"; the row's button is what reveals.
+      expect(
+        rows()[1].querySelector('.unhide')?.getAttribute('aria-label'),
+      ).toBe('Show this pin’s card again');
     });
 
     it('shows it again from the row’s own button', () => {
@@ -146,7 +166,7 @@ describe('createSetDock', () => {
     it('asks the owner to flip it, and shows the chord that does too', () => {
       dock.render([pin('c_a', 'a')]);
 
-      expect(node('.cards').textContent).toBe('👁 Cards');
+      expect(node('.cards').textContent).toBe('Cards');
       expect(node('.chord').textContent).toBe(CARDS_CHORD);
       expect(node('.cards').getAttribute('aria-label')).toContain(CARDS_CHORD);
 
@@ -159,7 +179,7 @@ describe('createSetDock', () => {
     it('says the cards are off once the owner says so', () => {
       dock.render([pin('c_a', 'a')], true);
 
-      expect(node('.cards').textContent).toBe('🙈 Cards');
+      expect(node('.cards').textContent).toBe('Cards');
       expect(node('.cards').getAttribute('aria-pressed')).toBe('true');
     });
 
@@ -204,7 +224,7 @@ describe('createSetDock', () => {
 
     // Clear is the one action with no undo, so one click only asks.
     it('asks before it clears, naming how many it would take', () => {
-      expect(node('.clear').textContent).toBe('🗑 Clear all (3)');
+      expect(node('.clear').textContent).toBe('Clear all (3)');
 
       node<HTMLButtonElement>('.clear').click();
 
@@ -238,7 +258,151 @@ describe('createSetDock', () => {
       dock.render([pin('c_a', 'a')]);
 
       expect(node('.setdock').classList.contains('confirming')).toBe(false);
-      expect(node('.clear').textContent).toBe('🗑 Clear all (1)');
+      expect(node('.clear').textContent).toBe('Clear all (1)');
+    });
+  });
+
+  // R5.2. The dock's row of emoji drew at whatever size each OS font chose,
+  // so the buttons were different heights.
+  describe('the chrome', () => {
+    const EMOJI = /\p{Extended_Pictographic}/u;
+
+    it('is lucide svgs, with no emoji left in it', () => {
+      dock.render([
+        { ...pin('c_a', 'Sessions › start'), hidden: true },
+        pin('c_b', 'Sessions › end'),
+      ]);
+
+      const buttons = Array.from(
+        node('.setdock').querySelectorAll('button.act'),
+      );
+      expect(buttons.length).toBeGreaterThan(0);
+      for (const button of buttons) {
+        expect(button.querySelector('svg')).not.toBeNull();
+        expect(button.getAttribute('aria-label')).toBeTruthy();
+      }
+      // The chord (⌘⇧H) is a key name, not an icon, so it stays.
+      expect(node('.setdock').textContent).not.toMatch(EMOJI);
+    });
+  });
+
+  // R5.1. A dock nailed to the bottom-right corner sits on whatever the
+  // reviewer wants to look at there.
+  describe('dragging the dock', () => {
+    const grip = () => node('.grip');
+    const point = (type: string, x: number, y: number) =>
+      grip().dispatchEvent(
+        new MouseEvent(type, {
+          clientX: x,
+          clientY: y,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    /** Grab at the dock's own origin, so the cursor IS the new top-left. */
+    const dragTo = (x: number, y: number) => {
+      point('pointerdown', 0, 0);
+      point('pointermove', x, y);
+      point('pointerup', x, y);
+    };
+
+    it('moves the dock and drops the default corner', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      dragTo(300, 200);
+
+      expect(node('.setdock').style.left).toBe('300px');
+      expect(node('.setdock').style.top).toBe('200px');
+      expect(node('.setdock').style.right).toBe('auto');
+      expect(node('.setdock').style.bottom).toBe('auto');
+    });
+
+    // A pick starts on a mousedown the page can see, and a drag across the
+    // header would otherwise select the labels it passes over.
+    it('takes the gesture, so it is neither a selection nor a pick', () => {
+      const down = new MouseEvent('pointerdown', {
+        clientX: 0,
+        clientY: 0,
+        bubbles: true,
+        cancelable: true,
+      });
+      grip().dispatchEvent(down);
+
+      expect(down.defaultPrevented).toBe(true);
+    });
+
+    // Pointer capture keeps every move on the grip; no row ever sees one.
+    it('runs no row action while the dock is being dragged', () => {
+      dock.render([pin('c_a', 'a'), pin('c_b', 'b')]);
+
+      dragTo(300, 200);
+
+      expect(located).toEqual([]);
+      expect(removed).toEqual([]);
+      expect(unhidden).toEqual([]);
+    });
+
+    it('keeps the position for the tab', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      dragTo(300, 200);
+
+      expect(sessionStorage.getItem(DOCK_POS_KEY)).toBe(
+        JSON.stringify({ left: 300, top: 200 }),
+      );
+    });
+
+    // The dock is 260px wide; 1024 - 260 - 8 is the rightmost `left` that
+    // still leaves it a margin.
+    it('clamps a drag past the edge back into the viewport', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      dragTo(4000, 4000);
+
+      expect(node('.setdock').style.left).toBe('756px');
+      expect(node('.setdock').style.top).toBe('760px');
+    });
+
+    it('restores a stored position, clamped into a smaller window', () => {
+      dock.dispose();
+      sessionStorage.setItem(
+        DOCK_POS_KEY,
+        JSON.stringify({ left: 900, top: 700 }),
+      );
+      viewport(600, 400);
+      dock = createSetDock({
+        root,
+        onCopyAll: () => copied++,
+        onClear: () => cleared++,
+        onLocate: (id) => located.push(id),
+        onRemove: (id) => removed.push(id),
+        onUnhide: (id) => unhidden.push(id),
+        onToggleCards: () => toggled++,
+      });
+
+      expect(node('.setdock').style.left).toBe('332px');
+      expect(node('.setdock').style.top).toBe('392px');
+    });
+
+    it('pulls a parked dock back in when the window shrinks', () => {
+      dock.render([pin('c_a', 'a')]);
+      dragTo(700, 500);
+
+      viewport(400, 300);
+      window.dispatchEvent(new Event('resize'));
+
+      expect(node('.setdock').style.left).toBe('132px');
+      expect(node('.setdock').style.top).toBe('292px');
+    });
+
+    it('leaves the default corner alone until something moves it', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      viewport(400, 300);
+      window.dispatchEvent(new Event('resize'));
+
+      expect(node('.setdock').style.left).toBe('');
+      expect(node('.setdock').style.top).toBe('');
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -48,6 +48,24 @@ const viewport = (width: number, height: number) => {
   });
 };
 
+/**
+ * jsdom lays nothing out, so every `offsetHeight` is 0 — including the one a
+ * real browser reports for a shown dock. Returns its own undo.
+ */
+const measureShownDockAs = (height: number) => {
+  const proto = HTMLElement.prototype;
+  const own = Object.getOwnPropertyDescriptor(proto, 'offsetHeight');
+  Object.defineProperty(proto, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.classList.contains('shown') ? height : 0;
+    },
+  });
+  return () => {
+    if (own) Object.defineProperty(proto, 'offsetHeight', own);
+  };
+};
+
 beforeEach(() => {
   document.body.innerHTML = '';
   sessionStorage.clear();
@@ -360,7 +378,8 @@ describe('createSetDock', () => {
       dragTo(4000, 4000);
 
       expect(node('.setdock').style.left).toBe('756px');
-      expect(node('.setdock').style.top).toBe('760px');
+      // 768 - 160 stand-in height - 8: jsdom measures every box as 0.
+      expect(node('.setdock').style.top).toBe('600px');
     });
 
     it('restores a stored position, clamped into a smaller window', () => {
@@ -381,7 +400,39 @@ describe('createSetDock', () => {
       });
 
       expect(node('.setdock').style.left).toBe('332px');
-      expect(node('.setdock').style.top).toBe('392px');
+      expect(node('.setdock').style.top).toBe('232px');
+    });
+
+    // Restore runs before the first `render`, while the dock is still
+    // `display: none` and measures 0 — clamping against that parks a dock
+    // stored low in a tall window below the fold of a short one, where its
+    // rows, its actions and the set they reach cannot be got at.
+    it('re-clamps against its real height once it is shown', () => {
+      const measured = measureShownDockAs(300);
+      try {
+        dock.dispose();
+        sessionStorage.setItem(
+          DOCK_POS_KEY,
+          JSON.stringify({ left: 900, top: 740 }),
+        );
+        viewport(1280, 480);
+        dock = createSetDock({
+          root,
+          onCopyAll: () => copied++,
+          onClear: () => cleared++,
+          onLocate: (id) => located.push(id),
+          onRemove: (id) => removed.push(id),
+          onUnhide: (id) => unhidden.push(id),
+          onToggleCards: () => toggled++,
+        });
+        dock.render([pin('c_a', 'a')]);
+
+        // 480 - 300 - 8: the whole dock, not the eight pixels of its top
+        // border that the stand-in height alone would have left on screen.
+        expect(node('.setdock').style.top).toBe('172px');
+      } finally {
+        measured();
+      }
     });
 
     it('pulls a parked dock back in when the window shrinks', () => {
@@ -392,7 +443,7 @@ describe('createSetDock', () => {
       window.dispatchEvent(new Event('resize'));
 
       expect(node('.setdock').style.left).toBe('132px');
-      expect(node('.setdock').style.top).toBe('292px');
+      expect(node('.setdock').style.top).toBe('132px');
     });
 
     it('leaves the default corner alone until something moves it', () => {

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -35,6 +35,8 @@ const pin = (id: string, label: string): SetPin => ({
 const node = <T extends HTMLElement>(selector: string) =>
   root.querySelector<T>(selector) as T;
 const rows = () => Array.from(root.querySelectorAll<HTMLElement>('.row'));
+const labelNode = () => node<HTMLElement>('.row .rowlabel');
+const label = () => labelNode().textContent;
 const shown = () => node('.setdock').classList.contains('shown');
 
 const viewport = (width: number, height: number) => {
@@ -140,6 +142,116 @@ describe('createSetDock', () => {
     expect(located).toEqual([]);
   });
 
+  /**
+   * R6.1: the reviewer wrote a sentence about the element; that sentence is
+   * what tells one row from another, not the route › landmark › tag path.
+   */
+  describe('what a row is called', () => {
+    const noted = (note?: string, n?: string): SetPin => ({
+      ...pin('c_a', 'Sessions › list › button "Start"'),
+      note,
+      anchor: { ...pin('c_a', 'x').anchor, n },
+    });
+
+    it('leads with the reviewer’s note', () => {
+      dock.render([noted('The label is cut off.')]);
+
+      expect(label()).toBe('The label is cut off.');
+      expect(labelNode().title).toBe('The label is cut off.');
+    });
+
+    // The row is one line high; the whole note is in the tooltip and the block.
+    it('collapses a multi-line note to one line, whole in the title', () => {
+      dock.render([noted('First line\n\n  second line')]);
+
+      expect(label()).toBe('First line second line');
+      expect(labelNode().title).toBe('First line\n\n  second line');
+    });
+
+    // A link's pin has only the capped note the anchor carries.
+    it('falls back to the note the link carried', () => {
+      dock.render([noted(undefined, 'From the link…')]);
+
+      expect(label()).toBe('From the link…');
+    });
+
+    it('keeps the landmark label when there is no note', () => {
+      dock.render([noted()]);
+
+      expect(label()).toBe('Sessions › list › button "Start"');
+    });
+
+    it('counts a whitespace-only note as none', () => {
+      dock.render([noted('   \n  ')]);
+
+      expect(label()).toBe('Sessions › list › button "Start"');
+    });
+  });
+
+  /**
+   * R7.3: the page matches but the element is not in the DOM right now — a
+   * closed modal, a collapsed section. That is not "not on this page", and the
+   * row is the only thing that can say so.
+   */
+  describe('a pin waiting for its element', () => {
+    const waiting = (over: Partial<SetPin> = {}) =>
+      dock.render(
+        [{ ...pin('c_a', 'Data › rw-permission › span'), ...over } as SetPin],
+        new Map([['c_a', { kind: 'waiting' }]]),
+      );
+
+    it('dims the row and says where the element was', () => {
+      waiting({ anchor: { v: 3, s: '#x', p: '/', tid: 'rw-permission' } });
+
+      expect(rows()[0].classList.contains('waiting')).toBe(true);
+      expect(rows()[0].querySelector('.where')?.textContent).toBe(
+        'waiting — rw-permission',
+      );
+      expect(rows()[0].querySelector<HTMLElement>('.where')?.title).toBe(
+        'Data › rw-permission › span',
+      );
+    });
+
+    it('names the dialog frame of the ⚛️ stack when there is no landmark', () => {
+      waiting({
+        anchor: { v: 3, s: '#x', p: '/', c: { name: 'RadioList' } },
+        stack: [
+          '  in RadioListItem (at /src/a.tsx:1:1)',
+          '  in FolderCreateModalV2 (at /src/b.tsx:2:2)',
+        ],
+      });
+
+      expect(rows()[0].querySelector('.where')?.textContent).toBe(
+        'waiting — FolderCreateModalV2',
+      );
+    });
+
+    it('falls back to the component, then to the element itself', () => {
+      waiting({ anchor: { v: 3, s: '#x', p: '/', c: { name: 'RadioList' } } });
+      expect(rows()[0].querySelector('.where')?.textContent).toBe(
+        'waiting — RadioList',
+      );
+
+      waiting({
+        anchor: { v: 3, s: '#x', p: '/', tag: 'button', txt: 'Save' },
+      });
+      expect(rows()[0].querySelector('.where')?.textContent).toBe(
+        'waiting — button "Save"',
+      );
+    });
+
+    // It is still in the set, and it is still the reviewer's to drop.
+    it('keeps the row a control', () => {
+      waiting();
+
+      rows()[0].querySelector<HTMLButtonElement>('.rowlabel')?.click();
+      rows()[0].querySelector<HTMLButtonElement>('.remove')?.click();
+
+      expect(located).toEqual(['c_a']);
+      expect(removed).toEqual(['c_a']);
+    });
+  });
+
   // ✕ on a card is not ✕ on the pin: the row is what still reaches it.
   describe('a pin whose card is hidden', () => {
     const withHidden = () =>
@@ -195,7 +307,7 @@ describe('createSetDock', () => {
 
     // The dock is the switch's home, so it says which way it is thrown.
     it('says the cards are off once the owner says so', () => {
-      dock.render([pin('c_a', 'a')], true);
+      dock.render([pin('c_a', 'a')], new Map(), true);
 
       expect(node('.cards').textContent).toBe('Cards');
       expect(node('.cards').getAttribute('aria-pressed')).toBe('true');
@@ -207,7 +319,7 @@ describe('createSetDock', () => {
       dock.render([pin('c_a', 'a')]);
       const named = node('.cards').getAttribute('aria-label');
 
-      dock.render([pin('c_a', 'a')], true);
+      dock.render([pin('c_a', 'a')], new Map(), true);
 
       expect(node('.cards').getAttribute('aria-label')).toBe(named);
       expect(node('.cards').title).toBe(named);

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -226,6 +226,36 @@ describe('createSetDock', () => {
       );
     });
 
+    // Every frame carries its source path, so a component that merely LIVES
+    // in a `*Modal.tsx` is not the thing the pin was inside.
+    it('reads the frame name, not the file path it was declared in', () => {
+      waiting({
+        stack: [
+          '  in RadioListItem (at /src/components/VFolderCreateModal.tsx:31:7)',
+          '  in FolderDrawer (at /src/components/panels.tsx:8:3)',
+        ],
+      });
+
+      expect(rows()[0].querySelector('.where')?.textContent).toBe(
+        'waiting — FolderDrawer',
+      );
+    });
+
+    // react-grab emits frames that name only a file; the row must not read
+    // `waiting — in /src/components/FolderCreateModalV2.tsx`.
+    it('names a file-only frame by its basename', () => {
+      waiting({
+        stack: [
+          '  in RadioListItem (@astryxdesign/core)',
+          '  in /src/components/FolderCreateModalV2.tsx',
+        ],
+      });
+
+      expect(rows()[0].querySelector('.where')?.textContent).toBe(
+        'waiting — FolderCreateModalV2',
+      );
+    });
+
     it('falls back to the component, then to the element itself', () => {
       waiting({ anchor: { v: 3, s: '#x', p: '/', c: { name: 'RadioList' } } });
       expect(rows()[0].querySelector('.where')?.textContent).toBe(

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -1,0 +1,156 @@
+/**
+ * The set dock: the draft set listed bottom-right, with the set-wide actions.
+ * It lists the SET, not what the layer managed to draw — a card can be
+ * anywhere on the page, and two of them can overlap, so this is the one place
+ * that reaches every pin.
+ *
+ * Labels come off links a stranger may have written, so every one of them goes
+ * in through `textContent`. Copy-all runs inside the click that asked for it:
+ * the gateway origin has only `execCommand`, so nothing may be awaited first.
+ */
+import type { SetPin } from './types.js';
+
+const STYLE = `
+  .setdock {
+    position: fixed; right: 12px; bottom: 12px; z-index: 2147483000;
+    display: none; flex-direction: column; width: 260px;
+    background: var(--bai-review-surface); color: var(--bai-review-text);
+    border: 1px solid var(--bai-review-border); border-radius: 8px;
+    box-shadow: 0 4px 18px var(--bai-review-shadow);
+    font-size: 13px; pointer-events: auto;
+  }
+  .setdock.shown { display: flex; }
+  .setdock.folded { display: none; }
+  .setdock .head {
+    display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+    padding: 6px 8px; border-bottom: 1px solid var(--bai-review-border);
+  }
+  .setdock .title { font-weight: 600; margin-right: auto; }
+  .setdock .act {
+    cursor: pointer; border: 0; background: none; padding: 2px 4px;
+    font: inherit; color: var(--bai-review-text-dim); border-radius: 4px;
+  }
+  .setdock .act:hover { color: var(--bai-review-text); }
+  .setdock .confirm { display: none; align-items: center; gap: 4px; }
+  .setdock.confirming .confirm { display: flex; }
+  .setdock.confirming .clear { display: none; }
+  .setdock .rows { max-height: 40vh; overflow-y: auto; }
+  .setdock .row {
+    display: flex; align-items: center; gap: 6px; padding: 4px 8px;
+  }
+  .setdock .idx {
+    flex: none; width: 16px; text-align: right;
+    color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
+  }
+  /* One line per pin: the whole label is in the block, not in this list. */
+  .setdock .rowlabel {
+    flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+export interface SetDockOptions {
+  /** The overlay's shadow root — the dock is a sibling of the pin layer. */
+  root: ShadowRoot;
+  /** Runs inside the click: build and write the set, synchronously. */
+  onCopyAll: () => void;
+  onClear: () => void;
+  /** Scroll the page back to this pin. */
+  onLocate: (id: string) => void;
+}
+
+const button = (
+  className: string,
+  text: string,
+  label: string,
+): HTMLButtonElement => {
+  const node = document.createElement('button');
+  node.className = `act ${className}`;
+  node.textContent = text;
+  // The glyph is the accessible name unless one is given, and "⧉" is not it.
+  node.title = label;
+  node.setAttribute('aria-label', label);
+  return node;
+};
+
+export function createSetDock(options: SetDockOptions) {
+  const style = document.createElement('style');
+  style.textContent = STYLE;
+  const dock = document.createElement('div');
+  dock.className = 'setdock';
+  const head = document.createElement('div');
+  head.className = 'head';
+  const title = document.createElement('span');
+  title.className = 'title';
+  const copyAll = button(
+    'copyall',
+    '⧉ Copy all',
+    'Copy every pin as one comment',
+  );
+  const clear = button('clear', '🗑 Clear all', 'Clear the whole set');
+  const confirm = document.createElement('span');
+  confirm.className = 'confirm';
+  const confirmText = document.createElement('span');
+  const yes = button('yes', '✓', 'Yes, clear the whole set');
+  const no = button('no', '✕', 'Keep the set');
+  confirm.append(confirmText, yes, no);
+  head.append(title, copyAll, clear, confirm);
+  const rows = document.createElement('div');
+  rows.className = 'rows';
+  dock.append(head, rows);
+  options.root.append(style, dock);
+
+  /** Clearing is the one action with no undo, so it is asked twice. */
+  const setConfirming = (on: boolean) =>
+    dock.classList.toggle('confirming', on);
+
+  copyAll.addEventListener('click', () => options.onCopyAll());
+  clear.addEventListener('click', () => setConfirming(true));
+  no.addEventListener('click', () => setConfirming(false));
+  yes.addEventListener('click', () => {
+    setConfirming(false);
+    options.onClear();
+  });
+
+  function render(pins: SetPin[]) {
+    setConfirming(false);
+    dock.classList.toggle('shown', pins.length > 0);
+    title.textContent = `📍 ${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
+    clear.textContent = `🗑 Clear all (${pins.length})`;
+    confirmText.textContent = `Clear all ${pins.length}?`;
+    rows.replaceChildren(
+      ...pins.map((pin, index) => {
+        const row = document.createElement('div');
+        row.className = 'row';
+        row.dataset.pinId = pin.id;
+        const idx = document.createElement('span');
+        idx.className = 'idx';
+        idx.textContent = String(index + 1);
+        const label = document.createElement('span');
+        label.className = 'rowlabel';
+        label.textContent = pin.label;
+        label.title = pin.label;
+        const locate = button('locate', '📍', 'Scroll back to this element');
+        locate.addEventListener('click', () => options.onLocate(pin.id));
+        row.append(idx, label, locate);
+        return row;
+      }),
+    );
+  }
+
+  return {
+    render,
+    /**
+     * Mid-pick the dock is 260px of the page the reviewer cannot pick through,
+     * the same way the cards are — so it folds away with them.
+     */
+    setCollapsed: (next: boolean) => dock.classList.toggle('folded', next),
+    /** Tests and hot reloads: one dock lives as long as the page. */
+    dispose() {
+      dock.remove();
+      style.remove();
+    },
+  };
+}
+
+export type SetDock = ReturnType<typeof createSetDock>;

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -245,11 +245,11 @@ export function createSetDock(options: SetDockOptions) {
   options.root.append(style, dock);
 
   /**
-   * Dragged position, or `null` for the default bottom-right corner. Clamped
-   * on every move, on resize and on restore, so a dock parked at the edge of a
-   * wide window is still reachable in a narrow one.
+   * Where the reviewer dragged it, or `null` for the default corner. The paint
+   * clamps a COPY of it, so a window too small to hold that spot borrows it
+   * for as long as it is small rather than overwriting it.
    */
-  let pos: DockPos | null = null;
+  let wanted: DockPos | null = null;
 
   function clamp({ left, top }: DockPos): DockPos {
     const width = dock.offsetWidth || DOCK_WIDTH;
@@ -268,17 +268,18 @@ export function createSetDock(options: SetDockOptions) {
 
   /** `right`/`bottom` are the CSS default; a placed dock has to drop them. */
   function moveTo(next: DockPos) {
-    pos = clamp(next);
-    dock.style.left = `${pos.left}px`;
-    dock.style.top = `${pos.top}px`;
+    wanted = next;
+    const at = clamp(next);
+    dock.style.left = `${at.left}px`;
+    dock.style.top = `${at.top}px`;
     dock.style.right = 'auto';
     dock.style.bottom = 'auto';
   }
 
   function savePos() {
-    if (!pos) return;
+    if (!wanted) return;
     try {
-      sessionStorage.setItem(DOCK_POS_KEY, JSON.stringify(pos));
+      sessionStorage.setItem(DOCK_POS_KEY, JSON.stringify(wanted));
     } catch {
       // Storage off or full: the dock still sits where it was dragged.
     }
@@ -326,7 +327,7 @@ export function createSetDock(options: SetDockOptions) {
   grip.addEventListener('pointercancel', endDrag);
 
   const reclamp = () => {
-    if (pos) moveTo(pos);
+    if (wanted) moveTo(wanted);
   };
   window.addEventListener('resize', reclamp);
 

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -22,6 +22,8 @@ export const DOCK_POS_KEY = 'bai-review:dock-pos';
 
 /** The dock's own `width`, for a jsdom clamp that has no layout to read. */
 const DOCK_WIDTH = 260;
+/** Stand-in height while the dock is still `display: none` and measures 0. */
+const DOCK_HEIGHT = 160;
 /** Margin the dock keeps to every viewport edge, dragged or default. */
 const EDGE_PAD = 8;
 
@@ -200,7 +202,7 @@ export function createSetDock(options: SetDockOptions) {
 
   function clamp({ left, top }: DockPos): DockPos {
     const width = dock.offsetWidth || DOCK_WIDTH;
-    const height = dock.offsetHeight;
+    const height = dock.offsetHeight || DOCK_HEIGHT;
     return {
       left: Math.min(
         Math.max(left, EDGE_PAD),
@@ -338,6 +340,9 @@ export function createSetDock(options: SetDockOptions) {
         return row;
       }),
     );
+    // The restore clamped against the stand-in height, with the dock still
+    // `display: none`; shown and filled, it has a real box to clamp against.
+    reclamp();
   }
 
   return {

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -32,6 +32,43 @@ export interface DockPos {
   top: number;
 }
 
+/**
+ * Where a pin is, as far as the dock is concerned. `waiting` is this page with
+ * the element not in the DOM right now — a closed modal, a collapsed section —
+ * which is not the same as gone, and the row is what says so (R7.3).
+ */
+export type PinPlace = { kind: 'here' } | { kind: 'waiting' };
+
+/** Component names a reviewer would recognise as "the thing it was inside". */
+const DIALOGISH = /dialog|modal|drawer|sheet|popover/i;
+
+/** `  in CreateButton (at /src/Create.tsx:12:8)` → `CreateButton`. */
+const frameName = (line: string): string =>
+  /\bin\s+([\w$.]+)/.exec(line)?.[1] ?? line.trim();
+
+/**
+ * Where the reviewer last saw a waiting pin's element, in the order R7.3
+ * gives: the landmark, else the dialog-ish frame of its ⚛️ stack, else the
+ * component, else the element itself.
+ */
+export function whereItWas(pin: SetPin): string {
+  const { tid, c, tag, txt } = pin.anchor;
+  if (tid) return tid;
+  const frame = pin.stack.find((line) => DIALOGISH.test(line));
+  if (frame) return frameName(frame);
+  const name = c?.dn ?? c?.name;
+  if (name) return name;
+  if (txt) return `${tag ?? 'element'} "${txt.slice(0, 40)}"`;
+  return tag ?? 'that element';
+}
+
+/**
+ * The row is one line: the reviewer's own note names the pin, and only a pin
+ * with none falls back to the landmark label (R6.1). Whitespace is no note.
+ */
+const rowNote = (pin: SetPin): string =>
+  (pin.note ?? pin.anchor.n ?? '').trim();
+
 const STYLE = `
   .setdock {
     position: fixed; right: 12px; bottom: 12px; z-index: 2147483000;
@@ -88,6 +125,13 @@ const STYLE = `
   }
   /* Its card is hidden; the pin is still in the set and still on the page. */
   .setdock .row.off .rowlabel { opacity: 0.55; }
+  /* Its page is this one; its element is not rendered right now. */
+  .setdock .row.waiting .rowlabel { opacity: 0.55; }
+  /* Where that pin was — the row is the only thing it has on screen. */
+  .setdock .where {
+    flex: none; max-width: 55%; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; font-size: 11px; color: var(--bai-review-text-dim);
+  }
 ${ICON_STYLE}
 `;
 
@@ -295,8 +339,16 @@ export function createSetDock(options: SetDockOptions) {
     options.onClear();
   });
 
-  /** `cardsHidden` is the switch's own state; each pin carries its own ✕. */
-  function render(pins: SetPin[], cardsHidden = false) {
+  /**
+   * `places` maps a pin to what the layer could do with it; anything missing
+   * is drawn here. `cardsHidden` is the switch's own state; each pin carries
+   * its own ✕.
+   */
+  function render(
+    pins: SetPin[],
+    places: ReadonlyMap<string, PinPlace> = new Map(),
+    cardsHidden = false,
+  ) {
     setConfirming(false);
     dock.classList.toggle('shown', pins.length > 0);
     titleText.textContent = `${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
@@ -316,15 +368,24 @@ export function createSetDock(options: SetDockOptions) {
         idx.textContent = String(index + 1);
         const label = document.createElement('button');
         label.className = 'rowlabel';
-        label.textContent = pin.label;
-        label.title = pin.label;
+        const note = rowNote(pin);
+        label.textContent = note ? note.replace(/\s+/g, ' ') : pin.label;
+        label.title = note || pin.label;
         // The card comes back with the pin the reviewer just asked to see.
         label.addEventListener('click', () => {
           if (pin.hidden) options.onUnhide(pin.id);
           options.onLocate(pin.id);
         });
         row.append(idx, label);
-        if (pin.hidden) {
+        const place = places.get(pin.id);
+        if (place?.kind === 'waiting') {
+          row.classList.add('waiting');
+          const where = document.createElement('span');
+          where.className = 'where';
+          where.textContent = `waiting — ${whereItWas(pin)}`;
+          where.title = pin.label;
+          row.append(where);
+        } else if (pin.hidden) {
           row.classList.add('off');
           const unhide = button('unhide', 'eye', 'Show this pin’s card again');
           unhide.addEventListener('click', () => options.onUnhide(pin.id));

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -326,8 +326,12 @@ export function createSetDock(options: SetDockOptions) {
   grip.addEventListener('pointerup', endDrag);
   grip.addEventListener('pointercancel', endDrag);
 
+  /**
+   * Folded, the dock is `display: none` and measures the stand-in box, so a
+   * clamp made then parks the real one off the bottom. It waits for the unfold.
+   */
   const reclamp = () => {
-    if (wanted) moveTo(wanted);
+    if (wanted && !dock.classList.contains('folded')) moveTo(wanted);
   };
   window.addEventListener('resize', reclamp);
 
@@ -425,9 +429,13 @@ export function createSetDock(options: SetDockOptions) {
     render,
     /**
      * Mid-pick the dock is 260px of the page the reviewer cannot pick through,
-     * the same way the cards are — so it folds away with them.
+     * the same way the cards are — so it folds away with them. Adding a pin
+     * re-renders it while it is folded, so the clamp it skipped happens here.
      */
-    setCollapsed: (next: boolean) => dock.classList.toggle('folded', next),
+    setCollapsed(next: boolean) {
+      dock.classList.toggle('folded', next);
+      if (!next) reclamp();
+    },
     /** Tests and hot reloads: one dock lives as long as the page. */
     dispose() {
       window.removeEventListener('resize', reclamp);

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -99,9 +99,9 @@ export interface SetDockOptions {
   onClear: () => void;
   /** Scroll the page back to this pin, and beat its marker again. */
   onLocate: (id: string) => void;
-  /** 🗑 on one row: that pin leaves the set. No confirm — one pin is cheap. */
+  /** A row's remove button: that pin leaves the set. No confirm — it is one pin. */
   onRemove: (id: string) => void;
-  /** Its card comes back: the row's 👁, or the row itself. */
+  /** Its card comes back: the row's eye button, or the row itself. */
   onUnhide: (id: string) => void;
   /** The header switch: every card off, or on again. */
   onToggleCards: () => void;

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -8,7 +8,11 @@
  * in through `textContent`. Copy-all runs inside the click that asked for it:
  * the gateway origin has only `execCommand`, so nothing may be awaited first.
  */
+import { isMac } from './picker.js';
 import type { SetPin } from './types.js';
+
+/** ⌘⇧H / Ctrl⇧H — plain ⌘H hides the app and Ctrl+H opens history. */
+export const CARDS_CHORD = isMac() ? '⌘⇧H' : 'Ctrl⇧H';
 
 const STYLE = `
   .setdock {
@@ -34,6 +38,9 @@ const STYLE = `
   .setdock .confirm { display: none; align-items: center; gap: 4px; }
   .setdock.confirming .confirm { display: flex; }
   .setdock.confirming .clear { display: none; }
+  .setdock .chord {
+    font-size: 11px; color: var(--bai-review-text-dim);
+  }
   .setdock .rows { max-height: 40vh; overflow-y: auto; }
   .setdock .row {
     display: flex; align-items: center; gap: 6px; padding: 4px 8px;
@@ -42,11 +49,15 @@ const STYLE = `
     flex: none; width: 16px; text-align: right;
     color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
   }
-  /* One line per pin: the whole label is in the block, not in this list. */
+  /* One line per pin: the whole label is in the block, not in this list. The
+     row IS the control — clicking it goes to the pin and beats its marker. */
   .setdock .rowlabel {
     flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: nowrap; text-align: left; cursor: pointer; border: 0;
+    background: none; padding: 0; font: inherit; color: inherit;
   }
+  /* Its card is hidden; the pin is still in the set and still on the page. */
+  .setdock .row.off .rowlabel { opacity: 0.55; }
 `;
 
 export interface SetDockOptions {
@@ -55,8 +66,14 @@ export interface SetDockOptions {
   /** Runs inside the click: build and write the set, synchronously. */
   onCopyAll: () => void;
   onClear: () => void;
-  /** Scroll the page back to this pin. */
+  /** Scroll the page back to this pin, and beat its marker again. */
   onLocate: (id: string) => void;
+  /** 🗑 on one row: that pin leaves the set. No confirm — one pin is cheap. */
+  onRemove: (id: string) => void;
+  /** Its card comes back: the row's 👁, or the row itself. */
+  onUnhide: (id: string) => void;
+  /** The header switch: every card off, or on again. */
+  onToggleCards: () => void;
 }
 
 const button = (
@@ -88,13 +105,17 @@ export function createSetDock(options: SetDockOptions) {
     'Copy every pin as one comment',
   );
   const clear = button('clear', '🗑 Clear all', 'Clear the whole set');
+  const cards = button('cards', '👁 Cards', 'Hide every pin card');
+  const chord = document.createElement('span');
+  chord.className = 'chord';
+  chord.textContent = CARDS_CHORD;
   const confirm = document.createElement('span');
   confirm.className = 'confirm';
   const confirmText = document.createElement('span');
   const yes = button('yes', '✓', 'Yes, clear the whole set');
   const no = button('no', '✕', 'Keep the set');
   confirm.append(confirmText, yes, no);
-  head.append(title, copyAll, clear, confirm);
+  head.append(title, chord, cards, copyAll, clear, confirm);
   const rows = document.createElement('div');
   rows.className = 'rows';
   dock.append(head, rows);
@@ -105,6 +126,7 @@ export function createSetDock(options: SetDockOptions) {
     dock.classList.toggle('confirming', on);
 
   copyAll.addEventListener('click', () => options.onCopyAll());
+  cards.addEventListener('click', () => options.onToggleCards());
   clear.addEventListener('click', () => setConfirming(true));
   no.addEventListener('click', () => setConfirming(false));
   yes.addEventListener('click', () => {
@@ -112,12 +134,20 @@ export function createSetDock(options: SetDockOptions) {
     options.onClear();
   });
 
-  function render(pins: SetPin[]) {
+  /** `cardsHidden` is the switch's own state; each pin carries its own ✕. */
+  function render(pins: SetPin[], cardsHidden = false) {
     setConfirming(false);
     dock.classList.toggle('shown', pins.length > 0);
     title.textContent = `📍 ${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
     clear.textContent = `🗑 Clear all (${pins.length})`;
     confirmText.textContent = `Clear all ${pins.length}?`;
+    cards.textContent = cardsHidden ? '🙈 Cards' : '👁 Cards';
+    cards.setAttribute('aria-pressed', String(cardsHidden));
+    const cardsLabel = cardsHidden
+      ? `Show every pin card (${CARDS_CHORD})`
+      : `Hide every pin card (${CARDS_CHORD})`;
+    cards.title = cardsLabel;
+    cards.setAttribute('aria-label', cardsLabel);
     rows.replaceChildren(
       ...pins.map((pin, index) => {
         const row = document.createElement('div');
@@ -126,13 +156,25 @@ export function createSetDock(options: SetDockOptions) {
         const idx = document.createElement('span');
         idx.className = 'idx';
         idx.textContent = String(index + 1);
-        const label = document.createElement('span');
+        const label = document.createElement('button');
         label.className = 'rowlabel';
         label.textContent = pin.label;
         label.title = pin.label;
-        const locate = button('locate', '📍', 'Scroll back to this element');
-        locate.addEventListener('click', () => options.onLocate(pin.id));
-        row.append(idx, label, locate);
+        // The card comes back with the pin the reviewer just asked to see.
+        label.addEventListener('click', () => {
+          if (pin.hidden) options.onUnhide(pin.id);
+          options.onLocate(pin.id);
+        });
+        row.append(idx, label);
+        if (pin.hidden) {
+          row.classList.add('off');
+          const unhide = button('unhide', '🙈', 'Show this pin’s card again');
+          unhide.addEventListener('click', () => options.onUnhide(pin.id));
+          row.append(unhide);
+        }
+        const remove = button('remove', '🗑', 'Remove this pin from the set');
+        remove.addEventListener('click', () => options.onRemove(pin.id));
+        row.append(remove);
         return row;
       }),
     );

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -14,6 +14,9 @@ import type { SetPin } from './types.js';
 /** ⌘⇧H / Ctrl⇧H — plain ⌘H hides the app and Ctrl+H opens history. */
 export const CARDS_CHORD = isMac() ? '⌘⇧H' : 'Ctrl⇧H';
 
+/** 🙈 in this dock means "hidden"; 👁 on a row is the action that undoes it. */
+const CARDS_LABEL = `Pin cards (${CARDS_CHORD})`;
+
 const STYLE = `
   .setdock {
     position: fixed; right: 12px; bottom: 12px; z-index: 2147483000;
@@ -105,7 +108,7 @@ export function createSetDock(options: SetDockOptions) {
     'Copy every pin as one comment',
   );
   const clear = button('clear', '🗑 Clear all', 'Clear the whole set');
-  const cards = button('cards', '👁 Cards', 'Hide every pin card');
+  const cards = button('cards', '👁 Cards', CARDS_LABEL);
   const chord = document.createElement('span');
   chord.className = 'chord';
   chord.textContent = CARDS_CHORD;
@@ -115,7 +118,7 @@ export function createSetDock(options: SetDockOptions) {
   const yes = button('yes', '✓', 'Yes, clear the whole set');
   const no = button('no', '✕', 'Keep the set');
   confirm.append(confirmText, yes, no);
-  head.append(title, chord, cards, copyAll, clear, confirm);
+  head.append(title, cards, chord, copyAll, clear, confirm);
   const rows = document.createElement('div');
   rows.className = 'rows';
   dock.append(head, rows);
@@ -141,13 +144,10 @@ export function createSetDock(options: SetDockOptions) {
     title.textContent = `📍 ${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
     clear.textContent = `🗑 Clear all (${pins.length})`;
     confirmText.textContent = `Clear all ${pins.length}?`;
+    // A toggle's name is stable and `aria-pressed` carries the state; naming
+    // it after the action it would take announces the opposite of the state.
     cards.textContent = cardsHidden ? '🙈 Cards' : '👁 Cards';
     cards.setAttribute('aria-pressed', String(cardsHidden));
-    const cardsLabel = cardsHidden
-      ? `Show every pin card (${CARDS_CHORD})`
-      : `Hide every pin card (${CARDS_CHORD})`;
-    cards.title = cardsLabel;
-    cards.setAttribute('aria-label', cardsLabel);
     rows.replaceChildren(
       ...pins.map((pin, index) => {
         const row = document.createElement('div');
@@ -168,7 +168,7 @@ export function createSetDock(options: SetDockOptions) {
         row.append(idx, label);
         if (pin.hidden) {
           row.classList.add('off');
-          const unhide = button('unhide', '🙈', 'Show this pin’s card again');
+          const unhide = button('unhide', '👁', 'Show this pin’s card again');
           unhide.addEventListener('click', () => options.onUnhide(pin.id));
           row.append(unhide);
         }

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -42,9 +42,14 @@ export type PinPlace = { kind: 'here' } | { kind: 'waiting' };
 /** Component names a reviewer would recognise as "the thing it was inside". */
 const DIALOGISH = /dialog|modal|drawer|sheet|popover/i;
 
-/** `  in CreateButton (at /src/Create.tsx:12:8)` → `CreateButton`. */
+/**
+ * `  in CreateButton (at /src/Create.tsx:12:8)` → `CreateButton`; a frame that
+ * names only its file (`  in /src/FolderModal.tsx`) → `FolderModal`.
+ */
 const frameName = (line: string): string =>
-  /\bin\s+([\w$.]+)/.exec(line)?.[1] ?? line.trim();
+  /\bin\s+([\w$.]+)/.exec(line)?.[1] ??
+  /([\w$.-]+)\.[jt]sx?\b/.exec(line)?.[1] ??
+  line.trim();
 
 /**
  * Where the reviewer last saw a waiting pin's element, in the order R7.3
@@ -54,7 +59,9 @@ const frameName = (line: string): string =>
 export function whereItWas(pin: SetPin): string {
   const { tid, c, tag, txt } = pin.anchor;
   if (tid) return tid;
-  const frame = pin.stack.find((line) => DIALOGISH.test(line));
+  // The NAME, never the raw line: every frame carries its source path, and
+  // `RadioListItem (at …/VFolderCreateModal.tsx)` is not a dialog.
+  const frame = pin.stack.find((line) => DIALOGISH.test(frameName(line)));
   if (frame) return frameName(frame);
   const name = c?.dn ?? c?.name;
   if (name) return name;

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -8,14 +8,27 @@
  * in through `textContent`. Copy-all runs inside the click that asked for it:
  * the gateway origin has only `execCommand`, so nothing may be awaited first.
  */
+import { icon, ICON_STYLE, type IconName } from './icons.js';
 import { isMac } from './picker.js';
 import type { SetPin } from './types.js';
 
 /** ⌘⇧H / Ctrl⇧H — plain ⌘H hides the app and Ctrl+H opens history. */
 export const CARDS_CHORD = isMac() ? '⌘⇧H' : 'Ctrl⇧H';
 
-/** 🙈 in this dock means "hidden"; 👁 on a row is the action that undoes it. */
 const CARDS_LABEL = `Pin cards (${CARDS_CHORD})`;
+
+/** Where a dragged dock is parked, per tab. Cleared with the tab, not the set. */
+export const DOCK_POS_KEY = 'bai-review:dock-pos';
+
+/** The dock's own `width`, for a jsdom clamp that has no layout to read. */
+const DOCK_WIDTH = 260;
+/** Margin the dock keeps to every viewport edge, dragged or default. */
+const EDGE_PAD = 8;
+
+export interface DockPos {
+  left: number;
+  top: number;
+}
 
 const STYLE = `
   .setdock {
@@ -32,10 +45,22 @@ const STYLE = `
     display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
     padding: 6px 8px; border-bottom: 1px solid var(--bai-review-border);
   }
-  .setdock .title { font-weight: 600; margin-right: auto; }
+  /* The whole dock moves from here, so it takes the pointer and never lets
+     the gesture reach the page as a selection or a pick. */
+  .setdock .grip {
+    flex: none; display: flex; align-items: center; cursor: grab;
+    color: var(--bai-review-text-dim); touch-action: none;
+    -webkit-user-select: none; user-select: none;
+  }
+  .setdock.dragging .grip { cursor: grabbing; }
+  .setdock .title {
+    font-weight: 600; margin-right: auto; display: flex; align-items: center;
+    gap: 4px;
+  }
   .setdock .act {
     cursor: pointer; border: 0; background: none; padding: 2px 4px;
     font: inherit; color: var(--bai-review-text-dim); border-radius: 4px;
+    display: inline-flex; align-items: center; gap: 4px;
   }
   .setdock .act:hover { color: var(--bai-review-text); }
   .setdock .confirm { display: none; align-items: center; gap: 4px; }
@@ -61,6 +86,7 @@ const STYLE = `
   }
   /* Its card is hidden; the pin is still in the set and still on the page. */
   .setdock .row.off .rowlabel { opacity: 0.55; }
+${ICON_STYLE}
 `;
 
 export interface SetDockOptions {
@@ -79,18 +105,51 @@ export interface SetDockOptions {
   onToggleCards: () => void;
 }
 
+/**
+ * The icon is `aria-hidden`, so `label` is the button's whole accessible name
+ * whether or not it also shows `text`.
+ */
 const button = (
   className: string,
-  text: string,
+  name: IconName,
   label: string,
+  text?: string,
 ): HTMLButtonElement => {
   const node = document.createElement('button');
   node.className = `act ${className}`;
-  node.textContent = text;
-  // The glyph is the accessible name unless one is given, and "⧉" is not it.
+  node.append(icon(name));
+  if (text !== undefined) {
+    const span = document.createElement('span');
+    span.className = 'lbl';
+    span.textContent = text;
+    node.append(span);
+  }
   node.title = label;
   node.setAttribute('aria-label', label);
   return node;
+};
+
+const setText = (node: HTMLElement, text: string) => {
+  (node.querySelector('.lbl') as HTMLElement).textContent = text;
+};
+
+const setIcon = (node: HTMLElement, name: IconName) => {
+  node.querySelector('svg')?.replaceWith(icon(name));
+};
+
+/** A tab that refuses storage still drags; it just forgets on reload. */
+const readPos = (): DockPos | null => {
+  try {
+    const raw = sessionStorage.getItem(DOCK_POS_KEY);
+    const value = raw ? (JSON.parse(raw) as unknown) : null;
+    if (!value || typeof value !== 'object') return null;
+    const { left, top } = value as Record<string, unknown>;
+    if (typeof left !== 'number' || typeof top !== 'number') return null;
+    if (!Number.isFinite(left) || !Number.isFinite(top)) return null;
+    return { left, top };
+  } catch {
+    return null;
+  }
 };
 
 export function createSetDock(options: SetDockOptions) {
@@ -100,29 +159,126 @@ export function createSetDock(options: SetDockOptions) {
   dock.className = 'setdock';
   const head = document.createElement('div');
   head.className = 'head';
+  const grip = document.createElement('span');
+  grip.className = 'grip';
+  grip.append(icon('grip-vertical'));
+  grip.title = 'Drag the dock';
   const title = document.createElement('span');
   title.className = 'title';
+  title.append(icon('map-pin'));
+  const titleText = document.createElement('span');
+  title.append(titleText);
   const copyAll = button(
     'copyall',
-    '⧉ Copy all',
+    'files',
     'Copy every pin as one comment',
+    'Copy all',
   );
-  const clear = button('clear', '🗑 Clear all', 'Clear the whole set');
-  const cards = button('cards', '👁 Cards', CARDS_LABEL);
+  const clear = button('clear', 'trash-2', 'Clear the whole set', 'Clear all');
+  const cards = button('cards', 'eye', CARDS_LABEL, 'Cards');
   const chord = document.createElement('span');
   chord.className = 'chord';
   chord.textContent = CARDS_CHORD;
   const confirm = document.createElement('span');
   confirm.className = 'confirm';
   const confirmText = document.createElement('span');
-  const yes = button('yes', '✓', 'Yes, clear the whole set');
-  const no = button('no', '✕', 'Keep the set');
+  const yes = button('yes', 'check', 'Yes, clear the whole set');
+  const no = button('no', 'x', 'Keep the set');
   confirm.append(confirmText, yes, no);
-  head.append(title, cards, chord, copyAll, clear, confirm);
+  head.append(grip, title, cards, chord, copyAll, clear, confirm);
   const rows = document.createElement('div');
   rows.className = 'rows';
   dock.append(head, rows);
   options.root.append(style, dock);
+
+  /**
+   * Dragged position, or `null` for the default bottom-right corner. Clamped
+   * on every move, on resize and on restore, so a dock parked at the edge of a
+   * wide window is still reachable in a narrow one.
+   */
+  let pos: DockPos | null = null;
+
+  function clamp({ left, top }: DockPos): DockPos {
+    const width = dock.offsetWidth || DOCK_WIDTH;
+    const height = dock.offsetHeight;
+    return {
+      left: Math.min(
+        Math.max(left, EDGE_PAD),
+        Math.max(EDGE_PAD, window.innerWidth - width - EDGE_PAD),
+      ),
+      top: Math.min(
+        Math.max(top, EDGE_PAD),
+        Math.max(EDGE_PAD, window.innerHeight - height - EDGE_PAD),
+      ),
+    };
+  }
+
+  /** `right`/`bottom` are the CSS default; a placed dock has to drop them. */
+  function moveTo(next: DockPos) {
+    pos = clamp(next);
+    dock.style.left = `${pos.left}px`;
+    dock.style.top = `${pos.top}px`;
+    dock.style.right = 'auto';
+    dock.style.bottom = 'auto';
+  }
+
+  function savePos() {
+    if (!pos) return;
+    try {
+      sessionStorage.setItem(DOCK_POS_KEY, JSON.stringify(pos));
+    } catch {
+      // Storage off or full: the dock still sits where it was dragged.
+    }
+  }
+
+  /** Grab offset inside the dock, so it does not jump to the cursor. */
+  let grab: { dx: number; dy: number } | null = null;
+
+  grip.addEventListener('pointerdown', (evt) => {
+    if (evt.button) return;
+    const box = dock.getBoundingClientRect();
+    grab = { dx: evt.clientX - box.left, dy: evt.clientY - box.top };
+    // Without this the gesture becomes a text selection, and react-grab's
+    // select mode would read it as a pick.
+    evt.preventDefault();
+    evt.stopPropagation();
+    dock.classList.add('dragging');
+    // Capture keeps the moves — and the click the release synthesises — on the
+    // grip, so a drag that ends over a row never fires that row's action.
+    try {
+      grip.setPointerCapture(evt.pointerId);
+    } catch {
+      // jsdom, and any browser that refuses a capture it has no pointer for.
+    }
+  });
+
+  grip.addEventListener('pointermove', (evt) => {
+    if (!grab) return;
+    evt.preventDefault();
+    moveTo({ left: evt.clientX - grab.dx, top: evt.clientY - grab.dy });
+  });
+
+  const endDrag = (evt: PointerEvent) => {
+    if (!grab) return;
+    grab = null;
+    dock.classList.remove('dragging');
+    try {
+      grip.releasePointerCapture(evt.pointerId);
+    } catch {
+      // Never captured; nothing to release.
+    }
+    savePos();
+  };
+  grip.addEventListener('pointerup', endDrag);
+  grip.addEventListener('pointercancel', endDrag);
+
+  const reclamp = () => {
+    if (pos) moveTo(pos);
+  };
+  window.addEventListener('resize', reclamp);
+
+  const stored = readPos();
+  if (stored) moveTo(stored);
 
   /** Clearing is the one action with no undo, so it is asked twice. */
   const setConfirming = (on: boolean) =>
@@ -141,12 +297,12 @@ export function createSetDock(options: SetDockOptions) {
   function render(pins: SetPin[], cardsHidden = false) {
     setConfirming(false);
     dock.classList.toggle('shown', pins.length > 0);
-    title.textContent = `📍 ${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
-    clear.textContent = `🗑 Clear all (${pins.length})`;
+    titleText.textContent = `${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
+    setText(clear, `Clear all (${pins.length})`);
     confirmText.textContent = `Clear all ${pins.length}?`;
     // A toggle's name is stable and `aria-pressed` carries the state; naming
     // it after the action it would take announces the opposite of the state.
-    cards.textContent = cardsHidden ? '🙈 Cards' : '👁 Cards';
+    setIcon(cards, cardsHidden ? 'eye-off' : 'eye');
     cards.setAttribute('aria-pressed', String(cardsHidden));
     rows.replaceChildren(
       ...pins.map((pin, index) => {
@@ -168,11 +324,15 @@ export function createSetDock(options: SetDockOptions) {
         row.append(idx, label);
         if (pin.hidden) {
           row.classList.add('off');
-          const unhide = button('unhide', '👁', 'Show this pin’s card again');
+          const unhide = button('unhide', 'eye', 'Show this pin’s card again');
           unhide.addEventListener('click', () => options.onUnhide(pin.id));
           row.append(unhide);
         }
-        const remove = button('remove', '🗑', 'Remove this pin from the set');
+        const remove = button(
+          'remove',
+          'trash-2',
+          'Remove this pin from the set',
+        );
         remove.addEventListener('click', () => options.onRemove(pin.id));
         row.append(remove);
         return row;
@@ -189,6 +349,7 @@ export function createSetDock(options: SetDockOptions) {
     setCollapsed: (next: boolean) => dock.classList.toggle('folded', next),
     /** Tests and hot reloads: one dock lives as long as the page. */
     dispose() {
+      window.removeEventListener('resize', reclamp);
       dock.remove();
       style.remove();
     },

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -337,6 +337,9 @@ export function createSetDock(options: SetDockOptions) {
   const setConfirming = (on: boolean) =>
     dock.classList.toggle('confirming', on);
 
+  /** The set the rows were last built from, as ids: what a re-render compares. */
+  let listed = '';
+
   copyAll.addEventListener('click', () => options.onCopyAll());
   cards.addEventListener('click', () => options.onToggleCards());
   clear.addEventListener('click', () => setConfirming(true));
@@ -356,7 +359,11 @@ export function createSetDock(options: SetDockOptions) {
     places: ReadonlyMap<string, PinPlace> = new Map(),
     cardsHidden = false,
   ) {
-    setConfirming(false);
+    // Ordinary page churn re-renders these rows; only a changed set changes
+    // the answer to "clear all N?", so only that takes the question back.
+    const ids = pins.map((pin) => pin.id).join(' ');
+    if (ids !== listed) setConfirming(false);
+    listed = ids;
     dock.classList.toggle('shown', pins.length > 0);
     titleText.textContent = `${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
     setText(clear, `Clear all (${pins.length})`);

--- a/react/vite-plugins/review-overlay/client/draft.test.ts
+++ b/react/vite-plugins/review-overlay/client/draft.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The draft set store (FR-3858): what the tab is building right now. Pure
+ * operations over the set, and a `sessionStorage` mirror that has to survive
+ * a hand-edited value, a full quota and a tab with storage switched off.
+ */
+import {
+  addPin,
+  createDraftStore,
+  DRAFT_KEY,
+  emptyDraft,
+  MAX_SET_PINS,
+  mergePins,
+  parseDraft,
+  removePin,
+} from './draft.js';
+import type { SetPin } from './types.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const pin = (id: string, over: Record<string, unknown> = {}): SetPin =>
+  ({
+    id,
+    origin: 'pick',
+    anchor: { v: 3, s: `[data-testid="${id}"]`, p: '/session/start' },
+    anchorB64: `PAYLOAD_${id}`,
+    label: `Sessions › ${id}`,
+    appHash: '',
+    stack: [],
+    at: '2026-08-31T09:00:00Z',
+    pr: 9330,
+    ...over,
+  }) as unknown as SetPin;
+
+const stored = () => parseDraft(sessionStorage.getItem(DRAFT_KEY)).pins;
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('the set as a value', () => {
+  it('appends a pin at the end of the set', () => {
+    const set = addPin(addPin(emptyDraft(), pin('c_a')), pin('c_b'));
+
+    expect(set.added).toBe(true);
+    expect(set.pins.map((p) => p.id)).toEqual(['c_a', 'c_b']);
+  });
+
+  // The link de-duplicates by id, so the set it is rendered from must too.
+  it('refuses a pin the set already holds', () => {
+    const once = addPin(emptyDraft(), pin('c_a'));
+
+    const twice = addPin(once, pin('c_a', { label: 'a different label' }));
+
+    expect(twice.added).toBe(false);
+    expect(twice.pins).toHaveLength(1);
+    expect(twice.pins[0].label).toBe('Sessions › c_a');
+  });
+
+  it(`stops at ${MAX_SET_PINS} pins`, () => {
+    let set = emptyDraft();
+    for (let i = 0; i < MAX_SET_PINS; i++) set = addPin(set, pin(`c_${i}`));
+
+    const over = addPin(set, pin('c_over'));
+
+    expect(over.added).toBe(false);
+    expect(over.pins).toHaveLength(MAX_SET_PINS);
+  });
+
+  it('removes one pin and leaves the order of the rest', () => {
+    const set = addPin(
+      addPin(addPin(emptyDraft(), pin('c_a')), pin('c_b')),
+      pin('c_c'),
+    );
+
+    expect(removePin(set, 'c_b').pins.map((p) => p.id)).toEqual(['c_a', 'c_c']);
+  });
+
+  describe('merging a link into it', () => {
+    const set = () => addPin(addPin(emptyDraft(), pin('c_a')), pin('c_b'));
+
+    it('appends what is new in link order and counts what was there', () => {
+      const merged = mergePins(set(), [pin('c_c'), pin('c_a'), pin('c_d')]);
+
+      expect(merged.pins.map((p) => p.id)).toEqual([
+        'c_a',
+        'c_b',
+        'c_c',
+        'c_d',
+      ]);
+      expect(merged).toMatchObject({ added: 2, present: 1 });
+    });
+
+    // A pin the set already holds keeps the `at`/`pr` it was picked with; the
+    // link carries neither, so taking the link's copy would disown the id.
+    it('leaves a pin the set already holds exactly as it was', () => {
+      const merged = mergePins(set(), [
+        pin('c_a', { origin: 'link', label: 'from the link', at: undefined }),
+      ]);
+
+      expect(merged.pins[0].label).toBe('Sessions › c_a');
+      expect(merged.pins[0].origin).toBe('pick');
+      expect(merged).toMatchObject({ added: 0, present: 1 });
+    });
+
+    it('takes nothing past the cap', () => {
+      let full = emptyDraft();
+      for (let i = 0; i < MAX_SET_PINS; i++) full = addPin(full, pin(`c_${i}`));
+
+      const merged = mergePins(full, [pin('c_over')]);
+
+      expect(merged.pins).toHaveLength(MAX_SET_PINS);
+      expect(merged.added).toBe(0);
+    });
+  });
+});
+
+describe('the stored mirror', () => {
+  it('is written on every change and read back at construction', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.add(pin('c_b'));
+
+    expect(stored().map((p) => p.id)).toEqual(['c_a', 'c_b']);
+    expect(createDraftStore().pins().map((p) => p.id)).toEqual(['c_a', 'c_b']);
+  });
+
+  it('says whether the pin joined, and answers `has` and `isFull`', () => {
+    const store = createDraftStore();
+
+    expect(store.add(pin('c_a'))).toEqual({ added: true });
+    expect(store.add(pin('c_a'))).toEqual({ added: false });
+    expect(store.has('c_a')).toBe(true);
+    expect(store.has('c_b')).toBe(false);
+    expect(store.isFull()).toBe(false);
+    for (let i = 0; i < MAX_SET_PINS; i++) store.add(pin(`c_${i}`));
+    expect(store.isFull()).toBe(true);
+  });
+
+  it('drops the key entirely once the set is cleared', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+
+    store.clear();
+
+    expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
+    expect(store.pins()).toEqual([]);
+  });
+
+  it('removes one pin and keeps the rest stored', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.add(pin('c_b'));
+
+    store.remove('c_a');
+
+    expect(stored().map((p) => p.id)).toEqual(['c_b']);
+  });
+
+  it('reloads what another tab of the same session left', () => {
+    const store = createDraftStore();
+    sessionStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ v: 1, pins: [pin('c_z')] }),
+    );
+
+    expect(store.load().pins.map((p) => p.id)).toEqual(['c_z']);
+    expect(store.pins().map((p) => p.id)).toEqual(['c_z']);
+  });
+
+  // The value is ours, but a reload can land on a half-written or a
+  // hand-edited one, and an empty set is always a usable answer.
+  describe('a value that is not a set', () => {
+    it('reads as empty when it is not JSON at all', () => {
+      sessionStorage.setItem(DRAFT_KEY, '{not json');
+      expect(createDraftStore().pins()).toEqual([]);
+    });
+
+    it('reads as empty when the version is not this one', () => {
+      sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ v: 2, pins: [] }));
+      expect(parseDraft(sessionStorage.getItem(DRAFT_KEY)).pins).toEqual([]);
+    });
+
+    it('keeps the members that are still pins and drops the rest', () => {
+      sessionStorage.setItem(
+        DRAFT_KEY,
+        JSON.stringify({
+          v: 1,
+          pins: [
+            pin('c_a'),
+            { id: 'c_b' },
+            { ...pin('c_c'), anchor: { v: 3, s: '', p: '/' } },
+            { ...pin('c_d'), anchor: { v: 3, s: 'a', p: 'javascript:1' } },
+            { ...pin('c_e'), stack: 'not lines' },
+            { ...pin('c_f'), origin: 'pick', at: undefined },
+            pin('c_g', { origin: 'link', at: undefined, pr: undefined }),
+          ],
+        }),
+      );
+
+      expect(createDraftStore().pins().map((p) => p.id)).toEqual([
+        'c_a',
+        'c_g',
+      ]);
+    });
+  });
+
+  // The reviewer keeps working; only the reload loses the set.
+  it('keeps the set in memory when there is no storage at all', () => {
+    const store = createDraftStore(null);
+
+    store.add(pin('c_a'));
+
+    expect(store.pins().map((p) => p.id)).toEqual(['c_a']);
+    expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  it('keeps the set in memory when the write is refused', () => {
+    const store = createDraftStore({
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('QuotaExceededError');
+      },
+      removeItem: () => undefined,
+    } as unknown as Storage);
+
+    store.add(pin('c_a'));
+
+    expect(store.pins().map((p) => p.id)).toEqual(['c_a']);
+  });
+});

--- a/react/vite-plugins/review-overlay/client/draft.test.ts
+++ b/react/vite-plugins/review-overlay/client/draft.test.ts
@@ -32,34 +32,45 @@ const pin = (id: string, over: Record<string, unknown> = {}): SetPin =>
 
 const stored = () => parseDraft(sessionStorage.getItem(DRAFT_KEY)).pins;
 
+const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+/** A distinct WELL-FORMED id per index — base32 is `a`-`z` and `2`-`7`. */
+const nthId = (i: number) =>
+  `c_${LETTERS[i % 26]}${LETTERS[Math.floor(i / 26)]}aaaaa`;
+
 beforeEach(() => {
   sessionStorage.clear();
 });
 
 describe('the set as a value', () => {
   it('appends a pin at the end of the set', () => {
-    const set = addPin(addPin(emptyDraft(), pin('c_a')), pin('c_b'));
+    const set = addPin(
+      addPin(emptyDraft(), pin('c_aaaaaaa')),
+      pin('c_bbbbbbb'),
+    );
 
     expect(set.added).toBe(true);
-    expect(set.pins.map((p) => p.id)).toEqual(['c_a', 'c_b']);
+    expect(set.pins.map((p) => p.id)).toEqual(['c_aaaaaaa', 'c_bbbbbbb']);
   });
 
   // The link de-duplicates by id, so the set it is rendered from must too.
   it('refuses a pin the set already holds', () => {
-    const once = addPin(emptyDraft(), pin('c_a'));
+    const once = addPin(emptyDraft(), pin('c_aaaaaaa'));
 
-    const twice = addPin(once, pin('c_a', { label: 'a different label' }));
+    const twice = addPin(
+      once,
+      pin('c_aaaaaaa', { label: 'a different label' }),
+    );
 
     expect(twice.added).toBe(false);
     expect(twice.pins).toHaveLength(1);
-    expect(twice.pins[0].label).toBe('Sessions › c_a');
+    expect(twice.pins[0].label).toBe('Sessions › c_aaaaaaa');
   });
 
   it(`stops at ${MAX_SET_PINS} pins`, () => {
     let set = emptyDraft();
-    for (let i = 0; i < MAX_SET_PINS; i++) set = addPin(set, pin(`c_${i}`));
+    for (let i = 0; i < MAX_SET_PINS; i++) set = addPin(set, pin(nthId(i)));
 
-    const over = addPin(set, pin('c_over'));
+    const over = addPin(set, pin('c_overaaa'));
 
     expect(over.added).toBe(false);
     expect(over.pins).toHaveLength(MAX_SET_PINS);
@@ -67,24 +78,32 @@ describe('the set as a value', () => {
 
   it('removes one pin and leaves the order of the rest', () => {
     const set = addPin(
-      addPin(addPin(emptyDraft(), pin('c_a')), pin('c_b')),
-      pin('c_c'),
+      addPin(addPin(emptyDraft(), pin('c_aaaaaaa')), pin('c_bbbbbbb')),
+      pin('c_ccccccc'),
     );
 
-    expect(removePin(set, 'c_b').pins.map((p) => p.id)).toEqual(['c_a', 'c_c']);
+    expect(removePin(set, 'c_bbbbbbb').pins.map((p) => p.id)).toEqual([
+      'c_aaaaaaa',
+      'c_ccccccc',
+    ]);
   });
 
   describe('merging a link into it', () => {
-    const set = () => addPin(addPin(emptyDraft(), pin('c_a')), pin('c_b'));
+    const set = () =>
+      addPin(addPin(emptyDraft(), pin('c_aaaaaaa')), pin('c_bbbbbbb'));
 
     it('appends what is new in link order and counts what was there', () => {
-      const merged = mergePins(set(), [pin('c_c'), pin('c_a'), pin('c_d')]);
+      const merged = mergePins(set(), [
+        pin('c_ccccccc'),
+        pin('c_aaaaaaa'),
+        pin('c_ddddddd'),
+      ]);
 
       expect(merged.pins.map((p) => p.id)).toEqual([
-        'c_a',
-        'c_b',
-        'c_c',
-        'c_d',
+        'c_aaaaaaa',
+        'c_bbbbbbb',
+        'c_ccccccc',
+        'c_ddddddd',
       ]);
       expect(merged).toMatchObject({ added: 2, present: 1 });
     });
@@ -93,19 +112,23 @@ describe('the set as a value', () => {
     // link carries neither, so taking the link's copy would disown the id.
     it('leaves a pin the set already holds exactly as it was', () => {
       const merged = mergePins(set(), [
-        pin('c_a', { origin: 'link', label: 'from the link', at: undefined }),
+        pin('c_aaaaaaa', {
+          origin: 'link',
+          label: 'from the link',
+          at: undefined,
+        }),
       ]);
 
-      expect(merged.pins[0].label).toBe('Sessions › c_a');
+      expect(merged.pins[0].label).toBe('Sessions › c_aaaaaaa');
       expect(merged.pins[0].origin).toBe('pick');
       expect(merged).toMatchObject({ added: 0, present: 1 });
     });
 
     it('takes nothing past the cap', () => {
       let full = emptyDraft();
-      for (let i = 0; i < MAX_SET_PINS; i++) full = addPin(full, pin(`c_${i}`));
+      for (let i = 0; i < MAX_SET_PINS; i++) full = addPin(full, pin(nthId(i)));
 
-      const merged = mergePins(full, [pin('c_over')]);
+      const merged = mergePins(full, [pin('c_overaaa')]);
 
       expect(merged.pins).toHaveLength(MAX_SET_PINS);
       expect(merged.added).toBe(0);
@@ -117,13 +140,13 @@ describe('the set as a value', () => {
 describe('what the set says is on screen', () => {
   it('marks one pin hidden, and takes the mark off again', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
-    store.add(pin('c_b'));
+    store.add(pin('c_aaaaaaa'));
+    store.add(pin('c_bbbbbbb'));
 
-    store.hide('c_b', true);
+    store.hide('c_bbbbbbb', true);
     expect(stored().map((p) => p.hidden)).toEqual([undefined, true]);
 
-    store.hide('c_b', false);
+    store.hide('c_bbbbbbb', false);
     expect(stored().map((p) => p.hidden)).toEqual([undefined, undefined]);
   });
 
@@ -131,9 +154,9 @@ describe('what the set says is on screen', () => {
   // control that says the cards are shown.
   it('clears every per-pin ✕ when the switch goes back on', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
-    store.add(pin('c_b'));
-    store.hide('c_a', true);
+    store.add(pin('c_aaaaaaa'));
+    store.add(pin('c_bbbbbbb'));
+    store.hide('c_aaaaaaa', true);
     store.hideCards(true);
 
     store.hideCards(false);
@@ -144,8 +167,8 @@ describe('what the set says is on screen', () => {
 
   it('leaves those flags alone when the switch goes off', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
-    store.hide('c_a', true);
+    store.add(pin('c_aaaaaaa'));
+    store.hide('c_aaaaaaa', true);
 
     store.hideCards(true);
 
@@ -154,7 +177,7 @@ describe('what the set says is on screen', () => {
 
   it('remembers the switch across a reload of the tab', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
+    store.add(pin('c_aaaaaaa'));
 
     store.hideCards(true);
 
@@ -164,7 +187,7 @@ describe('what the set says is on screen', () => {
   // The stack write-back re-saves the set; the switch is not its business.
   it('keeps the switch through a save that does not mention it', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
+    store.add(pin('c_aaaaaaa'));
     store.hideCards(true);
 
     store.save({ pins: [{ ...store.pins()[0], stack: ['in Thing'] }] });
@@ -179,7 +202,7 @@ describe('what the set says is on screen', () => {
       JSON.stringify({
         v: 1,
         cardsHidden: 'yes',
-        pins: [{ ...pin('c_a'), hidden: 'yes' }],
+        pins: [{ ...pin('c_aaaaaaa'), hidden: 'yes' }],
       }),
     );
 
@@ -193,32 +216,32 @@ describe('what the set says is on screen', () => {
 describe('the stored mirror', () => {
   it('is written on every change and read back at construction', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
-    store.add(pin('c_b'));
+    store.add(pin('c_aaaaaaa'));
+    store.add(pin('c_bbbbbbb'));
 
-    expect(stored().map((p) => p.id)).toEqual(['c_a', 'c_b']);
+    expect(stored().map((p) => p.id)).toEqual(['c_aaaaaaa', 'c_bbbbbbb']);
     expect(
       createDraftStore()
         .pins()
         .map((p) => p.id),
-    ).toEqual(['c_a', 'c_b']);
+    ).toEqual(['c_aaaaaaa', 'c_bbbbbbb']);
   });
 
   it('says whether the pin joined, and answers `has` and `isFull`', () => {
     const store = createDraftStore();
 
-    expect(store.add(pin('c_a'))).toEqual({ added: true });
-    expect(store.add(pin('c_a'))).toEqual({ added: false });
-    expect(store.has('c_a')).toBe(true);
-    expect(store.has('c_b')).toBe(false);
+    expect(store.add(pin('c_aaaaaaa'))).toEqual({ added: true });
+    expect(store.add(pin('c_aaaaaaa'))).toEqual({ added: false });
+    expect(store.has('c_aaaaaaa')).toBe(true);
+    expect(store.has('c_bbbbbbb')).toBe(false);
     expect(store.isFull()).toBe(false);
-    for (let i = 0; i < MAX_SET_PINS; i++) store.add(pin(`c_${i}`));
+    for (let i = 0; i < MAX_SET_PINS; i++) store.add(pin(nthId(i)));
     expect(store.isFull()).toBe(true);
   });
 
   it('drops the key entirely once the set is cleared', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
+    store.add(pin('c_aaaaaaa'));
 
     store.clear();
 
@@ -228,23 +251,23 @@ describe('the stored mirror', () => {
 
   it('removes one pin and keeps the rest stored', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
-    store.add(pin('c_b'));
+    store.add(pin('c_aaaaaaa'));
+    store.add(pin('c_bbbbbbb'));
 
-    store.remove('c_a');
+    store.remove('c_aaaaaaa');
 
-    expect(stored().map((p) => p.id)).toEqual(['c_b']);
+    expect(stored().map((p) => p.id)).toEqual(['c_bbbbbbb']);
   });
 
   it('reloads what another tab of the same session left', () => {
     const store = createDraftStore();
     sessionStorage.setItem(
       DRAFT_KEY,
-      JSON.stringify({ v: 1, pins: [pin('c_z')] }),
+      JSON.stringify({ v: 1, pins: [pin('c_zzzzzzz')] }),
     );
 
-    expect(store.load().pins.map((p) => p.id)).toEqual(['c_z']);
-    expect(store.pins().map((p) => p.id)).toEqual(['c_z']);
+    expect(store.load().pins.map((p) => p.id)).toEqual(['c_zzzzzzz']);
+    expect(store.pins().map((p) => p.id)).toEqual(['c_zzzzzzz']);
   });
 
   // The value is ours, but a reload can land on a half-written or a
@@ -266,13 +289,16 @@ describe('the stored mirror', () => {
         JSON.stringify({
           v: 1,
           pins: [
-            pin('c_a'),
-            { id: 'c_b' },
-            { ...pin('c_c'), anchor: { v: 3, s: '', p: '/' } },
-            { ...pin('c_d'), anchor: { v: 3, s: 'a', p: 'javascript:1' } },
-            { ...pin('c_e'), stack: 'not lines' },
-            { ...pin('c_f'), origin: 'pick', at: undefined },
-            pin('c_g', { origin: 'link', at: undefined, pr: undefined }),
+            pin('c_aaaaaaa'),
+            { id: 'c_bbbbbbb' },
+            { ...pin('c_ccccccc'), anchor: { v: 3, s: '', p: '/' } },
+            {
+              ...pin('c_ddddddd'),
+              anchor: { v: 3, s: 'a', p: 'javascript:1' },
+            },
+            { ...pin('c_eeeeeee'), stack: 'not lines' },
+            { ...pin('c_fffffff'), origin: 'pick', at: undefined },
+            pin('c_ggggggg', { origin: 'link', at: undefined, pr: undefined }),
           ],
         }),
       );
@@ -281,7 +307,34 @@ describe('the stored mirror', () => {
         createDraftStore()
           .pins()
           .map((p) => p.id),
-      ).toEqual(['c_a', 'c_g']);
+      ).toEqual(['c_aaaaaaa', 'c_ggggggg']);
+    });
+
+    // A pin the link grammar cannot carry is a pin whose link every reader
+    // drops on arrival — the store is the last place that can still say no.
+    it('drops a pin whose id or payload no link could carry', () => {
+      sessionStorage.setItem(
+        DRAFT_KEY,
+        JSON.stringify({
+          v: 1,
+          pins: [
+            pin('c_aaaaaaa'),
+            pin('c_b'),
+            pin('c_0000000'),
+            pin('c_aaaaaaaa'),
+            pin('C_AAAAAAA'),
+            { ...pin('c_bbbbbbb'), anchorB64: 'short' },
+            { ...pin('c_ccccccc'), anchorB64: 'has spaces in it' },
+            { ...pin('c_ddddddd'), anchorB64: 'a'.repeat(2049) },
+          ],
+        }),
+      );
+
+      expect(
+        createDraftStore()
+          .pins()
+          .map((p) => p.id),
+      ).toEqual(['c_aaaaaaa']);
     });
   });
 
@@ -289,9 +342,9 @@ describe('the stored mirror', () => {
   it('keeps the set in memory when there is no storage at all', () => {
     const store = createDraftStore(null);
 
-    store.add(pin('c_a'));
+    store.add(pin('c_aaaaaaa'));
 
-    expect(store.pins().map((p) => p.id)).toEqual(['c_a']);
+    expect(store.pins().map((p) => p.id)).toEqual(['c_aaaaaaa']);
     expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
   });
 
@@ -304,8 +357,8 @@ describe('the stored mirror', () => {
       removeItem: () => undefined,
     } as unknown as Storage);
 
-    store.add(pin('c_a'));
+    store.add(pin('c_aaaaaaa'));
 
-    expect(store.pins().map((p) => p.id)).toEqual(['c_a']);
+    expect(store.pins().map((p) => p.id)).toEqual(['c_aaaaaaa']);
   });
 });

--- a/react/vite-plugins/review-overlay/client/draft.test.ts
+++ b/react/vite-plugins/review-overlay/client/draft.test.ts
@@ -127,6 +127,31 @@ describe('what the set says is on screen', () => {
     expect(stored().map((p) => p.hidden)).toEqual([undefined, undefined]);
   });
 
+  // R5.5. The switch is hide-all / show-all; nothing may stay hidden behind a
+  // control that says the cards are shown.
+  it('clears every per-pin ✕ when the switch goes back on', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.add(pin('c_b'));
+    store.hide('c_a', true);
+    store.hideCards(true);
+
+    store.hideCards(false);
+
+    expect(store.pins().map((p) => p.hidden)).toEqual([undefined, undefined]);
+    expect(stored().map((p) => p.hidden)).toEqual([undefined, undefined]);
+  });
+
+  it('leaves those flags alone when the switch goes off', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.hide('c_a', true);
+
+    store.hideCards(true);
+
+    expect(store.pins()[0].hidden).toBe(true);
+  });
+
   it('remembers the switch across a reload of the tab', () => {
     const store = createDraftStore();
     store.add(pin('c_a'));

--- a/react/vite-plugins/review-overlay/client/draft.test.ts
+++ b/react/vite-plugins/review-overlay/client/draft.test.ts
@@ -113,6 +113,58 @@ describe('the set as a value', () => {
   });
 });
 
+// ✕ on a card, and the dock's switch: what is drawn, not what is pinned.
+describe('what the set says is on screen', () => {
+  it('marks one pin hidden, and takes the mark off again', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.add(pin('c_b'));
+
+    store.hide('c_b', true);
+    expect(stored().map((p) => p.hidden)).toEqual([undefined, true]);
+
+    store.hide('c_b', false);
+    expect(stored().map((p) => p.hidden)).toEqual([undefined, undefined]);
+  });
+
+  it('remembers the switch across a reload of the tab', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+
+    store.hideCards(true);
+
+    expect(createDraftStore().cardsHidden()).toBe(true);
+  });
+
+  // The stack write-back re-saves the set; the switch is not its business.
+  it('keeps the switch through a save that does not mention it', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.hideCards(true);
+
+    store.save({ pins: [{ ...store.pins()[0], stack: ['in Thing'] }] });
+
+    expect(store.cardsHidden()).toBe(true);
+    expect(store.pins()[0].stack).toEqual(['in Thing']);
+  });
+
+  it('reads a hand-edited flag as no flag at all', () => {
+    sessionStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({
+        v: 1,
+        cardsHidden: 'yes',
+        pins: [{ ...pin('c_a'), hidden: 'yes' }],
+      }),
+    );
+
+    const store = createDraftStore();
+
+    expect(store.cardsHidden()).toBe(false);
+    expect(store.pins()).toEqual([]);
+  });
+});
+
 describe('the stored mirror', () => {
   it('is written on every change and read back at construction', () => {
     const store = createDraftStore();
@@ -120,7 +172,11 @@ describe('the stored mirror', () => {
     store.add(pin('c_b'));
 
     expect(stored().map((p) => p.id)).toEqual(['c_a', 'c_b']);
-    expect(createDraftStore().pins().map((p) => p.id)).toEqual(['c_a', 'c_b']);
+    expect(
+      createDraftStore()
+        .pins()
+        .map((p) => p.id),
+    ).toEqual(['c_a', 'c_b']);
   });
 
   it('says whether the pin joined, and answers `has` and `isFull`', () => {
@@ -196,10 +252,11 @@ describe('the stored mirror', () => {
         }),
       );
 
-      expect(createDraftStore().pins().map((p) => p.id)).toEqual([
-        'c_a',
-        'c_g',
-      ]);
+      expect(
+        createDraftStore()
+          .pins()
+          .map((p) => p.id),
+      ).toEqual(['c_a', 'c_g']);
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/draft.ts
+++ b/react/vite-plugins/review-overlay/client/draft.ts
@@ -1,0 +1,169 @@
+/**
+ * The draft set: the pins this tab has made so far, and the single source of
+ * truth for what the layer draws. Pure operations over a `DraftSet`, plus a
+ * thin `sessionStorage` mirror so a reload — including the full reload a deep
+ * link causes — does not throw the set away. Reads are guarded: a malformed
+ * value is an empty set, never a crash, and a tab with storage switched off
+ * still keeps its set until it reloads.
+ */
+import { isAnchorV3 } from './anchor-guard.js';
+import { dedupeById, MAX_SET_PINS } from './deeplink.js';
+import type { DraftSet, SetPin } from './types.js';
+
+export const DRAFT_KEY = 'bai-review:draft-set';
+export { MAX_SET_PINS };
+
+export const emptyDraft = (): DraftSet => ({ v: 1, pins: [] });
+
+const isStrings = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((line) => typeof line === 'string');
+
+/** Storage is ours, but a half-written or hand-edited value is not a set. */
+export function isSetPin(value: unknown): value is SetPin {
+  if (!value || typeof value !== 'object') return false;
+  const pin = value as Record<string, unknown>;
+  if (typeof pin.id !== 'string' || !pin.id) return false;
+  if (pin.origin !== 'pick' && pin.origin !== 'link') return false;
+  if (typeof pin.anchorB64 !== 'string' || !pin.anchorB64) return false;
+  if (typeof pin.label !== 'string') return false;
+  if (typeof pin.appHash !== 'string') return false;
+  if (pin.note !== undefined && typeof pin.note !== 'string') return false;
+  if (!isStrings(pin.stack)) return false;
+  if (
+    pin.origin === 'pick' &&
+    (typeof pin.at !== 'string' || typeof pin.pr !== 'number')
+  )
+    return false;
+  return isAnchorV3(pin.anchor);
+}
+
+/** Whatever of a stored set is still a set; anything else is an empty one. */
+export function parseDraft(raw: string | null): DraftSet {
+  if (!raw) return emptyDraft();
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return emptyDraft();
+  }
+  if (!value || typeof value !== 'object') return emptyDraft();
+  const set = value as Record<string, unknown>;
+  if (set.v !== 1 || !Array.isArray(set.pins)) return emptyDraft();
+  return {
+    v: 1,
+    pins: dedupeById(set.pins.filter(isSetPin)).slice(0, MAX_SET_PINS),
+  };
+}
+
+export interface AddResult {
+  added: boolean;
+}
+
+export interface MergeResult {
+  /** Pins the set did not have, appended in the order they were given. */
+  added: number;
+  /** Pins it already had, which keep their place and their stored data. */
+  present: number;
+}
+
+/** Appended at the end, once. A full set takes nothing more. */
+export function addPin(set: DraftSet, pin: SetPin): DraftSet & AddResult {
+  if (set.pins.length >= MAX_SET_PINS || set.pins.some((p) => p.id === pin.id))
+    return { ...set, added: false };
+  return { v: 1, pins: [...set.pins, pin], added: true };
+}
+
+export function removePin(set: DraftSet, id: string): DraftSet {
+  return { v: 1, pins: set.pins.filter((pin) => pin.id !== id) };
+}
+
+/**
+ * A link merges into the set rather than replacing it: what is already there
+ * keeps its place and the data it was stored with, and the rest is appended
+ * in link order. The cap is what stops a pasted hash from growing it forever.
+ */
+export function mergePins(
+  set: DraftSet,
+  pins: SetPin[],
+): DraftSet & MergeResult {
+  const next = [...set.pins];
+  let added = 0;
+  let present = 0;
+  for (const pin of dedupeById(pins)) {
+    if (next.some((held) => held.id === pin.id)) {
+      present++;
+      continue;
+    }
+    if (next.length >= MAX_SET_PINS) continue;
+    next.push(pin);
+    added++;
+  }
+  return { v: 1, pins: next, added, present };
+}
+
+const safeStorage = (): Storage | null => {
+  try {
+    return sessionStorage;
+  } catch {
+    // A tab with storage disabled keeps its set in memory until it reloads.
+    return null;
+  }
+};
+
+export interface DraftStore {
+  load(): DraftSet;
+  save(set: DraftSet): void;
+  pins(): SetPin[];
+  has(id: string): boolean;
+  isFull(): boolean;
+  add(pin: SetPin): AddResult;
+  remove(id: string): void;
+  clear(): void;
+  merge(pins: SetPin[]): MergeResult;
+}
+
+export function createDraftStore(
+  storage: Storage | null = safeStorage(),
+): DraftStore {
+  const read = (): DraftSet => {
+    try {
+      return parseDraft(storage?.getItem(DRAFT_KEY) ?? null);
+    } catch {
+      return emptyDraft();
+    }
+  };
+  let current = read();
+  const write = (set: DraftSet): void => {
+    current = set;
+    try {
+      if (set.pins.length) storage?.setItem(DRAFT_KEY, JSON.stringify(set));
+      else storage?.removeItem(DRAFT_KEY);
+    } catch {
+      // Quota, or storage went away mid-session; memory still holds the set.
+    }
+  };
+  return {
+    load: () => (current = read()),
+    save: (set) =>
+      write({ v: 1, pins: dedupeById(set.pins).slice(0, MAX_SET_PINS) }),
+    pins: () => current.pins,
+    has: (id) => current.pins.some((pin) => pin.id === id),
+    isFull: () => current.pins.length >= MAX_SET_PINS,
+    add(pin) {
+      const { added, ...set } = addPin(current, pin);
+      if (added) write(set);
+      return { added };
+    },
+    remove(id) {
+      write(removePin(current, id));
+    },
+    clear() {
+      write(emptyDraft());
+    },
+    merge(pins) {
+      const { added, present, ...set } = mergePins(current, pins);
+      if (added) write(set);
+      return { added, present };
+    },
+  };
+}

--- a/react/vite-plugins/review-overlay/client/draft.ts
+++ b/react/vite-plugins/review-overlay/client/draft.ts
@@ -80,7 +80,7 @@ export function removePin(set: DraftSet, id: string): DraftSet {
 }
 
 /**
- * ✕ on a card. The pin keeps its place, its note and its identity — only its
+ * A card hidden. The pin keeps its place, its note and its identity — only its
  * card goes, and the flag is stored so a reload does not bring it back.
  */
 export function hidePin(set: DraftSet, id: string, hidden: boolean): DraftSet {
@@ -102,7 +102,7 @@ export function hideCards(set: DraftSet, hidden: boolean): DraftSet {
 
 /**
  * R5.5. The switch is hide-all / SHOW-all, not suspend-and-restore: turning it
- * on clears every per-pin ✕ so nothing is left stranded behind a control that
+ * on clears every per-pin hide so nothing is left stranded behind a control that
  * says the cards are shown.
  */
 export function showAllPins(set: DraftSet): DraftSet {
@@ -159,7 +159,7 @@ export interface DraftStore {
   remove(id: string): void;
   clear(): void;
   merge(pins: SetPin[]): MergeResult;
-  /** ✕ on one card. */
+  /** Hide or show one card. */
   hide(id: string, hidden: boolean): void;
   cardsHidden(): boolean;
   /** Turning the switch back ON also un-hides every individually hidden pin. */

--- a/react/vite-plugins/review-overlay/client/draft.ts
+++ b/react/vite-plugins/review-overlay/client/draft.ts
@@ -101,6 +101,21 @@ export function hideCards(set: DraftSet, hidden: boolean): DraftSet {
 }
 
 /**
+ * R5.5. The switch is hide-all / SHOW-all, not suspend-and-restore: turning it
+ * on clears every per-pin ✕ so nothing is left stranded behind a control that
+ * says the cards are shown.
+ */
+export function showAllPins(set: DraftSet): DraftSet {
+  return {
+    ...set,
+    pins: set.pins.map((pin) => {
+      const { hidden: _was, ...rest } = pin;
+      return rest as SetPin;
+    }),
+  };
+}
+
+/**
  * A link merges into the set rather than replacing it: what is already there
  * keeps its place and the data it was stored with, and the rest is appended
  * in link order. The cap is what stops a pasted hash from growing it forever.
@@ -147,6 +162,7 @@ export interface DraftStore {
   /** ✕ on one card. */
   hide(id: string, hidden: boolean): void;
   cardsHidden(): boolean;
+  /** Turning the switch back ON also un-hides every individually hidden pin. */
   hideCards(hidden: boolean): void;
 }
 
@@ -203,7 +219,8 @@ export function createDraftStore(
     },
     cardsHidden: () => current.cardsHidden === true,
     hideCards(hidden) {
-      write(hideCards(current, hidden));
+      const next = hideCards(current, hidden);
+      write(hidden ? next : showAllPins(next));
     },
   };
 }

--- a/react/vite-plugins/review-overlay/client/draft.ts
+++ b/react/vite-plugins/review-overlay/client/draft.ts
@@ -28,6 +28,7 @@ export function isSetPin(value: unknown): value is SetPin {
   if (typeof pin.label !== 'string') return false;
   if (typeof pin.appHash !== 'string') return false;
   if (pin.note !== undefined && typeof pin.note !== 'string') return false;
+  if (pin.hidden !== undefined && pin.hidden !== true) return false;
   if (!isStrings(pin.stack)) return false;
   if (
     pin.origin === 'pick' &&
@@ -52,6 +53,7 @@ export function parseDraft(raw: string | null): DraftSet {
   return {
     v: 1,
     pins: dedupeById(set.pins.filter(isSetPin)).slice(0, MAX_SET_PINS),
+    ...(set.cardsHidden === true ? { cardsHidden: true as const } : {}),
   };
 }
 
@@ -70,11 +72,32 @@ export interface MergeResult {
 export function addPin(set: DraftSet, pin: SetPin): DraftSet & AddResult {
   if (set.pins.length >= MAX_SET_PINS || set.pins.some((p) => p.id === pin.id))
     return { ...set, added: false };
-  return { v: 1, pins: [...set.pins, pin], added: true };
+  return { ...set, pins: [...set.pins, pin], added: true };
 }
 
 export function removePin(set: DraftSet, id: string): DraftSet {
-  return { v: 1, pins: set.pins.filter((pin) => pin.id !== id) };
+  return { ...set, pins: set.pins.filter((pin) => pin.id !== id) };
+}
+
+/**
+ * ✕ on a card. The pin keeps its place, its note and its identity — only its
+ * card goes, and the flag is stored so a reload does not bring it back.
+ */
+export function hidePin(set: DraftSet, id: string, hidden: boolean): DraftSet {
+  return {
+    ...set,
+    pins: set.pins.map((pin) => {
+      if (pin.id !== id) return pin;
+      const { hidden: _was, ...rest } = pin;
+      return (hidden ? { ...rest, hidden: true } : rest) as SetPin;
+    }),
+  };
+}
+
+/** The dock's switch, over the whole set. */
+export function hideCards(set: DraftSet, hidden: boolean): DraftSet {
+  const { cardsHidden: _was, ...rest } = set;
+  return hidden ? { ...rest, cardsHidden: true } : rest;
 }
 
 /**
@@ -98,7 +121,7 @@ export function mergePins(
     next.push(pin);
     added++;
   }
-  return { v: 1, pins: next, added, present };
+  return { ...set, pins: next, added, present };
 }
 
 const safeStorage = (): Storage | null => {
@@ -112,7 +135,8 @@ const safeStorage = (): Storage | null => {
 
 export interface DraftStore {
   load(): DraftSet;
-  save(set: DraftSet): void;
+  /** Fields the given set does not name — the switch, say — are kept. */
+  save(set: Partial<DraftSet> & { pins: SetPin[] }): void;
   pins(): SetPin[];
   has(id: string): boolean;
   isFull(): boolean;
@@ -120,6 +144,10 @@ export interface DraftStore {
   remove(id: string): void;
   clear(): void;
   merge(pins: SetPin[]): MergeResult;
+  /** ✕ on one card. */
+  hide(id: string, hidden: boolean): void;
+  cardsHidden(): boolean;
+  hideCards(hidden: boolean): void;
 }
 
 export function createDraftStore(
@@ -145,7 +173,12 @@ export function createDraftStore(
   return {
     load: () => (current = read()),
     save: (set) =>
-      write({ v: 1, pins: dedupeById(set.pins).slice(0, MAX_SET_PINS) }),
+      write({
+        ...current,
+        ...set,
+        v: 1,
+        pins: dedupeById(set.pins).slice(0, MAX_SET_PINS),
+      }),
     pins: () => current.pins,
     has: (id) => current.pins.some((pin) => pin.id === id),
     isFull: () => current.pins.length >= MAX_SET_PINS,
@@ -164,6 +197,13 @@ export function createDraftStore(
       const { added, present, ...set } = mergePins(current, pins);
       if (added) write(set);
       return { added, present };
+    },
+    hide(id, hidden) {
+      write(hidePin(current, id, hidden));
+    },
+    cardsHidden: () => current.cardsHidden === true,
+    hideCards(hidden) {
+      write(hideCards(current, hidden));
     },
   };
 }

--- a/react/vite-plugins/review-overlay/client/draft.ts
+++ b/react/vite-plugins/review-overlay/client/draft.ts
@@ -7,6 +7,7 @@
  * still keeps its set until it reloads.
  */
 import { isAnchorV3 } from './anchor-guard.js';
+import { PIN_BODY_SRC } from './codec.js';
 import { dedupeById, MAX_SET_PINS } from './deeplink.js';
 import type { DraftSet, SetPin } from './types.js';
 
@@ -18,13 +19,22 @@ export const emptyDraft = (): DraftSet => ({ v: 1, pins: [] });
 const isStrings = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((line) => typeof line === 'string');
 
+/**
+ * The `<id>.<anchor>` a stored pin has to be able to emit — the same grammar
+ * `parseFragments` reads back, so what the store keeps is what a link carries.
+ */
+const PIN_BODY_RE = new RegExp(`^${PIN_BODY_SRC}$`);
+
 /** Storage is ours, but a half-written or hand-edited value is not a set. */
 export function isSetPin(value: unknown): value is SetPin {
   if (!value || typeof value !== 'object') return false;
   const pin = value as Record<string, unknown>;
-  if (typeof pin.id !== 'string' || !pin.id) return false;
+  if (typeof pin.id !== 'string' || typeof pin.anchorB64 !== 'string')
+    return false;
+  // A pin whose id or payload no reader could parse is a pin whose link is
+  // dropped on arrival; the set is better off without it than carrying it.
+  if (!PIN_BODY_RE.test(`${pin.id}.${pin.anchorB64}`)) return false;
   if (pin.origin !== 'pick' && pin.origin !== 'link') return false;
-  if (typeof pin.anchorB64 !== 'string' || !pin.anchorB64) return false;
   if (typeof pin.label !== 'string') return false;
   if (typeof pin.appHash !== 'string') return false;
   if (pin.note !== undefined && typeof pin.note !== 'string') return false;

--- a/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
@@ -106,9 +106,9 @@ beforeEach(() => {
 
 afterEach(() => {
   // The pin outlives the module and keeps a MutationObserver on `body`; with
-  // no target it schedules nothing, so dismissing it first keeps the observer
-  // from firing into a torn-down jsdom.
-  click('.close');
+  // no target it schedules nothing, so removing it first keeps the observer
+  // from firing into a torn-down jsdom. ✕ only hides the card now.
+  click('.remove');
   vi.unstubAllGlobals();
   document.querySelector('[data-bai-review-overlay]')?.remove();
   document.body.innerHTML = '';

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -317,6 +317,21 @@ describe('adding to a set', () => {
     expect(storedIds()).toHaveLength(30);
     expect(composeOpen()).toBe(true);
   });
+
+  it('says the set is full on the button, before the ⌘⏎', async () => {
+    seed(
+      Array.from({ length: 30 }, (_, i) =>
+        storedPin(`c_seed${i}`, 'create', `Start › ${i}`),
+      ),
+    );
+    await bootOverlay();
+    stubExecCommand();
+
+    await pick('create', 'one too many');
+
+    expect(copyButton().textContent).toBe('Set is full (30)');
+    expect(copyButton().disabled).toBe(true);
+  });
 });
 
 describe('the set the tab was left with', () => {

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -206,7 +206,7 @@ describe('the first pin of a set', () => {
 });
 
 describe('adding to a set', () => {
-  it('copies every pin so far, behind one link', async () => {
+  it('copies every pin so far, behind its own link and one set link', async () => {
     await bootOverlay();
     stubExecCommand();
     await pickAndCopy('create', 'The label is cut off.');
@@ -218,12 +218,20 @@ describe('adding to a set', () => {
     expect(text.split('📍')).toHaveLength(3);
     expect(text).toContain('The label is cut off.');
     expect(text).toContain('And this one is unreachable.');
-    // One URL, in both blocks, carrying both pins.
+    // One link per block carrying that pin alone, then one carrying both —
+    // repeating the set's URL in every block made the comment grow as N².
     const urls = [...text.matchAll(/\(http[^)]+\)/g)].map((m) => m[0]);
-    expect(urls).toHaveLength(2);
-    expect(new Set(urls).size).toBe(1);
-    expect(urls[0].split('bai=v3.')).toHaveLength(3);
-    for (const id of storedIds()) expect(urls[0]).toContain(id);
+    expect(urls).toHaveLength(3);
+    expect(new Set(urls).size).toBe(3);
+    const ids = storedIds();
+    ids.forEach((id, i) => {
+      expect(urls[i].split('bai=v3.')).toHaveLength(2);
+      expect(urls[i]).toContain(id);
+    });
+    const setUrl = urls[urls.length - 1];
+    expect(setUrl.split('bai=v3.')).toHaveLength(3);
+    for (const id of ids) expect(setUrl).toContain(id);
+    expect(text).toContain(`[Open all 2 pins on dev server]${setUrl}`);
     expect(toast()).toBe('Copied all 2 pins — replaces your last paste');
   });
 

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Authoring a pin set (FR-3858), end to end through `main.ts`: pick, note,
+ * ⌘⏎ — and the pin stays, so the next ⌘⏎ copies every pin so far as one
+ * comment behind one link. Only `main.ts` composes the store, the composer,
+ * the layer and the dock, so this is where the flow can be asserted at all.
+ */
+import { DRAFT_KEY } from './draft.js';
+import type { SetPin } from './types.js';
+import type { Plugin, ReactGrabAPI } from 'react-grab';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ROOT = '/home/driver/Workspace/backend.ai-webui';
+const FILE = 'react/src/components/CreateButton.tsx';
+
+let plugin: Plugin | null = null;
+
+const shadow = () =>
+  document.querySelector('[data-bai-review-overlay]')?.shadowRoot as ShadowRoot;
+const node = <T extends HTMLElement>(selector: string) =>
+  shadow()?.querySelector<T>(selector) as T;
+const all = (selector: string) =>
+  Array.from(shadow()?.querySelectorAll<HTMLElement>(selector) ?? []);
+
+const textarea = () => node<HTMLTextAreaElement>('.compose textarea');
+const copyButton = () => node<HTMLButtonElement>('[data-act="copy"]');
+const toast = () => node('.toast')?.textContent ?? '';
+const dockRows = () => all('.setdock .row');
+const composeOpen = () => node('.compose').style.display === 'block';
+const storedIds = (): string[] => {
+  const raw = sessionStorage.getItem(DRAFT_KEY);
+  return raw
+    ? (JSON.parse(raw) as { pins: SetPin[] }).pins.map((p) => p.id)
+    : [];
+};
+
+const ticks = async (count: number, ms = 10) => {
+  for (let i = 0; i < count; i++) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+};
+
+/** jsdom has no editing host: `execCommand` never fires its own copy event. */
+function stubExecCommand(ok = true): Record<string, string> {
+  const written: Record<string, string> = {};
+  document.execCommand = vi.fn(() => {
+    const evt = new Event('copy', { bubbles: true, cancelable: true });
+    Object.defineProperty(evt, 'clipboardData', {
+      value: {
+        setData: (type: string, value: string) => {
+          written[type] = value;
+        },
+      },
+    });
+    document.dispatchEvent(evt);
+    return ok;
+  });
+  return written;
+}
+
+function mount(testid: string, text: string) {
+  document.body.insertAdjacentHTML(
+    'beforeend',
+    `<button data-testid="${testid}">${text}</button>`,
+  );
+}
+
+/** Boot the overlay with react-grab present, on a page with no link. */
+async function bootOverlay() {
+  window.__REACT_GRAB__ = {
+    activate: () => undefined,
+    deactivate: () => undefined,
+    isActive: () => false,
+    registerPlugin: (next: Plugin) => {
+      plugin = next;
+    },
+    getStackContext: () =>
+      Promise.resolve(`  in CreateButton (at ${ROOT}/${FILE})`),
+    getSource: () => Promise.resolve(null),
+  } as unknown as ReactGrabAPI;
+  vi.stubGlobal('fetch', () =>
+    Promise.resolve({ json: () => Promise.resolve({ pr: 42, root: ROOT }) }),
+  );
+  vi.resetModules();
+  delete window.__baiReviewOverlay;
+  await import('./main.js');
+  await ticks(4);
+}
+
+/** react-grab's own hook is the pick: the composer opens a tick later. */
+async function pick(testid: string, note: string) {
+  const element = document.querySelector(
+    `[data-testid="${testid}"]`,
+  ) as Element;
+  plugin?.hooks?.onElementSelect?.(element);
+  await ticks(6);
+  textarea().value = note;
+  textarea().dispatchEvent(new Event('input'));
+  // The note debounce, then the anchor re-encode it starts.
+  await ticks(6, 100);
+}
+
+const pressCopy = () =>
+  textarea().dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: 'Enter',
+      metaKey: true,
+      bubbles: true,
+    }),
+  );
+
+const pressEscape = () =>
+  document.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+  );
+
+async function pickAndCopy(testid: string, note: string) {
+  await pick(testid, note);
+  pressCopy();
+  await ticks(2);
+}
+
+const storedPin = (id: string, testid: string, label: string): SetPin => ({
+  id,
+  origin: 'pick',
+  anchor: { v: 3, s: `[data-testid="${testid}"]`, p: '/', tag: 'button' },
+  anchorB64: `PAYLOAD_${id}`,
+  label,
+  appHash: '',
+  stack: [],
+  at: '2026-08-31T09:00:00Z',
+  pr: 42,
+});
+
+const seed = (pins: SetPin[]) =>
+  sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ v: 1, pins }));
+
+beforeEach(() => {
+  plugin = null;
+  sessionStorage.clear();
+  history.replaceState({}, '', '/');
+  document.body.innerHTML = '';
+  mount('create', 'Create');
+  mount('cancel', 'Cancel');
+});
+
+afterEach(() => {
+  // The layer outlives the module and keeps a MutationObserver on `body`;
+  // taking every pin down first keeps it from firing into a torn-down jsdom.
+  for (const close of all('.card .close')) close.click();
+  vi.unstubAllGlobals();
+  // A secure-context run is one test's business, never the next one's.
+  Reflect.deleteProperty(navigator, 'clipboard');
+  document.querySelector('[data-bai-review-overlay]')?.remove();
+  document.body.innerHTML = '';
+  delete window.__REACT_GRAB__;
+});
+
+describe('the first pin of a set', () => {
+  it('copies the block the overlay has always copied', async () => {
+    await bootOverlay();
+    const written = stubExecCommand();
+
+    await pickAndCopy('create', 'The label is cut off.');
+
+    const id = storedIds()[0];
+    const lines = written['text/plain'].split('\n');
+    expect(lines.slice(0, 4)).toEqual([
+      'The label is cut off.',
+      '',
+      `> 📍 **/ › create › button "Create"** · \`${id}\``,
+      `> ⚛️ in CreateButton (at ${FILE})`,
+    ]);
+    // `at` is this copy's own instant; the id is what carries the identity.
+    expect(
+      lines[4].startsWith(
+        `> [Open on dev server](${location.origin}/#bai=v3.${id}.`,
+      ),
+    ).toBe(true);
+    expect(lines[5]).toContain(`<!-- bai-review v3 id=${id} pr=42 at=`);
+    expect(toast()).toContain('Copied — paste it');
+  });
+
+  // The pick used to be thrown away the moment the composer closed.
+  it('keeps the pin on screen and in the set', async () => {
+    await bootOverlay();
+    stubExecCommand();
+
+    await pickAndCopy('create', 'The label is cut off.');
+
+    expect(storedIds()).toHaveLength(1);
+    expect(dockRows()).toHaveLength(1);
+    expect(node('.setdock').classList.contains('shown')).toBe(true);
+    expect(node('.card').classList.contains('found')).toBe(true);
+    expect(composeOpen()).toBe(false);
+  });
+
+  it('says what the next ⌘⏎ will do', async () => {
+    await bootOverlay();
+    stubExecCommand();
+    expect(copyButton().textContent).toBe('📋 Copy block');
+
+    await pickAndCopy('create', 'The label is cut off.');
+
+    expect(copyButton().textContent).toBe('Add & copy all (2)');
+  });
+});
+
+describe('adding to a set', () => {
+  it('copies every pin so far, behind one link', async () => {
+    await bootOverlay();
+    stubExecCommand();
+    await pickAndCopy('create', 'The label is cut off.');
+    const written = stubExecCommand();
+
+    await pickAndCopy('cancel', 'And this one is unreachable.');
+
+    const text = written['text/plain'];
+    expect(text.split('📍')).toHaveLength(3);
+    expect(text).toContain('The label is cut off.');
+    expect(text).toContain('And this one is unreachable.');
+    // One URL, in both blocks, carrying both pins.
+    const urls = [...text.matchAll(/\(http[^)]+\)/g)].map((m) => m[0]);
+    expect(urls).toHaveLength(2);
+    expect(new Set(urls).size).toBe(1);
+    expect(urls[0].split('bai=v3.')).toHaveLength(3);
+    for (const id of storedIds()) expect(urls[0]).toContain(id);
+    expect(toast()).toBe('Copied all 2 pins — replaces your last paste');
+  });
+
+  it('draws the whole set, numbered', async () => {
+    await bootOverlay();
+    stubExecCommand();
+    await pickAndCopy('create', 'one');
+
+    await pickAndCopy('cancel', 'two');
+
+    expect(storedIds()).toHaveLength(2);
+    expect(dockRows()).toHaveLength(2);
+    expect(all('.pin').map((marker) => marker.textContent)).toEqual(['1', '2']);
+  });
+
+  // The clipboard is the whole point: a pin that was never handed over must
+  // not be in the set the next copy claims to have written.
+  it('adds nothing when the clipboard write fails', async () => {
+    await bootOverlay();
+    stubExecCommand();
+    await pickAndCopy('create', 'one');
+    stubExecCommand(false);
+
+    await pickAndCopy('cancel', 'two');
+
+    expect(storedIds()).toHaveLength(1);
+    expect(dockRows()).toHaveLength(1);
+    // The note is still in the box, for the ⌘⏎ that retries it.
+    expect(composeOpen()).toBe(true);
+    expect(textarea().value).toBe('two');
+  });
+
+  /**
+   * A secure-context dev run gets `navigator.clipboard`, and its write lands
+   * a tick later — long enough for the composer to be gone by then.
+   */
+  it('commits the pin the copy actually wrote, whatever closed meanwhile', async () => {
+    await bootOverlay();
+    let landed: () => void = () => undefined;
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          landed = resolve;
+        }),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    });
+
+    await pick('create', 'one');
+    pressCopy();
+    // A second ⌘⏎ would build a second pin for the same pick.
+    pressCopy();
+    await ticks(1);
+    expect(storedIds()).toHaveLength(0);
+    pressEscape();
+    landed();
+    await ticks(2);
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(storedIds()).toHaveLength(1);
+    expect(dockRows()).toHaveLength(1);
+  });
+
+  it('refuses the pin that would overflow the set', async () => {
+    seed(
+      Array.from({ length: 30 }, (_, i) =>
+        storedPin(`c_seed${i}`, 'create', `Start › ${i}`),
+      ),
+    );
+    await bootOverlay();
+    const written = stubExecCommand();
+
+    await pickAndCopy('create', 'one too many');
+
+    expect(written['text/plain']).toBeUndefined();
+    expect(toast()).toContain('full at 30 pins');
+    expect(storedIds()).toHaveLength(30);
+    expect(composeOpen()).toBe(true);
+  });
+});
+
+describe('the set the tab was left with', () => {
+  it('is drawn and listed again at boot', async () => {
+    seed([storedPin('c_kept', 'create', 'Start › create › button "Create"')]);
+
+    await bootOverlay();
+    await ticks(4);
+
+    expect(dockRows()).toHaveLength(1);
+    expect(node('.setdock .rowlabel').textContent).toBe(
+      'Start › create › button "Create"',
+    );
+    expect(node('.card').classList.contains('found')).toBe(true);
+  });
+
+  it('copies from the dock, from one click', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+    ]);
+    await bootOverlay();
+    const written = stubExecCommand();
+
+    node<HTMLButtonElement>('.setdock .copyall').click();
+
+    expect(written['text/plain'].split('📍')).toHaveLength(3);
+    expect(toast()).toBe('Copied all 2 pins — replaces your last paste');
+  });
+
+  it('drops one pin when its ✕ is pressed', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+
+    node<HTMLButtonElement>('.card[data-pin-id="c_one"] .close').click();
+
+    expect(storedIds()).toEqual(['c_two']);
+    expect(dockRows()).toHaveLength(1);
+    expect(copyButton().textContent).toBe('Add & copy all (2)');
+  });
+
+  // The dock is 260px of chrome over the app; the next pick has to reach
+  // whatever is under it, the same way it reaches under a card.
+  it('folds the dock away while the next pick is being composed', async () => {
+    seed([storedPin('c_one', 'create', 'Start › create')]);
+    await bootOverlay();
+    await ticks(2);
+    expect(node('.setdock').classList.contains('folded')).toBe(false);
+
+    await pick('cancel', 'two');
+    expect(node('.setdock').classList.contains('folded')).toBe(true);
+
+    pressEscape();
+
+    expect(node('.setdock').classList.contains('folded')).toBe(false);
+  });
+
+  // The dock is the one control that reaches every pin, including the ones
+  // the layer never found.
+  it('says so when the dock cannot reach a pin', async () => {
+    seed([storedPin('c_gone', 'missing', 'Start › missing')]);
+    await bootOverlay();
+    await ticks(2);
+
+    node<HTMLButtonElement>('.setdock .locate').click();
+
+    expect(toast()).toBe('That pin is not on this page');
+  });
+
+  it('ends the set once the dock asks twice', async () => {
+    seed([storedPin('c_one', 'create', 'Start › create')]);
+    await bootOverlay();
+    await ticks(2);
+
+    node<HTMLButtonElement>('.setdock .clear').click();
+    expect(storedIds()).toEqual(['c_one']);
+    node<HTMLButtonElement>('.setdock .yes').click();
+
+    expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
+    expect(node('.setdock').classList.contains('shown')).toBe(false);
+    expect(all('.card.found')).toHaveLength(0);
+  });
+});

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -26,12 +26,16 @@ const copyButton = () => node<HTMLButtonElement>('[data-act="copy"]');
 const toast = () => node('.toast')?.textContent ?? '';
 const dockRows = () => all('.setdock .row');
 const composeOpen = () => node('.compose').style.display === 'block';
-const storedIds = (): string[] => {
+const storedSet = (): { pins: SetPin[]; cardsHidden?: true } => {
   const raw = sessionStorage.getItem(DRAFT_KEY);
   return raw
-    ? (JSON.parse(raw) as { pins: SetPin[] }).pins.map((p) => p.id)
-    : [];
+    ? (JSON.parse(raw) as { pins: SetPin[]; cardsHidden?: true })
+    : { pins: [] };
 };
+const storedPins = (): SetPin[] => storedSet().pins;
+const storedIds = (): string[] => storedPins().map((pin) => pin.id);
+const hiddenCard = (id: string) =>
+  node(`.card[data-pin-id="${id}"]`).classList.contains('hidden');
 
 const ticks = async (count: number, ms = 10) => {
   for (let i = 0; i < count; i++) {
@@ -108,6 +112,19 @@ const pressCopy = () =>
     }),
   );
 
+/** Both modifiers: the platform one is whichever this environment reports. */
+const pressCardsChord = () =>
+  document.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: 'H',
+      code: 'KeyH',
+      shiftKey: true,
+      metaKey: true,
+      ctrlKey: true,
+      bubbles: true,
+    }),
+  );
+
 const pressEscape = () =>
   document.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
@@ -146,7 +163,7 @@ beforeEach(() => {
 afterEach(() => {
   // The layer outlives the module and keeps a MutationObserver on `body`;
   // taking every pin down first keeps it from firing into a torn-down jsdom.
-  for (const close of all('.card .close')) close.click();
+  for (const remove of all('.card .remove')) remove.click();
   vi.unstubAllGlobals();
   // A secure-context run is one test's business, never the next one's.
   Reflect.deleteProperty(navigator, 'clipboard');
@@ -348,6 +365,29 @@ describe('the set the tab was left with', () => {
     expect(node('.card').classList.contains('found')).toBe(true);
   });
 
+  // The dock's ⧉ is the set; a card is where the reviewer points at one thing.
+  it('copies one pin, and only that one, from its own card', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+    const written = stubExecCommand();
+
+    node<HTMLButtonElement>('.card[data-pin-id="c_two"] .copyall').click();
+
+    const text = written['text/plain'];
+    expect(text.split('📍')).toHaveLength(2);
+    expect(text).toContain('Start › cancel');
+    expect(text).not.toContain('Start › create');
+    const urls = [...text.matchAll(/\(http[^)]+\)/g)].map((m) => m[0]);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toContain('c_two');
+    expect(urls[0].split('bai=v3.')).toHaveLength(2);
+    expect(toast()).toBe('Copied 1 pin');
+  });
+
   it('copies from the dock, from one click', async () => {
     seed([
       storedPin('c_one', 'create', 'Start › create'),
@@ -362,7 +402,24 @@ describe('the set the tab was left with', () => {
     expect(toast()).toBe('Copied all 2 pins — replaces your last paste');
   });
 
-  it('drops one pin when its ✕ is pressed', async () => {
+  it('drops one pin when its 🗑 is pressed', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+
+    node<HTMLButtonElement>('.card[data-pin-id="c_one"] .remove').click();
+
+    expect(storedIds()).toEqual(['c_two']);
+    expect(dockRows()).toHaveLength(1);
+    expect(copyButton().textContent).toBe('Add & copy all (2)');
+  });
+
+  // ✕ is about the card being in the way of the thing under it, and the
+  // reviewer should not lose a pin by tidying the screen.
+  it('only puts the card away when its ✕ is pressed, and remembers', async () => {
     seed([
       storedPin('c_one', 'create', 'Start › create'),
       storedPin('c_two', 'cancel', 'Start › cancel'),
@@ -372,9 +429,115 @@ describe('the set the tab was left with', () => {
 
     node<HTMLButtonElement>('.card[data-pin-id="c_one"] .close').click();
 
+    expect(storedIds()).toEqual(['c_one', 'c_two']);
+    expect(storedPins()[0].hidden).toBe(true);
+    expect(hiddenCard('c_one')).toBe(true);
+    expect(hiddenCard('c_two')).toBe(false);
+    // The marker is what still says where the pin is.
+    expect(node('.pin[data-pin-id="c_one"]').classList.contains('found')).toBe(
+      true,
+    );
+    expect(dockRows()[0].classList.contains('off')).toBe(true);
+  });
+
+  it('draws a hidden pin’s card again from its dock row', async () => {
+    seed([{ ...storedPin('c_one', 'create', 'Start › create'), hidden: true }]);
+    await bootOverlay();
+    await ticks(2);
+    expect(hiddenCard('c_one')).toBe(true);
+
+    node<HTMLButtonElement>('.setdock .row .unhide').click();
+
+    expect(hiddenCard('c_one')).toBe(false);
+    expect(storedPins()[0].hidden).toBeUndefined();
+  });
+
+  it('removes the pin the row’s 🗑 names, and renumbers the rest', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+
+    node<HTMLButtonElement>('.setdock .row .remove').click();
+
     expect(storedIds()).toEqual(['c_two']);
-    expect(dockRows()).toHaveLength(1);
-    expect(copyButton().textContent).toBe('Add & copy all (2)');
+    expect(toast()).toBe('Removed pin 1 of 2');
+    expect(all('.setdock .idx').map((idx) => idx.textContent)).toEqual(['1']);
+  });
+
+  // The marker is the only thing that says which of them is meant.
+  it('scrolls to the pin the row names and beats its marker again', async () => {
+    seed([storedPin('c_one', 'create', 'Start › create')]);
+    const scrolled: string[] = [];
+    (
+      document.querySelector('[data-testid="create"]') as HTMLElement
+    ).scrollIntoView = () => {
+      scrolled.push('create');
+    };
+    await bootOverlay();
+    await ticks(2);
+    const marker = node('.pin[data-pin-id="c_one"]');
+    marker.classList.remove('pulse');
+
+    node<HTMLButtonElement>('.setdock .rowlabel').click();
+
+    expect(scrolled).toEqual(['create']);
+    expect(marker.classList.contains('pulse')).toBe(true);
+  });
+
+  describe('the cards switch', () => {
+    beforeEach(async () => {
+      seed([
+        storedPin('c_one', 'create', 'Start › create'),
+        storedPin('c_two', 'cancel', 'Start › cancel'),
+      ]);
+      await bootOverlay();
+      await ticks(2);
+    });
+
+    it('takes every card off the page from the dock, and remembers', () => {
+      node<HTMLButtonElement>('.setdock .cards').click();
+
+      expect(hiddenCard('c_one')).toBe(true);
+      expect(hiddenCard('c_two')).toBe(true);
+      expect(storedSet().cardsHidden).toBe(true);
+      expect(
+        node('.pin[data-pin-id="c_one"]').classList.contains('found'),
+      ).toBe(true);
+
+      node<HTMLButtonElement>('.setdock .cards').click();
+      expect(hiddenCard('c_one')).toBe(false);
+      expect(storedSet().cardsHidden).toBeUndefined();
+    });
+
+    it('flips from the chord too', () => {
+      pressCardsChord();
+
+      expect(hiddenCard('c_one')).toBe(true);
+
+      pressCardsChord();
+      expect(hiddenCard('c_one')).toBe(false);
+    });
+
+    // Every key belongs to the note while one is being typed.
+    it('ignores the chord while the composer has the keyboard', async () => {
+      await pick('cancel', 'typing an h in here');
+
+      pressCardsChord();
+
+      expect(hiddenCard('c_one')).toBe(false);
+    });
+
+    // The switch is about the cards; the composer is how the next pin is made.
+    it('leaves the composer visible whatever the switch says', async () => {
+      node<HTMLButtonElement>('.setdock .cards').click();
+
+      await pick('cancel', 'still authoring');
+
+      expect(composeOpen()).toBe(true);
+    });
   });
 
   // The dock is 260px of chrome over the app; the next pick has to reach
@@ -400,7 +563,7 @@ describe('the set the tab was left with', () => {
     await bootOverlay();
     await ticks(2);
 
-    node<HTMLButtonElement>('.setdock .locate').click();
+    node<HTMLButtonElement>('.setdock .rowlabel').click();
 
     expect(toast()).toBe('That pin is not on this page');
   });

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -333,6 +333,42 @@ describe('adding to a set', () => {
     expect(dockRows()).toHaveLength(1);
   });
 
+  /**
+   * The write settles long after the composer it ran from is gone, and the
+   * reviewer is by then typing into the next pick.
+   */
+  it('never closes a composer opened after the copy it settles for', async () => {
+    await bootOverlay();
+    let landed: () => void = () => undefined;
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          landed = resolve;
+        }),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    });
+
+    await pick('create', 'one');
+    pressCopy();
+    await ticks(1);
+    pressEscape();
+    await pick('cancel', 'two');
+    landed();
+    await ticks(2);
+
+    expect(composeOpen()).toBe(true);
+    expect(textarea().value).toBe('two');
+    // The first pick still joined the set: closing did not cancel its write.
+    expect(storedIds()).toHaveLength(1);
+  });
+
   it('refuses the pin that would overflow the set', async () => {
     seed(
       Array.from({ length: 30 }, (_, i) =>

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -415,6 +415,8 @@ describe('the set the tab was left with', () => {
     expect(storedIds()).toEqual(['c_two']);
     expect(dockRows()).toHaveLength(1);
     expect(copyButton().textContent).toBe('Add & copy all (2)');
+    // Same action, same sentence, whichever 🗑 the reviewer reached for.
+    expect(toast()).toBe('Removed pin 1 of 2');
   });
 
   // ✕ is about the card being in the way of the thing under it, and the

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -148,6 +148,11 @@ const storedPin = (id: string, testid: string, label: string): SetPin => ({
   pr: 42,
 });
 
+const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+/** A distinct WELL-FORMED id per index — base32 is `a`-`z` and `2`-`7`. */
+const nthId = (i: number) =>
+  `c_s${LETTERS[i % 26]}${LETTERS[Math.floor(i / 26)]}aaaa`;
+
 const seed = (pins: SetPin[]) =>
   sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ v: 1, pins }));
 
@@ -372,7 +377,7 @@ describe('adding to a set', () => {
   it('refuses the pin that would overflow the set', async () => {
     seed(
       Array.from({ length: 30 }, (_, i) =>
-        storedPin(`c_seed${i}`, 'create', `Start › ${i}`),
+        storedPin(nthId(i), 'create', `Start › ${i}`),
       ),
     );
     await bootOverlay();
@@ -389,7 +394,7 @@ describe('adding to a set', () => {
   it('says the set is full on the button, before the ⌘⏎', async () => {
     seed(
       Array.from({ length: 30 }, (_, i) =>
-        storedPin(`c_seed${i}`, 'create', `Start › ${i}`),
+        storedPin(nthId(i), 'create', `Start › ${i}`),
       ),
     );
     await bootOverlay();
@@ -404,7 +409,9 @@ describe('adding to a set', () => {
 
 describe('the set the tab was left with', () => {
   it('is drawn and listed again at boot', async () => {
-    seed([storedPin('c_kept', 'create', 'Start › create › button "Create"')]);
+    seed([
+      storedPin('c_keptaaa', 'create', 'Start › create › button "Create"'),
+    ]);
 
     await bootOverlay();
     await ticks(4);
@@ -419,14 +426,14 @@ describe('the set the tab was left with', () => {
   // The dock's ⧉ is the set; a card is where the reviewer points at one thing.
   it('copies one pin, and only that one, from its own card', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
     ]);
     await bootOverlay();
     await ticks(2);
     const written = stubExecCommand();
 
-    node<HTMLButtonElement>('.card[data-pin-id="c_two"] .copyall').click();
+    node<HTMLButtonElement>('.card[data-pin-id="c_twoaaaa"] .copyall').click();
 
     const text = written['text/plain'];
     expect(text.split('📍')).toHaveLength(2);
@@ -434,15 +441,15 @@ describe('the set the tab was left with', () => {
     expect(text).not.toContain('Start › create');
     const urls = [...text.matchAll(/\(http[^)]+\)/g)].map((m) => m[0]);
     expect(urls).toHaveLength(1);
-    expect(urls[0]).toContain('c_two');
+    expect(urls[0]).toContain('c_twoaaaa');
     expect(urls[0].split('bai=v3.')).toHaveLength(2);
     expect(toast()).toBe('Copied 1 pin');
   });
 
   it('copies from the dock, from one click', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
     ]);
     await bootOverlay();
     const written = stubExecCommand();
@@ -457,18 +464,18 @@ describe('the set the tab was left with', () => {
   // The dock row is the one place a pin can be removed from now.
   it('drops one pin when its row’s 🗑 is pressed', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
     ]);
     await bootOverlay();
     await ticks(2);
 
     expect(all('.card .remove')).toHaveLength(0);
     node<HTMLButtonElement>(
-      '.setdock .row[data-pin-id="c_one"] .remove',
+      '.setdock .row[data-pin-id="c_oneaaaa"] .remove',
     ).click();
 
-    expect(storedIds()).toEqual(['c_two']);
+    expect(storedIds()).toEqual(['c_twoaaaa']);
     expect(dockRows()).toHaveLength(1);
     expect(copyButton().textContent).toBe('Add & copy all (2)');
     expect(toast()).toBe('Removed pin 1 of 2');
@@ -478,55 +485,57 @@ describe('the set the tab was left with', () => {
   // reviewer should not lose a pin by tidying the screen.
   it('only puts the card away when its ✕ is pressed, and remembers', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
     ]);
     await bootOverlay();
     await ticks(2);
 
-    node<HTMLButtonElement>('.card[data-pin-id="c_one"] .close').click();
+    node<HTMLButtonElement>('.card[data-pin-id="c_oneaaaa"] .close').click();
 
-    expect(storedIds()).toEqual(['c_one', 'c_two']);
+    expect(storedIds()).toEqual(['c_oneaaaa', 'c_twoaaaa']);
     expect(storedPins()[0].hidden).toBe(true);
-    expect(hiddenCard('c_one')).toBe(true);
-    expect(hiddenCard('c_two')).toBe(false);
+    expect(hiddenCard('c_oneaaaa')).toBe(true);
+    expect(hiddenCard('c_twoaaaa')).toBe(false);
     // The marker is what still says where the pin is.
-    expect(node('.pin[data-pin-id="c_one"]').classList.contains('found')).toBe(
-      true,
-    );
+    expect(
+      node('.pin[data-pin-id="c_oneaaaa"]').classList.contains('found'),
+    ).toBe(true);
     expect(dockRows()[0].classList.contains('off')).toBe(true);
   });
 
   it('draws a hidden pin’s card again from its dock row', async () => {
-    seed([{ ...storedPin('c_one', 'create', 'Start › create'), hidden: true }]);
+    seed([
+      { ...storedPin('c_oneaaaa', 'create', 'Start › create'), hidden: true },
+    ]);
     await bootOverlay();
     await ticks(2);
-    expect(hiddenCard('c_one')).toBe(true);
+    expect(hiddenCard('c_oneaaaa')).toBe(true);
 
     node<HTMLButtonElement>('.setdock .row .unhide').click();
 
-    expect(hiddenCard('c_one')).toBe(false);
+    expect(hiddenCard('c_oneaaaa')).toBe(false);
     expect(storedPins()[0].hidden).toBeUndefined();
   });
 
   it('removes the pin the row’s 🗑 names, and renumbers the rest', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
     ]);
     await bootOverlay();
     await ticks(2);
 
     node<HTMLButtonElement>('.setdock .row .remove').click();
 
-    expect(storedIds()).toEqual(['c_two']);
+    expect(storedIds()).toEqual(['c_twoaaaa']);
     expect(toast()).toBe('Removed pin 1 of 2');
     expect(all('.setdock .idx').map((idx) => idx.textContent)).toEqual(['1']);
   });
 
   // The marker is the only thing that says which of them is meant.
   it('scrolls to the pin the row names and beats its marker again', async () => {
-    seed([storedPin('c_one', 'create', 'Start › create')]);
+    seed([storedPin('c_oneaaaa', 'create', 'Start › create')]);
     const scrolled: string[] = [];
     (
       document.querySelector('[data-testid="create"]') as HTMLElement
@@ -535,7 +544,7 @@ describe('the set the tab was left with', () => {
     };
     await bootOverlay();
     await ticks(2);
-    const marker = node('.pin[data-pin-id="c_one"]');
+    const marker = node('.pin[data-pin-id="c_oneaaaa"]');
     marker.classList.remove('pulse');
 
     node<HTMLButtonElement>('.setdock .rowlabel').click();
@@ -548,22 +557,22 @@ describe('the set the tab was left with', () => {
   // the ladder re-toasts its 10 s give-up line once per flip.
   it('does not re-run the resolution ladder to hide a card', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_gone', 'missing', 'Start › missing'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_goneaaa', 'missing', 'Start › missing'),
     ]);
     await bootOverlay();
     await ticks(2);
     const scan = vi.spyOn(document, 'querySelector');
 
     node<HTMLButtonElement>('.setdock .cards').click();
-    node<HTMLButtonElement>('.card[data-pin-id="c_one"] .close').click();
+    node<HTMLButtonElement>('.card[data-pin-id="c_oneaaaa"] .close').click();
 
     expect(
       scan.mock.calls.filter(([selector]) =>
         String(selector).includes('missing'),
       ),
     ).toEqual([]);
-    expect(hiddenCard('c_one')).toBe(true);
+    expect(hiddenCard('c_oneaaaa')).toBe(true);
     scan.mockRestore();
   });
 
@@ -574,7 +583,7 @@ describe('the set the tab was left with', () => {
   it('dims the row of a pin whose element is not on the page', async () => {
     seed([
       {
-        ...storedPin('c_gone', 'missing', 'Start › missing'),
+        ...storedPin('c_goneaaa', 'missing', 'Start › missing'),
         anchor: { v: 3, s: '[data-testid="missing"]', p: '/', tid: 'missing' },
       },
     ]);
@@ -597,9 +606,9 @@ describe('the set the tab was left with', () => {
   // retry driver — running into the next test file.
   it('takes every pin down when the set is torn down', async () => {
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
-      storedPin('c_three', 'create', 'Start › create'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
+      storedPin('c_threeaa', 'create', 'Start › create'),
     ]);
     await bootOverlay();
     await ticks(2);
@@ -614,8 +623,8 @@ describe('the set the tab was left with', () => {
   describe('the cards switch', () => {
     beforeEach(async () => {
       seed([
-        storedPin('c_one', 'create', 'Start › create'),
-        storedPin('c_two', 'cancel', 'Start › cancel'),
+        storedPin('c_oneaaaa', 'create', 'Start › create'),
+        storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
       ]);
       await bootOverlay();
       await ticks(2);
@@ -624,25 +633,25 @@ describe('the set the tab was left with', () => {
     it('takes every card off the page from the dock, and remembers', () => {
       node<HTMLButtonElement>('.setdock .cards').click();
 
-      expect(hiddenCard('c_one')).toBe(true);
-      expect(hiddenCard('c_two')).toBe(true);
+      expect(hiddenCard('c_oneaaaa')).toBe(true);
+      expect(hiddenCard('c_twoaaaa')).toBe(true);
       expect(storedSet().cardsHidden).toBe(true);
       expect(
-        node('.pin[data-pin-id="c_one"]').classList.contains('found'),
+        node('.pin[data-pin-id="c_oneaaaa"]').classList.contains('found'),
       ).toBe(true);
 
       node<HTMLButtonElement>('.setdock .cards').click();
-      expect(hiddenCard('c_one')).toBe(false);
+      expect(hiddenCard('c_oneaaaa')).toBe(false);
       expect(storedSet().cardsHidden).toBeUndefined();
     });
 
     it('flips from the chord too', () => {
       pressCardsChord();
 
-      expect(hiddenCard('c_one')).toBe(true);
+      expect(hiddenCard('c_oneaaaa')).toBe(true);
 
       pressCardsChord();
-      expect(hiddenCard('c_one')).toBe(false);
+      expect(hiddenCard('c_oneaaaa')).toBe(false);
     });
 
     // Every key belongs to the note while one is being typed.
@@ -651,7 +660,7 @@ describe('the set the tab was left with', () => {
 
       pressCardsChord();
 
-      expect(hiddenCard('c_one')).toBe(false);
+      expect(hiddenCard('c_oneaaaa')).toBe(false);
     });
 
     // The switch is about the cards; the composer is how the next pin is made.
@@ -667,7 +676,7 @@ describe('the set the tab was left with', () => {
   // The dock is 260px of chrome over the app; the next pick has to reach
   // whatever is under it, the same way it reaches under a card.
   it('folds the dock away while the next pick is being composed', async () => {
-    seed([storedPin('c_one', 'create', 'Start › create')]);
+    seed([storedPin('c_oneaaaa', 'create', 'Start › create')]);
     await bootOverlay();
     await ticks(2);
     expect(node('.setdock').classList.contains('folded')).toBe(false);
@@ -683,7 +692,7 @@ describe('the set the tab was left with', () => {
   // The dock is the one control that reaches every pin, including the ones
   // the layer never found.
   it('says so when the dock cannot reach a pin', async () => {
-    seed([storedPin('c_gone', 'missing', 'Start › missing')]);
+    seed([storedPin('c_goneaaa', 'missing', 'Start › missing')]);
     await bootOverlay();
     await ticks(2);
 
@@ -693,12 +702,12 @@ describe('the set the tab was left with', () => {
   });
 
   it('ends the set once the dock asks twice', async () => {
-    seed([storedPin('c_one', 'create', 'Start › create')]);
+    seed([storedPin('c_oneaaaa', 'create', 'Start › create')]);
     await bootOverlay();
     await ticks(2);
 
     node<HTMLButtonElement>('.setdock .clear').click();
-    expect(storedIds()).toEqual(['c_one']);
+    expect(storedIds()).toEqual(['c_oneaaaa']);
     node<HTMLButtonElement>('.setdock .yes').click();
 
     expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
@@ -718,29 +727,29 @@ describe('the cards switch as show-all', () => {
   it('shows every card again, including the ones hidden one by one', async () => {
     mount('save', 'Save');
     seed([
-      { ...storedPin('c_one', 'create', 'Start › create'), hidden: true },
-      storedPin('c_two', 'cancel', 'Start › cancel'),
-      { ...storedPin('c_three', 'save', 'Start › save'), hidden: true },
+      { ...storedPin('c_oneaaaa', 'create', 'Start › create'), hidden: true },
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
+      { ...storedPin('c_threeaa', 'save', 'Start › save'), hidden: true },
     ]);
     await bootOverlay();
     await ticks(2);
-    expect(hiddenCard('c_one')).toBe(true);
-    expect(hiddenCard('c_three')).toBe(true);
+    expect(hiddenCard('c_oneaaaa')).toBe(true);
+    expect(hiddenCard('c_threeaa')).toBe(true);
 
     cardsSwitch().click();
     cardsSwitch().click();
 
-    expect(hiddenCard('c_one')).toBe(false);
-    expect(hiddenCard('c_two')).toBe(false);
-    expect(hiddenCard('c_three')).toBe(false);
+    expect(hiddenCard('c_oneaaaa')).toBe(false);
+    expect(hiddenCard('c_twoaaaa')).toBe(false);
+    expect(hiddenCard('c_threeaa')).toBe(false);
     expect(storedPins().some((pin) => pin.hidden)).toBe(false);
   });
 
   // Off is not "remember what was hidden and hide everything else".
   it('leaves the per-pin flags alone on the way off', async () => {
     seed([
-      { ...storedPin('c_one', 'create', 'Start › create'), hidden: true },
-      storedPin('c_two', 'cancel', 'Start › cancel'),
+      { ...storedPin('c_oneaaaa', 'create', 'Start › create'), hidden: true },
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
     ]);
     await bootOverlay();
     await ticks(2);

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -161,13 +161,14 @@ beforeEach(() => {
 });
 
 /**
- * Views are reused BY POSITION and popped from the END, so a snapshot of the
- * buttons goes stale on the first click — the trailing ones then belong to
- * disposed views and do nothing. Drain the live ones instead.
+ * The dock row's 🗑 is the only remove control (R6.2). Its rows are rebuilt on
+ * every render, so a snapshot goes stale on the first click — take the live
+ * head of the list each time.
  */
 function tearDownPins() {
   for (let left = MAX_SET_PINS; left > 0; left--) {
-    const remove = all('.card .remove')[0] as HTMLButtonElement | undefined;
+    const remove = all('.setdock .row .remove')[0] as
+      HTMLButtonElement | undefined;
     if (!remove) return;
     remove.click();
   }
@@ -416,7 +417,9 @@ describe('the set the tab was left with', () => {
     expect(toast()).toBe('Copied all 2 pins — replaces your last paste');
   });
 
-  it('drops one pin when its 🗑 is pressed', async () => {
+  // R6.2: the card's 🗑 sat 20px from ⧉, so reaching for copy ended the pin.
+  // The dock row is the one place a pin can be removed from now.
+  it('drops one pin when its row’s 🗑 is pressed', async () => {
     seed([
       storedPin('c_one', 'create', 'Start › create'),
       storedPin('c_two', 'cancel', 'Start › cancel'),
@@ -424,12 +427,14 @@ describe('the set the tab was left with', () => {
     await bootOverlay();
     await ticks(2);
 
-    node<HTMLButtonElement>('.card[data-pin-id="c_one"] .remove').click();
+    expect(all('.card .remove')).toHaveLength(0);
+    node<HTMLButtonElement>(
+      '.setdock .row[data-pin-id="c_one"] .remove',
+    ).click();
 
     expect(storedIds()).toEqual(['c_two']);
     expect(dockRows()).toHaveLength(1);
     expect(copyButton().textContent).toBe('Add & copy all (2)');
-    // Same action, same sentence, whichever 🗑 the reviewer reached for.
     expect(toast()).toBe('Removed pin 1 of 2');
   });
 
@@ -524,6 +529,32 @@ describe('the set the tab was left with', () => {
     ).toEqual([]);
     expect(hiddenCard('c_one')).toBe(true);
     scan.mockRestore();
+  });
+
+  /**
+   * R7.2/R7.3: the element is not rendered right now — a closed modal — which
+   * is a different thing from gone, and the row is what has to say so.
+   */
+  it('dims the row of a pin whose element is not on the page', async () => {
+    seed([
+      {
+        ...storedPin('c_gone', 'missing', 'Start › missing'),
+        anchor: { v: 3, s: '[data-testid="missing"]', p: '/', tid: 'missing' },
+      },
+    ]);
+    await bootOverlay();
+    await ticks(2);
+
+    expect(dockRows()[0].classList.contains('waiting')).toBe(true);
+    expect(dockRows()[0].querySelector('.where')?.textContent).toBe(
+      'waiting — missing',
+    );
+
+    mount('missing', 'Missing');
+    await ticks(60);
+
+    expect(dockRows()[0].classList.contains('waiting')).toBe(false);
+    expect(dockRows()[0].querySelector('.where')).toBeNull();
   });
 
   // A teardown that halves the set leaves a live layer — MutationObserver and

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -228,7 +228,7 @@ describe('the first pin of a set', () => {
   it('says what the next ⌘⏎ will do', async () => {
     await bootOverlay();
     stubExecCommand();
-    expect(copyButton().textContent).toBe('📋 Copy block');
+    expect(copyButton().textContent).toBe('Copy block');
 
     await pickAndCopy('create', 'The label is cut off.');
 
@@ -637,5 +637,49 @@ describe('the set the tab was left with', () => {
     expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
     expect(node('.setdock').classList.contains('shown')).toBe(false);
     expect(all('.card.found')).toHaveLength(0);
+  });
+});
+
+/**
+ * R5.5. The switch is hide-all / SHOW-all, not suspend-and-restore: a reviewer
+ * who presses "show" expects to see everything, not everything except what
+ * they hid one card at a time.
+ */
+describe('the cards switch as show-all', () => {
+  const cardsSwitch = () => node<HTMLButtonElement>('.setdock .cards');
+
+  it('shows every card again, including the ones hidden one by one', async () => {
+    mount('save', 'Save');
+    seed([
+      { ...storedPin('c_one', 'create', 'Start › create'), hidden: true },
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+      { ...storedPin('c_three', 'save', 'Start › save'), hidden: true },
+    ]);
+    await bootOverlay();
+    await ticks(2);
+    expect(hiddenCard('c_one')).toBe(true);
+    expect(hiddenCard('c_three')).toBe(true);
+
+    cardsSwitch().click();
+    cardsSwitch().click();
+
+    expect(hiddenCard('c_one')).toBe(false);
+    expect(hiddenCard('c_two')).toBe(false);
+    expect(hiddenCard('c_three')).toBe(false);
+    expect(storedPins().some((pin) => pin.hidden)).toBe(false);
+  });
+
+  // Off is not "remember what was hidden and hide everything else".
+  it('leaves the per-pin flags alone on the way off', async () => {
+    seed([
+      { ...storedPin('c_one', 'create', 'Start › create'), hidden: true },
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+
+    cardsSwitch().click();
+
+    expect(storedPins()[0].hidden).toBe(true);
   });
 });

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -4,7 +4,7 @@
  * comment behind one link. Only `main.ts` composes the store, the composer,
  * the layer and the dock, so this is where the flow can be asserted at all.
  */
-import { DRAFT_KEY } from './draft.js';
+import { DRAFT_KEY, MAX_SET_PINS } from './draft.js';
 import type { SetPin } from './types.js';
 import type { Plugin, ReactGrabAPI } from 'react-grab';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -160,10 +160,24 @@ beforeEach(() => {
   mount('cancel', 'Cancel');
 });
 
+/**
+ * Views are reused BY POSITION and popped from the END, so a snapshot of the
+ * buttons goes stale on the first click — the trailing ones then belong to
+ * disposed views and do nothing. Drain the live ones instead.
+ */
+function tearDownPins() {
+  for (let left = MAX_SET_PINS; left > 0; left--) {
+    const remove = all('.card .remove')[0] as HTMLButtonElement | undefined;
+    if (!remove) return;
+    remove.click();
+  }
+}
+
 afterEach(() => {
-  // The layer outlives the module and keeps a MutationObserver on `body`;
-  // taking every pin down first keeps it from firing into a torn-down jsdom.
-  for (const remove of all('.card .remove')) remove.click();
+  // The layer outlives the module and keeps a MutationObserver on `body` plus
+  // a 10 s retry driver; taking every pin down first keeps them from firing
+  // into a torn-down jsdom.
+  tearDownPins();
   vi.unstubAllGlobals();
   // A secure-context run is one test's business, never the next one's.
   Reflect.deleteProperty(navigator, 'clipboard');
@@ -510,6 +524,24 @@ describe('the set the tab was left with', () => {
     ).toEqual([]);
     expect(hiddenCard('c_one')).toBe(true);
     scan.mockRestore();
+  });
+
+  // A teardown that halves the set leaves a live layer — MutationObserver and
+  // retry driver — running into the next test file.
+  it('takes every pin down when the set is torn down', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_three', 'create', 'Start › create'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+
+    tearDownPins();
+
+    expect(storedIds()).toEqual([]);
+    expect(all('.card')).toHaveLength(0);
+    expect(dockRows()).toHaveLength(0);
   });
 
   describe('the cards switch', () => {

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -487,6 +487,29 @@ describe('the set the tab was left with', () => {
     expect(marker.classList.contains('pulse')).toBe(true);
   });
 
+  // Nothing about hiding a card changes what can be resolved, and re-running
+  // the ladder re-toasts its 10 s give-up line once per flip.
+  it('does not re-run the resolution ladder to hide a card', async () => {
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_gone', 'missing', 'Start › missing'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+    const scan = vi.spyOn(document, 'querySelector');
+
+    node<HTMLButtonElement>('.setdock .cards').click();
+    node<HTMLButtonElement>('.card[data-pin-id="c_one"] .close').click();
+
+    expect(
+      scan.mock.calls.filter(([selector]) =>
+        String(selector).includes('missing'),
+      ),
+    ).toEqual([]);
+    expect(hiddenCard('c_one')).toBe(true);
+    scan.mockRestore();
+  });
+
   describe('the cards switch', () => {
     beforeEach(async () => {
       seed([

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -399,7 +399,7 @@ function boot() {
     draft = store.pins();
     pruneStacks();
     dock.render(draft);
-    ui.setDraftSize(draft.length);
+    ui.setDraftSize(draft.length, store.isFull());
   }
 
   /** The whole set, from a click; nothing may be awaited before the write. */

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -1,20 +1,23 @@
 /**
- * Dev review overlay (FR-3811 write side, FR-3813 deep link).
+ * Dev review overlay (FR-3811 write side, FR-3813 deep link, FR-3858 sets).
  *
  * Pick an element with react-grab (⌘⌃C, or the same chord bound by the overlay
  * itself when react-grab is missing), type a note, press ⌘⏎: a self-describing
  * `#bai=v3` block lands on the clipboard as both markdown and HTML, so it
  * pastes right into a GitHub PR comment, the PR's Teams thread, or a Claude
- * prompt. Opening that block's link on this server is the read side: the hash
- * carries the whole anchor, so the element is pinned with no lookup at all.
+ * prompt. The pin stays in the DRAFT SET, so the next ⌘⏎ copies every pin so
+ * far as one comment behind one link. Opening that link on this server is the
+ * read side: the hash carries the whole anchor, so the element is pinned with
+ * no lookup at all.
  */
 import { isAnchorV3 } from './anchor-guard.js';
 import { captureAnchorSignals, withNote } from './anchor.js';
 import {
   blockStamp,
-  buildBlockFromCapture,
   buildBlockHtml,
   buildBlockText,
+  buildSetHtml,
+  buildSetText,
   captureForBlock,
   landmarkLabel,
   resolveRouteLabel,
@@ -23,10 +26,14 @@ import {
 import { decodeAnchor } from './codec.js';
 import {
   createNavigationGuard,
+  otherFragment,
   parseFragment,
   pathNeedsChange,
   pinUrl,
 } from './deeplink.js';
+import { createSetDock } from './dock.js';
+import { createDraftStore, MAX_SET_PINS } from './draft.js';
+import { pinId } from './id.js';
 import { createPicker } from './picker.js';
 import { createPinLayer, type DeepLinkPinTarget } from './pin.js';
 import type {
@@ -34,8 +41,9 @@ import type {
   AnchorV3,
   CopyPayload,
   ReviewServerState,
+  SetPin,
 } from './types.js';
-import { createOverlayUI } from './ui.js';
+import { COPIED_ONE, createOverlayUI } from './ui.js';
 
 /** The SPA's own `<Navigate replace>` redirects drop the fragment on login. */
 const BOOT_HASH = location.hash;
@@ -69,24 +77,54 @@ function boot() {
   /** Typing faster than `encodeAnchor` resolves; only the last one counts. */
   let encodeSeq = 0;
   let pickActive = false;
+
+  // ------------------------------------------------- the draft set (FR-3858)
+
+  const store = createDraftStore();
+  let draft: SetPin[] = store.pins();
+  /** The pin a link opened; FR-3859 merges it into the draft instead. */
+  let linkTarget: DeepLinkPinTarget | null = null;
+
   /**
-   * Drawn cards sit over the app, so the next pick would land on one. The
-   * markers are click-through already; only the cards have to fold away.
+   * Drawn chrome sits over the app, so the next pick would land on it. The
+   * markers are click-through already; the cards and the dock fold away.
    */
-  const syncCollapse = () =>
-    pins.setCollapsed(pickActive || ui.getComposeTarget() !== null);
+  function syncCollapse() {
+    const busy = pickActive || ui.getComposeTarget() !== null;
+    pins.setCollapsed(busy);
+    dock.setCollapsed(busy);
+  }
+
+  /** The set's success line, whatever wrote it. */
+  const copiedToast = (count: number) =>
+    count > 1
+      ? `Copied all ${count} pins — replaces your last paste`
+      : COPIED_ONE;
 
   const ui = createOverlayUI({
     onBuildBlock: (text) => {
       const target = ui.getComposeTarget();
       if (!target || capture?.target !== target || capture.note !== text)
         return null;
-      const built = buildBlockFromCapture(capture.value, {
-        text,
-        pr: serverState?.pr ?? 0,
-        routeLabel: currentRouteLabel(),
-      });
-      return { text: built.block, html: built.html };
+      if (store.isFull())
+        return {
+          refused: `Your set is full at ${MAX_SET_PINS} pins — clear it or dismiss one`,
+        };
+      const pin = pickedPin(capture.value, text);
+      if (store.has(pin.id)) return { refused: 'Already pinned' };
+      const set = [...draft, pin];
+      return {
+        text: buildSetText(set),
+        html: buildSetHtml(set),
+        toast: copiedToast(set.length),
+        // The pin joins the set only once THIS write has landed: a copy that
+        // failed, or a composer closed while it was in flight, adds nothing.
+        commit: () => {
+          store.add(pin);
+          syncDraft();
+          redraw();
+        },
+      };
     },
     onNoteChanged: (text) => void encodeFor(text),
     onComposeClosed: () => {
@@ -182,55 +220,110 @@ function boot() {
   const currentRouteLabel = () =>
     resolveRouteLabel(location.pathname, window.__BAI_REVIEW__?.routeLabel);
 
+  /**
+   * The pin the composer would add, stamped now: `at` fixes the identity, and
+   * the label and the app fragment are what the reviewer sees at this moment.
+   * Every part of it is synchronous — the anchor was encoded at pick time.
+   */
+  function pickedPin(value: AnchorCapture, note: string): SetPin {
+    const at = blockStamp();
+    const pr = serverState?.pr ?? 0;
+    return {
+      id: pinId(pr, value.anchorB64, at),
+      origin: 'pick',
+      anchor: value.anchor,
+      anchorB64: value.anchorB64,
+      label: landmarkLabel(currentRouteLabel(), value.anchor),
+      appHash: otherFragment(location.hash),
+      stack: value.stack,
+      note,
+      at,
+      pr,
+    };
+  }
+
   // ------------------------------------------------- deep link (FR-3813)
 
   /** A pin that locates before react-grab registers, retried into a stack. */
   const STACK_TRIES = 8;
   const STACK_RETRY_MS = 500;
   /**
-   * The ⚛️ stack the copied comment quotes. The anchor does not carry it — it
-   * is re-read here, from the element this pin landed on, the same way the
-   * composer read it when the comment was written.
+   * The ⚛️ stack a copied comment quotes, per pin. The anchor does not carry
+   * it — it is re-read from the element that pin landed on, the same way the
+   * composer read it when the comment was written. A pin the reviewer picked
+   * on this tab already has its stack stored, so only a link's pins pay this.
    */
-  let pinStack: string[] = [];
-  let stackOf: Element | null = null;
-  /** False until `pr` and the stack are both this element's — see `buildComment`. */
-  let pinReady = false;
+  interface PinStack {
+    element: Element;
+    stack: string[];
+    /** False until `pr` and the stack are both this element's. */
+    ready: boolean;
+  }
+  const stacks = new Map<string, PinStack>();
 
-  async function readPinStack(element: Element | null) {
-    stackOf = element;
-    pinStack = [];
-    pinReady = false;
-    if (!element) return;
+  /** A pin nothing draws any more must not keep its element alive. */
+  function pruneStacks() {
+    for (const id of stacks.keys())
+      if (!store.has(id) && linkTarget?.id !== id) stacks.delete(id);
+  }
+
+  async function readPinStack(
+    target: DeepLinkPinTarget | null,
+    element: Element | null,
+  ) {
+    if (!target) return;
+    const id = target.id;
+    if (draft.some((pin) => pin.id === id && pin.origin === 'pick')) return;
+    if (!element) {
+      stacks.delete(id);
+      return;
+    }
+    const held = stacks.get(id);
+    if (held?.element === element && held.ready) return;
+    // The entry IS the cancellation token: a later locate replaces it, and
+    // every await below drops out when the map no longer holds this one.
+    const entry: PinStack = { element, stack: [], ready: false };
+    stacks.set(id, entry);
     // `pr` is part of the block, so the copy waits for the same gate the
     // composer waits for rather than writing `pr=0`.
     await stateReady;
     for (let left = STACK_TRIES; ; left--) {
       const stack = await picker.getStack(element);
-      if (stackOf !== element) return;
-      pinStack = stack;
-      pinReady = true;
+      if (stacks.get(id) !== entry) return;
+      entry.stack = stack;
+      entry.ready = true;
       // An empty stack is the answer once react-grab is there; before that it
       // only means the app has not finished booting.
       if (stack.length || left <= 0 || picker.hasReactGrab()) return;
       await new Promise((resolve) => setTimeout(resolve, STACK_RETRY_MS));
-      if (stackOf !== element) return;
+      if (stacks.get(id) !== entry) return;
     }
   }
 
   /**
-   * The comment this pin was written as, re-rendered here. The note, the label
-   * and the link all come off the fragment, so they are the reviewer's own;
-   * `pr` and `at` describe this copy, and the id is what carries the identity.
-   * `null` while the element's own reads are still in flight — a block missing
-   * its stack, or claiming `pr=0`, is not the comment that was written.
+   * What the card's ⧉ writes. A pin the draft set holds copies the WHOLE set —
+   * one comment, one link, whichever card was pressed. A pin that only a link
+   * put on screen is re-rendered here instead: the note, the label and the
+   * link come off the fragment, `pr` and `at` describe this copy, and the id
+   * is what carries the identity. `null` while this element's own reads are
+   * still in flight — a block missing its stack, or claiming `pr=0`, is not
+   * the comment that was written.
    */
   function buildComment(target: DeepLinkPinTarget): CopyPayload | null {
-    if (!pinReady) return null;
+    if (draft.some((pin) => pin.id === target.id))
+      return {
+        text: buildSetText(draft),
+        html: buildSetHtml(draft),
+        // The card would otherwise describe one pin, and claim a truncated
+        // note the set's blocks do not have.
+        toast: copiedToast(draft.length),
+      };
+    const read = stacks.get(target.id);
+    if (!read?.ready) return null;
     const input = {
       label: target.label,
       id: target.id,
-      stack: pinStack,
+      stack: read.stack,
       text: target.anchor.n ?? '',
       // The app's own fragment rides alongside the pin (`#tab=logs&bai=v3.…`),
       // and dropping it would reopen the page on a different tab.
@@ -247,12 +340,80 @@ function boot() {
     copyText: ui.copyText,
     showToast: ui.showToast,
     buildComment,
-    onLocated: (element) => void readPinStack(element),
+    onLocated: (element, target) => void readPinStack(target, element),
+    onDismiss: (target) => {
+      stacks.delete(target.id);
+      if (linkTarget?.id === target.id) linkTarget = null;
+      if (!store.has(target.id)) return;
+      store.remove(target.id);
+      syncDraft();
+    },
   });
-  // After the layer: registering the plugin can activate react-grab straight
-  // away, and `syncCollapse` reaches `pins`.
+  const dock = createSetDock({
+    root: ui.root,
+    onCopyAll: copySet,
+    onClear: () => {
+      store.clear();
+      syncDraft();
+      redraw();
+    },
+    onLocate: (id) => {
+      const element = pins.locatedElement(id);
+      // The one control that reaches every pin has to answer for the ones the
+      // layer never found; FR-3859 turns that into the "go" button.
+      if (!element) return ui.showToast('That pin is not on this page');
+      element.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
+    },
+  });
+  // After the layer and the dock: registering the plugin can activate
+  // react-grab straight away, and `syncCollapse` reaches both.
   picker.watchForReactGrab();
   const guard = createNavigationGuard();
+
+  const targetOf = (pin: SetPin): DeepLinkPinTarget => ({
+    id: pin.id,
+    anchor: pin.anchor,
+    anchorB64: pin.anchorB64,
+    label: pin.label,
+  });
+
+  function drawnTargets(): DeepLinkPinTarget[] {
+    const targets = draft.map(targetOf);
+    const link = linkTarget;
+    if (link && !draft.some((pin) => pin.id === link.id)) targets.push(link);
+    return targets;
+  }
+
+  /**
+   * `focusId: null` by default: restoring a set, or growing one, must not
+   * scroll the page out from under the reviewer. Only a link names a pin.
+   */
+  function redraw(focusId: string | null = null) {
+    // Only the draft is the set; a link's pin is drawn beside it, uncounted,
+    // so the glyphs never claim a membership the copy does not have.
+    pins.show(drawnTargets(), { focusId, setSize: draft.length });
+  }
+
+  /** The store is the truth; the dock and the composer's button follow it. */
+  function syncDraft() {
+    draft = store.pins();
+    pruneStacks();
+    dock.render(draft);
+    ui.setDraftSize(draft.length);
+  }
+
+  /** The whole set, from a click; nothing may be awaited before the write. */
+  function copySet() {
+    if (!draft.length) return;
+    const count = draft.length;
+    const copied = ui.copyText(buildSetText(draft), buildSetHtml(draft));
+    const done = (ok: boolean) =>
+      ui.showToast(
+        ok ? copiedToast(count) : 'Could not reach the clipboard — try again',
+      );
+    if (typeof copied === 'boolean') done(copied);
+    else void copied.then(done);
+  }
 
   /** The route the pin was made on, not the one the reader happens to be on. */
   const anchorRouteLabel = (anchor: AnchorV3) =>
@@ -289,15 +450,14 @@ function boot() {
       guard.landed();
     }
     // The layer owns the retry ladder: one driver for however many pins the
-    // link carried, and one give-up sentence for all of them.
-    pins.show([
-      {
-        id: fragment.id,
-        anchor,
-        anchorB64: fragment.anchorB64,
-        label: landmarkLabel(anchorRouteLabel(anchor), anchor),
-      },
-    ]);
+    // draft set and the link add up to, and one give-up sentence for them all.
+    linkTarget = {
+      id: fragment.id,
+      anchor,
+      anchorB64: fragment.anchorB64,
+      label: landmarkLabel(anchorRouteLabel(anchor), anchor),
+    };
+    redraw(fragment.id);
   }
 
   window.addEventListener('hashchange', () => {
@@ -305,5 +465,7 @@ function boot() {
     void applyFragment(location.hash);
   });
 
+  syncDraft();
+  if (draft.length) redraw();
   void applyFragment(BOOT_HASH);
 }

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -39,7 +39,7 @@ import { createPinLayer, type DeepLinkPinTarget } from './pin.js';
 import type {
   AnchorComponent,
   AnchorV3,
-  CopyPayload,
+  PinCopyPayload,
   ReviewServerState,
   SetPin,
 } from './types.js';
@@ -316,7 +316,7 @@ function boot() {
    * flight — a block missing its stack, or claiming `pr=0`, is not the
    * comment that was written.
    */
-  function buildComment(target: DeepLinkPinTarget): CopyPayload | null {
+  function buildComment(target: DeepLinkPinTarget): PinCopyPayload | null {
     const pin = draft.find((held) => held.id === target.id);
     if (pin)
       return {

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -443,6 +443,10 @@ function boot() {
   function toggleCards() {
     store.hideCards(!store.cardsHidden());
     pins.setCardsHidden(store.cardsHidden());
+    // Switching back ON cleared every pin's own ✕ (R5.5); the layer has to
+    // hear about that or the cards it hid one at a time stay hidden.
+    for (const pin of store.pins())
+      pins.setCardHidden(pin.id, pin.hidden === true);
     syncDraft();
   }
 

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -34,7 +34,7 @@ import {
 import { createSetDock } from './dock.js';
 import { createDraftStore, MAX_SET_PINS } from './draft.js';
 import { pinId } from './id.js';
-import { createPicker } from './picker.js';
+import { createPicker, isEditable, isMac } from './picker.js';
 import { createPinLayer, type DeepLinkPinTarget } from './pin.js';
 import type {
   AnchorComponent,
@@ -100,6 +100,16 @@ function boot() {
     count > 1
       ? `Copied all ${count} pins — replaces your last paste`
       : COPIED_ONE;
+
+  /**
+   * One card's ⧉. A link caps the note it carries, and a block rendered from
+   * that cap — a link's pin has no fuller copy — says so rather than losing it
+   * quietly.
+   */
+  const onePinToast = (pin: { note?: string; anchor: AnchorV3 }): string =>
+    pin.note === undefined && pin.anchor.nt === 1
+      ? 'Copied 1 pin — the note is the shortened one the link carries'
+      : 'Copied 1 pin';
 
   const ui = createOverlayUI({
     onBuildBlock: (text) => {
@@ -301,22 +311,22 @@ function boot() {
   }
 
   /**
-   * What the card's ⧉ writes. A pin the draft set holds copies the WHOLE set —
-   * one comment, one link, whichever card was pressed. A pin that only a link
-   * put on screen is re-rendered here instead: the note, the label and the
-   * link come off the fragment, `pr` and `at` describe this copy, and the id
-   * is what carries the identity. `null` while this element's own reads are
-   * still in flight — a block missing its stack, or claiming `pr=0`, is not
-   * the comment that was written.
+   * What the card's ⧉ writes: THAT pin, one block behind its own link. The
+   * set as a whole is the dock's ⧉ — a card is where the reviewer points at
+   * one thing, so it hands over one thing. A pin that only a link put on
+   * screen is re-rendered here instead: the note, the label and the link come
+   * off the fragment, `pr` and `at` describe this copy, and the id is what
+   * carries the identity. `null` while this element's own reads are still in
+   * flight — a block missing its stack, or claiming `pr=0`, is not the
+   * comment that was written.
    */
   function buildComment(target: DeepLinkPinTarget): CopyPayload | null {
-    if (draft.some((pin) => pin.id === target.id))
+    const pin = draft.find((held) => held.id === target.id);
+    if (pin)
       return {
-        text: buildSetText(draft),
-        html: buildSetHtml(draft),
-        // The card would otherwise describe one pin, and claim a truncated
-        // note the set's blocks do not have.
-        toast: copiedToast(draft.length),
+        text: buildSetText([pin]),
+        html: buildSetHtml([pin]),
+        toast: onePinToast(pin),
       };
     const read = stacks.get(target.id);
     if (!read?.ready) return null;
@@ -331,7 +341,11 @@ function boot() {
       pr: serverState?.pr ?? 0,
       at: blockStamp(),
     };
-    return { text: buildBlockText(input), html: buildBlockHtml(input) };
+    return {
+      text: buildBlockText(input),
+      html: buildBlockHtml(input),
+      toast: onePinToast({ anchor: target.anchor }),
+    };
   }
 
   const pins = createPinLayer({
@@ -341,13 +355,8 @@ function boot() {
     showToast: ui.showToast,
     buildComment,
     onLocated: (element, target) => void readPinStack(target, element),
-    onDismiss: (target) => {
-      stacks.delete(target.id);
-      if (linkTarget?.id === target.id) linkTarget = null;
-      if (!store.has(target.id)) return;
-      store.remove(target.id);
-      syncDraft();
-    },
+    onDismiss: (target) => removePin(target.id),
+    onHide: (target) => setHidden(target.id, true),
   });
   const dock = createSetDock({
     root: ui.root,
@@ -363,7 +372,18 @@ function boot() {
       // layer never found; FR-3859 turns that into the "go" button.
       if (!element) return ui.showToast('That pin is not on this page');
       element.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
+      // The arrival beat is long spent — this is a deliberate "that one".
+      pins.pulse(id);
     },
+    onRemove: (id) => {
+      const index = draft.findIndex((pin) => pin.id === id);
+      if (index < 0) return;
+      const size = draft.length;
+      removePin(id);
+      ui.showToast(`Removed pin ${index + 1} of ${size}`);
+    },
+    onUnhide: (id) => setHidden(id, false),
+    onToggleCards: toggleCards,
   });
   // After the layer and the dock: registering the plugin can activate
   // react-grab straight away, and `syncCollapse` reaches both.
@@ -389,16 +409,46 @@ function boot() {
    * scroll the page out from under the reviewer. Only a link names a pin.
    */
   function redraw(focusId: string | null = null) {
+    pins.setCardsHidden(store.cardsHidden());
     // Only the draft is the set; a link's pin is drawn beside it, uncounted,
     // so the glyphs never claim a membership the copy does not have.
     pins.show(drawnTargets(), { focusId, setSize: draft.length });
+    // Adopting a pin gives it a fresh card, so its ✕ is re-applied here.
+    for (const pin of draft) pins.setCardHidden(pin.id, pin.hidden === true);
+  }
+
+  /** 🗑, from a card or from a dock row. */
+  function removePin(id: string) {
+    stacks.delete(id);
+    if (linkTarget?.id === id) linkTarget = null;
+    if (!store.has(id)) return;
+    store.remove(id);
+    syncDraft();
+    redraw();
+  }
+
+  /** ✕ on a card, or 👁 on its row: the pin stays in the set, the card goes. */
+  function setHidden(id: string, hidden: boolean) {
+    // A pin only a link put on screen is in nobody's set, and its card is
+    // still the reviewer's to close.
+    if (!store.has(id)) return pins.setCardHidden(id, hidden);
+    store.hide(id, hidden);
+    syncDraft();
+    redraw();
+  }
+
+  /** The dock's 👁 switch and its chord, one path. */
+  function toggleCards() {
+    store.hideCards(!store.cardsHidden());
+    syncDraft();
+    redraw();
   }
 
   /** The store is the truth; the dock and the composer's button follow it. */
   function syncDraft() {
     draft = store.pins();
     pruneStacks();
-    dock.render(draft);
+    dock.render(draft, store.cardsHidden());
     ui.setDraftSize(draft.length, store.isFull());
   }
 
@@ -459,6 +509,22 @@ function boot() {
     };
     redraw(fragment.id);
   }
+
+  /**
+   * The switch's chord. Plain ⌘H hides the Mac app and Ctrl+H opens the
+   * browser's history, so Shift is what makes this one ours. It belongs to the
+   * dock, so it does nothing without a set — and nothing at all while a note
+   * is being typed, where every key belongs to the note.
+   */
+  document.addEventListener('keydown', (evt) => {
+    if (!evt.shiftKey || evt.altKey) return;
+    if (!(isMac() ? evt.metaKey : evt.ctrlKey)) return;
+    if (evt.code !== 'KeyH' && evt.key?.toLowerCase() !== 'h') return;
+    if (!draft.length || ui.isTyping() || isEditable(document.activeElement))
+      return;
+    evt.preventDefault();
+    toggleCards();
+  });
 
   window.addEventListener('hashchange', () => {
     guard.reset();

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -118,7 +118,7 @@ function boot() {
         return null;
       if (store.isFull())
         return {
-          refused: `Your set is full at ${MAX_SET_PINS} pins — clear it or dismiss one`,
+          refused: `Your set is full at ${MAX_SET_PINS} pins — clear it or remove a pin`,
         };
       const pin = pickedPin(capture.value, text);
       if (store.has(pin.id)) return { refused: 'Already pinned' };

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -427,21 +427,24 @@ function boot() {
     redraw();
   }
 
-  /** ✕ on a card, or 👁 on its row: the pin stays in the set, the card goes. */
+  /**
+   * ✕ on a card, or its row's eye. Visibility only — `redraw()` would restart
+   * the resolution ladder and re-toast its give-up line at every flip.
+   */
   function setHidden(id: string, hidden: boolean) {
-    // A pin only a link put on screen is in nobody's set, and its card is
-    // still the reviewer's to close.
-    if (!store.has(id)) return pins.setCardHidden(id, hidden);
+    pins.setCardHidden(id, hidden);
+    // A pin only a link put on screen is in nobody's set; the card is still
+    // the reviewer's to close, but there is no draft flag to persist.
+    if (!store.has(id)) return;
     store.hide(id, hidden);
     syncDraft();
-    redraw();
   }
 
-  /** The dock's 👁 switch and its chord, one path. */
+  /** The dock's cards switch and its chord, one path — visibility only. */
   function toggleCards() {
     store.hideCards(!store.cardsHidden());
+    pins.setCardsHidden(store.cardsHidden());
     syncDraft();
-    redraw();
   }
 
   /** The store is the truth; the dock and the composer's button follow it. */

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -101,11 +101,7 @@ function boot() {
       ? `Copied all ${count} pins — replaces your last paste`
       : COPIED_ONE;
 
-  /**
-   * One card's ⧉. A link caps the note it carries, and a block rendered from
-   * that cap — a link's pin has no fuller copy — says so rather than losing it
-   * quietly.
-   */
+  /** One card's ⧉: a link's pin has only the capped note the link carries. */
   const onePinToast = (pin: { note?: string; anchor: AnchorV3 }): string =>
     pin.note === undefined && pin.anchor.nt === 1
       ? 'Copied 1 pin — the note is the shortened one the link carries'
@@ -516,12 +512,7 @@ function boot() {
     redraw(fragment.id);
   }
 
-  /**
-   * The switch's chord. Plain ⌘H hides the Mac app and Ctrl+H opens the
-   * browser's history, so Shift is what makes this one ours. It belongs to the
-   * dock, so it does nothing without a set — and nothing at all while a note
-   * is being typed, where every key belongs to the note.
-   */
+  /** The cards chord: no set, no switch — and never while a note is typed. */
   document.addEventListener('keydown', (evt) => {
     if (!evt.shiftKey || evt.altKey) return;
     if (!(isMac() ? evt.metaKey : evt.ctrlKey)) return;

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -31,7 +31,7 @@ import {
   pathNeedsChange,
   pinUrl,
 } from './deeplink.js';
-import { createSetDock } from './dock.js';
+import { createSetDock, type PinPlace } from './dock.js';
 import { createDraftStore, MAX_SET_PINS } from './draft.js';
 import { pinId } from './id.js';
 import { createPicker, isEditable, isMac } from './picker.js';
@@ -82,6 +82,10 @@ function boot() {
 
   const store = createDraftStore();
   let draft: SetPin[] = store.pins();
+  /** The waiting ids the dock's rows were last built from. */
+  let drawn = '';
+  /** True while `redraw()` is resolving pins, so the dock is built once. */
+  let drawing = false;
   /** The pin a link opened; FR-3859 merges it into the draft instead. */
   let linkTarget: DeepLinkPinTarget | null = null;
 
@@ -350,8 +354,12 @@ function boot() {
     copyText: ui.copyText,
     showToast: ui.showToast,
     buildComment,
-    onLocated: (element, target) => void readPinStack(target, element),
-    onDismiss: (target) => removeFromSet(target.id),
+    onLocated: (element, target) => {
+      // A pin that finally landed — or lost its element — changes what its
+      // row says, and the rows are all a waiting pin has (R7.3).
+      if (!drawing) renderDockIfPlacesMoved();
+      void readPinStack(target, element);
+    },
     onHide: (target) => setHidden(target.id, true),
   });
   const dock = createSetDock({
@@ -399,15 +407,20 @@ function boot() {
    * scroll the page out from under the reviewer. Only a link names a pin.
    */
   function redraw(focusId: string | null = null) {
+    // Every pin `show()` resolves calls back into `onLocated`; the dock is
+    // rendered once here instead of once per pin.
+    drawing = true;
     pins.setCardsHidden(store.cardsHidden());
     // Only the draft is the set; a link's pin is drawn beside it, uncounted,
     // so the glyphs never claim a membership the copy does not have.
     pins.show(drawnTargets(), { focusId, setSize: draft.length });
     // Adopting a pin gives it a fresh card, so its ✕ is re-applied here.
     for (const pin of draft) pins.setCardHidden(pin.id, pin.hidden === true);
+    drawing = false;
+    renderDockIfPlacesMoved();
   }
 
-  /** 🗑, wherever it was pressed: the card and the row say the same thing. */
+  /** The dock row's 🗑 — the one control that ends a pin (R6.2). */
   function removeFromSet(id: string) {
     const index = draft.findIndex((pin) => pin.id === id);
     if (index < 0) return removePin(id);
@@ -450,11 +463,33 @@ function boot() {
     syncDraft();
   }
 
+  /**
+   * A pin the layer has not resolved is waiting for its element, not gone: the
+   * ladder ends, the observer does not (R7.2), so the row says where it was.
+   */
+  const waitingIds = (): string[] =>
+    draft.filter((pin) => !pins.locatedElement(pin.id)).map((pin) => pin.id);
+
+  function renderDock() {
+    const ids = waitingIds();
+    drawn = ids.join(' ');
+    dock.render(
+      draft,
+      new Map(ids.map((id) => [id, { kind: 'waiting' } as PinPlace])),
+      store.cardsHidden(),
+    );
+  }
+
+  /** Rebuilding every row on every `locate()` is O(N²) rows for one redraw. */
+  function renderDockIfPlacesMoved() {
+    if (waitingIds().join(' ') !== drawn) renderDock();
+  }
+
   /** The store is the truth; the dock and the composer's button follow it. */
   function syncDraft() {
     draft = store.pins();
     pruneStacks();
-    dock.render(draft, store.cardsHidden());
+    renderDock();
     ui.setDraftSize(draft.length, store.isFull());
   }
 

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -355,7 +355,7 @@ function boot() {
     showToast: ui.showToast,
     buildComment,
     onLocated: (element, target) => void readPinStack(target, element),
-    onDismiss: (target) => removePin(target.id),
+    onDismiss: (target) => removeFromSet(target.id),
     onHide: (target) => setHidden(target.id, true),
   });
   const dock = createSetDock({
@@ -375,13 +375,7 @@ function boot() {
       // The arrival beat is long spent — this is a deliberate "that one".
       pins.pulse(id);
     },
-    onRemove: (id) => {
-      const index = draft.findIndex((pin) => pin.id === id);
-      if (index < 0) return;
-      const size = draft.length;
-      removePin(id);
-      ui.showToast(`Removed pin ${index + 1} of ${size}`);
-    },
+    onRemove: removeFromSet,
     onUnhide: (id) => setHidden(id, false),
     onToggleCards: toggleCards,
   });
@@ -417,7 +411,16 @@ function boot() {
     for (const pin of draft) pins.setCardHidden(pin.id, pin.hidden === true);
   }
 
-  /** 🗑, from a card or from a dock row. */
+  /** 🗑, wherever it was pressed: the card and the row say the same thing. */
+  function removeFromSet(id: string) {
+    const index = draft.findIndex((pin) => pin.id === id);
+    if (index < 0) return removePin(id);
+    const size = draft.length;
+    removePin(id);
+    ui.showToast(`Removed pin ${index + 1} of ${size}`);
+  }
+
+  /** The store, the stacks and the layer, one pin shorter. */
   function removePin(id: string) {
     stacks.delete(id);
     if (linkTarget?.id === id) linkTarget = null;

--- a/react/vite-plugins/review-overlay/client/picker.ts
+++ b/react/vite-plugins/review-overlay/client/picker.ts
@@ -37,7 +37,7 @@ export interface PickerCallbacks {
 const PLUGIN_NAME = 'bai-review-pick';
 
 /** react-grab reads `navigator.platform` first and falls back to the UA. */
-const isMac = (): boolean =>
+export const isMac = (): boolean =>
   typeof navigator !== 'undefined' &&
   /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent);
 
@@ -52,7 +52,7 @@ export function isReactGrabChord(evt: KeyboardEvent): boolean {
 }
 
 /** react-grab does not activate inside a field either; ⌘C there is copy. */
-const isEditable = (node: EventTarget | null): boolean =>
+export const isEditable = (node: EventTarget | null): boolean =>
   node instanceof HTMLElement &&
   (node.isContentEditable ||
     node instanceof HTMLInputElement ||

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -14,7 +14,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 let host: HTMLElement;
 let layer: PinLayer;
 let toasts: string[];
-let dismissed: string[];
 let hidden: string[];
 let scrolled: string[];
 let pending: string[][];
@@ -84,7 +83,6 @@ const mount = (testid: string, box: Partial<DOMRect> = {}): HTMLElement => {
 beforeEach(() => {
   document.body.innerHTML = '';
   toasts = [];
-  dismissed = [];
   hidden = [];
   scrolled = [];
   pending = [];
@@ -109,7 +107,6 @@ beforeEach(() => {
       html: '<p>block</p>',
       toast: 'Copied 1 pin',
     }),
-    onDismiss: (pin) => dismissed.push(pin.id),
     onHide: (pin) => hidden.push(pin.id),
   });
 });
@@ -287,12 +284,10 @@ describe('createPinLayer', () => {
       expect(markerOf('c_b').classList.contains('found')).toBe(true);
     });
 
-    // 🗑 is a set edit, and only the set's owner knows what that costs.
-    it('hands the pin back to the owner when 🗑 is what did it', () => {
-      cardOf('c_b').querySelector<HTMLButtonElement>('.remove')?.click();
-
-      expect(dismissed).toEqual(['c_b']);
-      expect(layer.ids()).toEqual(['c_a']);
+    // R6.2: the card destroys nothing — its 🗑 sat 20px from ⧉, so reaching
+    // for copy ended the pin. Removing one is the dock row's alone now.
+    it('carries no remove control on any card', () => {
+      expect(shadow().querySelector('.card .remove')).toBeNull();
     });
 
     // ✕ is about the card being in the way, not about the pin.
@@ -300,7 +295,6 @@ describe('createPinLayer', () => {
       cardOf('c_b').querySelector<HTMLButtonElement>('.close')?.click();
 
       expect(hidden).toEqual(['c_b']);
-      expect(dismissed).toEqual([]);
       expect(layer.ids()).toEqual(['c_a', 'c_b']);
       expect(markerOf('c_b').classList.contains('found')).toBe(true);
     });
@@ -321,8 +315,8 @@ describe('createPinLayer', () => {
     });
 
     // Two pins minus one is a set of one, which never numbered itself.
-    it('drops back to a lone map-pin when 🗑 leaves one pin', () => {
-      cardOf('c_a').querySelector<HTMLButtonElement>('.remove')?.click();
+    it('drops back to a lone map-pin when one pin is left', () => {
+      layer.dismiss('c_a');
 
       expect(markerGlyph('c_b')).toBe('map-pin');
       expect(countOf('c_b')).toBe('');
@@ -416,7 +410,11 @@ describe('createPinLayer', () => {
         host,
         copyText: () => true,
         showToast: (message) => toasts.push(message),
-        buildComment: () => ({ text: 'block', html: '<p>block</p>' }),
+        buildComment: () => ({
+          text: 'block',
+          html: '<p>block</p>',
+          toast: 'Copied 1 pin',
+        }),
         onGiveUp: (ids) => pending.push(ids),
       });
       mount('one');

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -248,6 +248,34 @@ describe('createPinLayer', () => {
     expect(toasts).toEqual([]);
   });
 
+  // The twin of the above, for a removal from the MIDDLE. Trimming the tail
+  // to the new length first drops the LAST pin's card and re-seats that pin
+  // onto its neighbour's, losing the element it had already located.
+  it('leaves a drawn pin on its element when the set shrinks around it', () => {
+    mount('one');
+    mount('two');
+    const three = mount('three');
+    layer.show(
+      [target('c_a', 'one'), target('c_b', 'two'), target('c_c', 'three')],
+      { focusId: null },
+    );
+    layer.locate();
+    expect(layer.locatedElement('c_c')).toBe(three);
+    // A re-render the pin survived: nothing about the anchor resolves now.
+    three.setAttribute('data-testid', 'renamed');
+    three.textContent = 'renamed';
+
+    layer.show([target('c_a', 'one'), target('c_c', 'three')], {
+      focusId: null,
+    });
+
+    expect(layer.locatedElement('c_c')).toBe(three);
+    expect(cardOf('c_c').classList.contains('found')).toBe(true);
+    expect(cardOf('c_b')).toBeNull();
+    expect(countOf('c_c')).toBe('2 / 2');
+    expect(toasts).toEqual([]);
+  });
+
   // A link's pin rides along with the draft set without joining it, so the
   // glyphs must not claim a membership the copied comment does not have.
   it('numbers only the pins the set holds', () => {

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -264,7 +264,7 @@ describe('createPinLayer', () => {
 
     expect(markerOf('c_a').textContent).toBe('1');
     expect(countOf('c_b')).toBe('2 / 2');
-    expect(markerOf('c_link').textContent).toBe('📍');
+    expect(markerGlyph('c_link')).toBe('map-pin');
     expect(countOf('c_link')).toBe('');
   });
 

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -205,6 +205,60 @@ describe('createPinLayer', () => {
       expect(scrolled).toEqual(['two']);
       expect(markerOf('c_b').classList.contains('pulse')).toBe(true);
     });
+
+    // Growing a set is not an arrival: an explicit `null` draws every pin
+    // without moving the page the reviewer is picking on.
+    it('is nobody at all when the caller passes null', () => {
+      mount('one');
+      mount('two');
+      layer.show([target('c_a', 'one'), target('c_b', 'two')], {
+        focusId: null,
+      });
+
+      expect(scrolled).toEqual([]);
+      expect(markerOf('c_a').classList.contains('pulse')).toBe(false);
+      expect(markerOf('c_b').classList.contains('pulse')).toBe(false);
+      expect(cardOf('c_a').classList.contains('found')).toBe(true);
+      expect(cardOf('c_b').classList.contains('found')).toBe(true);
+    });
+  });
+
+  // `reposition()` can hold an element `findAnchorTarget` would no longer
+  // find; re-adopting the pin would drop it and give up on a drawn card.
+  it('leaves a drawn pin on its element when the set grows around it', () => {
+    const one = mount('one');
+    layer.show([target('c_a', 'one')], { focusId: null });
+    layer.locate();
+    expect(layer.locatedElement('c_a')).toBe(one);
+    // A re-render the pin survived: nothing about the anchor resolves now.
+    one.setAttribute('data-testid', 'renamed');
+    one.textContent = 'renamed';
+
+    mount('two');
+    layer.show([target('c_a', 'one'), target('c_b', 'two')], {
+      focusId: null,
+    });
+
+    expect(layer.locatedElement('c_a')).toBe(one);
+    expect(cardOf('c_a').classList.contains('found')).toBe(true);
+    expect(toasts).toEqual([]);
+  });
+
+  // A link's pin rides along with the draft set without joining it, so the
+  // glyphs must not claim a membership the copied comment does not have.
+  it('numbers only the pins the set holds', () => {
+    mount('one');
+    mount('two');
+    mount('three');
+    layer.show(
+      [target('c_a', 'one'), target('c_b', 'two'), target('c_link', 'three')],
+      { focusId: null, setSize: 2 },
+    );
+
+    expect(markerOf('c_a').textContent).toBe('1');
+    expect(countOf('c_b')).toBe('2 / 2');
+    expect(markerOf('c_link').textContent).toBe('📍');
+    expect(countOf('c_link')).toBe('');
   });
 
   describe('dismissing one pin of a set', () => {

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -104,7 +104,11 @@ beforeEach(() => {
     host,
     copyText: () => true,
     showToast: (message) => toasts.push(message),
-    buildComment: () => ({ text: 'block', html: '<p>block</p>' }),
+    buildComment: () => ({
+      text: 'block',
+      html: '<p>block</p>',
+      toast: 'Copied 1 pin',
+    }),
     onDismiss: (pin) => dismissed.push(pin.id),
     onHide: (pin) => hidden.push(pin.id),
   });

--- a/react/vite-plugins/review-overlay/client/pin-layer.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin-layer.test.ts
@@ -15,6 +15,7 @@ let host: HTMLElement;
 let layer: PinLayer;
 let toasts: string[];
 let dismissed: string[];
+let hidden: string[];
 let scrolled: string[];
 let pending: string[][];
 
@@ -84,6 +85,7 @@ beforeEach(() => {
   document.body.innerHTML = '';
   toasts = [];
   dismissed = [];
+  hidden = [];
   scrolled = [];
   pending = [];
   host = document.createElement('div');
@@ -104,6 +106,7 @@ beforeEach(() => {
     showToast: (message) => toasts.push(message),
     buildComment: () => ({ text: 'block', html: '<p>block</p>' }),
     onDismiss: (pin) => dismissed.push(pin.id),
+    onHide: (pin) => hidden.push(pin.id),
   });
 });
 
@@ -280,12 +283,22 @@ describe('createPinLayer', () => {
       expect(markerOf('c_b').classList.contains('found')).toBe(true);
     });
 
-    // ✕ is a set edit, and only the set's owner knows what that costs.
-    it('hands the pin back to the owner when ✕ is what did it', () => {
-      cardOf('c_b').querySelector<HTMLButtonElement>('.close')?.click();
+    // 🗑 is a set edit, and only the set's owner knows what that costs.
+    it('hands the pin back to the owner when 🗑 is what did it', () => {
+      cardOf('c_b').querySelector<HTMLButtonElement>('.remove')?.click();
 
       expect(dismissed).toEqual(['c_b']);
       expect(layer.ids()).toEqual(['c_a']);
+    });
+
+    // ✕ is about the card being in the way, not about the pin.
+    it('leaves the pin in the set when ✕ is what did it', () => {
+      cardOf('c_b').querySelector<HTMLButtonElement>('.close')?.click();
+
+      expect(hidden).toEqual(['c_b']);
+      expect(dismissed).toEqual([]);
+      expect(layer.ids()).toEqual(['c_a', 'c_b']);
+      expect(markerOf('c_b').classList.contains('found')).toBe(true);
     });
 
     it('renumbers what is left, so the heads still count the set', () => {
@@ -304,8 +317,8 @@ describe('createPinLayer', () => {
     });
 
     // Two pins minus one is a set of one, which never numbered itself.
-    it('drops back to a lone map-pin when ✕ leaves one pin', () => {
-      cardOf('c_a').querySelector<HTMLButtonElement>('.close')?.click();
+    it('drops back to a lone map-pin when 🗑 leaves one pin', () => {
+      cardOf('c_a').querySelector<HTMLButtonElement>('.remove')?.click();
 
       expect(markerGlyph('c_b')).toBe('map-pin');
       expect(countOf('c_b')).toBe('');

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -797,14 +797,16 @@ describe('createDeepLinkPin', () => {
 
     it('names every icon-only control for a screen reader', () => {
       show();
-      const named = ['.idcopy', '.close', '.locate', '.copyall'].map((sel) =>
-        host.shadowRoot?.querySelector(sel)?.getAttribute('aria-label'),
+      const named = ['.idcopy', '.close', '.locate', '.copyall', '.remove'].map(
+        (sel) =>
+          host.shadowRoot?.querySelector(sel)?.getAttribute('aria-label'),
       );
       expect(named).toEqual([
         'Copy this comment id',
-        'Dismiss this pin',
+        'Hide this card',
         'Scroll back to this element',
-        'Copy the whole comment',
+        'Copy this pin',
+        'Remove this pin from the set',
       ]);
     });
 

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -817,17 +817,18 @@ describe('createDeepLinkPin', () => {
 
     it('names every icon-only control for a screen reader', () => {
       show();
-      const named = ['.idcopy', '.close', '.locate', '.copyall', '.remove'].map(
-        (sel) =>
-          host.shadowRoot?.querySelector(sel)?.getAttribute('aria-label'),
+      const named = ['.idcopy', '.close', '.locate', '.copyall'].map((sel) =>
+        host.shadowRoot?.querySelector(sel)?.getAttribute('aria-label'),
       );
       expect(named).toEqual([
         'Copy this comment id',
         'Hide this card',
         'Scroll back to this element',
         'Copy this pin',
-        'Remove this pin from the set',
       ]);
+      // R6.2: removing a pin lives in the dock, where the rows are far enough
+      // apart that a reach for ⧉ cannot end one.
+      expect(host.shadowRoot?.querySelector('.card .remove')).toBeNull();
     });
 
     it('says which id it copied', () => {

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -199,6 +199,22 @@ describe('createDeepLinkPin', () => {
     expect(marker().classList.contains('pulse')).toBe(true);
   });
 
+  // The compat surface passes `onHide` straight through, so a layer built
+  // without one used to leave ✕ inert.
+  it('puts the card away on ✕ with no owner wired to hear it', () => {
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<button data-testid="create">Create</button>',
+    );
+    show();
+    pin.locate();
+
+    (host.shadowRoot?.querySelector('.close') as HTMLButtonElement).click();
+
+    expect(card().classList.contains('hidden')).toBe(true);
+    expect(marker().classList.contains('found')).toBe(true);
+  });
+
   describe('place', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'innerHeight', {

--- a/react/vite-plugins/review-overlay/client/pin.test.ts
+++ b/react/vite-plugins/review-overlay/client/pin.test.ts
@@ -3,7 +3,7 @@ import {
   type DeepLinkPin,
   type DeepLinkPinTarget,
 } from './pin.js';
-import type { AnchorV3, CopyPayload } from './types.js';
+import type { AnchorV3, PinCopyPayload } from './types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const anchor = (over: Partial<AnchorV3> = {}): AnchorV3 => ({
@@ -23,7 +23,7 @@ let toasts: string[];
 let copyResult: boolean | Promise<boolean>;
 let located: (Element | null)[];
 /** What `main.ts` would render for this pin; null stands for "cannot". */
-let comment: CopyPayload | null;
+let comment: PinCopyPayload | null;
 let commentFor: DeepLinkPinTarget | null;
 
 const show = (over: Partial<AnchorV3> = {}) =>
@@ -77,7 +77,11 @@ beforeEach(() => {
   toasts = [];
   located = [];
   copyResult = true;
-  comment = { text: 'the whole comment', html: '<p>the whole comment</p>' };
+  comment = {
+    text: 'the whole comment',
+    html: '<p>the whole comment</p>',
+    toast: 'Copied 1 pin',
+  };
   commentFor = null;
   pin = createDeepLinkPin({
     root: host.attachShadow({ mode: 'open' }),
@@ -868,7 +872,7 @@ describe('createDeepLinkPin', () => {
       commentCopy().click();
       expect(copied).toEqual(['the whole comment']);
       expect(copiedHtml).toEqual(['<p>the whole comment</p>']);
-      expect(toasts).toEqual(['Copied the whole comment']);
+      expect(toasts).toEqual(['Copied 1 pin']);
     });
 
     it('hands the owner the pin it is showing, payload included', () => {
@@ -882,12 +886,18 @@ describe('createDeepLinkPin', () => {
       expect(commentFor?.anchor.n).toBe('Misaligned.');
     });
 
-    // The link caps the note it carries, so a copy off a capped link is short.
-    it('says so when the link only carries a shortened note', () => {
+    // The owner renders the block, so the owner owns what the toast claims —
+    // whether the note it wrote is the capped one a link carries.
+    it('says what the owner’s payload says it wrote', () => {
+      comment = {
+        text: 'the whole comment',
+        html: '<p>the whole comment</p>',
+        toast: 'Copied 1 pin — the note is the shortened one the link carries',
+      };
       show({ n: 'A very long note…', nt: 1 });
       commentCopy().click();
       expect(toasts).toEqual([
-        'Copied — the note is the shortened one the link carries',
+        'Copied 1 pin — the note is the shortened one the link carries',
       ]);
     });
 

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -228,8 +228,11 @@ interface PinView {
   readonly card: HTMLElement;
   id(): string;
   show(next: DeepLinkPinTarget): void;
-  /** Set order, for the marker glyph and the `3 / 5` header. */
-  setOrdinal(index: number, total: number): void;
+  /**
+   * Set order, for the marker glyph and the `3 / 5` header; `null` for a pin
+   * the set does not hold.
+   */
+  setOrdinal(index: number | null, total: number): void;
   setCollapsed(collapsed: boolean): void;
   /** This card alone; the pin keeps its marker and its box. */
   setHidden(hidden: boolean): void;
@@ -243,6 +246,10 @@ interface PinView {
   reposition(): void;
   dismiss(): void;
   isShowing(): boolean;
+  /** False for a drawn pin the set does not count, e.g. a link's. */
+  isMember(): boolean;
+  /** Already this pin, payload and all — nothing to re-adopt. */
+  holds(next: DeepLinkPinTarget): boolean;
   isLocated(): boolean;
   locatedElement(): Element | null;
   dispose(): void;
@@ -329,6 +336,8 @@ function createPinView(deps: ViewDeps): PinView {
   let missedScans = 0;
   /** The landmark at the last batch; its return re-arms the escalated scan. */
   let hadLandmark = false;
+  /** False for a pin the set does not hold: it stays a lone 📍. */
+  let member = true;
   /** One arrival pulse per link — the box is what stays. */
   let pulsed = false;
   let pulseTimer = 0;
@@ -633,10 +642,11 @@ function createPinView(deps: ViewDeps): PinView {
       payload.text,
       payload.html,
       // The link caps the note it carries, and a copy that quietly loses the
-      // rest is worse than one that says so.
-      target.anchor.nt === 1
-        ? 'Copied — the note is the shortened one the link carries'
-        : 'Copied the whole comment',
+      // rest is worse than one that says so — unless the payload says better.
+      payload.toast ??
+        (target.anchor.nt === 1
+          ? 'Copied — the note is the shortened one the link carries'
+          : 'Copied the whole comment'),
     );
   });
 
@@ -679,11 +689,13 @@ function createPinView(deps: ViewDeps): PinView {
     },
 
     // A set of one is what a single pin has always been — the map-pin glyph
-    // and no header. Only a real set numbers itself.
-    setOrdinal(index: number, total: number) {
-      if (total > 1) head.textContent = String(index + 1);
+    // and no header. Only a real set numbers itself; `null` is not a member.
+    setOrdinal(index: number | null, total: number) {
+      member = index !== null;
+      const numbered = index !== null && total > 1;
+      if (numbered) head.textContent = String(index + 1);
       else head.replaceChildren(icon('map-pin', MARKER_ICON_SIZE));
-      count.textContent = total > 1 ? `${index + 1} / ${total}` : '';
+      count.textContent = numbered ? `${index + 1} / ${total}` : '';
     },
 
     setCollapsed(next: boolean) {
@@ -731,6 +743,10 @@ function createPinView(deps: ViewDeps): PinView {
 
     dismiss,
     isShowing: () => !!target,
+    isMember: () => member,
+    /** Same pin, same payload — nothing to re-adopt. */
+    holds: (next: DeepLinkPinTarget) =>
+      target?.id === next.id && target.anchorB64 === next.anchorB64,
     isLocated: () => !!located,
     locatedElement: () => located,
 
@@ -755,6 +771,8 @@ export function createPinLayer(options: PinLayerOptions) {
   /** The dock's switch: every card off, markers and boxes still on the page. */
   let cardsHidden = false;
   let focusId: string | null = null;
+  /** False while the set is only being re-drawn: nothing scrolls, nothing pulses. */
+  let autoFocus = true;
   let frame = 0;
   let settleUntil = 0;
   let timer = 0;
@@ -851,19 +869,20 @@ export function createPinLayer(options: PinLayerOptions) {
 
   /** A set one pin shorter says so: the glyphs and the `n / N` heads move up. */
   function renumber() {
-    const shown = showingViews();
-    for (const [index, view] of shown.entries())
-      view.setOrdinal(index, shown.length);
+    const members = showingViews().filter((view) => view.isMember());
+    for (const [index, view] of members.entries())
+      view.setOrdinal(index, members.length);
   }
 
   function locateAll(skipLocated: boolean): boolean {
     const shown = showingViews();
     // A stored focus id can name a pin this set does not have; the set still
     // has to scroll somewhere.
-    const focus =
-      shown.find((view) => view.id() === focusId)?.id() ??
-      shown[0]?.id() ??
-      null;
+    const focus = autoFocus
+      ? (shown.find((view) => view.id() === focusId)?.id() ??
+        shown[0]?.id() ??
+        null)
+      : null;
     let missing = 0;
     let landed = false;
     for (const view of shown) {
@@ -938,14 +957,27 @@ export function createPinLayer(options: PinLayerOptions) {
     /**
      * Draw exactly these pins, in set order, and start the one retry driver
      * that resolves whatever is not on the page yet. `focusId` names the pin
-     * that scrolls and pulses; the first pin is the default.
+     * that scrolls and pulses; the first pin is the default, and an explicit
+     * `null` is a re-draw — an authoring set must not move the page under the
+     * reviewer every time they add a pin to it. `setSize` is how many of the
+     * leading targets the SET holds; the rest are drawn as lone pins.
      */
-    show(targets: DeepLinkPinTarget[], opts: { focusId?: string } = {}) {
+    show(
+      targets: DeepLinkPinTarget[],
+      opts: { focusId?: string | null; setSize?: number } = {},
+    ) {
       resize(targets.length);
+      autoFocus = opts.focusId !== null;
       focusId = opts.focusId ?? targets[0]?.id ?? null;
+      const size = opts.setSize ?? targets.length;
+      // Only the pin this call focuses is re-adopted: the rest keep the
+      // element `reposition()` may be holding through a re-render.
+      const arriving =
+        opts.focusId === undefined ? (targets[0]?.id ?? null) : opts.focusId;
       targets.forEach((target, index) => {
-        views[index].show(target);
-        views[index].setOrdinal(index, targets.length);
+        const view = views[index];
+        if (target.id === arriving || !view.holds(target)) view.show(target);
+        view.setOrdinal(index < size ? index : null, size);
       });
       startRetry();
     },

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -615,7 +615,13 @@ function createPinView(deps: ViewDeps): PinView {
   // ✕ takes the card off the element, not the pin off the set: the reviewer
   // wants to see what they pinned. 🗑 is what ends a pin.
   close.addEventListener('click', () => {
-    if (target) deps.onHide?.(target);
+    if (!target) return;
+    // The card goes now, not when the owner answers: the button is honest
+    // even in a layer built without `onHide`, and the owner re-applies it.
+    hidden = true;
+    syncHidden();
+    deps.placeSoon();
+    deps.onHide?.(target);
   });
   removeButton.addEventListener('click', () => {
     const dismissed = target;

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -850,16 +850,37 @@ export function createPinLayer(options: PinLayerOptions) {
     followScroll,
   };
 
-  /** Views are reused BY POSITION, so a card the set keeps keeps its node. */
+  function newView(): PinView {
+    const view = createPinView(deps);
+    view.setCollapsed(collapsed);
+    view.setCardsHidden(cardsHidden);
+    layer.append(...view.nodes);
+    return view;
+  }
+
+  /** Only ever grows or trims the tail; `adopt` is what re-seats a set. */
   function resize(count: number) {
     while (views.length > count) views.pop()?.dispose();
-    while (views.length < count) {
-      const view = createPinView(deps);
-      view.setCollapsed(collapsed);
-      view.setCardsHidden(cardsHidden);
-      layer.append(...view.nodes);
-      views.push(view);
-    }
+    while (views.length < count) views.push(newView());
+  }
+
+  /**
+   * Line the views up with the pins, BY ID: the view that already holds a pin
+   * keeps it, wherever the pin has moved to. Trimming the tail first would
+   * drop the last card and re-seat every pin after a removal onto its
+   * neighbour's, losing the element each had already located.
+   */
+  function adopt(targets: DeepLinkPinTarget[]) {
+    const spare = [...views];
+    const held = targets.map((target) => {
+      const at = spare.findIndex(
+        (view) => view.isShowing() && view.id() === target.id,
+      );
+      return at < 0 ? null : spare.splice(at, 1)[0];
+    });
+    views.length = 0;
+    for (const view of held) views.push(view ?? spare.shift() ?? newView());
+    for (const view of spare) view.dispose();
   }
 
   const showingViews = () => views.filter((view) => view.isShowing());
@@ -963,7 +984,7 @@ export function createPinLayer(options: PinLayerOptions) {
       targets: DeepLinkPinTarget[],
       opts: { focusId?: string | null; setSize?: number } = {},
     ) {
-      resize(targets.length);
+      adopt(targets);
       autoFocus = opts.focusId !== null;
       focusId = opts.focusId ?? targets[0]?.id ?? null;
       const size = opts.setSize ?? targets.length;

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -102,18 +102,18 @@ const STYLE = `
   .card.hidden { display: none; }
   .card .count {
     color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
-    margin-bottom: 4px; padding-right: 62px;
+    margin-bottom: 4px; padding-right: 82px;
   }
   .card .count:empty { display: none; }
   .card .awaynote {
     color: var(--bai-review-text-dim); font-size: 11px; margin-bottom: 6px;
-    padding-right: 62px;
+    padding-right: 82px;
   }
   .card .awaynote:empty { display: none; }
   /* The reviewer's own words lead. An anchor from before the note travelled
      carries none, and :empty leaves no gap where it would have been. */
   .card .note {
-    white-space: pre-wrap; word-break: break-word; padding-right: 62px;
+    white-space: pre-wrap; word-break: break-word; padding-right: 82px;
     margin-bottom: 6px;
   }
   .card .note:empty { display: none; }
@@ -123,7 +123,7 @@ const STYLE = `
   }
   .card .trunc.shown { display: block; }
   .card .label {
-    font-weight: 600; word-break: break-word; padding-right: 62px;
+    font-weight: 600; word-break: break-word; padding-right: 82px;
   }
   .card .sub {
     color: var(--bai-review-text-dim); font-size: 13px; margin-top: 3px;
@@ -141,7 +141,7 @@ const STYLE = `
     color: var(--bai-review-text-dim); vertical-align: -3px;
   }
   .card .idcopy:hover { color: var(--bai-review-text); }
-  .card .close, .card .locate, .card .copyall {
+  .card .close, .card .locate, .card .copyall, .card .remove {
     position: absolute; top: 4px; cursor: pointer; border: 0; padding: 0;
     background: none; color: var(--bai-review-text-dim);
     display: flex; align-items: center; justify-content: center;
@@ -150,9 +150,9 @@ const STYLE = `
   .card .close { right: 4px; }
   .card .locate { right: 24px; }
   .card .copyall { right: 44px; }
-  .card .close:hover, .card .locate:hover, .card .copyall:hover {
-    color: var(--bai-review-text);
-  }
+  .card .remove { right: 64px; }
+  .card .close:hover, .card .locate:hover, .card .copyall:hover,
+  .card .remove:hover { color: var(--bai-review-text); }
 ${ICON_STYLE}
   /* The pick box's own style, so arriving on a link looks like the pick that
      made it: a thin stroke over a light fill, on our layer — never the app's. */
@@ -187,8 +187,13 @@ export interface PinLayerOptions {
     element: Element | null,
     target: DeepLinkPinTarget | null,
   ) => void;
-  /** The reviewer pressed ✕; whoever owns the set decides what that means. */
+  /** The reviewer pressed 🗑; whoever owns the set decides what that means. */
   onDismiss?: (target: DeepLinkPinTarget) => void;
+  /**
+   * The reviewer pressed ✕: the card is in the way, the pin is not. The owner
+   * persists that and hides the card — the marker and the box stay drawn.
+   */
+  onHide?: (target: DeepLinkPinTarget) => void;
   /**
    * The ladder ran out with these still unresolved; they stay pending (R7.2).
    * Without it the layer keeps its own line.
@@ -215,6 +220,7 @@ interface ViewDeps {
   buildComment: PinLayerOptions['buildComment'];
   onLocated?: PinLayerOptions['onLocated'];
   onDismiss?: PinLayerOptions['onDismiss'];
+  onHide?: PinLayerOptions['onHide'];
   /** One layout read per frame, however many views ask for one. */
   placeSoon: () => void;
   /** A smooth scroll ends after `locate()` returns; follow it to its stop. */
@@ -301,9 +307,14 @@ function createPinView(deps: ViewDeps): PinView {
   sub.append(idText, idCopy, componentText);
   const close = document.createElement('button');
   close.className = 'close';
-  close.append(icon('x'));
-  close.title = 'Dismiss this pin';
-  close.setAttribute('aria-label', 'Dismiss this pin');
+  close.append(icon('eye-off'));
+  close.title = 'Hide this card';
+  close.setAttribute('aria-label', 'Hide this card');
+  const removeButton = document.createElement('button');
+  removeButton.className = 'remove';
+  removeButton.append(icon('trash-2'));
+  removeButton.title = 'Remove this pin from the set';
+  removeButton.setAttribute('aria-label', 'Remove this pin from the set');
   const locateButton = document.createElement('button');
   locateButton.className = 'locate';
   locateButton.append(icon('crosshair'));
@@ -312,12 +323,13 @@ function createPinView(deps: ViewDeps): PinView {
   const commentCopy = document.createElement('button');
   commentCopy.className = 'copyall';
   commentCopy.append(icon('copy'));
-  commentCopy.title = 'Copy the whole comment';
-  commentCopy.setAttribute('aria-label', 'Copy the whole comment');
+  commentCopy.title = 'Copy this pin';
+  commentCopy.setAttribute('aria-label', 'Copy this pin');
   card.append(
     close,
     locateButton,
     commentCopy,
+    removeButton,
     count,
     away,
     note,
@@ -600,7 +612,12 @@ function createPinView(deps: ViewDeps): PinView {
   locateButton.addEventListener('click', () =>
     located?.scrollIntoView?.({ block: 'center', behavior: 'smooth' }),
   );
+  // ✕ takes the card off the element, not the pin off the set: the reviewer
+  // wants to see what they pinned. 🗑 is what ends a pin.
   close.addEventListener('click', () => {
+    if (target) deps.onHide?.(target);
+  });
+  removeButton.addEventListener('click', () => {
     const dismissed = target;
     dismiss();
     if (dismissed) deps.onDismiss?.(dismissed);
@@ -849,6 +866,7 @@ export function createPinLayer(options: PinLayerOptions) {
       renumber();
       options.onDismiss?.(target);
     },
+    onHide: options.onHide,
     placeSoon,
     followScroll,
   };

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -19,7 +19,7 @@ import {
   textMatches,
 } from './resolve.js';
 import { projectFraction } from './selection.js';
-import type { AnchorV3, CopyPayload } from './types.js';
+import type { AnchorV3, PinCopyPayload } from './types.js';
 
 const REPOSITION_DEBOUNCE_MS = 300;
 /** Long enough for a `behavior: 'smooth'` scroll and its momentum to stop. */
@@ -181,7 +181,7 @@ export interface PinLayerOptions {
    * gesture. `main.ts` owns it: the server state and the stack live there, and
    * `null` means those reads have not landed for this element yet.
    */
-  buildComment: (target: DeepLinkPinTarget) => CopyPayload | null;
+  buildComment: (target: DeepLinkPinTarget) => PinCopyPayload | null;
   /** The pin settled on a different element — or on none. */
   onLocated?: (
     element: Element | null,
@@ -661,16 +661,7 @@ function createPinView(deps: ViewDeps): PinView {
       deps.showToast('Still reading this element — try again');
       return;
     }
-    write(
-      payload.text,
-      payload.html,
-      // The link caps the note it carries, and a copy that quietly loses the
-      // rest is worse than one that says so — unless the payload says better.
-      payload.toast ??
-        (target.anchor.nt === 1
-          ? 'Copied — the note is the shortened one the link carries'
-          : 'Copied the whole comment'),
-    );
+    write(payload.text, payload.html, payload.toast);
   });
 
   function dismiss() {

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -3,7 +3,8 @@
  * `<style>`, the mutation observer, the scroll/resize listeners, the placement
  * batch, the retry driver and the docked column; one VIEW per pin owns its
  * marker, its card leading with the note the reviewer typed, and the
- * translucent box over the element.
+ * translucent box over the element. Nothing on a card destroys anything:
+ * removing a pin is the dock's, so a reach for ⧉ cannot end one (R6.2).
  *
  * The card text comes off a link anyone can write, so it goes in through
  * `textContent` — never `innerHTML`. The box is state, not a one-shot effect:
@@ -102,18 +103,18 @@ const STYLE = `
   .card.hidden { display: none; }
   .card .count {
     color: var(--bai-review-text-dim); font-size: 11px; font-weight: 600;
-    margin-bottom: 4px; padding-right: 82px;
+    margin-bottom: 4px; padding-right: 62px;
   }
   .card .count:empty { display: none; }
   .card .awaynote {
     color: var(--bai-review-text-dim); font-size: 11px; margin-bottom: 6px;
-    padding-right: 82px;
+    padding-right: 62px;
   }
   .card .awaynote:empty { display: none; }
   /* The reviewer's own words lead. An anchor from before the note travelled
      carries none, and :empty leaves no gap where it would have been. */
   .card .note {
-    white-space: pre-wrap; word-break: break-word; padding-right: 82px;
+    white-space: pre-wrap; word-break: break-word; padding-right: 62px;
     margin-bottom: 6px;
   }
   .card .note:empty { display: none; }
@@ -123,7 +124,7 @@ const STYLE = `
   }
   .card .trunc.shown { display: block; }
   .card .label {
-    font-weight: 600; word-break: break-word; padding-right: 82px;
+    font-weight: 600; word-break: break-word; padding-right: 62px;
   }
   .card .sub {
     color: var(--bai-review-text-dim); font-size: 13px; margin-top: 3px;
@@ -141,7 +142,7 @@ const STYLE = `
     color: var(--bai-review-text-dim); vertical-align: -3px;
   }
   .card .idcopy:hover { color: var(--bai-review-text); }
-  .card .close, .card .locate, .card .copyall, .card .remove {
+  .card .close, .card .locate, .card .copyall {
     position: absolute; top: 4px; cursor: pointer; border: 0; padding: 0;
     background: none; color: var(--bai-review-text-dim);
     display: flex; align-items: center; justify-content: center;
@@ -150,9 +151,8 @@ const STYLE = `
   .card .close { right: 4px; }
   .card .locate { right: 24px; }
   .card .copyall { right: 44px; }
-  .card .remove { right: 64px; }
-  .card .close:hover, .card .locate:hover, .card .copyall:hover,
-  .card .remove:hover { color: var(--bai-review-text); }
+  .card .close:hover, .card .locate:hover,
+  .card .copyall:hover { color: var(--bai-review-text); }
 ${ICON_STYLE}
   /* The pick box's own style, so arriving on a link looks like the pick that
      made it: a thin stroke over a light fill, on our layer — never the app's. */
@@ -187,8 +187,6 @@ export interface PinLayerOptions {
     element: Element | null,
     target: DeepLinkPinTarget | null,
   ) => void;
-  /** The reviewer removed the pin; whoever owns the set decides what that means. */
-  onDismiss?: (target: DeepLinkPinTarget) => void;
   /**
    * The reviewer hid the card: it is in the way, the pin is not. The owner
    * persists that and hides the card — the marker and the box stay drawn.
@@ -219,7 +217,6 @@ interface ViewDeps {
   showToast: PinLayerOptions['showToast'];
   buildComment: PinLayerOptions['buildComment'];
   onLocated?: PinLayerOptions['onLocated'];
-  onDismiss?: PinLayerOptions['onDismiss'];
   onHide?: PinLayerOptions['onHide'];
   /** One layout read per frame, however many views ask for one. */
   placeSoon: () => void;
@@ -310,11 +307,6 @@ function createPinView(deps: ViewDeps): PinView {
   close.append(icon('eye-off'));
   close.title = 'Hide this card';
   close.setAttribute('aria-label', 'Hide this card');
-  const removeButton = document.createElement('button');
-  removeButton.className = 'remove';
-  removeButton.append(icon('trash-2'));
-  removeButton.title = 'Remove this pin from the set';
-  removeButton.setAttribute('aria-label', 'Remove this pin from the set');
   const locateButton = document.createElement('button');
   locateButton.className = 'locate';
   locateButton.append(icon('crosshair'));
@@ -329,7 +321,6 @@ function createPinView(deps: ViewDeps): PinView {
     close,
     locateButton,
     commentCopy,
-    removeButton,
     count,
     away,
     note,
@@ -623,11 +614,6 @@ function createPinView(deps: ViewDeps): PinView {
     deps.placeSoon();
     deps.onHide?.(target);
   });
-  removeButton.addEventListener('click', () => {
-    const dismissed = target;
-    dismiss();
-    if (dismissed) deps.onDismiss?.(dismissed);
-  });
 
   function write(text: string, html: string | undefined, ok: string) {
     const done = (written: boolean) =>
@@ -859,10 +845,6 @@ export function createPinLayer(options: PinLayerOptions) {
     showToast,
     buildComment: options.buildComment,
     onLocated: options.onLocated,
-    onDismiss: (target) => {
-      renumber();
-      options.onDismiss?.(target);
-    },
     onHide: options.onHide,
     placeSoon,
     followScroll,

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -187,10 +187,10 @@ export interface PinLayerOptions {
     element: Element | null,
     target: DeepLinkPinTarget | null,
   ) => void;
-  /** The reviewer pressed 🗑; whoever owns the set decides what that means. */
+  /** The reviewer removed the pin; whoever owns the set decides what that means. */
   onDismiss?: (target: DeepLinkPinTarget) => void;
   /**
-   * The reviewer pressed ✕: the card is in the way, the pin is not. The owner
+   * The reviewer hid the card: it is in the way, the pin is not. The owner
    * persists that and hides the card — the marker and the box stay drawn.
    */
   onHide?: (target: DeepLinkPinTarget) => void;
@@ -612,8 +612,8 @@ function createPinView(deps: ViewDeps): PinView {
   locateButton.addEventListener('click', () =>
     located?.scrollIntoView?.({ block: 'center', behavior: 'smooth' }),
   );
-  // ✕ takes the card off the element, not the pin off the set: the reviewer
-  // wants to see what they pinned. 🗑 is what ends a pin.
+  // Hiding takes the card off the element, not the pin off the set: the
+  // reviewer wants to see what they pinned. Removing is what ends a pin.
   close.addEventListener('click', () => {
     if (!target) return;
     // The card goes now, not when the owner answers: the button is honest

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -79,6 +79,11 @@ interface SetPinBase {
   appHash: string;
   /** `getStackContext()` output, split into lines. */
   stack: string[];
+  /**
+   * The reviewer's whole note. `anchor.n` is the shortened one the link
+   * carries (`NOTE_MAX`), and the block is what keeps the rest.
+   */
+  note?: string;
 }
 
 /** The id hashes from `pr` + anchor + `at`, so a block may claim it. */
@@ -96,6 +101,12 @@ interface LinkedSetPin extends SetPinBase {
 }
 
 export type SetPin = PickedSetPin | LinkedSetPin;
+
+/** The pin set a tab is building right now, as `sessionStorage` holds it. */
+export interface DraftSet {
+  v: 1;
+  pins: SetPin[];
+}
 
 declare global {
   interface Window {
@@ -115,6 +126,8 @@ declare global {
 export interface CopyPayload {
   text: string;
   html: string;
+  /** Replaces the default success line — a set says how many pins it wrote. */
+  toast?: string;
 }
 
 /** `/__review/state` — the write side needs the PR number and the repo root. */

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -85,7 +85,7 @@ interface SetPinBase {
    */
   note?: string;
   /**
-   * The reviewer pressed ✕ on this pin's card. Draft-only — the wire carries
+   * The reviewer hid this pin's card. Draft-only — the wire carries
    * no such thing — and persisted, so a reload does not bring the card back.
    */
   hidden?: true;
@@ -111,7 +111,7 @@ export type SetPin = PickedSetPin | LinkedSetPin;
 export interface DraftSet {
   v: 1;
   pins: SetPin[];
-  /** The dock's 👁 switch: every card off at once, markers and boxes drawn. */
+  /** The dock's cards switch: every card off at once, markers and boxes drawn. */
   cardsHidden?: true;
 }
 
@@ -137,7 +137,7 @@ export interface CopyPayload {
   toast?: string;
 }
 
-/** A card's ⧉: whoever renders the block owns what the toast claims it wrote. */
+/** A card's copy: whoever renders the block owns what the toast claims. */
 export interface PinCopyPayload extends CopyPayload {
   toast: string;
 }

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -137,6 +137,11 @@ export interface CopyPayload {
   toast?: string;
 }
 
+/** A card's ⧉: whoever renders the block owns what the toast claims it wrote. */
+export interface PinCopyPayload extends CopyPayload {
+  toast: string;
+}
+
 /** `/__review/state` — the write side needs the PR number and the repo root. */
 export interface ReviewServerState {
   pr: number | null;

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -84,6 +84,11 @@ interface SetPinBase {
    * carries (`NOTE_MAX`), and the block is what keeps the rest.
    */
   note?: string;
+  /**
+   * The reviewer pressed ✕ on this pin's card. Draft-only — the wire carries
+   * no such thing — and persisted, so a reload does not bring the card back.
+   */
+  hidden?: true;
 }
 
 /** The id hashes from `pr` + anchor + `at`, so a block may claim it. */
@@ -106,6 +111,8 @@ export type SetPin = PickedSetPin | LinkedSetPin;
 export interface DraftSet {
   v: 1;
   pins: SetPin[];
+  /** The dock's 👁 switch: every card off at once, markers and boxes drawn. */
+  cardsHidden?: true;
 }
 
 declare global {

--- a/react/vite-plugins/review-overlay/client/ui.test.ts
+++ b/react/vite-plugins/review-overlay/client/ui.test.ts
@@ -297,6 +297,21 @@ describe('gating the copy on the note', () => {
     expect(compose().textContent).not.toMatch(/\p{Extended_Pictographic}/u);
   });
 
+  /**
+   * R5.2 put an icon and a label span inside the copy button, so a click on
+   * the words has the span as its target and the delegated handler saw no
+   * button at all — the composer answered only the keyboard.
+   */
+  it('copies from a click on the button’s own label, not just its padding', () => {
+    ui.setComposeReady(true, '');
+
+    copyButton()
+      .querySelector('.lbl')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(err().textContent).toBe('Still reading the element — try again.');
+  });
+
   it('re-disables the button the moment the note leaves the capture', () => {
     expect(copyButton().disabled).toBe(true);
     ui.setComposeReady(true, '');

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -28,13 +28,31 @@ const NOTE_DEBOUNCE_MS = 250;
 const COMPOSE_GAP = 10;
 const VIEWPORT_PAD = 8;
 
+/** What the composer copies, and what to run once it has. */
+export interface ComposedCopy extends CopyPayload {
+  /**
+   * Runs only when THIS copy landed on the clipboard, so a write that failed —
+   * or a composer the reviewer closed while it was in flight — adds nothing.
+   */
+  commit?: () => void;
+}
+
+/** Nothing is copied and the composer stays open; the toast says why. */
+export interface RefusedCopy {
+  refused: string;
+}
+
+/** The composer's success line for a single pin; a set writes its own. */
+export const COPIED_ONE =
+  'Copied — paste it into the PR comment, the Teams thread, or Claude 📋';
+
 export interface OverlayUICallbacks {
   /**
    * Render the block for this note, SYNCHRONOUSLY — everything async was done
    * at pick time. `null` means the capture is not ready, which the composer
    * prevents by keeping the copy button disabled until it is.
    */
-  onBuildBlock: (text: string) => CopyPayload | null;
+  onBuildBlock: (text: string) => ComposedCopy | RefusedCopy | null;
   /** Debounced: the note rides in the anchor, so it has to be re-encoded. */
   onNoteChanged: (text: string) => void;
   onComposeClosed: () => void;
@@ -233,10 +251,14 @@ ${ICON_STYLE}
    */
   let readyNote: string | null = null;
   let noteTimer = 0;
+  /** A second ⌘⏎ over an unresolved write would build a second pin. */
+  let copyInFlight = false;
 
   function syncCopyEnabled() {
     copyButton.disabled =
-      readyNote === null || composeText.value.trim() !== readyNote;
+      copyInFlight ||
+      readyNote === null ||
+      composeText.value.trim() !== readyNote;
   }
 
   function setComposeReady(ready: boolean, note = '') {
@@ -372,6 +394,15 @@ ${ICON_STYLE}
     pickActive = active;
   }
 
+  /**
+   * The button says what ⌘⏎ will do: with a set already going, the pick joins
+   * it and the whole set is what lands on the clipboard.
+   */
+  function setDraftSize(size: number) {
+    copyButton.textContent =
+      size > 0 ? `Add & copy all (${size + 1})` : '📋 Copy block';
+  }
+
   // ------------------------------------------------------------- clipboard
 
   /**
@@ -440,6 +471,7 @@ ${ICON_STYLE}
   // ---------------------------------------------------------------- events
 
   function runCopy() {
+    if (copyInFlight) return;
     // Empty text is allowed — the block still carries label, stack and link.
     const note = composeText.value.trim();
     // ⌘⏎ can beat the debounce, and the note is part of the anchor now: start
@@ -450,32 +482,48 @@ ${ICON_STYLE}
       composeErr.style.display = 'block';
       return;
     }
-    let block: CopyPayload | null;
+    let built: ComposedCopy | RefusedCopy | null;
     try {
-      block = callbacks.onBuildBlock(note);
+      built = callbacks.onBuildBlock(note);
     } catch (e) {
       composeErr.textContent = `Could not build the block: ${e}`;
       composeErr.style.display = 'block';
       return;
     }
-    if (!block) {
+    // A full set is not a broken composer: it is a set-level answer, and it
+    // leaves the note where the reviewer typed it.
+    if (built && 'refused' in built) {
+      showToast(built.refused);
+      return;
+    }
+    if (!built) {
       composeErr.textContent = 'Still reading the element — try again.';
       composeErr.style.display = 'block';
       return;
     }
+    const block = built;
     const copied = copyText(block.text, block.html);
     // Close only on success. A failed copy tells the reviewer to press ⌘⏎
     // again, so the composer and the note they typed have to still be there.
     const done = (ok: boolean) => {
+      copyInFlight = false;
+      // Bound to this block, not to whatever the composer holds by now: the
+      // reviewer can close it while an async write is still in flight.
+      if (ok) block.commit?.();
+      syncCopyEnabled();
       showToast(
         ok
-          ? 'Copied — paste it into the PR comment, the Teams thread, or Claude'
+          ? (block.toast ?? COPIED_ONE)
           : 'Could not reach the clipboard — press ⌘⏎ again',
       );
       if (ok) closeCompose();
     };
     if (typeof copied === 'boolean') done(copied);
-    else void copied.then(done);
+    else {
+      copyInFlight = true;
+      syncCopyEnabled();
+      void copied.then(done);
+    }
   }
 
   compose.addEventListener('click', (evt) => {
@@ -531,6 +579,7 @@ ${ICON_STYLE}
     setComposeLabel,
     appendComposeLabel,
     setComposeReady,
+    setDraftSize,
     getComposeTarget,
     currentNote: () => composeText.value.trim(),
     setPickActive,

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -44,7 +44,7 @@ export interface RefusedCopy {
 
 /** The composer's success line for a single pin; a set writes its own. */
 export const COPIED_ONE =
-  'Copied — paste it into the PR comment, the Teams thread, or Claude 📋';
+  'Copied — paste it into the PR comment, the Teams thread, or Claude';
 
 export interface OverlayUICallbacks {
   /**
@@ -402,11 +402,11 @@ ${ICON_STYLE}
    */
   function setDraftSize(size: number, full = false) {
     draftFull = full;
-    copyButton.textContent = full
+    copyLabel.textContent = full
       ? `Set is full (${size})`
       : size > 0
         ? `Add & copy all (${size + 1})`
-        : '📋 Copy block';
+        : 'Copy block';
     syncCopyEnabled();
   }
 

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -534,10 +534,13 @@ ${ICON_STYLE}
   }
 
   compose.addEventListener('click', (evt) => {
-    const button = evt.target;
-    if (!(button instanceof HTMLButtonElement)) return;
-    if (button.dataset.act === 'cancel') closeCompose();
-    if (button.dataset.act === 'copy') runCopy();
+    // `closest`, not the target: the copy button holds an icon and a label
+    // span, so a click on the words never reaches the button itself (R5.2).
+    const target = evt.target instanceof Element ? evt.target : null;
+    const act =
+      target?.closest<HTMLButtonElement>('button[data-act]')?.dataset.act;
+    if (act === 'cancel') closeCompose();
+    if (act === 'copy') runCopy();
   });
 
   composeText.addEventListener('keydown', (evt) => {

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -31,8 +31,8 @@ const VIEWPORT_PAD = 8;
 /** What the composer copies, and what to run once it has. */
 export interface ComposedCopy extends CopyPayload {
   /**
-   * Runs only when THIS copy landed on the clipboard, so a write that failed —
-   * or a composer the reviewer closed while it was in flight — adds nothing.
+   * Runs only when THIS copy landed on the clipboard; closing the composer
+   * mid-write does not cancel it, so a write that failed adds nothing.
    */
   commit?: () => void;
 }
@@ -253,6 +253,8 @@ ${ICON_STYLE}
   let noteTimer = 0;
   /** A second ⌘⏎ over an unresolved write would build a second pin. */
   let copyInFlight = false;
+  /** Bumped by every open: a settled copy may only close the composer it ran from. */
+  let composeEpoch = 0;
   let draftFull = false;
 
   function syncCopyEnabled() {
@@ -308,6 +310,7 @@ ${ICON_STYLE}
     y: number,
     region?: Box | null,
   ) {
+    composeEpoch += 1;
     pickTarget = target;
     composeErr.style.display = 'none';
     composeText.value = '';
@@ -509,6 +512,7 @@ ${ICON_STYLE}
       return;
     }
     const block = built;
+    const epoch = composeEpoch;
     const copied = copyText(block.text, block.html);
     // Close only on success. A failed copy tells the reviewer to press ⌘⏎
     // again, so the composer and the note they typed have to still be there.
@@ -523,7 +527,9 @@ ${ICON_STYLE}
           ? (block.toast ?? COPIED_ONE)
           : 'Could not reach the clipboard — press ⌘⏎ again',
       );
-      if (ok) closeCompose();
+      // Only the composer this copy ran from: an async write that settles after
+      // the reviewer moved on must not close the pick they are typing into now.
+      if (ok && epoch === composeEpoch) closeCompose();
     };
     if (typeof copied === 'boolean') done(copied);
     else {

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -588,6 +588,8 @@ ${ICON_STYLE}
     setComposeReady,
     setDraftSize,
     getComposeTarget,
+    /** The reviewer is typing a note; a bare-letter chord is not for us. */
+    isTyping: () => root.activeElement === composeText,
     currentNote: () => composeText.value.trim(),
     setPickActive,
     placeCompose,

--- a/react/vite-plugins/review-overlay/client/ui.ts
+++ b/react/vite-plugins/review-overlay/client/ui.ts
@@ -253,9 +253,11 @@ ${ICON_STYLE}
   let noteTimer = 0;
   /** A second ⌘⏎ over an unresolved write would build a second pin. */
   let copyInFlight = false;
+  let draftFull = false;
 
   function syncCopyEnabled() {
     copyButton.disabled =
+      draftFull ||
       copyInFlight ||
       readyNote === null ||
       composeText.value.trim() !== readyNote;
@@ -396,11 +398,16 @@ ${ICON_STYLE}
 
   /**
    * The button says what ⌘⏎ will do: with a set already going, the pick joins
-   * it and the whole set is what lands on the clipboard.
+   * it; a full set says so instead of promising a copy it would refuse.
    */
-  function setDraftSize(size: number) {
-    copyButton.textContent =
-      size > 0 ? `Add & copy all (${size + 1})` : '📋 Copy block';
+  function setDraftSize(size: number, full = false) {
+    draftFull = full;
+    copyButton.textContent = full
+      ? `Set is full (${size})`
+      : size > 0
+        ? `Add & copy all (${size + 1})`
+        : '📋 Copy block';
+    syncCopyEnabled();
   }
 
   // ------------------------------------------------------------- clipboard


### PR DESCRIPTION
Resolves #9435 (FR-3858)

Part of the pin-set stack (#9442): #9437 → #9438 → #9439 → #9440 → #9441. Design record: `docs/adr/0002-pin-set-link-grammar-and-single-codec.md`; vocabulary: `react/vite-plugins/review-overlay/CONTEXT.md`.

A pick used to be thrown away the moment the composer closed: one element, one
note, one block, and the next remark started from nothing. The pins a reviewer
makes in one sitting now accumulate in a DRAFT SET, and every ⌘⏎ copies the
whole set as one comment: a link per block, plus the set's one link at the end.
`draft.ts` is that set — pure operations over a `DraftSet` plus a
`sessionStorage` mirror under `bai-review:draft-set`, guarded the way
`deeplink.ts` guards its own storage: a hand-edited or half-written value reads
as an empty set, a tab with storage switched off keeps its set in memory until
it reloads, and a refused write does not lose what the reviewer already has.
The store is the single source of truth for what the layer draws, so boot
restores the set the tab was left with and draws it before any link is applied.

The composer's button says what ⌘⏎ will do — copy this block for the first pin,
`Add & copy all (N+1)` once a set is going — and the candidate pin joins the
set only in `done(ok === true)`. That ordering is the point: a clipboard write
that failed leaves the composer open with the note still in it and adds
nothing, so the set never claims to have handed over a pin that never reached
the clipboard. Everything the candidate needs is synchronous (`pinId`,
`blockStamp`, `landmarkLabel`, `otherFragment`; the anchor was encoded at pick
time), so nothing is awaited between the gesture and `execCommand`. The cap is
30: the pin that would overflow the set is refused with a toast and nothing is
copied, which `ui.ts` expresses as a third answer from `onBuildBlock` — copy,
refuse, or "not ready" — rather than overloading the composer's error line with
a set-level answer.

The set dock lists the set: the count, copy-all, clear-all with a two-step
inline confirm, and one row per pin with its index, its label and a way back to
it. It lists the SET rather than what the layer managed to draw, because two
anchored cards can overlap and a card can be anywhere on the page — the dock is
the one control that reaches every pin. Copy-all builds and writes from inside
the click for the same gesture reason.

Two seams widen for this. `pin.ts`'s `show` takes `focusId: null`, meaning no
pin scrolls or pulses — growing or restoring a set must not move the page under
the reviewer, while a link still names the pin that owns the arrival. And the
per-element stack read in `main.ts` becomes a map keyed by pin id, each entry
its own cancellation token, so N pins can be read at once; a pin the reviewer
picked here already carries the stack it was picked with and pays nothing.

Deviation from the design, and the reason: `SetPin` gains an optional `note`,
and `buildSetText` / `buildSetHtml` prefer it over `anchor.n`. The design had
the block's prose come off the anchor, but the anchor's note is capped at
`NOTE_MAX` — `nt` exists precisely to tell the card that the comment keeps the
rest — so rendering a set from `anchor.n` would have truncated the reviewer's
own words in the block for the first time. A link's pins have no `note` and
still render from `anchor.n`, which is the design's rule where it applies.

The link a set of one produces is byte-identical to the one the overlay copied
before this change; the read side still opens a link as a single pin, and
#9441 is what merges it into the draft.

## What else this branch carries

This branch owns the reviewer-facing chrome, so most of what came back from
driving the overlay on the QA server landed here — R4, R5 and R6 in full, plus
R7's dock-side half. Eighteen commits; the ones worth knowing about:

**R4 — hide is not remove, and the dock does the reaching.** A card's ✕ hides
only that card; the marker and the box stay on the element, and the flag is
persisted per pin so it survives a reload. A card's copy control copies just
that one pin (one block, its own link, its marker) — the dock's copy-all
remains the set copy. A header switch hides every card at once, with a
⌘/Ctrl+Shift+H chord that is ignored while the composer's textarea has focus
(plain ⌘H hides the app on macOS and Ctrl+H opens history, hence the Shift).
Clicking a dock row scrolls to its pin and replays the arrival pulse so the
reviewer can find it.

**R5.1 — the dock can be dragged.** It was nailed to the bottom-right corner,
which is exactly where a reviewer often wants to look. A grip in its header
drags it with pointer events: `pointerdown` takes the gesture (so it is neither
a text selection nor a react-grab pick) and captures the pointer on the grip,
so every move — and the click the release synthesises — stays there and a drag
ending over a row never fires that row's action. The position is per tab and
clamped into the viewport on every move, on `resize` and on restore. A
follow-up fixes the restore clamp, which ran while the dock was still
`display: none` so `offsetHeight` was 0 and the vertical clamp did nothing: a
dock parked low in a tall window came back in a short one with only its top
border on screen. Height now falls back the way width does and `render`
re-clamps at its end, where the box is real; the resize clamp deliberately does
not persist what it corrects, so the reviewer's chosen spot is given back when
the window grows again.

**R5.2 — the dock's chrome becomes lucide svgs** at one size, from
`client/icons.ts` (#9439), each button keeping the `aria-label` that names it.
The composer's copy button follows. One bug fell out of this and is fixed here:
the composer delegates clicks off `evt.target`, so once the button contained an
icon and a `.lbl` span, a click anywhere on its contents reported the span,
`instanceof HTMLButtonElement` failed, and the handler returned silently — no
toast, no error line, nothing added to the set. Only the thin padding ring
still worked, so the composer answered the keyboard alone. `closest` is what a
delegated handler over a button with children needs. Found by driving the QA
server with a mouse.

**R5.5 — "show all" honestly shows all.** The switch was suspend-and-restore:
turning cards back on left every individually hidden pin hidden, so a reviewer
who pressed "show" still could not see everything and had no way to tell why.
Turning it ON now clears every per-pin `hidden` flag, in the store, so both the
button and the chord get it; turning it OFF still leaves those flags alone.

**R6.2 — nothing on a card destroys a pin.** The card's remove button sat 20px
from copy, so a reach for copy ended the pin. The card keeps hide, scroll-to
and copy-this-pin; removing lives only in the dock — a row's own remove, or
"Clear all". The dock is on screen whenever the set is non-empty and its rows
are far enough apart that the same slip cannot happen. Rejected: a two-step
confirm (a click on every real delete), plain spacing (reduces the risk,
does not remove it), an undo toast (transient state, unrecoverable if missed).

**R6.1 — a row is titled by the reviewer's own note**, collapsed to one line
with the whole of it in the tooltip; whitespace is no note, and a pin without
one keeps the `route › landmark › tag "text"` label. The old label was what
every row had in common, not what told them apart.

**R7.3 (dock half) — a waiting row says where the pin was.** A pin whose page
matches but whose element is not in the DOM right now is waiting, not gone: its
row is dimmed and names the landmark, else the dialog-ish frame of its ⚛️
stack, else the component, else the element. A follow-up fixes that lookup,
which ran over the whole stack LINE — including the source path — so any
component merely living in a `*Modal.tsx` matched and the innermost frame won
(a radio item inside the folder-create modal reported `RadioListItem`), and
react-grab's file-only frames printed raw and truncated. Both go through one
parse now: the frame's name, else its file's basename.

**Two correctness fixes worth calling out.** The two-step "Clear all" confirm
was reset by `render()`, and the rows re-render on ordinary page activity (a
pin landing or losing its element flips its row between `here` and `waiting` on
the observer's batch) — so an app re-render between the question and the ✓
swapped the controls under the cursor and the confirming click landed on the
wrong one. Only a changed set takes the question back now. And the suite's
teardown iterated a NodeList of remove buttons taken before the first click,
but removing a pin re-runs `pins.show()`, which pops views from the END while
reusing them BY POSITION — so the trailing entries belonged to disposed views,
a three-pin set left one pin standing, and with it a live layer (a
MutationObserver on `body` and the 10 s retry driver) fired into the next test
file. That was the source of the suite's intermittent `document is not
defined`; the teardown drains live buttons and a test holds the line.

**Where the R6.2 hunk sits.** Taking removal off the card also deletes
`PinLayerOptions.onDismiss` and its `ViewDeps` plumbing in `pin.ts`, the file
the stack otherwise assigns to #9439. It is committed here because the decision
it implements is this branch's, and the branches were already pushed when that
was pointed out; the hunk was deliberately not moved down rather than rewriting
history under an open stack. Read #9439's card together with this diff.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (run on the stack top, `feat/FR-3859-pin-set-read`)
- `pnpm vitest run vite-plugins/review-overlay` (from `react/`) → 23 files, 557 tests, all passing on the stack top
- New here: `draft.test.ts` (the set as a value, the stored mirror, and the four ways a stored value can fail), `dock.test.ts` (the list, the row actions, drag and the stored position, the two-step clear) and `main-set-authoring.test.ts` (the flow end to end through `main.ts`: the first pin's block unchanged, two pins with one set link at the end, the button label, commit only on a successful copy, the cap refusal, boot restore, dock copy-all, hide, remove and Clear).
- Each branch was reviewed by two independent review agents (correctness, design conformance) and their blocker/major findings were fixed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhEbqZ9DDe2HFJF43rAVP1
