### PR TITLE
feat(FR-3859): open a multi-pin link into the draft set

### DIFF
--- a/react/vite-plugins/review-overlay/client/deeplink.test.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.test.ts
@@ -1,5 +1,7 @@
 import {
+  createFocusStore,
   createNavigationGuard,
+  focusPinId,
   hasLegacyFragment,
   MAX_SET_PINS,
   parseFragment,
@@ -7,9 +9,12 @@ import {
   pathNeedsChange,
   pinSetFragment,
   pinSetUrl,
+  pinSetUrlAt,
   pinUrl,
   readablePath,
   retryUntil,
+  stripPinParts,
+  watchRoute,
 } from './deeplink.js';
 import type { AnchorV3, SetPin } from './types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -378,5 +383,159 @@ describe('pinSetUrl', () => {
 
   it('has no link to build for an empty set', () => {
     expect(pinSetUrl([])).toBe('');
+  });
+});
+
+describe('stripPinParts', () => {
+  it('leaves the app’s own fragment and takes every pin out', () => {
+    expect(
+      stripPinParts(
+        '#tab=logs&bai=v3.c_zdv3rhz.QUJD&x=1&bai=v3.c_abcdef2.WkhH',
+      ),
+    ).toBe('tab=logs&x=1');
+  });
+
+  it('is empty when the fragment was only pins', () => {
+    expect(stripPinParts('#bai=v3.c_zdv3rhz.QUJD')).toBe('');
+    expect(stripPinParts('')).toBe('');
+  });
+});
+
+describe('pinSetUrlAt', () => {
+  const at = (id: string, p: string, q?: string, appHash = '') => ({
+    id,
+    anchorB64: `PAYLOAD_${id}`,
+    anchor: { v: 3 as const, s: 'button', p, q },
+    appHash,
+  });
+  const set = [at('c_aaaaaaa', '/session'), at('c_bbbbbbb', '/start', 'x=1')];
+  const both =
+    'bai=v3.c_aaaaaaa.PAYLOAD_c_aaaaaaa&bai=v3.c_bbbbbbb.PAYLOAD_c_bbbbbbb';
+
+  // The set travels whole; only the page it opens on moves.
+  it('opens on the named pin’s page and still carries every pin', () => {
+    expect(pinSetUrlAt(set, 'c_bbbbbbb', '')).toBe(`/start?x=1#${both}`);
+  });
+
+  // The tab a pin was made on travels with it: the reader's own fragment
+  // belongs to the page they are standing on, not to the one this opens.
+  it('takes the app fragment off the pin it opens on', () => {
+    const tabbed = [
+      at('c_aaaaaaa', '/session'),
+      at('c_bbbbbbb', '/start', undefined, 'tab=logs'),
+    ];
+    expect(pinSetUrlAt(tabbed, 'c_bbbbbbb')).toBe(
+      '/start#tab=logs&bai=v3.c_aaaaaaa.PAYLOAD_c_aaaaaaa&bai=v3.c_bbbbbbb.PAYLOAD_c_bbbbbbb',
+    );
+  });
+
+  it('keeps the app fragment it is handed', () => {
+    expect(pinSetUrlAt([set[0]], 'c_aaaaaaa', 'tab=logs')).toBe(
+      '/session#tab=logs&bai=v3.c_aaaaaaa.PAYLOAD_c_aaaaaaa',
+    );
+  });
+
+  // A "go" written before that pin was dismissed still has to open the link.
+  it('falls back to the first pin for an id the set no longer holds', () => {
+    expect(pinSetUrlAt(set, 'c_gone', '')).toBe(`/session#${both}`);
+  });
+
+  it('has no link to build for an empty set', () => {
+    expect(pinSetUrlAt([], 'c_aaaaaaa', '')).toBe('');
+  });
+});
+
+describe('focusPinId', () => {
+  const pin = (id: string, p: string) => ({
+    id,
+    anchor: { v: 3 as const, s: 'button', p },
+  });
+  const here = { pathname: '/session', search: '' };
+  const set = [pin('c_aaaaaaa', '/start'), pin('c_bbbbbbb', '/session')];
+
+  it('takes the id a “go” handed over', () => {
+    expect(focusPinId(set, here, 'c_aaaaaaa')).toBe('c_aaaaaaa');
+  });
+
+  // The stored id outlives the pin it named; the set still has to focus one.
+  it('ignores a stored id the set no longer holds', () => {
+    expect(focusPinId(set, here, 'c_gone')).toBe('c_bbbbbbb');
+  });
+
+  it('falls back to the first pin this page can draw', () => {
+    expect(focusPinId(set, here)).toBe('c_bbbbbbb');
+  });
+
+  it('falls back to the head of the set when none is on this page', () => {
+    expect(focusPinId(set, { pathname: '/other', search: '' })).toBe(
+      'c_aaaaaaa',
+    );
+  });
+
+  it('has nothing to focus in an empty set', () => {
+    expect(focusPinId([], here, 'c_aaaaaaa')).toBeNull();
+  });
+});
+
+describe('createFocusStore', () => {
+  const fakeStorage = (): Storage => {
+    const map = new Map<string, string>();
+    return {
+      getItem: (key) => map.get(key) ?? null,
+      setItem: (key, value) => void map.set(key, value),
+      removeItem: (key) => void map.delete(key),
+      clear: () => map.clear(),
+      key: () => null,
+      get length() {
+        return map.size;
+      },
+    } as Storage;
+  };
+
+  // The handover is for the document `location.assign` starts and no other: a
+  // later reload must not scroll the page away again.
+  it('hands the id over exactly once', () => {
+    const store = createFocusStore(fakeStorage());
+    store.set('c_zdv3rhz');
+    expect(store.take()).toBe('c_zdv3rhz');
+    expect(store.take()).toBeNull();
+  });
+
+  it('survives storage being unavailable', () => {
+    const store = createFocusStore(null);
+    store.set('c_zdv3rhz');
+    expect(store.take()).toBeNull();
+  });
+});
+
+describe('watchRoute', () => {
+  // React Router owns the history: without the patch every in-app navigation
+  // is silent, and a set that spans pages never re-partitions.
+  it('reports a pushState, a replaceState and a back button alike', () => {
+    const seen = vi.fn();
+    const stop = watchRoute(seen);
+
+    history.pushState({}, '', '/a');
+    history.replaceState({}, '', '/b');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    expect(seen).toHaveBeenCalledTimes(3);
+    stop();
+    history.pushState({}, '', '/c');
+    expect(seen).toHaveBeenCalledTimes(3);
+  });
+
+  it('patches the history once, however many overlays watch it', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const stopFirst = watchRoute(first);
+    const stopSecond = watchRoute(second);
+
+    history.pushState({}, '', '/d');
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    stopFirst();
+    stopSecond();
   });
 });

--- a/react/vite-plugins/review-overlay/client/deeplink.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.ts
@@ -70,6 +70,9 @@ export function otherFragment(hash: string): string {
     .join('&');
 }
 
+/** The scrub a merged link leaves behind: the app's own parts only (D4). */
+export const stripPinParts = otherFragment;
+
 /**
  * First-seen wins, in set order. The link and the blocks render off the same
  * list, or a pin added twice would be one part and two blocks.
@@ -96,16 +99,47 @@ export function pinSetFragment(
 type UrlPin = Pick<SetPin, 'id' | 'anchorB64' | 'anchor' | 'appHash'>;
 
 /**
+ * The set's one link, opened on the page of ONE of its pins — the whole set
+ * still rides in the fragment, and the app's own fragment is THAT pin's, so
+ * the set reopens on the tab it was made on. An id the set no longer holds
+ * falls back to the first pin, so a stale "go" opens the link rather than
+ * nothing.
+ */
+export function pinSetUrlAt(
+  pins: UrlPin[],
+  id: string,
+  appHash?: string,
+): string {
+  const at = pins.find((pin) => pin.id === id) ?? pins[0];
+  if (!at) return '';
+  const query = at.anchor.q ? `?${at.anchor.q}` : '';
+  const fragment = appHash ?? at.appHash;
+  return `${at.anchor.p}${query}#${fragment ? `${fragment}&` : ''}${pinSetFragment(pins)}`;
+}
+
+/**
  * The one link a pin set has, origin-relative. Path, query and the app's own
  * fragment come from the FIRST pin — the set may span pages, and that is the
  * page the link opens on.
  */
 export function pinSetUrl(pins: UrlPin[]): string {
   const first = pins[0];
-  if (!first) return '';
-  const query = first.anchor.q ? `?${first.anchor.q}` : '';
-  const app = first.appHash;
-  return `${first.anchor.p}${query}#${app ? `${app}&` : ''}${pinSetFragment(pins)}`;
+  return first ? pinSetUrlAt(pins, first.id) : '';
+}
+
+/**
+ * The one pin that navigates, scrolls and pulses (D2): the id a dock "go"
+ * handed over if the set still holds it, else the first pin this page can
+ * draw, else the head of the set.
+ */
+export function focusPinId(
+  pins: Array<{ id: string; anchor: AnchorV3 }>,
+  location: { pathname: string; search: string },
+  stored: string | null = null,
+): string | null {
+  if (stored && pins.some((pin) => pin.id === stored)) return stored;
+  const here = pins.find((pin) => !pathNeedsChange(pin.anchor, location));
+  return here?.id ?? pins[0]?.id ?? null;
 }
 
 /** A pin set of one. */
@@ -188,6 +222,87 @@ export function createNavigationGuard(
     reset() {
       navigatedHere = false;
     },
+  };
+}
+
+/** The focus pin a "go" hands to the document `location.assign` starts (D2). */
+const FOCUS_KEY = 'bai-review:focus';
+/** The merge sentence a link computed before it navigated to the set's page. */
+const NOTE_KEY = 'bai-review:note';
+
+export interface FocusStore {
+  /** One-shot: the value is cleared as it is read, so a reload does not repeat it. */
+  take(): string | null;
+  set(value: string): void;
+}
+
+function createHandover(key: string, storage: Storage | null): FocusStore {
+  return {
+    take() {
+      try {
+        const value = storage?.getItem(key) ?? null;
+        storage?.removeItem(key);
+        return value;
+      } catch {
+        return null;
+      }
+    },
+    set(value) {
+      try {
+        storage?.setItem(key, value);
+      } catch {
+        // The set still opens on that pin's page; only the pulse moves.
+      }
+    },
+  };
+}
+
+export const createFocusStore = (
+  storage: Storage | null = safeStorage(),
+): FocusStore => createHandover(FOCUS_KEY, storage);
+
+/**
+ * What the open that navigated found, carried to the page it navigated to:
+ * that page re-merges the very pins it was just handed, and would otherwise
+ * report them as duplicates of themselves.
+ */
+export const createNoteStore = (
+  storage: Storage | null = safeStorage(),
+): FocusStore => createHandover(NOTE_KEY, storage);
+
+/** Dispatched by the patched `history`, so every listener hears one navigation. */
+const ROUTE_EVENT = 'bai-review:route';
+
+/**
+ * React Router owns the history and changes route without a reload, so a
+ * `popstate` listener alone misses every in-app navigation. Patched once per
+ * document: a second overlay boot adds a listener, not another wrapper.
+ */
+function patchHistory(): void {
+  const patched = history as History & { __baiReviewRouted?: true };
+  if (patched.__baiReviewRouted) return;
+  patched.__baiReviewRouted = true;
+  for (const name of ['pushState', 'replaceState'] as const) {
+    const original = history[name];
+    history[name] = function (
+      this: History,
+      ...args: Parameters<History['pushState']>
+    ) {
+      const result = original.apply(this, args);
+      window.dispatchEvent(new Event(ROUTE_EVENT));
+      return result;
+    };
+  }
+}
+
+/** Every SPA navigation, so the set can re-partition into views and rows. */
+export function watchRoute(onChange: () => void): () => void {
+  patchHistory();
+  window.addEventListener(ROUTE_EVENT, onChange);
+  window.addEventListener('popstate', onChange);
+  return () => {
+    window.removeEventListener(ROUTE_EVENT, onChange);
+    window.removeEventListener('popstate', onChange);
   };
 }
 

--- a/react/vite-plugins/review-overlay/client/deeplink.ts
+++ b/react/vite-plugins/review-overlay/client/deeplink.ts
@@ -252,6 +252,7 @@ function createHandover(key: string, storage: Storage | null): FocusStore {
         storage?.setItem(key, value);
       } catch {
         // The set still opens on that pin's page; only the pulse moves.
+        return;
       }
     },
   };

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -341,16 +341,28 @@ describe('createSetDock', () => {
       expect(toggled).toBe(1);
     });
 
-    // The dock is the switch's home, so it says which way it is thrown.
-    it('says the cards are off once the owner says so', () => {
+    // A name that changes with the action carries the state already, and
+    // `aria-pressed` on top of it announces the opposite of what it does:
+    // "Show every card, pressed" is what a screen reader said with the cards
+    // hidden. The name is the whole story, so nothing states it twice.
+    it('leaves the state to the name it just changed', () => {
       dock.render([pin('c_a', 'a')], new Map(), true);
 
       expect(node('.cards').textContent).toBe('Cards');
-      expect(node('.cards').getAttribute('aria-pressed')).toBe('true');
+      expect(node('.cards').getAttribute('aria-label')).toBe(
+        `Show every card (${CARDS_CHORD})`,
+      );
+      expect(node('.cards').hasAttribute('aria-pressed')).toBe(false);
+
+      dock.render([pin('c_a', 'a')], new Map(), false);
+
+      expect(node('.cards').getAttribute('aria-label')).toBe(
+        `Hide every card (${CARDS_CHORD})`,
+      );
+      expect(node('.cards').hasAttribute('aria-pressed')).toBe(false);
     });
 
-    // R8.1: the glyph and the name are what pressing it DOES; the state it is
-    // in is `aria-pressed`, which a glyph cannot say twice.
+    // R8.1: the glyph and the name are what pressing it DOES.
     it('names and draws the action, not the state', () => {
       dock.render([pin('c_a', 'a')]);
 

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -19,6 +19,7 @@ let toggled: number;
 let located: string[];
 let removed: string[];
 let unhidden: string[];
+let went: string[];
 
 const pin = (id: string, label: string): SetPin => ({
   id,
@@ -80,6 +81,7 @@ beforeEach(() => {
   located = [];
   removed = [];
   unhidden = [];
+  went = [];
   const host = document.createElement('div');
   document.body.append(host);
   root = host.attachShadow({ mode: 'open' });
@@ -91,6 +93,7 @@ beforeEach(() => {
     onRemove: (id) => removed.push(id),
     onUnhide: (id) => unhidden.push(id),
     onToggleCards: () => toggled++,
+    onGo: (id) => went.push(id),
   });
 });
 
@@ -652,6 +655,57 @@ describe('createSetDock', () => {
 
       expect(node('.setdock').style.left).toBe('');
       expect(node('.setdock').style.top).toBe('');
+    });
+  });
+
+  // A set spans pages, and an off-page pin has no card — the row is the only
+  // thing it has on screen.
+  describe('a pin on another page', () => {
+    const spread = () => {
+      dock.render(
+        [pin('c_a', 'Sessions › start'), pin('c_b', 'Start › create')],
+        new Map([['c_b', 'Start']]),
+      );
+    };
+
+    it('says what differs and offers to go there instead of scrolling', () => {
+      spread();
+
+      const away = rows()[1];
+      expect(away.classList.contains('away')).toBe(true);
+      expect(away.querySelector('.where')?.textContent).toBe('Start');
+      expect(away.querySelector('.go')).not.toBeNull();
+    });
+
+    it('leaves the rows on this page scrolling to their own pin', () => {
+      spread();
+
+      expect(rows()[0].classList.contains('away')).toBe(false);
+      expect(rows()[0].querySelector('.go')).toBeNull();
+
+      rows()[0].querySelector<HTMLButtonElement>('.rowlabel')?.click();
+
+      expect(located).toEqual(['c_a']);
+      expect(went).toEqual([]);
+    });
+
+    it('hands back the id of the row whose go was pressed', () => {
+      spread();
+
+      rows()[1].querySelector<HTMLButtonElement>('.go')?.click();
+
+      expect(went).toEqual(['c_b']);
+      expect(located).toEqual([]);
+    });
+
+    // Scrolling to a pin that is not on this page is not a thing to do.
+    it('goes there when the off-page row itself is clicked', () => {
+      spread();
+
+      rows()[1].querySelector<HTMLButtonElement>('.rowlabel')?.click();
+
+      expect(went).toEqual(['c_b']);
+      expect(located).toEqual([]);
     });
   });
 

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -8,6 +8,7 @@ import {
   DOCK_POS_KEY,
   type SetDock,
 } from './dock.js';
+import { ICON_NODES } from './icons.js';
 import type { SetPin } from './types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -348,16 +349,40 @@ describe('createSetDock', () => {
       expect(node('.cards').getAttribute('aria-pressed')).toBe('true');
     });
 
-    // A pressed toggle named after the action that un-presses it announces
-    // the opposite of its own state.
-    it('keeps one name whichever way it is thrown', () => {
+    // R8.1: the glyph and the name are what pressing it DOES; the state it is
+    // in is `aria-pressed`, which a glyph cannot say twice.
+    it('names and draws the action, not the state', () => {
       dock.render([pin('c_a', 'a')]);
-      const named = node('.cards').getAttribute('aria-label');
+
+      const hide = node('.cards').getAttribute('aria-label');
+      expect(hide).toContain('Hide');
+      expect(node('.cards').title).toBe(hide);
+      expect(node('.cards svg path')?.getAttribute('d')).toBe(
+        ICON_NODES['eye-off'][0][1].d,
+      );
 
       dock.render([pin('c_a', 'a')], new Map(), true);
 
-      expect(node('.cards').getAttribute('aria-label')).toBe(named);
-      expect(node('.cards').title).toBe(named);
+      const show = node('.cards').getAttribute('aria-label');
+      expect(show).toContain('Show');
+      expect(node('.cards').title).toBe(show);
+      expect(node('.cards svg path')?.getAttribute('d')).toBe(
+        ICON_NODES.eye[0][1].d,
+      );
+    });
+
+    // R8.2: with the switch thrown, a row that offered nothing was a dead end.
+    it('offers every row a reveal while it is hiding the cards', () => {
+      dock.render([pin('c_a', 'a'), pin('c_b', 'b')], new Map(), true);
+
+      expect(rows().every((row) => row.querySelector('.unhide'))).toBe(true);
+      // The header already says the switch is thrown; dimming is for a card
+      // hidden on its own.
+      expect(rows().some((row) => row.classList.contains('off'))).toBe(false);
+
+      rows()[1].querySelector<HTMLButtonElement>('.unhide')?.click();
+
+      expect(unhidden).toEqual(['c_b']);
     });
 
     // A 260px header wraps; a hint stranded on the title's line reads as part

--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -664,7 +664,16 @@ describe('createSetDock', () => {
     const spread = () => {
       dock.render(
         [pin('c_a', 'Sessions › start'), pin('c_b', 'Start › create')],
-        new Map([['c_b', 'Start']]),
+        new Map([
+          [
+            'c_b',
+            {
+              kind: 'elsewhere',
+              where: 'Start',
+              href: 'http://dev.test/start#bai=v3.c_b.PAYLOAD',
+            },
+          ],
+        ]),
       );
     };
 
@@ -686,6 +695,48 @@ describe('createSetDock', () => {
       rows()[0].querySelector<HTMLButtonElement>('.rowlabel')?.click();
 
       expect(located).toEqual(['c_a']);
+      expect(went).toEqual([]);
+    });
+
+    /**
+     * R7.1: the platform already has "here" and "in a new tab"; we take only
+     * the plain click and leave every other one to the browser.
+     */
+    it('is a real link, so the browser owns the other intents', () => {
+      spread();
+
+      const link = rows()[1].querySelector<HTMLAnchorElement>('a.rowlabel');
+      expect(link?.getAttribute('href')).toBe(
+        'http://dev.test/start#bai=v3.c_b.PAYLOAD',
+      );
+      expect(rows()[1].querySelector<HTMLAnchorElement>('a.go')?.href).toBe(
+        link?.href,
+      );
+      // A row on this page stays a button: it scrolls, it does not navigate.
+      expect(rows()[0].querySelector('a.rowlabel')).toBeNull();
+    });
+
+    it('leaves a modifier or middle click to the browser', () => {
+      spread();
+      const link = rows()[1].querySelector<HTMLAnchorElement>(
+        'a.rowlabel',
+      ) as HTMLAnchorElement;
+
+      for (const init of [
+        { metaKey: true },
+        { ctrlKey: true },
+        { shiftKey: true },
+        { altKey: true },
+        { button: 1 },
+      ]) {
+        const evt = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          ...init,
+        });
+        link.dispatchEvent(evt);
+        expect(evt.defaultPrevented).toBe(false);
+      }
       expect(went).toEqual([]);
     });
 

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -415,10 +415,11 @@ export function createSetDock(options: SetDockOptions) {
     titleText.textContent = `${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
     setText(clear, `Clear all (${pins.length})`);
     confirmText.textContent = `Clear all ${pins.length}?`;
-    // Glyph and name are the ACTION; `aria-pressed` is where the state goes.
+    // Glyph and name are the ACTION (R8.1), and the name is the whole story:
+    // `aria-pressed` on a name that changes with the action reads out as its
+    // own contradiction — "Show every card, pressed" while they are hidden.
     setIcon(cards, cardsHidden ? 'eye' : 'eye-off');
     setLabel(cards, cardsHidden ? SHOW_CARDS_LABEL : HIDE_CARDS_LABEL);
-    cards.setAttribute('aria-pressed', String(cardsHidden));
     rows.replaceChildren(
       ...pins.map((pin, index) => {
         const row = document.createElement('div');

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -33,10 +33,8 @@ export interface DockPos {
 }
 
 /**
- * Where a pin is, as far as the dock is concerned. `elsewhere` is another
- * page — `where` is what differs about it. `waiting` is THIS page with the
- * element not in the DOM right now — a closed modal, a collapsed section —
- * which is not the same as gone, and the row is what says so (R7.3).
+ * Where a pin is (R7): another page — `where` is what differs — or this one
+ * with its element not in the DOM right now, which is not the same as gone.
  */
 export type PinPlace =
   | { kind: 'here' }
@@ -44,11 +42,7 @@ export type PinPlace =
   | { kind: 'elsewhere'; where: string; href: string }
   | { kind: 'waiting' };
 
-/**
- * A plain left-click is ours; every other click is the browser's — ⌘/Ctrl and
- * middle open the set in a new tab, where the link rehydrates it, and "copy
- * link address" needs the href untouched (R7.1).
- */
+/** A plain left-click is ours; every other click is the browser's (R7.1). */
 const plainClick = (evt: MouseEvent): boolean =>
   evt.button === 0 &&
   !evt.metaKey &&

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -33,11 +33,15 @@ export interface DockPos {
 }
 
 /**
- * Where a pin is, as far as the dock is concerned. `waiting` is this page with
- * the element not in the DOM right now — a closed modal, a collapsed section —
+ * Where a pin is, as far as the dock is concerned. `elsewhere` is another
+ * page — `where` is what differs about it. `waiting` is THIS page with the
+ * element not in the DOM right now — a closed modal, a collapsed section —
  * which is not the same as gone, and the row is what says so (R7.3).
  */
-export type PinPlace = { kind: 'here' } | { kind: 'waiting' };
+export type PinPlace =
+  | { kind: 'here' }
+  | { kind: 'elsewhere'; where: string }
+  | { kind: 'waiting' };
 
 /** Component names a reviewer would recognise as "the thing it was inside". */
 const DIALOGISH = /dialog|modal|drawer|sheet|popover/i;
@@ -132,11 +136,13 @@ const STYLE = `
   }
   /* Its card is hidden; the pin is still in the set and still on the page. */
   .setdock .row.off .rowlabel { opacity: 0.55; }
+  /* Its page is not this one; the row is all it has on screen. */
+  .setdock .row.away .rowlabel { color: var(--bai-review-text-dim); }
   /* Its page is this one; its element is not rendered right now. */
   .setdock .row.waiting .rowlabel { opacity: 0.55; }
-  /* Where that pin was — the row is the only thing it has on screen. */
+  /* Where that pin is, or was — the row is the only thing that can say. */
   .setdock .where {
-    flex: none; max-width: 55%; overflow: hidden; text-overflow: ellipsis;
+    flex: none; max-width: 50%; overflow: hidden; text-overflow: ellipsis;
     white-space: nowrap; font-size: 11px; color: var(--bai-review-text-dim);
   }
 ${ICON_STYLE}
@@ -156,6 +162,8 @@ export interface SetDockOptions {
   onUnhide: (id: string) => void;
   /** The header switch: every card off, or on again. */
   onToggleCards: () => void;
+  /** Open the whole set on that pin's own page — it is not on this one (D2). */
+  onGo?: (id: string) => void;
 }
 
 /**
@@ -355,9 +363,10 @@ export function createSetDock(options: SetDockOptions) {
   });
 
   /**
-   * `places` maps a pin to what the layer could do with it; anything missing
-   * is drawn here. `cardsHidden` is the switch's own state; each pin carries
-   * its own ✕.
+   * `places` says where each pin is; anything missing is drawn here. Those
+   * rows are the ONLY thing a pin the layer cannot draw has on screen, so an
+   * `elsewhere` one opens the set on its own page instead of scrolling.
+   * `cardsHidden` is the switch's own state; each pin carries its own ✕.
    */
   function render(
     pins: SetPin[],
@@ -390,14 +399,32 @@ export function createSetDock(options: SetDockOptions) {
         const note = rowNote(pin);
         label.textContent = note ? note.replace(/\s+/g, ' ') : pin.label;
         label.title = note || pin.label;
-        // The card comes back with the pin the reviewer just asked to see.
+        const place = places.get(pin.id);
+        const elsewhere =
+          place?.kind === 'elsewhere' ? place.where : undefined;
+        // The row is the control, and what it does is where its pin is: on
+        // this page, go to it; on another, open the set there.
         label.addEventListener('click', () => {
+          if (elsewhere !== undefined) return options.onGo?.(pin.id);
+          // The card comes back with the pin the reviewer asked to see.
           if (pin.hidden) options.onUnhide(pin.id);
           options.onLocate(pin.id);
         });
         row.append(idx, label);
-        const place = places.get(pin.id);
-        if (place?.kind === 'waiting') {
+        if (elsewhere !== undefined) {
+          row.classList.add('away');
+          const where = document.createElement('span');
+          where.className = 'where';
+          where.textContent = elsewhere;
+          where.title = elsewhere;
+          const go = button(
+            'go',
+            'external-link',
+            'Open the set on this pin’s page',
+          );
+          go.addEventListener('click', () => options.onGo?.(pin.id));
+          row.append(where, go);
+        } else if (place?.kind === 'waiting') {
           row.classList.add('waiting');
           const where = document.createElement('span');
           where.className = 'where';

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -15,7 +15,9 @@ import type { SetPin } from './types.js';
 /** ⌘⇧H / Ctrl⇧H — plain ⌘H hides the app and Ctrl+H opens history. */
 export const CARDS_CHORD = isMac() ? '⌘⇧H' : 'Ctrl⇧H';
 
-const CARDS_LABEL = `Pin cards (${CARDS_CHORD})`;
+/** A toggle is named for what pressing it DOES, never for its state (R8.1). */
+const HIDE_CARDS_LABEL = `Hide every card (${CARDS_CHORD})`;
+const SHOW_CARDS_LABEL = `Show every card (${CARDS_CHORD})`;
 
 /** Where a dragged dock is parked, per tab. Cleared with the tab, not the set. */
 export const DOCK_POS_KEY = 'bai-review:dock-pos';
@@ -224,6 +226,11 @@ const setIcon = (node: HTMLElement, name: IconName) => {
   node.querySelector('svg')?.replaceWith(icon(name));
 };
 
+const setLabel = (node: HTMLElement, label: string) => {
+  node.title = label;
+  node.setAttribute('aria-label', label);
+};
+
 /** A tab that refuses storage still drags; it just forgets on reload. */
 const readPos = (): DockPos | null => {
   try {
@@ -262,7 +269,7 @@ export function createSetDock(options: SetDockOptions) {
     'Copy all',
   );
   const clear = button('clear', 'trash-2', 'Clear the whole set', 'Clear all');
-  const cards = button('cards', 'eye', CARDS_LABEL, 'Cards');
+  const cards = button('cards', 'eye-off', HIDE_CARDS_LABEL, 'Cards');
   const chord = document.createElement('span');
   chord.className = 'chord';
   chord.textContent = CARDS_CHORD;
@@ -408,9 +415,9 @@ export function createSetDock(options: SetDockOptions) {
     titleText.textContent = `${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
     setText(clear, `Clear all (${pins.length})`);
     confirmText.textContent = `Clear all ${pins.length}?`;
-    // A toggle's name is stable and `aria-pressed` carries the state; naming
-    // it after the action it would take announces the opposite of the state.
-    setIcon(cards, cardsHidden ? 'eye-off' : 'eye');
+    // Glyph and name are the ACTION; `aria-pressed` is where the state goes.
+    setIcon(cards, cardsHidden ? 'eye' : 'eye-off');
+    setLabel(cards, cardsHidden ? SHOW_CARDS_LABEL : HIDE_CARDS_LABEL);
     cards.setAttribute('aria-pressed', String(cardsHidden));
     rows.replaceChildren(
       ...pins.map((pin, index) => {
@@ -468,8 +475,11 @@ export function createSetDock(options: SetDockOptions) {
           where.textContent = `waiting — ${whereItWas(pin)}`;
           where.title = pin.label;
           row.append(where);
-        } else if (pin.hidden) {
-          row.classList.add('off');
+        } else if (pin.hidden || cardsHidden) {
+          // Whatever hid the card — its own ✕ or the switch — the row is what
+          // offers it back (R8.2). Only an individual hide dims the row: with
+          // the switch thrown the header already says so, for every row.
+          if (pin.hidden) row.classList.add('off');
           const unhide = button('unhide', 'eye', 'Show this pin’s card again');
           unhide.addEventListener('click', () => options.onUnhide(pin.id));
           row.append(unhide);

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -40,8 +40,21 @@ export interface DockPos {
  */
 export type PinPlace =
   | { kind: 'here' }
-  | { kind: 'elsewhere'; where: string }
+  /** `href` is absolute: the row is a real link, so the browser owns it too. */
+  | { kind: 'elsewhere'; where: string; href: string }
   | { kind: 'waiting' };
+
+/**
+ * A plain left-click is ours; every other click is the browser's — ⌘/Ctrl and
+ * middle open the set in a new tab, where the link rehydrates it, and "copy
+ * link address" needs the href untouched (R7.1).
+ */
+const plainClick = (evt: MouseEvent): boolean =>
+  evt.button === 0 &&
+  !evt.metaKey &&
+  !evt.ctrlKey &&
+  !evt.shiftKey &&
+  !evt.altKey;
 
 /** Component names a reviewer would recognise as "the thing it was inside". */
 const DIALOGISH = /dialog|modal|drawer|sheet|popover/i;
@@ -138,6 +151,9 @@ const STYLE = `
   .setdock .row.off .rowlabel { opacity: 0.55; }
   /* Its page is not this one; the row is all it has on screen. */
   .setdock .row.away .rowlabel { color: var(--bai-review-text-dim); }
+  /* An off-page row is a real link, and a link is not underlined here. */
+  .setdock a.rowlabel { display: block; text-decoration: none; }
+  .setdock a.act { text-decoration: none; }
   /* Its page is this one; its element is not rendered right now. */
   .setdock .row.waiting .rowlabel { opacity: 0.55; }
   /* Where that pin is, or was — the row is the only thing that can say. */
@@ -185,6 +201,22 @@ const button = (
     span.textContent = text;
     node.append(span);
   }
+  node.title = label;
+  node.setAttribute('aria-label', label);
+  return node;
+};
+
+/** The same chrome as `button`, as a real link (R7.1). */
+const link = (
+  className: string,
+  name: IconName,
+  label: string,
+  href: string,
+): HTMLAnchorElement => {
+  const node = document.createElement('a');
+  node.className = `act ${className}`;
+  node.href = href;
+  node.append(icon(name));
   node.title = label;
   node.setAttribute('aria-label', label);
   return node;
@@ -394,36 +426,47 @@ export function createSetDock(options: SetDockOptions) {
         const idx = document.createElement('span');
         idx.className = 'idx';
         idx.textContent = String(index + 1);
-        const label = document.createElement('button');
+        const place = places.get(pin.id);
+        const off = place?.kind === 'elsewhere' ? place : null;
+        // An off-page row IS a link: the platform already has both intents, so
+        // ⌘/Ctrl-click and middle-click reach the browser untouched (R7.1).
+        const label: HTMLElement = document.createElement(off ? 'a' : 'button');
         label.className = 'rowlabel';
         const note = rowNote(pin);
         label.textContent = note ? note.replace(/\s+/g, ' ') : pin.label;
         label.title = note || pin.label;
-        const place = places.get(pin.id);
-        const elsewhere =
-          place?.kind === 'elsewhere' ? place.where : undefined;
         // The row is the control, and what it does is where its pin is: on
         // this page, go to it; on another, open the set there.
-        label.addEventListener('click', () => {
-          if (elsewhere !== undefined) return options.onGo?.(pin.id);
-          // The card comes back with the pin the reviewer asked to see.
-          if (pin.hidden) options.onUnhide(pin.id);
-          options.onLocate(pin.id);
-        });
+        const go = (evt: MouseEvent) => {
+          if (!plainClick(evt)) return;
+          evt.preventDefault();
+          options.onGo?.(pin.id);
+        };
+        if (off) {
+          (label as HTMLAnchorElement).href = off.href;
+          label.addEventListener('click', go);
+        } else {
+          label.addEventListener('click', () => {
+            // The card comes back with the pin the reviewer asked to see.
+            if (pin.hidden) options.onUnhide(pin.id);
+            options.onLocate(pin.id);
+          });
+        }
         row.append(idx, label);
-        if (elsewhere !== undefined) {
+        if (off) {
           row.classList.add('away');
           const where = document.createElement('span');
           where.className = 'where';
-          where.textContent = elsewhere;
-          where.title = elsewhere;
-          const go = button(
+          where.textContent = off.where;
+          where.title = off.where;
+          const open = link(
             'go',
             'external-link',
             'Open the set on this pin’s page',
+            off.href,
           );
-          go.addEventListener('click', () => options.onGo?.(pin.id));
-          row.append(where, go);
+          open.addEventListener('click', go);
+          row.append(where, open);
         } else if (place?.kind === 'waiting') {
           row.classList.add('waiting');
           const where = document.createElement('span');

--- a/react/vite-plugins/review-overlay/client/draft.test.ts
+++ b/react/vite-plugins/review-overlay/client/draft.test.ts
@@ -165,6 +165,22 @@ describe('what the set says is on screen', () => {
     expect(stored().map((p) => p.hidden)).toEqual([undefined, undefined]);
   });
 
+  // R8.3. Revealing one card while the switch hides them all keeps visibility
+  // one expression: the switch goes off and the rest carry the flag.
+  it('reveals one card by hiding every other pin', () => {
+    const store = createDraftStore();
+    store.add(pin('c_a'));
+    store.add(pin('c_b'));
+    store.add(pin('c_c'));
+    store.hideCards(true);
+
+    store.showOnly('c_b');
+
+    expect(store.cardsHidden()).toBe(false);
+    expect(store.pins().map((p) => p.hidden)).toEqual([true, undefined, true]);
+    expect(stored().map((p) => p.hidden)).toEqual([true, undefined, true]);
+  });
+
   it('leaves those flags alone when the switch goes off', () => {
     const store = createDraftStore();
     store.add(pin('c_aaaaaaa'));

--- a/react/vite-plugins/review-overlay/client/draft.test.ts
+++ b/react/vite-plugins/review-overlay/client/draft.test.ts
@@ -169,12 +169,12 @@ describe('what the set says is on screen', () => {
   // one expression: the switch goes off and the rest carry the flag.
   it('reveals one card by hiding every other pin', () => {
     const store = createDraftStore();
-    store.add(pin('c_a'));
-    store.add(pin('c_b'));
-    store.add(pin('c_c'));
+    store.add(pin('c_aaaaaaa'));
+    store.add(pin('c_bbbbbbb'));
+    store.add(pin('c_ccccccc'));
     store.hideCards(true);
 
-    store.showOnly('c_b');
+    store.showOnly('c_bbbbbbb');
 
     expect(store.cardsHidden()).toBe(false);
     expect(store.pins().map((p) => p.hidden)).toEqual([true, undefined, true]);

--- a/react/vite-plugins/review-overlay/client/draft.ts
+++ b/react/vite-plugins/review-overlay/client/draft.ts
@@ -126,6 +126,22 @@ export function showAllPins(set: DraftSet): DraftSet {
 }
 
 /**
+ * R8.3. One card revealed while the switch hides them all: the switch goes off
+ * and every OTHER pin takes the per-pin flag, so visibility stays the single
+ * expression it is instead of gaining a "shown in spite of the switch" state.
+ */
+export function showOnlyPin(set: DraftSet, id: string): DraftSet {
+  const { cardsHidden: _was, ...rest } = set;
+  return {
+    ...rest,
+    pins: set.pins.map((pin) => {
+      const { hidden: _flag, ...bare } = pin;
+      return (pin.id === id ? bare : { ...bare, hidden: true }) as SetPin;
+    }),
+  };
+}
+
+/**
  * A link merges into the set rather than replacing it: what is already there
  * keeps its place and the data it was stored with, and the rest is appended
  * in link order. The cap is what stops a pasted hash from growing it forever.
@@ -174,6 +190,8 @@ export interface DraftStore {
   cardsHidden(): boolean;
   /** Turning the switch back ON also un-hides every individually hidden pin. */
   hideCards(hidden: boolean): void;
+  /** Show this pin's card and no other: the switch goes off, the rest hide. */
+  showOnly(id: string): void;
 }
 
 export function createDraftStore(
@@ -231,6 +249,9 @@ export function createDraftStore(
     hideCards(hidden) {
       const next = hideCards(current, hidden);
       write(hidden ? next : showAllPins(next));
+    },
+    showOnly(id) {
+      write(showOnlyPin(current, id));
     },
   };
 }

--- a/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-comment-copy.test.ts
@@ -130,10 +130,11 @@ describe('copying the whole comment off a deep link', () => {
       `> ⚛️ in CreateButton (at ${FILE})`,
       `> [Open on dev server](${location.origin}/#bai=v3.${ID}.${anchorB64})`,
     ]);
-    // `at` is this copy's own instant; the id is what carries the identity.
-    expect(lines[5]).toMatch(
-      new RegExp(`^<!-- bai-review v3 id=${ID} pr=42 at=\\S+ -->$`),
-    );
+    // No marker (D5): a link carries no `at`/`pr`, and a fabricated stamp
+    // would write a marker whose id hash does not verify. The link is the
+    // canonical carrier of a pin that came off one.
+    expect(lines).toHaveLength(5);
+    expect(written['text/plain']).not.toContain('<!-- bai-review');
   });
 
   it('writes the rich flavour too, so a Teams paste stays a quote', async () => {

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -690,15 +690,23 @@ describe('the set the tab was left with', () => {
   });
 
   // The dock is the one control that reaches every pin, including the ones
-  // the layer never found.
-  it('says so when the dock cannot reach a pin', async () => {
-    seed([storedPin('c_goneaaa', 'missing', 'Start › missing')]);
+  // the layer never found. R7.3: waiting is not gone, so the row says where
+  // the element was rather than that the pin missed the page.
+  it('says where a pin it cannot reach was', async () => {
+    seed([
+      {
+        ...storedPin('c_goneaaa', 'missing', 'Start › missing'),
+        anchor: { v: 3, s: '[data-testid="missing"]', p: '/', tid: 'missing' },
+      },
+    ]);
     await bootOverlay();
     await ticks(2);
 
     node<HTMLButtonElement>('.setdock .rowlabel').click();
 
-    expect(toast()).toBe('That pin is not on this page');
+    expect(toast()).toBe(
+      '1 pin is waiting for its element (it was inside missing)',
+    );
   });
 
   it('ends the set once the dock asks twice', async () => {

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -753,6 +753,45 @@ describe('the cards switch as show-all', () => {
     expect(storedPins().some((pin) => pin.hidden)).toBe(false);
   });
 
+  /**
+   * R8.3. The row's reveal while the switch is on means "that one, alone":
+   * the switch goes off and the rest take the per-pin flag, so no card is
+   * shown in spite of the switch.
+   */
+  it('reveals one card alone, and the switch still brings them all back', async () => {
+    mount('save', 'Save');
+    seed([
+      storedPin('c_one', 'create', 'Start › create'),
+      storedPin('c_two', 'cancel', 'Start › cancel'),
+      storedPin('c_three', 'save', 'Start › save'),
+    ]);
+    await bootOverlay();
+    await ticks(2);
+    cardsSwitch().click();
+    expect(hiddenCard('c_two')).toBe(true);
+
+    node<HTMLButtonElement>(
+      '.setdock .row[data-pin-id="c_two"] .unhide',
+    ).click();
+
+    expect(hiddenCard('c_one')).toBe(true);
+    expect(hiddenCard('c_two')).toBe(false);
+    expect(hiddenCard('c_three')).toBe(true);
+    expect(storedSet().cardsHidden).toBeUndefined();
+    expect(storedPins().map((pin) => pin.hidden)).toEqual([
+      true,
+      undefined,
+      true,
+    ]);
+
+    cardsSwitch().click();
+    cardsSwitch().click();
+
+    expect(storedPins().some((pin) => pin.hidden)).toBe(false);
+    expect(hiddenCard('c_one')).toBe(false);
+    expect(hiddenCard('c_three')).toBe(false);
+  });
+
   // Off is not "remember what was hidden and hide everything else".
   it('leaves the per-pin flags alone on the way off', async () => {
     seed([

--- a/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-authoring.test.ts
@@ -761,22 +761,22 @@ describe('the cards switch as show-all', () => {
   it('reveals one card alone, and the switch still brings them all back', async () => {
     mount('save', 'Save');
     seed([
-      storedPin('c_one', 'create', 'Start › create'),
-      storedPin('c_two', 'cancel', 'Start › cancel'),
-      storedPin('c_three', 'save', 'Start › save'),
+      storedPin('c_oneaaaa', 'create', 'Start › create'),
+      storedPin('c_twoaaaa', 'cancel', 'Start › cancel'),
+      storedPin('c_threeaa', 'save', 'Start › save'),
     ]);
     await bootOverlay();
     await ticks(2);
     cardsSwitch().click();
-    expect(hiddenCard('c_two')).toBe(true);
+    expect(hiddenCard('c_twoaaaa')).toBe(true);
 
     node<HTMLButtonElement>(
-      '.setdock .row[data-pin-id="c_two"] .unhide',
+      '.setdock .row[data-pin-id="c_twoaaaa"] .unhide',
     ).click();
 
-    expect(hiddenCard('c_one')).toBe(true);
-    expect(hiddenCard('c_two')).toBe(false);
-    expect(hiddenCard('c_three')).toBe(true);
+    expect(hiddenCard('c_oneaaaa')).toBe(true);
+    expect(hiddenCard('c_twoaaaa')).toBe(false);
+    expect(hiddenCard('c_threeaa')).toBe(true);
     expect(storedSet().cardsHidden).toBeUndefined();
     expect(storedPins().map((pin) => pin.hidden)).toEqual([
       true,
@@ -788,8 +788,8 @@ describe('the cards switch as show-all', () => {
     cardsSwitch().click();
 
     expect(storedPins().some((pin) => pin.hidden)).toBe(false);
-    expect(hiddenCard('c_one')).toBe(false);
-    expect(hiddenCard('c_three')).toBe(false);
+    expect(hiddenCard('c_oneaaaa')).toBe(false);
+    expect(hiddenCard('c_threeaa')).toBe(false);
   });
 
   // Off is not "remember what was hidden and hide everything else".

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -280,6 +280,28 @@ describe('a set that spans pages', () => {
     expect(node('.card.found .count')?.textContent).toBe('2 / 2');
   });
 
+  // Only the page the app is on publishes a route label, so a pin from another
+  // page can be named at all only by the label it was stamped with.
+  it('names an off-page pin by the route its own label leads with', async () => {
+    seed([
+      storedPin(A, 'create', {
+        anchor: {
+          v: 3,
+          s: '[data-testid="create"]',
+          p: '/project/a한국어가능_cde/start',
+          tag: 'button',
+        },
+        label: 'Start › page-start › button "Create"',
+      }),
+    ]);
+
+    await bootOn('');
+
+    const away = dockRows()[0];
+    expect(away.classList.contains('away')).toBe(true);
+    expect(away.querySelector('.where')?.textContent).toBe('Start');
+  });
+
   // The row is the only thing an off-page pin has, and "/" is not a difference.
   it('names the missing query on a pin whose page differs only by it', async () => {
     seed([storedPin(A, 'create')]);

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Opening a pin set's link (FR-3859), end to end through `main.ts`: every pin
+ * the fragment carries MERGES into the draft set this tab is building, the
+ * members on this page are drawn and the rest are rows in the dock. Only
+ * `main.ts` composes the codec, the store, the layer and the dock, so this is
+ * where the read flow can be asserted at all.
+ */
+import { encodeAnchor } from './codec.js';
+import { DRAFT_KEY, MAX_SET_PINS } from './draft.js';
+import type { AnchorV3, SetPin } from './types.js';
+import type { Plugin, ReactGrabAPI } from 'react-grab';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ROOT = '/home/driver/Workspace/backend.ai-webui';
+const FILE = 'react/src/components/CreateButton.tsx';
+const APPLIED_KEY = 'bai-review-applied';
+const FOCUS_KEY = 'bai-review:focus';
+const A = 'c_aaaaaaa';
+const B = 'c_bbbbbbb';
+
+const shadow = () =>
+  document.querySelector('[data-bai-review-overlay]')?.shadowRoot as ShadowRoot;
+const node = <T extends HTMLElement>(selector: string) =>
+  shadow()?.querySelector<T>(selector) as T | null;
+const all = (selector: string) =>
+  Array.from(shadow()?.querySelectorAll<HTMLElement>(selector) ?? []);
+
+const toast = () => node('.toast')?.textContent ?? '';
+const dockRows = () => all('.setdock .row');
+const cards = () => all('.card.found');
+const storedPins = (): SetPin[] => {
+  const raw = sessionStorage.getItem(DRAFT_KEY);
+  return raw ? (JSON.parse(raw) as { pins: SetPin[] }).pins : [];
+};
+const storedIds = () => storedPins().map((pin) => pin.id);
+
+const ticks = async (count: number, ms = 10) => {
+  for (let i = 0; i < count; i++) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+};
+
+function mount(testid: string) {
+  document.body.insertAdjacentHTML(
+    'beforeend',
+    `<button data-testid="${testid}">${testid}</button>`,
+  );
+}
+
+interface PinSpec {
+  id: string;
+  testid: string;
+  /** The page the pin was made on; this document's is `/`. */
+  path?: string;
+}
+
+/** One `bai=v3.<id>.<anchor>` part, encoded by the real codec. */
+async function part(spec: PinSpec): Promise<string> {
+  const anchor: AnchorV3 = {
+    v: 3,
+    s: `[data-testid="${spec.testid}"]`,
+    p: spec.path ?? '/',
+    tag: 'button',
+    txt: spec.testid,
+    n: `note for ${spec.testid}`,
+  };
+  return `bai=v3.${spec.id}.${await encodeAnchor(anchor)}`;
+}
+
+/** A pin the reviewer already had in this tab, as the store holds it. */
+const storedPin = (
+  id: string,
+  testid: string,
+  over: Partial<SetPin> = {},
+): SetPin => {
+  const pin: SetPin = {
+    id,
+    origin: 'pick',
+    anchor: { v: 3, s: `[data-testid="${testid}"]`, p: '/', tag: 'button' },
+    anchorB64: `PAYLOAD_${id}`,
+    label: `Start › ${testid}`,
+    appHash: '',
+    stack: [],
+    note: 'picked here',
+    at: '2026-08-31T09:00:00Z',
+    pr: 42,
+  };
+  return Object.assign(pin, over);
+};
+
+const seed = (pins: SetPin[]) =>
+  sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ v: 1, pins }));
+
+/** Boot the overlay on `<path>#<hash>`, with react-grab already present. */
+async function bootOn(
+  hash: string,
+  path = '/',
+  getStackContext = () =>
+    Promise.resolve(`  in CreateButton (at ${ROOT}/${FILE})`),
+) {
+  window.__REACT_GRAB__ = {
+    activate: () => undefined,
+    deactivate: () => undefined,
+    isActive: () => false,
+    registerPlugin: (_plugin: Plugin) => undefined,
+    getStackContext,
+    getSource: () => Promise.resolve(null),
+  } as unknown as ReactGrabAPI;
+  vi.stubGlobal('fetch', () =>
+    Promise.resolve({ json: () => Promise.resolve({ pr: 42, root: ROOT }) }),
+  );
+  history.replaceState({}, '', `${path}${hash ? `#${hash}` : ''}`);
+  vi.resetModules();
+  delete window.__baiReviewOverlay;
+  await import('./main.js');
+  await ticks(12);
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  history.replaceState({}, '', '/');
+  document.body.innerHTML = '';
+  mount('create');
+  mount('cancel');
+  mount('deploy');
+});
+
+afterEach(() => {
+  // The layer outlives the module and keeps a MutationObserver on `body`;
+  // taking every pin down first keeps it from firing into a torn-down jsdom.
+  for (const remove of all('.card .remove')) remove.click();
+  vi.unstubAllGlobals();
+  document.querySelector('[data-bai-review-overlay]')?.remove();
+  document.body.innerHTML = '';
+  delete window.__REACT_GRAB__;
+});
+
+describe('opening a link that carries a set', () => {
+  it('draws every pin it carries, numbered, and lists them all', async () => {
+    const hash = [
+      await part({ id: A, testid: 'create' }),
+      await part({ id: B, testid: 'cancel' }),
+    ].join('&');
+
+    await bootOn(hash);
+
+    expect(storedIds()).toEqual([A, B]);
+    expect(dockRows()).toHaveLength(2);
+    expect(cards()).toHaveLength(2);
+    expect(all('.pin').map((marker) => marker.textContent)).toEqual(['1', '2']);
+    expect(toast()).toBe('Added 2 pins from the link');
+  });
+
+  // A reload must not re-apply the link and resurrect a pin just dismissed.
+  it('takes the pins out of the address bar and leaves the app’s fragment', async () => {
+    const hash = `tab=logs&${await part({ id: A, testid: 'create' })}`;
+
+    await bootOn(hash);
+
+    expect(location.hash).toBe('#tab=logs');
+  });
+
+  it('leaves nothing behind when the fragment was only pins', async () => {
+    await bootOn(await part({ id: A, testid: 'create' }));
+
+    expect(location.hash).toBe('');
+  });
+
+  // The set the tab is building is the truth; a link adds to it.
+  it('appends to the set the tab already had, keeping what it held', async () => {
+    seed([storedPin(A, 'create')]);
+    const hash = await part({ id: B, testid: 'cancel' });
+
+    await bootOn(hash);
+
+    expect(storedIds()).toEqual([A, B]);
+    expect(storedPins()[0].origin).toBe('pick');
+    expect(storedPins()[0].note).toBe('picked here');
+    expect(toast()).toBe('Added 1 pin from the link');
+  });
+
+  it('says so when the set already had every pin in the link', async () => {
+    seed([storedPin(A, 'create'), storedPin(B, 'cancel')]);
+    const hash = [
+      await part({ id: A, testid: 'create' }),
+      await part({ id: B, testid: 'cancel' }),
+    ].join('&');
+
+    await bootOn(hash);
+
+    expect(storedIds()).toEqual([A, B]);
+    expect(toast()).toBe('All 2 pins are already in your set');
+  });
+
+  // A pasted hash is untrusted: one unreadable part must not cost the others.
+  it('keeps the parts it can read and counts the ones it cannot', async () => {
+    const hash = [
+      await part({ id: A, testid: 'create' }),
+      'bai=v3.c_ccccccc.QUJDREVGR0g',
+    ].join('&');
+
+    await bootOn(hash);
+
+    expect(storedIds()).toEqual([A]);
+    expect(toast()).toBe(
+      'Added 1 pin from the link · 1 of 2 pins could not be read',
+    );
+  });
+
+  // The 31st pin is refused, and one sentence has to say what did not fit.
+  it('says what the link brought that the full set could not take', async () => {
+    seed(
+      Array.from({ length: MAX_SET_PINS }, (_, index) =>
+        storedPin(`c_seed${index}`, 'create'),
+      ),
+    );
+
+    await bootOn(await part({ id: A, testid: 'cancel' }));
+
+    expect(storedIds()).toHaveLength(MAX_SET_PINS);
+    expect(storedIds()).not.toContain(A);
+    expect(toast()).toBe(`1 did not fit — your set is full at ${MAX_SET_PINS}`);
+  });
+
+  // The link is the only carrier of a pin that came off one, so its block has
+  // to quote the ⚛️ stack of the element it landed on.
+  it('writes the stack it read back into the set', async () => {
+    await bootOn(await part({ id: A, testid: 'create' }));
+
+    expect(storedPins()[0].stack.join('\n')).toContain(
+      `in CreateButton (at ${FILE})`,
+    );
+  });
+
+  // The card's ⧉ refuses that same block; the dock must not emit it either.
+  it('will not copy the set while a pin’s ⚛️ frames are still unread', async () => {
+    await bootOn(
+      await part({ id: A, testid: 'create' }),
+      '/',
+      () => new Promise<string>(() => undefined),
+    );
+
+    node<HTMLButtonElement>('.setdock .copyall')?.click();
+
+    expect(toast()).toBe('Still reading a pin — try again');
+  });
+});
+
+describe('a set that spans pages', () => {
+  const spread = async () =>
+    [
+      await part({ id: A, testid: 'create' }),
+      await part({ id: B, testid: 'deploy', path: '/start' }),
+    ].join('&');
+
+  it('draws what is here and leaves the rest to the dock', async () => {
+    await bootOn(await spread());
+
+    expect(storedIds()).toEqual([A, B]);
+    expect(cards()).toHaveLength(1);
+    expect(cards()[0].dataset.pinId).toBe(A);
+    expect(dockRows()).toHaveLength(2);
+    const away = dockRows()[1];
+    expect(away.classList.contains('away')).toBe(true);
+    expect(away.querySelector('.where')?.textContent).toBe('/start');
+  });
+
+  // The glyph is the pin's place in the SET, not in what this page can draw.
+  it('numbers an on-page pin by its place in the whole set', async () => {
+    const hash = [
+      await part({ id: A, testid: 'create', path: '/start' }),
+      await part({ id: B, testid: 'cancel' }),
+    ].join('&');
+
+    await bootOn(hash);
+
+    expect(all('.pin.found').map((marker) => marker.textContent)).toEqual([
+      '2',
+    ]);
+    expect(node('.card.found .count')?.textContent).toBe('2 / 2');
+  });
+
+  // The row is the only thing an off-page pin has, and "/" is not a difference.
+  it('names the missing query on a pin whose page differs only by it', async () => {
+    seed([storedPin(A, 'create')]);
+
+    await bootOn('', '/?tab=logs');
+
+    const away = dockRows()[0];
+    expect(away.classList.contains('away')).toBe(true);
+    expect(away.querySelector('.where')?.textContent).toBe('no query');
+  });
+
+  // The reader's own fragment belongs to the page they are standing on: the
+  // set has to reopen on the tab its focus pin was made on.
+  it('opens the set on the focus pin’s own app fragment', async () => {
+    seed([
+      storedPin(A, 'create', {
+        anchor: { v: 3, s: '[data-testid="create"]', p: '/start' },
+        appHash: 'tab=logs',
+      }),
+    ]);
+
+    await bootOn(
+      `env=dev&${await part({ id: A, testid: 'create', path: '/start' })}`,
+      '/elsewhere',
+    );
+
+    expect(sessionStorage.getItem(APPLIED_KEY) ?? '').toContain(
+      `/start#tab=logs&bai=v3.${A}.`,
+    );
+  });
+
+  it('hands the focus pin over to the page the go button opens', async () => {
+    await bootOn(await spread());
+
+    dockRows()[1].querySelector<HTMLButtonElement>('.go')?.click();
+
+    expect(sessionStorage.getItem(FOCUS_KEY)).toBe(B);
+  });
+
+  // Arriving on pin 2's page must not bounce the reviewer back to pin 1's.
+  it('stays put while any member of the set is on this page', async () => {
+    await bootOn(await spread());
+
+    expect(sessionStorage.getItem(APPLIED_KEY)).toBeNull();
+  });
+
+  it('opens on the focus pin’s page when none of the set is here', async () => {
+    const hash = await spread();
+
+    await bootOn(hash, '/elsewhere');
+
+    const applied = sessionStorage.getItem(APPLIED_KEY) ?? '';
+    expect(applied.startsWith(`${A} /#bai=v3.${A}.`)).toBe(true);
+    // The whole set travels, whichever page it opens on.
+    expect(applied).toContain(`&bai=v3.${B}.`);
+  });
+
+  // An SPA navigation does not reload, so nothing else would re-partition.
+  it('re-partitions when the app navigates', async () => {
+    await bootOn(await spread());
+
+    history.pushState({}, '', '/start');
+    await ticks(4);
+
+    expect(cards()).toHaveLength(1);
+    expect(cards()[0].dataset.pinId).toBe(B);
+    expect(dockRows()[0].classList.contains('away')).toBe(true);
+  });
+});
+
+describe('the focus pin', () => {
+  const twoHere = async () =>
+    [
+      await part({ id: A, testid: 'create' }),
+      await part({ id: B, testid: 'cancel' }),
+    ].join('&');
+
+  // A "go" re-opens the set it just persisted; calling those duplicates would
+  // report an action the reviewer never took.
+  it('says nothing about duplicates when a go re-opened the set', async () => {
+    seed([storedPin(A, 'create'), storedPin(B, 'cancel')]);
+    sessionStorage.setItem(FOCUS_KEY, B);
+
+    await bootOn(await twoHere());
+
+    expect(storedIds()).toEqual([A, B]);
+    expect(toast()).toBe('');
+  });
+
+  it('is the head of the set by default', async () => {
+    await bootOn(await twoHere());
+
+    expect(node('.pin.pulse')?.dataset.pinId).toBe(A);
+  });
+
+  // What the dock's go button wrote before it reloaded the document.
+  it('is the id a go handed over, not the first pin', async () => {
+    const hash = await twoHere();
+    sessionStorage.setItem(FOCUS_KEY, B);
+
+    await bootOn(hash);
+
+    expect(node('.pin.pulse')?.dataset.pinId).toBe(B);
+    // One-shot: the next link opened in this tab focuses its own pin.
+    expect(sessionStorage.getItem(FOCUS_KEY)).toBeNull();
+  });
+});

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -182,6 +182,19 @@ describe('opening a link that carries a set', () => {
     expect(dockRows()).toHaveLength(0);
   });
 
+  // Opening a link at a pin whose card was tidied away must not land the
+  // reviewer on a bare marker: the link is what asked to see it.
+  it('brings back the card of the pin it opens on', async () => {
+    seed([storedPin(A, 'create', { hidden: true })]);
+
+    await bootOn(await part({ id: A, testid: 'create' }));
+
+    expect(storedPins()[0].hidden).toBeUndefined();
+    expect(
+      node(`.card[data-pin-id="${A}"]`)?.classList.contains('hidden'),
+    ).toBe(false);
+  });
+
   // A reload must not re-apply the link and resurrect a pin just dismissed.
   it('takes the pins out of the address bar and leaves the app’s fragment', async () => {
     const hash = `tab=logs&${await part({ id: A, testid: 'create' })}`;

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -34,6 +34,9 @@ const storedPins = (): SetPin[] => {
 };
 const storedIds = () => storedPins().map((pin) => pin.id);
 
+/** `ANCHOR_TRIES` + a beat: the give-up sentence lands after the ladder. */
+const LADDER_TICKS = 22;
+
 const ticks = async (count: number, ms = 10) => {
   for (let i = 0; i < count; i++) {
     await new Promise((resolve) => setTimeout(resolve, ms));
@@ -126,13 +129,14 @@ beforeEach(() => {
 });
 
 /**
- * Views are reused BY POSITION and popped from the END, so a snapshot of the
- * buttons goes stale on the first click — the trailing ones then belong to
- * disposed views and do nothing. Drain the live ones instead.
+ * The dock row's 🗑 is the only remove control (R6.2). Its rows are rebuilt on
+ * every render, so a snapshot goes stale on the first click — take the live
+ * head of the list each time.
  */
 function tearDownPins() {
   for (let left = MAX_SET_PINS; left > 0; left--) {
-    const remove = all('.card .remove')[0] as HTMLButtonElement | undefined;
+    const remove = all('.setdock .row .remove')[0] as
+      HTMLButtonElement | undefined;
     if (!remove) return;
     remove.click();
   }
@@ -383,6 +387,117 @@ describe('a set that spans pages', () => {
     dockRows()[1].querySelector<HTMLButtonElement>('.go')?.click();
 
     expect(sessionStorage.getItem(FOCUS_KEY)).toBe(B);
+  });
+
+  /**
+   * R7.1: an off-page row is a real link. The platform already has both
+   * intents — this tab, or a new one — so we intercept only the plain click
+   * and leave ⌘/Ctrl-click, middle-click and "copy link address" alone.
+   */
+  describe('the link an off-page row is', () => {
+    const awayLink = () =>
+      dockRows()[1].querySelector<HTMLAnchorElement>('a.rowlabel') as
+        HTMLAnchorElement | undefined;
+
+    it('carries the whole set behind an absolute href', async () => {
+      await bootOn(await spread());
+
+      const href = awayLink()?.getAttribute('href') ?? '';
+      expect(href.startsWith(`${location.origin}/start#`)).toBe(true);
+      expect(href).toContain(`bai=v3.${A}.`);
+      expect(href).toContain(`bai=v3.${B}.`);
+      expect(dockRows()[1].querySelector<HTMLAnchorElement>('a.go')?.href).toBe(
+        href,
+      );
+    });
+
+    it('keeps a plain click in this tab', async () => {
+      await bootOn(await spread());
+      const evt = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+      awayLink()?.dispatchEvent(evt);
+
+      expect(evt.defaultPrevented).toBe(true);
+      expect(sessionStorage.getItem(FOCUS_KEY)).toBe(B);
+    });
+
+    it('lets a modifier or middle click reach the browser', async () => {
+      await bootOn(await spread());
+
+      for (const init of [
+        { metaKey: true },
+        { ctrlKey: true },
+        { shiftKey: true },
+        { altKey: true },
+        { button: 1 },
+      ]) {
+        const evt = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          ...init,
+        });
+        awayLink()?.dispatchEvent(evt);
+        expect(evt.defaultPrevented).toBe(false);
+      }
+      expect(sessionStorage.getItem(FOCUS_KEY)).toBeNull();
+    });
+  });
+
+  /**
+   * R7.4: "N of M pins are not on this page" answered two different questions
+   * with one sentence. Another page is opened from the list; this page with no
+   * element yet is waiting, and will draw itself when the element appears.
+   */
+  describe('what the set says about the pins it cannot draw', () => {
+    it('names the pins that are on other pages', async () => {
+      await bootOn(await spread());
+
+      expect(toast()).toBe(
+        'Added 2 pins from the link · ' +
+          '1 pin is on another page — open it from the list',
+      );
+    });
+
+    it('says what a waiting pin was inside', async () => {
+      seed([
+        storedPin(A, 'create', {
+          anchor: { v: 3, s: '[data-testid="gone"]', p: '/', tid: 'gone' },
+        }),
+      ]);
+
+      await bootOn('');
+      await ticks(LADDER_TICKS, 500);
+
+      expect(toast()).toBe(
+        '1 pin is waiting for its element (it was inside gone)',
+      );
+    }, 30_000);
+
+    // Two different facts arrive at two different moments: the page a pin is
+    // on is known at once, that its element never turned up is not.
+    it('says each in its own moment when the set is spread both ways', async () => {
+      seed([
+        storedPin(A, 'create', {
+          anchor: { v: 3, s: '[data-testid="gone"]', p: '/', tid: 'gone' },
+        }),
+        storedPin(B, 'deploy', {
+          anchor: { v: 3, s: '[data-testid="gone2"]', p: '/', tid: 'gone2' },
+        }),
+        storedPin('c_c', 'create', {
+          anchor: { v: 3, s: '[data-testid="create"]', p: '/start' },
+          label: 'Start › create',
+        }),
+      ]);
+
+      await bootOn('');
+      expect(toast()).toBe('1 pin is on another page — open it from the list');
+
+      await ticks(LADDER_TICKS, 500);
+
+      expect(toast()).toBe(
+        '2 pins are waiting for their elements — the list says where',
+      );
+    }, 30_000);
   });
 
   // Arriving on pin 2's page must not bounce the reviewer back to pin 1's.

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -91,6 +91,11 @@ const storedPin = (
   return Object.assign(pin, over);
 };
 
+const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+/** A distinct WELL-FORMED id per index — base32 is `a`-`z` and `2`-`7`. */
+const nthId = (i: number) =>
+  `c_s${LETTERS[i % 26]}${LETTERS[Math.floor(i / 26)]}aaaa`;
+
 const seed = (pins: SetPin[]) =>
   sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ v: 1, pins }));
 
@@ -259,7 +264,7 @@ describe('opening a link that carries a set', () => {
   it('says what the link brought that the full set could not take', async () => {
     seed(
       Array.from({ length: MAX_SET_PINS }, (_, index) =>
-        storedPin(`c_seed${index}`, 'create'),
+        storedPin(nthId(index), 'create'),
       ),
     );
 
@@ -483,7 +488,7 @@ describe('a set that spans pages', () => {
         storedPin(B, 'deploy', {
           anchor: { v: 3, s: '[data-testid="gone2"]', p: '/', tid: 'gone2' },
         }),
-        storedPin('c_c', 'create', {
+        storedPin('c_ccccccc', 'create', {
           anchor: { v: 3, s: '[data-testid="create"]', p: '/start' },
           label: 'Start › create',
         }),

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -500,6 +500,33 @@ describe('a set that spans pages', () => {
     }, 30_000);
   });
 
+  /**
+   * R7.3: the row of a pin whose element is not rendered re-runs ITS resolve.
+   * A link's arrival leaves the layer with a focus pin, so re-running the whole
+   * layer would scroll the page to a pin the reviewer did not click.
+   */
+  it('re-resolves the clicked pin alone, scrolling nothing', async () => {
+    const hash = [
+      await part({ id: A, testid: 'create' }),
+      await part({ id: B, testid: 'gone' }),
+    ].join('&');
+    await bootOn(hash);
+    const scrolled: string[] = [];
+    for (const testid of ['create', 'cancel', 'deploy']) {
+      const element = document.querySelector<HTMLElement>(
+        `[data-testid="${testid}"]`,
+      ) as HTMLElement;
+      element.scrollIntoView = () => scrolled.push(testid);
+    }
+
+    dockRows()[1].querySelector<HTMLButtonElement>('.rowlabel')?.click();
+
+    expect(scrolled).toEqual([]);
+    expect(toast()).toBe(
+      '1 pin is waiting for its element (it was inside button "gone")',
+    );
+  });
+
   // Arriving on pin 2's page must not bounce the reviewer back to pin 1's.
   it('stays put while any member of the set is on this page', async () => {
     await bootOn(await spread());

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -527,6 +527,38 @@ describe('a set that spans pages', () => {
     );
   });
 
+  /**
+   * R7.4 says the line on arrival and after a re-partition. The app writes its
+   * own fragment — its "Skip to content" link is one — and that moves nothing.
+   */
+  describe('repeating the off-page line', () => {
+    it('stays quiet when only the app’s own fragment changed', async () => {
+      await bootOn(await spread());
+      expect(toast()).toContain('1 pin is on another page');
+      const banner = node('.toast') as HTMLElement;
+      banner.textContent = '';
+
+      history.replaceState({}, '', '/#astryx-app-shell-main');
+      window.dispatchEvent(new Event('hashchange'));
+      await ticks(4);
+
+      expect(banner.textContent).toBe('');
+    });
+
+    it('says it again when a navigation moved a pin off the page', async () => {
+      await bootOn(await spread());
+      const banner = node('.toast') as HTMLElement;
+      banner.textContent = '';
+
+      history.pushState({}, '', '/start');
+      await ticks(4);
+
+      expect(banner.textContent).toBe(
+        '1 pin is on another page — open it from the list',
+      );
+    });
+  });
+
   // Arriving on pin 2's page must not bounce the reviewer back to pin 1's.
   it('stays put while any member of the set is on this page', async () => {
     await bootOn(await spread());

--- a/react/vite-plugins/review-overlay/client/main-set-read.test.ts
+++ b/react/vite-plugins/review-overlay/client/main-set-read.test.ts
@@ -125,10 +125,24 @@ beforeEach(() => {
   mount('deploy');
 });
 
+/**
+ * Views are reused BY POSITION and popped from the END, so a snapshot of the
+ * buttons goes stale on the first click — the trailing ones then belong to
+ * disposed views and do nothing. Drain the live ones instead.
+ */
+function tearDownPins() {
+  for (let left = MAX_SET_PINS; left > 0; left--) {
+    const remove = all('.card .remove')[0] as HTMLButtonElement | undefined;
+    if (!remove) return;
+    remove.click();
+  }
+}
+
 afterEach(() => {
-  // The layer outlives the module and keeps a MutationObserver on `body`;
-  // taking every pin down first keeps it from firing into a torn-down jsdom.
-  for (const remove of all('.card .remove')) remove.click();
+  // The layer outlives the module and keeps a MutationObserver on `body` plus
+  // a 10 s retry driver; taking every pin down first keeps them from firing
+  // into a torn-down jsdom.
+  tearDownPins();
   vi.unstubAllGlobals();
   document.querySelector('[data-bai-review-overlay]')?.remove();
   document.body.innerHTML = '';
@@ -149,6 +163,23 @@ describe('opening a link that carries a set', () => {
     expect(cards()).toHaveLength(2);
     expect(all('.pin').map((marker) => marker.textContent)).toEqual(['1', '2']);
     expect(toast()).toBe('Added 2 pins from the link');
+  });
+
+  // A teardown that halves the set leaves a live layer — MutationObserver and
+  // retry driver — running into the next test file.
+  it('takes every pin down when the set is torn down', async () => {
+    const hash = [
+      await part({ id: A, testid: 'create' }),
+      await part({ id: B, testid: 'cancel' }),
+      await part({ id: 'c_ddddddd', testid: 'deploy' }),
+    ].join('&');
+    await bootOn(hash);
+
+    tearDownPins();
+
+    expect(storedIds()).toEqual([]);
+    expect(all('.card')).toHaveLength(0);
+    expect(dockRows()).toHaveLength(0);
   });
 
   // A reload must not re-apply the link and resurrect a pin just dismissed.

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -111,7 +111,7 @@ function boot() {
       ? `Copied all ${count} pins — replaces your last paste`
       : COPIED_ONE;
 
-  /** One card's ⧉: a link's pin has only the capped note the link carries. */
+  /** One card's copy: a link's pin has only the capped note it carries. */
   const onePinToast = (pin: { note?: string; anchor: AnchorV3 }): string =>
     pin.note === undefined && pin.anchor.nt === 1
       ? 'Copied 1 pin — the note is the shortened one the link carries'
@@ -343,8 +343,8 @@ function boot() {
   }
 
   /**
-   * What the card's ⧉ writes: THAT pin, one block behind its own link. The set
-   * as a whole is the dock's ⧉ — a card is where the reviewer points at one
+   * What the card's copy writes: THAT pin, one block behind its own link. The
+   * set as a whole is the dock's — a card is where the reviewer points at one
    * thing, so it hands over one thing. Every drawn pin is a member of the
    * draft, because a link merges into it (D4). `null` while a link's pin is
    * still having its ⚛️ stack read off the element it landed on — a block
@@ -460,7 +460,7 @@ function boot() {
     pins.setCardsHidden(store.cardsHidden());
     const { here } = partition();
     pins.show(here, { focusId, setSize: draft.length });
-    // Adopting a pin gives it a fresh card, so its ✕ is re-applied here.
+    // Adopting a pin gives it a fresh card, so hidden is re-applied here.
     for (const pin of draft) pins.setCardHidden(pin.id, pin.hidden === true);
     // What the layer no longer draws holds an element from a page we left.
     pruneStacks(here);
@@ -487,7 +487,7 @@ function boot() {
   }
 
   /**
-   * ✕ on a card, or its row's eye. Visibility only — `redraw()` would restart
+   * A card hidden, or its row's eye. Visibility only — `redraw()` would restart
    * the resolution ladder and re-toast its give-up line at every flip.
    */
   function setHidden(id: string, hidden: boolean) {
@@ -501,7 +501,7 @@ function boot() {
   function toggleCards() {
     store.hideCards(!store.cardsHidden());
     pins.setCardsHidden(store.cardsHidden());
-    // Switching back ON cleared every pin's own ✕ (R5.5); the layer has to
+    // Switching back ON cleared every per-pin hide (R5.5); the layer has to
     // hear about that or the cards it hid one at a time stay hidden.
     for (const pin of store.pins())
       pins.setCardHidden(pin.id, pin.hidden === true);
@@ -549,7 +549,7 @@ function boot() {
   /** The whole set, from a click; nothing may be awaited before the write. */
   function copySet() {
     if (!draft.length) return;
-    // The same gate the card's ⧉ has: a block missing the ⚛️ frames of the
+    // The same gate the card's copy has: a block missing the ⚛️ frames of the
     // element its pin just landed on is not the comment that was written.
     if (draft.some((pin) => stackPending(pin) && pins.locatedElement(pin.id))) {
       ui.showToast('Still reading a pin — try again');

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -390,10 +390,10 @@ function boot() {
       redraw();
     },
     onLocate: (id) => {
-      // Its page matches but the element is not rendered: one more pass of the
-      // full ladder, then say where it was rather than that it is gone (R7.3).
+      // Its page matches but the element is not rendered: one more pass of
+      // THAT pin's ladder — the rest of the set is not what was asked (R7.3).
       const element =
-        pins.locatedElement(id) ?? (pins.locate(), pins.locatedElement(id));
+        pins.locatedElement(id) ?? (pins.locate(id), pins.locatedElement(id));
       if (!element) return ui.showToast(waitingLine([id]));
       element.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
       // The arrival beat is long spent — this is a deliberate "that one".

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -552,15 +552,26 @@ function boot() {
    * on arrival and after a re-partition; a pin on THIS one is waiting for its
    * element and gets `waitingLine` when the ladder ends.
    */
+  /** The off-page pins this line was last said for (R7.4). */
+  let saidAway = '';
+
+  const awayKey = () => [...partition().away.keys()].sort().join(' ');
+
   function elsewhereLine(): string {
     const count = partition().away.size;
+    saidAway = awayKey();
     if (!count) return '';
     return count === 1
       ? '1 pin is on another page — open it from the list'
       : `${count} pins are on other pages — open them from the list`;
   }
 
+  /**
+   * Only a re-partition that MOVED something is news: the app writes its own
+   * hashes and queries, and the same sentence twice reads as a second pin.
+   */
   const sayElsewhere = () => {
+    if (awayKey() === saidAway) return;
     const line = elsewhereLine();
     if (line) ui.showToast(line);
   };

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -400,7 +400,7 @@ function boot() {
       pins.pulse(id);
     },
     onRemove: removeFromSet,
-    onUnhide: (id) => setHidden(id, false),
+    onUnhide: revealPin,
     onToggleCards: toggleCards,
     onGo: (id) => {
       // Built from the DRAFT SET, never from `location.hash`: the hash was
@@ -497,6 +497,21 @@ function boot() {
     if (!store.has(id)) return;
     store.hide(id, hidden);
     pins.setCardHidden(id, hidden);
+    syncDraft();
+  }
+
+  /**
+   * A row's reveal. While the switch hides everything, showing one card means
+   * showing it ALONE: the switch goes off and the rest take the per-pin flag,
+   * so nothing is shown in spite of the switch (R8.3).
+   */
+  function revealPin(id: string) {
+    if (!store.has(id)) return;
+    if (!store.cardsHidden()) return setHidden(id, false);
+    store.showOnly(id);
+    pins.setCardsHidden(false);
+    for (const pin of store.pins())
+      pins.setCardHidden(pin.id, pin.hidden === true);
     syncDraft();
   }
 

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -692,6 +692,12 @@ function boot() {
       guard.landed();
     }
     scrubPinParts();
+    // The pin a link opens on is an explicit "show me this one": a card the
+    // reviewer had tidied away comes back rather than leaving a bare marker.
+    if (focusId && opened.some((pin) => pin.id === focusId)) {
+      store.hide(focusId, false);
+      syncDraft();
+    }
     const said = carriedNote ?? message;
     if (said) ui.showToast(said);
     // The layer owns the retry ladder: one driver for every on-page member,

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -688,6 +688,7 @@ function boot() {
     } catch {
       // A browser that refuses the rewrite still shows the set; only a reload
       // would re-apply the link.
+      return;
     }
   }
 

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -423,10 +423,9 @@ function boot() {
     index,
   });
 
-  /** What differs about an off-page pin's page, for its dock row (D2). */
   /**
-   * A stored label leads with the route it was made on; only THIS page's route
-   * can be resolved from here, so that beats a raw path — when it is not one.
+   * What differs about an off-page pin's page, for its dock row (D2). A stored
+   * label leads with the route it was made on, and beats a raw path.
    */
   const awayNote = (pin: SetPin): string => {
     if (pin.anchor.p === location.pathname)
@@ -546,17 +545,12 @@ function boot() {
     return `${ids.length} pins are waiting for their elements — the list says where`;
   }
 
-  /**
-   * R7.4: "not on this page" answered two different questions with one
-   * sentence. A pin on ANOTHER page is opened from the list — this line, said
-   * on arrival and after a re-partition; a pin on THIS one is waiting for its
-   * element and gets `waitingLine` when the ladder ends.
-   */
   /** The off-page pins this line was last said for (R7.4). */
   let saidAway = '';
 
   const awayKey = () => [...partition().away.keys()].sort().join(' ');
 
+  /** R7.4: an off-page pin is opened from the list; a waiting one cannot be. */
   function elsewhereLine(): string {
     const count = partition().away.size;
     saidAway = awayKey();

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -37,7 +37,7 @@ import {
   stripPinParts,
   watchRoute,
 } from './deeplink.js';
-import { createSetDock, type PinPlace } from './dock.js';
+import { createSetDock, whereItWas, type PinPlace } from './dock.js';
 import { createDraftStore, MAX_SET_PINS } from './draft.js';
 import { pinId } from './id.js';
 import { createPicker, isEditable, isMac } from './picker.js';
@@ -377,6 +377,9 @@ function boot() {
       void readPinStack(target, element);
     },
     onHide: (target) => setHidden(target.id, true),
+    // The ladder ended with these still unresolved. Only the set knows that
+    // this is a closed modal rather than a missed page, so it does the talking.
+    onGiveUp: (ids) => ui.showToast(waitingLine(ids)),
   });
   const dock = createSetDock({
     root: ui.root,
@@ -387,10 +390,11 @@ function boot() {
       redraw();
     },
     onLocate: (id) => {
-      const element = pins.locatedElement(id);
-      // On this page but never resolved — the ladder gave up, or the app has
-      // not rendered it. An off-page pin gets the "go" button instead.
-      if (!element) return ui.showToast('That pin is not on this page');
+      // Its page matches but the element is not rendered: one more pass of the
+      // full ladder, then say where it was rather than that it is gone (R7.3).
+      const element =
+        pins.locatedElement(id) ?? (pins.locate(), pins.locatedElement(id));
+      if (!element) return ui.showToast(waitingLine([id]));
       element.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
       // The arrival beat is long spent — this is a deliberate "that one".
       pins.pulse(id);
@@ -518,12 +522,48 @@ function boot() {
     const map = new Map<string, PinPlace>();
     for (const pin of draft) {
       const where = away.get(pin.id);
-      if (where !== undefined) map.set(pin.id, { kind: 'elsewhere', where });
+      if (where !== undefined)
+        map.set(pin.id, {
+          kind: 'elsewhere',
+          where,
+          // Absolute, so the browser's own "copy link address" yields a URL
+          // someone else can open (R7.1).
+          href: `${location.origin}${pinSetUrlAt(draft, pin.id)}`,
+        });
       else if (!pins.locatedElement(pin.id))
         map.set(pin.id, { kind: 'waiting' });
     }
     return map;
   }
+
+  /** One pin says what it was inside; a handful says to read the list. */
+  function waitingLine(ids: string[]): string {
+    if (ids.length === 1) {
+      const pin = draft.find((held) => held.id === ids[0]);
+      const where = pin ? whereItWas(pin) : 'that page';
+      return `1 pin is waiting for its element (it was inside ${where})`;
+    }
+    return `${ids.length} pins are waiting for their elements — the list says where`;
+  }
+
+  /**
+   * R7.4: "not on this page" answered two different questions with one
+   * sentence. A pin on ANOTHER page is opened from the list — this line, said
+   * on arrival and after a re-partition; a pin on THIS one is waiting for its
+   * element and gets `waitingLine` when the ladder ends.
+   */
+  function elsewhereLine(): string {
+    const count = partition().away.size;
+    if (!count) return '';
+    return count === 1
+      ? '1 pin is on another page — open it from the list'
+      : `${count} pins are on other pages — open them from the list`;
+  }
+
+  const sayElsewhere = () => {
+    const line = elsewhereLine();
+    if (line) ui.showToast(line);
+  };
 
   const placesKey = (map: ReadonlyMap<string, PinPlace>): string =>
     [...map].map(([id, place]) => `${id}:${place.kind}`).join(' ');
@@ -642,6 +682,9 @@ function boot() {
         ui.showToast(
           'That is an old #bai-review link — pick the element again',
         );
+      // A stored set the tab was left with: nothing was added, but part of it
+      // may still be on another page, and only the rows can reach that.
+      else sayElsewhere();
       return;
     }
     const appHash = stripPinParts(hash);
@@ -698,7 +741,9 @@ function boot() {
       store.hide(focusId, false);
       syncDraft();
     }
-    const said = carriedNote ?? message;
+    const said = [carriedNote ?? message, elsewhereLine()]
+      .filter(Boolean)
+      .join(' · ');
     if (said) ui.showToast(said);
     // The layer owns the retry ladder: one driver for every on-page member,
     // and one give-up sentence for them all.
@@ -731,6 +776,9 @@ function boot() {
     routeKey = key;
     syncDraft();
     redraw();
+    // A re-partition moves pins between views and rows; what is now off this
+    // page is only reachable from the list.
+    sayElsewhere();
   });
 
   syncDraft();

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -7,15 +7,14 @@
  * pastes right into a GitHub PR comment, the PR's Teams thread, or a Claude
  * prompt. The pin stays in the DRAFT SET, so the next ⌘⏎ copies every pin so
  * far as one comment behind one link. Opening that link on this server is the
- * read side: the hash carries the whole anchor, so the element is pinned with
- * no lookup at all.
+ * read side (FR-3859): the hash carries every pin's whole anchor, so they are
+ * MERGED into the draft set and pinned with no lookup at all — the ones on
+ * this page as cards, the rest as rows in the dock.
  */
 import { isAnchorV3 } from './anchor-guard.js';
 import { captureAnchorSignals, withNote } from './anchor.js';
 import {
   blockStamp,
-  buildBlockHtml,
-  buildBlockText,
   buildSetHtml,
   buildSetText,
   captureForBlock,
@@ -25,11 +24,18 @@ import {
 } from './block.js';
 import { decodeAnchor } from './codec.js';
 import {
+  createFocusStore,
   createNavigationGuard,
+  createNoteStore,
+  dedupeById,
+  focusPinId,
+  hasLegacyFragment,
   otherFragment,
-  parseFragment,
+  parseFragments,
   pathNeedsChange,
-  pinUrl,
+  pinSetUrlAt,
+  stripPinParts,
+  watchRoute,
 } from './deeplink.js';
 import { createSetDock, type PinPlace } from './dock.js';
 import { createDraftStore, MAX_SET_PINS } from './draft.js';
@@ -86,8 +92,8 @@ function boot() {
   let drawn = '';
   /** True while `redraw()` is resolving pins, so the dock is built once. */
   let drawing = false;
-  /** The pin a link opened; FR-3859 merges it into the draft instead. */
-  let linkTarget: DeepLinkPinTarget | null = null;
+  const focus = createFocusStore();
+  const carried = createNoteStore();
 
   /**
    * Drawn chrome sits over the app, so the next pick would land on it. The
@@ -272,9 +278,31 @@ function boot() {
   const stacks = new Map<string, PinStack>();
 
   /** A pin nothing draws any more must not keep its element alive. */
-  function pruneStacks() {
+  function pruneStacks(drawn: DeepLinkPinTarget[]) {
+    const live = new Set(drawn.map((target) => target.id));
     for (const id of stacks.keys())
-      if (!store.has(id) && linkTarget?.id !== id) stacks.delete(id);
+      if (!store.has(id) || !live.has(id)) stacks.delete(id);
+  }
+
+  /**
+   * A link's pin joins the set with no stack — the wire does not carry one —
+   * so the first element it lands on gives it one, and that is what its block
+   * quotes from then on.
+   */
+  function freezeStack(id: string, stack: string[]) {
+    const pins = store.pins();
+    const pin = pins.find((held) => held.id === id);
+    if (!pin || pin.origin !== 'link') return;
+    if (
+      pin.stack.length === stack.length &&
+      pin.stack.every((line, index) => line === stack[index])
+    )
+      return;
+    store.save({
+      v: 1,
+      pins: pins.map((held) => (held.id === id ? { ...held, stack } : held)),
+    });
+    syncDraft();
   }
 
   async function readPinStack(
@@ -283,7 +311,10 @@ function boot() {
   ) {
     if (!target) return;
     const id = target.id;
-    if (draft.some((pin) => pin.id === id && pin.origin === 'pick')) return;
+    // A pin the reviewer picked here already has its stack, and a link's is
+    // frozen once it has one; only an empty one is still worth re-reading.
+    const member = draft.find((pin) => pin.id === id);
+    if (member && (member.origin === 'pick' || member.stack.length)) return;
     if (!element) {
       stacks.delete(id);
       return;
@@ -302,6 +333,7 @@ function boot() {
       if (stacks.get(id) !== entry) return;
       entry.stack = stack;
       entry.ready = true;
+      freezeStack(id, stack);
       // An empty stack is the answer once react-grab is there; before that it
       // only means the app has not finished booting.
       if (stack.length || left <= 0 || picker.hasReactGrab()) return;
@@ -311,40 +343,24 @@ function boot() {
   }
 
   /**
-   * What the card's ⧉ writes: THAT pin, one block behind its own link. The
-   * set as a whole is the dock's ⧉ — a card is where the reviewer points at
-   * one thing, so it hands over one thing. A pin that only a link put on
-   * screen is re-rendered here instead: the note, the label and the link come
-   * off the fragment, `pr` and `at` describe this copy, and the id is what
-   * carries the identity. `null` while this element's own reads are still in
-   * flight — a block missing its stack, or claiming `pr=0`, is not the
-   * comment that was written.
+   * What the card's ⧉ writes: THAT pin, one block behind its own link. The set
+   * as a whole is the dock's ⧉ — a card is where the reviewer points at one
+   * thing, so it hands over one thing. Every drawn pin is a member of the
+   * draft, because a link merges into it (D4). `null` while a link's pin is
+   * still having its ⚛️ stack read off the element it landed on — a block
+   * missing its frames is not the comment that was written.
    */
+  const stackPending = (pin: SetPin): boolean =>
+    pin.origin === 'link' && !pin.stack.length && !stacks.get(pin.id)?.ready;
+
   function buildComment(target: DeepLinkPinTarget): PinCopyPayload | null {
     const pin = draft.find((held) => held.id === target.id);
-    if (pin)
-      return {
-        text: buildSetText([pin]),
-        html: buildSetHtml([pin]),
-        toast: onePinToast(pin),
-      };
-    const read = stacks.get(target.id);
-    if (!read?.ready) return null;
-    const input = {
-      label: target.label,
-      id: target.id,
-      stack: read.stack,
-      text: target.anchor.n ?? '',
-      // The app's own fragment rides alongside the pin (`#tab=logs&bai=v3.…`),
-      // and dropping it would reopen the page on a different tab.
-      url: `${location.origin}${pinUrl(target.anchor, target.id, target.anchorB64, location.hash)}`,
-      pr: serverState?.pr ?? 0,
-      at: blockStamp(),
-    };
+    if (!pin) return null;
+    if (stackPending(pin)) return null;
     return {
-      text: buildBlockText(input),
-      html: buildBlockHtml(input),
-      toast: onePinToast({ anchor: target.anchor }),
+      text: buildSetText([pin]),
+      html: buildSetHtml([pin]),
+      toast: onePinToast(pin),
     };
   }
 
@@ -372,8 +388,8 @@ function boot() {
     },
     onLocate: (id) => {
       const element = pins.locatedElement(id);
-      // The one control that reaches every pin has to answer for the ones the
-      // layer never found; FR-3859 turns that into the "go" button.
+      // On this page but never resolved — the ladder gave up, or the app has
+      // not rendered it. An off-page pin gets the "go" button instead.
       if (!element) return ui.showToast('That pin is not on this page');
       element.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
       // The arrival beat is long spent — this is a deliberate "that one".
@@ -382,24 +398,49 @@ function boot() {
     onRemove: removeFromSet,
     onUnhide: (id) => setHidden(id, false),
     onToggleCards: toggleCards,
+    onGo: (id) => {
+      // Built from the DRAFT SET, never from `location.hash`: the hash was
+      // scrubbed the moment the link merged (D4), and the tab this pin belongs
+      // on is the one it stored, not the one the reviewer stands on.
+      focus.set(id);
+      location.assign(pinSetUrlAt(draft, id));
+    },
   });
   // After the layer and the dock: registering the plugin can activate
   // react-grab straight away, and `syncCollapse` reaches both.
   picker.watchForReactGrab();
   const guard = createNavigationGuard();
 
-  const targetOf = (pin: SetPin): DeepLinkPinTarget => ({
+  const targetOf = (pin: SetPin, index: number): DeepLinkPinTarget => ({
     id: pin.id,
     anchor: pin.anchor,
     anchorB64: pin.anchorB64,
     label: pin.label,
+    index,
   });
 
-  function drawnTargets(): DeepLinkPinTarget[] {
-    const targets = draft.map(targetOf);
-    const link = linkTarget;
-    if (link && !draft.some((pin) => pin.id === link.id)) targets.push(link);
-    return targets;
+  /** What differs about an off-page pin's page, for its dock row (D2). */
+  const awayNote = (pin: SetPin): string =>
+    pin.anchor.p !== location.pathname
+      ? resolveRouteLabel(pin.anchor.p)
+      : pin.anchor.q
+        ? `?${pin.anchor.q}`
+        : 'no query';
+
+  /**
+   * A set may span pages. Only its members on THIS page get a view — an
+   * off-page pin runs no resolution ladder, so an identical testid on another
+   * page cannot draw it; the dock row is all it has.
+   */
+  function partition() {
+    const here: DeepLinkPinTarget[] = [];
+    const away = new Map<string, string>();
+    draft.forEach((pin, index) => {
+      if (pathNeedsChange(pin.anchor, location))
+        away.set(pin.id, awayNote(pin));
+      else here.push(targetOf(pin, index));
+    });
+    return { here, away };
   }
 
   /**
@@ -411,11 +452,12 @@ function boot() {
     // rendered once here instead of once per pin.
     drawing = true;
     pins.setCardsHidden(store.cardsHidden());
-    // Only the draft is the set; a link's pin is drawn beside it, uncounted,
-    // so the glyphs never claim a membership the copy does not have.
-    pins.show(drawnTargets(), { focusId, setSize: draft.length });
+    const { here } = partition();
+    pins.show(here, { focusId, setSize: draft.length });
     // Adopting a pin gives it a fresh card, so its ✕ is re-applied here.
     for (const pin of draft) pins.setCardHidden(pin.id, pin.hidden === true);
+    // What the layer no longer draws holds an element from a page we left.
+    pruneStacks(here);
     drawing = false;
     renderDockIfPlacesMoved();
   }
@@ -432,7 +474,6 @@ function boot() {
   /** The store, the stacks and the layer, one pin shorter. */
   function removePin(id: string) {
     stacks.delete(id);
-    if (linkTarget?.id === id) linkTarget = null;
     if (!store.has(id)) return;
     store.remove(id);
     syncDraft();
@@ -444,11 +485,9 @@ function boot() {
    * the resolution ladder and re-toast its give-up line at every flip.
    */
   function setHidden(id: string, hidden: boolean) {
-    pins.setCardHidden(id, hidden);
-    // A pin only a link put on screen is in nobody's set; the card is still
-    // the reviewer's to close, but there is no draft flag to persist.
     if (!store.has(id)) return;
     store.hide(id, hidden);
+    pins.setCardHidden(id, hidden);
     syncDraft();
   }
 
@@ -464,31 +503,39 @@ function boot() {
   }
 
   /**
-   * A pin the layer has not resolved is waiting for its element, not gone: the
-   * ladder ends, the observer does not (R7.2), so the row says where it was.
+   * Where every pin is (R7): another page, or this one with its element not in
+   * the DOM right now — waiting, not gone, because the ladder ends and the
+   * observer does not (R7.2). Anything else the layer has drawn.
    */
-  const waitingIds = (): string[] =>
-    draft.filter((pin) => !pins.locatedElement(pin.id)).map((pin) => pin.id);
+  function places(): Map<string, PinPlace> {
+    const { away } = partition();
+    const map = new Map<string, PinPlace>();
+    for (const pin of draft) {
+      const where = away.get(pin.id);
+      if (where !== undefined) map.set(pin.id, { kind: 'elsewhere', where });
+      else if (!pins.locatedElement(pin.id))
+        map.set(pin.id, { kind: 'waiting' });
+    }
+    return map;
+  }
+
+  const placesKey = (map: ReadonlyMap<string, PinPlace>): string =>
+    [...map].map(([id, place]) => `${id}:${place.kind}`).join(' ');
 
   function renderDock() {
-    const ids = waitingIds();
-    drawn = ids.join(' ');
-    dock.render(
-      draft,
-      new Map(ids.map((id) => [id, { kind: 'waiting' } as PinPlace])),
-      store.cardsHidden(),
-    );
+    const map = places();
+    drawn = placesKey(map);
+    dock.render(draft, map, store.cardsHidden());
   }
 
   /** Rebuilding every row on every `locate()` is O(N²) rows for one redraw. */
   function renderDockIfPlacesMoved() {
-    if (waitingIds().join(' ') !== drawn) renderDock();
+    if (placesKey(places()) !== drawn) renderDock();
   }
 
   /** The store is the truth; the dock and the composer's button follow it. */
   function syncDraft() {
     draft = store.pins();
-    pruneStacks();
     renderDock();
     ui.setDraftSize(draft.length, store.isFull());
   }
@@ -496,6 +543,12 @@ function boot() {
   /** The whole set, from a click; nothing may be awaited before the write. */
   function copySet() {
     if (!draft.length) return;
+    // The same gate the card's ⧉ has: a block missing the ⚛️ frames of the
+    // element its pin just landed on is not the comment that was written.
+    if (draft.some((pin) => stackPending(pin) && pins.locatedElement(pin.id))) {
+      ui.showToast('Still reading a pin — try again');
+      return;
+    }
     const count = draft.length;
     const copied = ui.copyText(buildSetText(draft), buildSetHtml(draft));
     const done = (ok: boolean) =>
@@ -512,27 +565,119 @@ function boot() {
       ? currentRouteLabel()
       : resolveRouteLabel(anchor.p);
 
+  /**
+   * A pin a link brought. It carries no `at`/`pr` — the wire has none — so its
+   * block emits no marker comment: a fabricated stamp would produce one whose
+   * hash does not verify (D5). The app's own fragment travels with it, or the
+   * set would reopen on a different tab.
+   */
+  const linkPin = (
+    part: { id: string; anchorB64: string },
+    anchor: AnchorV3,
+    appHash: string,
+  ): SetPin => ({
+    id: part.id,
+    origin: 'link',
+    anchor,
+    anchorB64: part.anchorB64,
+    label: landmarkLabel(anchorRouteLabel(anchor), anchor),
+    appHash,
+    stack: [],
+  });
+
+  /** One sentence for the whole link, however many parts it turned out to have. */
+  function mergeToast(
+    parts: number,
+    added: number,
+    present: number,
+    unread: number,
+    refused: number,
+  ): string {
+    const said: string[] = [];
+    if (added)
+      said.push(`Added ${added} ${added === 1 ? 'pin' : 'pins'} from the link`);
+    else if (present)
+      said.push(
+        present === 1
+          ? 'That pin is already in your set'
+          : `All ${present} pins are already in your set`,
+      );
+    if (unread)
+      said.push(
+        parts === 1
+          ? 'Could not read the anchor in that link'
+          : `${unread} of ${parts} pins could not be read`,
+      );
+    if (refused)
+      said.push(`${refused} did not fit — your set is full at ${MAX_SET_PINS}`);
+    return said.join(' · ');
+  }
+
+  /** A reload must not re-apply the link and resurrect a dismissed pin (D4). */
+  function scrubPinParts() {
+    const rest = stripPinParts(location.hash);
+    const url = `${location.pathname}${location.search}${rest ? `#${rest}` : ''}`;
+    try {
+      history.replaceState(history.state, '', url);
+    } catch {
+      // A browser that refuses the rewrite still shows the set; only a reload
+      // would re-apply the link.
+    }
+  }
+
   async function applyFragment(hash: string) {
-    const fragment = parseFragment(hash);
-    if (!fragment) return;
-    if (fragment.kind === 'legacy') {
-      ui.showToast('That is an old #bai-review link — pick the element again');
+    // One-shot handovers from the document that navigated here, read before
+    // the first `await` so a hash the SPA rewrites cannot lose them.
+    const handover = focus.take();
+    const carriedNote = carried.take();
+    const parts = parseFragments(hash);
+    if (!parts.length) {
+      if (hasLegacyFragment(hash))
+        ui.showToast(
+          'That is an old #bai-review link — pick the element again',
+        );
       return;
     }
-    const anchor = await decodeAnchor(fragment.anchorB64);
+    const appHash = stripPinParts(hash);
+    const decoded = await Promise.all(
+      parts.map((part) => decodeAnchor(part.anchorB64)),
+    );
     // The link is a stranger's: `decodeAnchor` checks `v`, `s` and `p`, the
-    // rest of the payload reaches `querySelector` and the DOM unchecked.
-    if (!anchor || !isAnchorV3(anchor)) {
-      ui.showToast('Could not read the anchor in that link');
-      return;
-    }
-    if (pathNeedsChange(anchor, location)) {
-      // The fragment this call was handed, not the live one: the SPA can
-      // rewrite the hash while `decodeAnchor` is still in flight.
-      const target = pinUrl(anchor, fragment.id, fragment.anchorB64, hash);
-      if (guard.shouldNavigate(fragment.id, target)) {
-        // Path and query first (R3.3): a full reload, because React Router
-        // owns the history and re-running our boot is cheap.
+    // rest of the payload reaches `querySelector` and the DOM unchecked. A
+    // part that fails costs only itself.
+    const opened = parts.flatMap((part, index) => {
+      const anchor = decoded[index];
+      return anchor && isAnchorV3(anchor)
+        ? [linkPin(part, anchor, appHash)]
+        : [];
+    });
+    const { added, present } = store.merge(opened);
+    syncDraft();
+    const message = mergeToast(
+      parts.length,
+      added,
+      // Our own "go" re-opens the set it just persisted; reporting those back
+      // as duplicates would answer an action the reviewer never took.
+      handover ? 0 : present,
+      parts.length - opened.length,
+      dedupeById(opened).length - added - present,
+    );
+
+    const set = store.pins();
+    const focusId = focusPinId(set, location, handover);
+    // Path and query are applied only when NO member is here (D2): arriving on
+    // pin 3's page must not bounce the reviewer back to pin 1's.
+    if (focusId && !set.some((pin) => !pathNeedsChange(pin.anchor, location))) {
+      // The focus pin's own fragment, not the live hash: the SPA can rewrite
+      // that while `decodeAnchor` is in flight, and it belongs to this page.
+      const target = pinSetUrlAt(set, focusId);
+      if (guard.shouldNavigate(focusId, target)) {
+        focus.set(focusId);
+        // The counts belong to this open; the page it lands on sees only its
+        // own pins coming back.
+        if (message) carried.set(message);
+        // A full reload, because React Router owns the history and re-running
+        // our boot is cheap.
         location.assign(target);
         return;
       }
@@ -540,15 +685,12 @@ function boot() {
     } else {
       guard.landed();
     }
-    // The layer owns the retry ladder: one driver for however many pins the
-    // draft set and the link add up to, and one give-up sentence for them all.
-    linkTarget = {
-      id: fragment.id,
-      anchor,
-      anchorB64: fragment.anchorB64,
-      label: landmarkLabel(anchorRouteLabel(anchor), anchor),
-    };
-    redraw(fragment.id);
+    scrubPinParts();
+    const said = carriedNote ?? message;
+    if (said) ui.showToast(said);
+    // The layer owns the retry ladder: one driver for every on-page member,
+    // and one give-up sentence for them all.
+    redraw(focusId);
   }
 
   /** The cards chord: no set, no switch — and never while a note is typed. */
@@ -564,7 +706,19 @@ function boot() {
 
   window.addEventListener('hashchange', () => {
     guard.reset();
+    // A hash that changed only the app's own part carries no part to hydrate,
+    // and the partition reads path and query only — so nothing else moves.
     void applyFragment(location.hash);
+  });
+
+  /** An SPA navigation re-partitions the set: new views here, rows for the rest. */
+  let routeKey = location.pathname + location.search;
+  watchRoute(() => {
+    const key = location.pathname + location.search;
+    if (key === routeKey) return;
+    routeKey = key;
+    syncDraft();
+    redraw();
   });
 
   syncDraft();

--- a/react/vite-plugins/review-overlay/client/main.ts
+++ b/react/vite-plugins/review-overlay/client/main.ts
@@ -420,12 +420,18 @@ function boot() {
   });
 
   /** What differs about an off-page pin's page, for its dock row (D2). */
-  const awayNote = (pin: SetPin): string =>
-    pin.anchor.p !== location.pathname
-      ? resolveRouteLabel(pin.anchor.p)
-      : pin.anchor.q
-        ? `?${pin.anchor.q}`
-        : 'no query';
+  /**
+   * A stored label leads with the route it was made on; only THIS page's route
+   * can be resolved from here, so that beats a raw path — when it is not one.
+   */
+  const awayNote = (pin: SetPin): string => {
+    if (pin.anchor.p === location.pathname)
+      return pin.anchor.q ? `?${pin.anchor.q}` : 'no query';
+    const route = pin.label.split(' › ')[0]?.trim() ?? '';
+    return route && !route.startsWith('/')
+      ? route
+      : resolveRouteLabel(pin.anchor.p);
+  };
 
   /**
    * A set may span pages. Only its members on THIS page get a view — an

--- a/react/vite-plugins/review-overlay/client/pin.ts
+++ b/react/vite-plugins/review-overlay/client/pin.ts
@@ -209,6 +209,12 @@ export interface DeepLinkPinTarget {
   anchorB64: string;
   /** `<route> › <landmark> › <tag "quoted text">` from the block. */
   label: string;
+  /**
+   * Zero-based place in the SET, when only part of one is drawn — a set that
+   * spans pages leaves its off-page members to the dock, and pin 3 of 5 still
+   * has to say 3.
+   */
+  index?: number;
 }
 
 interface ViewDeps {
@@ -995,7 +1001,8 @@ export function createPinLayer(options: PinLayerOptions) {
       targets.forEach((target, index) => {
         const view = views[index];
         if (target.id === arriving || !view.holds(target)) view.show(target);
-        view.setOrdinal(index < size ? index : null, size);
+        const place = target.index ?? index;
+        view.setOrdinal(place < size ? place : null, size);
       });
       startRetry();
     },

--- a/react/vite-plugins/review-overlay/client/types.ts
+++ b/react/vite-plugins/review-overlay/client/types.ts
@@ -75,7 +75,7 @@ interface SetPinBase {
   anchorB64: string;
   /** `landmarkLabel(...)` output. */
   label: string;
-  /** `otherFragment(location.hash)` at add time; `''` for a link's pins. */
+  /** The app's own fragment the pin was picked — or opened from a link — with. */
   appHash: string;
   /** `getStackContext()` output, split into lines. */
   stack: string[];


### PR DESCRIPTION
Resolves #9436 (FR-3859)

Part of the pin-set stack (#9442): #9437 → #9438 → #9439 → #9440 → #9441. Design record: `docs/adr/0002-pin-set-link-grammar-and-single-codec.md`; vocabulary: `react/vite-plugins/review-overlay/CONTEXT.md`.

The read side of pin sets. `applyFragment` now parses EVERY `bai=v3` part of
the hash instead of only the first, decodes them in one pass, and MERGES the
result into the draft set rather than drawing a single pin beside it. Pins the
set already holds keep their place and the data they were stored with; new ones
are appended in link order; a part whose payload will not decode costs only
itself and is counted in the one toast the merge reports ("Added 3 pins from
the link · 1 of 4 pins could not be read"). Once the link has landed its parts
are scrubbed out of the address bar with `replaceState`, so a reload cannot
re-apply it and resurrect a pin the reviewer just dismissed; the app's own
fragment stays.

A set may span pages, so the read flow partitions it on every navigation.
Members whose path and query match this document get a view and take part in
the layer's resolution ladder; the rest are demoted to rows in the set dock,
carrying what differs about their page (the route label, or the query) and a
way to reopen the whole set on that page — built from the draft set, never from
the hash that was just scrubbed. An off-page pin runs no ladder at all, so an
identical testid on another page cannot draw it. SPA navigations reach us
through a once-per-document `history.pushState` / `replaceState` patch plus
`popstate`, filtered on path+query so a query-syncing app does not restart the
ladder on every keystroke.

Navigation, scroll-into-view and the arrival pulse belong to one pin, the focus
pin: the id a "go" handed over (one-shot, in `sessionStorage`) if the set still
holds it, else the first member on this page, else the head of the set. Path
and query are applied only when NO member is on the current page, so arriving
on pin 3's page no longer bounces the reviewer back to pin 1's. Marker glyphs
and the `n / N` card header are the pin's place in the SET, not in the subset
this page happens to draw, so a target may now carry its own `index`.

A link's pins join the set with no `at` / `pr` — the wire carries none — so
their blocks emit no marker comment (D5): a fabricated stamp would write a
marker whose id hash does not verify, which is exactly what the CLI's
`idVerified` reports on. Their ⚛️ stack is not on the wire either, so it is
read off the element the pin lands on, written back into the store on first
locate and then frozen; the card's copy control withholds the copy until that
read has landed, as it did before. `main-comment-copy.test.ts` loses its marker
assertion for that reason and gains one that the block carries none.

Deviation from the design: the data model note says a link's pin stores
`appHash: ''`. It stores the app fragment the link arrived with instead,
because D1 makes the read side's keep-the-app-fragment behaviour the only one —
dropping it would reopen the set on a different tab, and `pinSetUrlAt` reads
the fragment from that field.

## What else this branch carries

The read side is where "this pin is not here" has to be answered, so R7's
user-facing half and all of R8 landed on this branch after the first round.

**R7.1 — an off-page row is a real link.** The dock could only open an off-page
pin in this tab, so a reviewer who wanted it beside the page they were on had
nowhere to click. The row is an `<a href>` carrying the whole set behind an
absolute `pinSetUrlAt(draft, id)`: a plain left-click still hands the focus pin
over and navigates here, and every other click — ⌘/Ctrl, shift, alt, middle —
is left to the browser, so a new tab rehydrates the set and "copy link address"
yields something sendable. We do not ask which the reviewer meant; the platform
already has both gestures.

**R7.4 — three answers instead of one sentence.** "N of M pins are not on this
page" answered two different questions at once and neither answer told the
reviewer what to do. A pin on ANOTHER page is reported on arrival and after a
re-partition, pointing at the list that can open it; a pin on THIS page whose
element is not rendered is reported when the ladder ends, naming what it was
inside. A pin whose element is genuinely gone is indistinguishable from one
waiting for a closed modal and is reported the same way — the overlay cannot
tell, and the observer will draw it if it ever comes back. `places()` is the
three-state partition (`elsewhere` with its page and href / `waiting` /
drawn) the dock renders from.

A follow-up bounds when that line is said: R7.4 says "on arrival and after a
re-partition", but it was firing on every `hashchange` — including the app's
own "Skip to content" hash — and on every SPA URL change, including the query a
search box writes on each debounced keystroke. Neither re-partitions anything,
so the reviewer got the same sentence again and read it as a new pin. The line
now tracks the off-page ids it was last said for.

**R7.3 — a waiting row re-resolves only itself.** Clicking it asked the layer
for another pass with `pins.locate()`, which is the whole layer: it ran the
document-wide ladder for every drawn pin and, because a link's arrival leaves
`autoFocus` on, focused the focus pin — so clicking the row of a pin inside a
closed modal scrolled and pulsed a DIFFERENT pin, and paid N `querySelectorAll`
scans to do it. The layer grew a per-pin `locate(id)` (#9439) for exactly this.

**R8 — a toggle's icon is its action, never its state.** The dock's cards
switch now shows `eye-off` / "Hide every card" while the cards are visible and
`eye` / "Show every card" while they are hidden; the state it used to announce
twice stays in `aria-pressed`. A row offers to reveal whenever its card is not
visible, whatever hid it — with the switch thrown, every row used to offer
nothing at all, so the only way back to one card was to show them all.
Revealing one row while the switch hides everything shows that card ALONE: the
switch goes off and every other pin takes the per-pin flag, so visibility stays
the single expression it was (`shown iff !cardsHidden && !pin.hidden &&
!pickCollapsed`) instead of gaining a third "shown in spite of the switch"
state. Pressing the switch back on still clears every per-pin flag (R5.5), so
one press returns the screen to everything visible.

**Two smaller corrections.** A link merges into the draft and keeps what each
member was stored with, `hidden` included — so opening a link at a pin whose
card the reviewer had put away drew a bare marker with nothing on screen saying
why, which bit hardest on the dock's own "go". A link naming a pin is an
explicit "show me this one", so the focus pin's card comes back; the rest keep
whatever the reviewer tidied away. And an off-page row fell back to its raw
decoded pathname, because `resolveRouteLabel` can only name the route the app
currently publishes — the stored label already leads with the route label it
was stamped with, so that is used instead. The set-read suite also picked up
the same teardown leak as the authoring suite (remove buttons snapshotted
before the first click, views reused by position, a pin and its live layer
surviving into the next test file); it drains live buttons now.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (run on this branch, the stack top)
- `pnpm vitest run vite-plugins/review-overlay` (from `react/`) → 23 files, 557 tests, all passing
- New here: `main-set-read.test.ts` (multi-part apply, merge and scrub, the focus pin, the three-state partition and its three toasts, the SPA route hook, stack write-back, the R8 toggle and per-row reveal) plus additions to `deeplink.test.ts`, `dock.test.ts` and `draft.test.ts`.
- Each branch was reviewed by two independent review agents (correctness, design conformance) and their blocker/major findings were fixed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhEbqZ9DDe2HFJF43rAVP1
