### PR TITLE
feat(agent-cli): fix alignment false positives, WebUI links and agent-facing ergonomics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ bai-agent · 13 commands
 Agent-facing CLI over this checkout: the user manual, the GraphQL schema, the i18n stores and — once logged in — the live manager.
 CLI: run every command as `pnpm run bai-agent <cmd>` from the repository root (shown below as `bai-agent ...`).
 The proxy runs the bundle, so build it first: `pnpm --filter backend.ai-agent-cli build`. Without the proxy, still from the repository root: `node packages/backend.ai-agent-cli/dist/cli.js <cmd>`.
-Preflight, answer-or-link rules and a ready-to-run query cookbook: the `bai-agent` skill, shipped with the CLI (`packages/backend.ai-agent-cli/skill/SKILL.md`) and installed per user by `pnpm run bai-agent init --skill --no-login`.
+Preflight, answer-or-link rules and a ready-to-run query cookbook: the `bai-agent` skill, shipped with the CLI (`packages/backend.ai-agent-cli/skill/SKILL.md`, cookbook at `packages/backend.ai-agent-cli/skill/references/query-cookbook.md`) and installed per user by `pnpm run bai-agent init --skill --no-login`.
 
 WORKFLOW — discover, don't guess. Before answering anything about Backend.AI data:
 1. `bai-agent doctor` — checkout and stored session in one pass; exit 0 means the environment is ok. Then `bai-agent whoami` — exit 3 means log in (see RULES).
@@ -188,6 +188,8 @@ WORKFLOW — discover, don't guess. Before answering anything about Backend.AI d
 4. `bai-agent query '<document>'` — ask the manager. Validated against the checkout's SDL before any network call. Rows come back carrying `webui_path` / `webui_url` under `data.links` — hand that to the user so they can open it themselves.
 
 OUTPUT: `--json` prints one envelope on stdout — {"apiVersion":"bai-agent/v1","type":…,"data":…}; a failure prints {"apiVersion","error","code","suggestions?","hint?"} on stderr and nothing on stdout. Text is the same data as aligned `key: value` records. `hint` is a concrete next step — a command to run, or for a refused mutation, the WebUI page to do it on — never prose.
+`query` results: rows are at `data.result.<rootField>`, links at `data.links[]` (`webui_path` / `webui_url`); the same fields are also inlined on each linked row.
+Piping through `| head` hides the exit code and truncates doctor's alignment/session checks — read the JSON `code` field or the exit status instead.
 EXIT: 0 ok · 1 error (schema_mismatch, version_mismatch, repo_not_found, repo_incomplete, internal) · 2 usage · 3 auth_required · 4 mutation_refused · 5 not_found.
 
 RULES:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,20 +175,20 @@ The ASTRYX block above is `astryx init --features agents` output (run from `reac
 The block's `pnpm exec astryx <cmd>` assumes you are **inside `react/`**. `@astryxdesign/cli` is a devDependency of that workspace only, so the root `node_modules/.bin` has no `astryx` binary — and `pnpm exec` resolves binaries, not package scripts, so it fails at the root with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`. **From the repository root, run `pnpm run astryx <cmd>` instead** (root `package.json` proxies it to the same CLI). Both forms take identical arguments.
 
 <!-- BAI-AGENT:start -->
-bai-agent · 13 commands
+bai-agent · 14 commands
 Agent-facing CLI over this checkout: the user manual, the GraphQL schema, the i18n stores and — once logged in — the live manager.
 CLI: run every command as `pnpm run bai-agent <cmd>` from the repository root (shown below as `bai-agent ...`).
 The proxy runs the bundle, so build it first: `pnpm --filter backend.ai-agent-cli build`. Without the proxy, still from the repository root: `node packages/backend.ai-agent-cli/dist/cli.js <cmd>`.
 Preflight, answer-or-link rules and a ready-to-run query cookbook: the `bai-agent` skill, shipped with the CLI (`packages/backend.ai-agent-cli/skill/SKILL.md`, cookbook at `packages/backend.ai-agent-cli/skill/references/query-cookbook.md`) and installed per user by `pnpm run bai-agent init --skill --no-login`.
 
 WORKFLOW — discover, don't guess. Before answering anything about Backend.AI data:
-1. `bai-agent doctor` — checkout and stored session in one pass; exit 0 means the environment is ok. Then `bai-agent whoami` — exit 3 means log in (see RULES).
+1. `bai-agent doctor --brief` (`doctor --json` for a specific field) — run it ONCE: checkout and stored session in one pass; exit 0 means the environment is ok. Run `bai-agent whoami` only when doctor's session check is `warn` — exit 3 means log in (see RULES).
 2. `bai-agent search "<english UI term>"` — START HERE: one ranked list over manual + schema + terminology. Every hit carries the `command:` that opens it.
 3. `bai-agent docs show <id>` · `schema show <Type>.<field>` · `explain <Type>.<field>=<VALUE>` — the hit in full. `schema show` is what the SDL declares; `explain` is what it means to a user.
 4. `bai-agent query '<document>'` — ask the manager. Validated against the checkout's SDL before any network call. Rows come back carrying `webui_path` / `webui_url` under `data.links` — hand that to the user so they can open it themselves.
 
 OUTPUT: `--json` prints one envelope on stdout — {"apiVersion":"bai-agent/v1","type":…,"data":…}; a failure prints {"apiVersion","error","code","suggestions?","hint?"} on stderr and nothing on stdout. Text is the same data as aligned `key: value` records. `hint` is a concrete next step — a command to run, or for a refused mutation, the WebUI page to do it on — never prose.
-`query` results: rows are at `data.result.<rootField>`, links at `data.links[]` (`webui_path` / `webui_url`); the same fields are also inlined on each linked row.
+`query` results: rows are at `data.result.<rootField>`, links at `data.links[]` (`webui_path` / `webui_url`); the same fields are also inlined on each linked row. When you post-process the envelope (jq/python), print `data.links` too — a filter that drops it drops the answer's link.
 Piping through `| head` hides the exit code and truncates doctor's alignment/session checks — read the JSON `code` field or the exit status instead.
 EXIT: 0 ok · 1 error (schema_mismatch, version_mismatch, repo_not_found, repo_incomplete, internal) · 2 usage · 3 auth_required · 4 mutation_refused · 5 not_found.
 
@@ -200,6 +200,9 @@ RULES:
 - Destructive actions (delete, purge, terminate, revoke) are never run from here. Give the human the WebUI page from the refusal's `hint` and let them press the button.
 - Exit 3 `auth_required` → `bai-agent login --endpoint <url>`; take the endpoint and the account from the `webui-connection-info` skill. The CLI never handles a password: `login` borrows the browser's session, and `--paste` covers a browser that cannot reach this machine.
 - Cite what the CLI returned: `search`, `docs show` and `explain` carry a deployed-docs `url`. `explain` prints `MISSING` for a piece nothing curates — report that, never fill it in from memory.
+- Empty `data.links` means the resource has no addressable page: say so, never compose a WebUI path by hand. A row carrying `webui_link_hint` is the other case — the id you selected cannot build a link; re-run selecting `row_id`. When several rows share a name, pick the link by `id`.
+- Never read the session store (`~/.config/backend.ai-agent/sessions`) or reuse its session id outside `bai-agent` — the mutation gate only applies to calls that go through the CLI.
+- Run `bai-agent` from wherever you already are, never `cd` first. The synced data copy holds schema, i18n and docs only — no React source, so do not grep it for `.tsx`.
 - Re-run `bai-agent init --features agents` after any CLI change and re-sync this block.
 
 COMMANDS:
@@ -215,6 +218,7 @@ COMMANDS:
   logout    Delete the stored session file. The manager is not contacted.
   whoami    Show the account the stored session belongs to.
   query     Run a raw GraphQL document against the manager, pre-validated against the checkout SDL.
+  cookbook  Print a ready-to-run query from the skill cookbook, by entry number or root field.
   explain   Explain what a schema type, field or value means to a WebUI user, tagged by where each piece came from.
 <!-- BAI-AGENT:end -->
 

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -664,13 +664,13 @@ than blowing past it, and a row that does not survive drops out of
 
 ### WebUI links
 
-Every node whose root field returns a type with a resource page is annotated in
-place with `webui_path` (and `webui_url` when an origin is known), and the same
-set is listed in `data.links`. The origin is `--webui`, else the stored
+Every node whose root field returns a type with a **detail** page is annotated
+in place with `webui_path` (and `webui_url` when an origin is known), and the
+same set is listed in `data.links`. The origin is `--webui`, else the stored
 session's `webui` field; with neither, only `webui_path` is emitted.
 
-The type table (`src/query/links.ts`) is small and hand-maintained on purpose —
-an unrecognised type produces no link rather than a guessed one. One container
+The type tables (`src/query/links.ts`) are small and hand-maintained on purpose
+— an unrecognised type produces no link rather than a guessed one. One container
 level is unwrapped: a Relay `*Connection` (`edges { node }`), a Graphene `*List`
 (`items`), or a single-field Strawberry `*Payload`.
 
@@ -688,6 +688,30 @@ string. **Known limitation:** Strawberry types (`VFolder`, `SessionV2`, …)
 expose no `row_id`, so their annotation falls back to the base64 Relay global
 id, which the pages do not accept. Graphene `*Node` types, which do carry
 `row_id`, produce links that open.
+
+#### List-only resources
+
+Several pages list rows but address none of them — there is no per-row URL
+param to put in a link. A root field resolving to one of these gets **one**
+entry in `data.links` per root field, pointing at the list page, with no `id`
+and no annotation on the rows themselves. An empty or null root field gets no
+link at all.
+
+| Return type                          | Resource        | Page                             |
+| ------------------------------------ | --------------- | -------------------------------- |
+| `User`, `UserNode`, `UserV2`         | user            | `/admin/users?tab=users`         |
+| `KeyPair`                            | keypair         | `/admin/users?tab=credentials`   |
+| `Agent`, `AgentNode`, `AgentV2`      | agent           | `/admin/agent?tab=agents`        |
+| `ScalingGroup`, `ResourceGroup`      | resource_group  | `/admin/agent?tab=resourceGroup` |
+| `Group`, `GroupNode`, `ProjectV2`    | project         | `/admin/project`                 |
+| `ResourcePreset`, `ResourcePresetV2` | resource_preset | `/admin/environment?tab=preset`  |
+| `Image`, `ImageNode`                 | environment     | `/admin/environment`             |
+
+So `user_nodes`, `user_list`, `adminUsersV2` and friends all land on the users
+list; `resource_presets` and `adminResourcePresetsV2` on the environment page's
+preset tab; `scaling_groups` and `adminResourceGroups` on the resources page's
+resource-group tab; `groups`, `group_nodes`, `adminProjectsV2` and
+`domainProjectsV2` on the projects page.
 
 ### Path rules are restated, not imported
 

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -710,11 +710,18 @@ path that opens nothing.
 #### List-only resources
 
 Several pages list rows but address none of them — there is no per-row URL
-param to put in a link. A root field resolving to one of these gets **one**
-entry in `data.links` per root field, pointing at the list page, with no `id`
-and no annotation on the rows themselves. An empty root field gets no link at
-all — null, `[]`, a Relay connection whose `edges` is empty, or a Graphene list
-whose `items` is empty.
+param to put in a link. A **list-shaped** root field resolving to one of these
+gets **one** entry in `data.links` per root field, pointing at the list page,
+with no `id` and no annotation on the rows themselves.
+
+List-shaped is read off the SDL, not off the response: the root field's type is
+a GraphQL list (`[User]`), a Relay connection (`edges`), or a Graphene list
+container (`items`). A singular root field returning a bare object of the same
+type — `user`, `keypair`, `image`, `group`, `resource_preset` — gets **no**
+link: a list page is not where one row lives, and most of these pages are
+admin-only, so a non-admin would get a link they cannot open. An empty
+list-shaped root field gets no link either — null, `[]`, a connection whose
+`edges` is empty, or a Graphene list whose `items` is empty.
 
 | Return type                            | Resource        | Page                             |
 | -------------------------------------- | --------------- | -------------------------------- |

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -132,6 +132,7 @@ bai-agent manifest             # every command with its description and flags
 bai-agent init                 # set this machine up (see The init wizard below)
 bai-agent init --features agents  # the CLAUDE.md agent block (see The agent block below)
 bai-agent doctor               # environment + checkout + auth diagnostics
+bai-agent doctor --brief       # the auth/alignment/checkout lines + only what warns
 bai-agent sync                 # fetch the checkout data for use outside a checkout
 bai-agent search "<query>"     # one ranked list over docs + schema + terminology
 bai-agent docs search "<q>"    # alias of `search --domain docs`
@@ -143,6 +144,7 @@ bai-agent login                # hand this machine a WebUI session (see Auth bel
 bai-agent whoami               # who the stored session belongs to
 bai-agent logout               # delete the stored session file
 bai-agent query '<document>'   # raw GraphQL, SDL-validated (see Query below)
+bai-agent cookbook [<n>|<field>]  # one ready-to-run query from the skill cookbook
 bai-agent explain <target>     # what a type, field or value means to a user
 bai-agent --help               # generated from the same registry as `manifest`
 ```
@@ -604,8 +606,14 @@ validator message under `suggestions`, and a hint naming the nearest type:
 error: The document does not match the checkout's schema (1 problem(s)).
 code:  schema_mismatch
 - Cannot query field "nope_field" on type "ComputeSessionNode".
+- bai-agent cookbook compute_session_nodes
 hint:  bai-agent schema show ComputeSessionNode
 ```
+
+The last suggestion is the [cookbook](#cookbook) entry for the root field the
+document tried to use — a rejected document is nearly always a hand-written
+one, and the cookbook has a working version. It falls back to
+`bai-agent cookbook --list` when no entry covers the field.
 
 A message that names only built-in scalars — a variable's nullability, say —
 falls back to the operation's root field (`bai-agent schema show
@@ -684,10 +692,13 @@ level is unwrapped: a Relay `*Connection` (`edges { node }`), a Graphene `*List`
 | `Artifact`, `ArtifactNode`                          | artifact   | `/admin/reservoir/<id>`       |
 
 The id is the first of `row_id`, `endpoint_id`, `id` that carries a non-empty
-string. **Known limitation:** Strawberry types (`VFolder`, `SessionV2`, …)
-expose no `row_id`, so their annotation falls back to the base64 Relay global
-id, which the pages do not accept. Graphene `*Node` types, which do carry
-`row_id`, produce links that open.
+string, **resolved to the form the page reads**: these pages take the raw uuid,
+so a base64 Relay global id (`<TypeName>:<uuid>` — all a Strawberry type like
+`VFolder` or `SessionV2` exposes) is decoded to the uuid first. `/admin/rbac` is
+the exception: it matches `roleDetail` against the node's global `id`, so a role
+link keeps it. An id that is neither a uuid nor a decodable global id produces
+**no** link — the node carries `webui_link_hint` ("select row_id") instead of a
+path that opens nothing.
 
 #### List-only resources
 
@@ -721,6 +732,24 @@ host app, so nothing is imported. `src/webui-path.fixture.json` pins the
 expected path per resource ref and `webui-path.test.ts` asserts every case.
 When the app renames a route or a query param, update the rule and the fixture
 together.
+
+## Cookbook
+
+`bai-agent cookbook` reads the same file the skill points at —
+`skill/references/query-cookbook.md`, shipped in the package next to `dist/` and
+located at runtime the way the skill installer locates it (`shippedSkillDir()`),
+so it works from a checkout and from the npm install alike.
+
+```bash
+bai-agent cookbook --list          # number, title and root field(s) per entry
+bai-agent cookbook 3               # one entry: heading, prose, GraphQL document
+bai-agent cookbook vfolder_nodes   # the entry whose document uses that root field
+```
+
+An argument that is all digits selects by entry number; anything else is matched
+against the root fields parsed out of each entry's `graphql` block. No match
+exits **5** `not_found` with the whole list under `suggestions`. `--json` returns
+`{ entries: [...] }` for the list and `{ entry }` for one entry.
 
 ## Explain
 

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -430,6 +430,13 @@ endpoint answers; a manager with introspection disabled reports nothing and the
 schema still comes from the committed SDL. Without a stored session none of this
 happens and no request is made.
 
+A recorded tag equal to the manager's version means the SDL **is** the
+manager's, so nothing can be ahead of it and every finding is suppressed. That
+short-circuit is taken only while `data/schema.meta.json`'s `sha256` still
+hashes the committed SDL — a stale meta file describes some other bytes, so the
+gate (and `doctor`'s verdict) ignores its tag and falls back to the marker
+comparison, with the metadata warning reported separately.
+
 Field-level markers are compared through `markerSource`: a member with no marker
 of its own inherits its type's. A **named** selection uses that effective marker;
 a whole-schema comparison counts only markers a member owns, because its type
@@ -705,24 +712,27 @@ path that opens nothing.
 Several pages list rows but address none of them — there is no per-row URL
 param to put in a link. A root field resolving to one of these gets **one**
 entry in `data.links` per root field, pointing at the list page, with no `id`
-and no annotation on the rows themselves. An empty or null root field gets no
-link at all.
+and no annotation on the rows themselves. An empty root field gets no link at
+all — null, `[]`, a Relay connection whose `edges` is empty, or a Graphene list
+whose `items` is empty.
 
-| Return type                          | Resource        | Page                             |
-| ------------------------------------ | --------------- | -------------------------------- |
-| `User`, `UserNode`, `UserV2`         | user            | `/admin/users?tab=users`         |
-| `KeyPair`                            | keypair         | `/admin/users?tab=credentials`   |
-| `Agent`, `AgentNode`, `AgentV2`      | agent           | `/admin/agent?tab=agents`        |
-| `ScalingGroup`, `ResourceGroup`      | resource_group  | `/admin/agent?tab=resourceGroup` |
-| `Group`, `GroupNode`, `ProjectV2`    | project         | `/admin/project`                 |
-| `ResourcePreset`, `ResourcePresetV2` | resource_preset | `/admin/environment?tab=preset`  |
-| `Image`, `ImageNode`                 | environment     | `/admin/environment`             |
+| Return type                            | Resource        | Page                             |
+| -------------------------------------- | --------------- | -------------------------------- |
+| `User`, `UserNode`, `UserV2`           | user            | `/admin/users?tab=users`         |
+| `KeyPair`, `KeyPairV2`                 | keypair         | `/admin/users?tab=credentials`   |
+| `Agent`, `AgentNode`, `AgentV2`        | agent           | `/admin/agent?tab=agents`        |
+| `ScalingGroup`, `ResourceGroup`        | resource_group  | `/admin/agent?tab=resourceGroup` |
+| `Group`, `GroupNode`, `ProjectV2`      | project         | `/admin/project`                 |
+| `ResourcePreset`, `ResourcePresetV2`   | resource_preset | `/admin/environment?tab=preset`  |
+| `Image`, `ImageNode`, `ImageV2`        | environment     | `/admin/environment`             |
 
 So `user_nodes`, `user_list`, `adminUsersV2` and friends all land on the users
 list; `resource_presets` and `adminResourcePresetsV2` on the environment page's
 preset tab; `scaling_groups` and `adminResourceGroups` on the resources page's
 resource-group tab; `groups`, `group_nodes`, `adminProjectsV2` and
-`domainProjectsV2` on the projects page.
+`domainProjectsV2` on the projects page; `keypair_list`, `myKeypairs` and
+`adminKeypairsV2` on the credentials tab; `images`, `image_nodes` and
+`adminImagesV2` on the environment page.
 
 ### Path rules are restated, not imported
 

--- a/packages/backend.ai-agent-cli/skill/SKILL.md
+++ b/packages/backend.ai-agent-cli/skill/SKILL.md
@@ -25,46 +25,41 @@ in, when to answer versus link, and which neighbour owns what.
 
 ## Preflight
 
-The CLI runs in one of two places; find out which first.
+Run `bai-agent doctor --json` once, from wherever you already are — never `cd`
+first. Its `checkout detection` check says whether you are in a checkout or
+running on synced data; its session/auth check says whether you are logged
+in. Run `bai-agent whoami` only when that check is `warn`.
 
-- **Inside a `backend.ai-webui` checkout** — `pnpm --filter backend.ai-agent-cli
-  build` once per session, then every command as `pnpm run bai-agent <cmd>`
-  from the repository root (the proxy runs the bundle, not the source). The
-  data is the checkout's own.
-- **Anywhere else** — `bai-agent <cmd>` from the npm package
-  (`npm i -g backend.ai-agent-cli`). The data is a synced copy that
-  `bai-agent init` fetched for the manager's version; `bai-agent sync`
-  refreshes it. The workflow contract lives next to this file in
-  `references/agent-block.md` (generated at install), not in a CLAUDE.md.
+The workflow contract is already loaded: in a checkout it is the `BAI-AGENT`
+block in `CLAUDE.md`; installed, it is `references/agent-block.md`. Read
+whichever applies — don't `cat` it unless the block is absent — and don't grep
+for a CLAUDE.md outside a checkout; there isn't one.
 
-Then:
+**When `whoami` says `auth_required` (exit 3):**
 
-1. `bai-agent doctor --json` — data and session in one pass. It only ever
-   exits 0 or 1, and a missing session is a `warn`, so exit 0 means the
-   environment is ok — not that you are logged in. `fail` with no data at all
-   means `bai-agent init` (or `bai-agent sync`) has not run on this machine.
-2. `bai-agent whoami` — the auth check; exit 3 (`auth_required`) means log in:
-   - In a checkout, get the endpoint and the account from the
-     **`webui-connection-info`** skill; elsewhere the endpoint is the one
-     `init` recorded (`doctor` prints it). Never ask the user for a password,
-     and never put one in a command.
-   - Browser on this machine: `bai-agent login --endpoint <url>`, then confirm on
-     the `/cli-login` page it opens. That page is the WebUI's; in a checkout it
-     is the dev server, elsewhere the endpoint's own origin — pass
-     `--webui <origin>` when the UI lives somewhere else.
-   - Browser anywhere else, or a tunnelled/HTTPS tab: `bai-agent login --paste
-     --endpoint <url>` and paste the session id the page reveals.
-   - `bai-agent logout` when you are done with a borrowed session.
-3. **`search`, `docs show`, `schema show` and `explain` need no session at all.**
-   A "what does X mean" question never requires logging in — go straight to it.
+- Get the endpoint and the account from the **`webui-connection-info`** skill
+  in a checkout; elsewhere the endpoint is the one `init` recorded (`doctor`
+  prints it). Never ask the user for a password, and never put one in a
+  command.
+- Browser on this machine: `bai-agent login --endpoint <url>`, then confirm on
+  the `/cli-login` page it opens. That page is the WebUI's; in a checkout it
+  is the dev server, elsewhere the endpoint's own origin — pass
+  `--webui <origin>` when the UI lives somewhere else.
+- Browser anywhere else, or a tunnelled/HTTPS tab: `bai-agent login --paste
+  --endpoint <url>` and paste the session id the page reveals.
+- `bai-agent logout` when you are done with a borrowed session.
+
+**`search`, `docs show`, `schema show` and `explain` need no session at all.**
+A "what does X mean" question never requires logging in — go straight to it.
 
 ## Answer, or link
 
 | The user wants | Do this |
 | --- | --- |
-| to understand a term, field or status value | `explain` (meaning) or `docs show` (the manual). Answer in the words the UI uses, and cite the deployed-docs `url` the CLI returned. |
-| a count, a list, a value | `query` — start from `references/query-cookbook.md`, adapt, never invent a shape. Summarise the rows; do not paste the raw envelope. |
-| to see it, or act on it | Give the `webui_url` (or `webui_path`) `query` already annotated onto the row, under `data.links`, so the user can open it themselves. Never describe a click path you could report directly. |
+| to understand a status value ("what does status X mean") | Try `explain <Type>.<field>=<VALUE>` first — e.g. `explain ComputeSessionNode.status=PENDING`, `explain UserNode.status=before-verification`. Fall back to `explain <Type>.<field>` (no value) or `docs show` for a term or field in general. |
+| to understand a term or field | `explain` (meaning) or `docs show` (the manual). Answer in the words the UI uses, and cite the deployed-docs `url` the CLI returned. |
+| a count, a list, a value | `query` — start from the Cookbook below, adapt, never invent a shape. Summarise the rows; do not paste the raw envelope. |
+| to see it, or act on it | Give the `webui_url` (or `webui_path`) `query` already annotated onto the row, under `data.links`, so the user can open it themselves. Never describe a click path you could report directly. If `data.links` is empty for a result, say the resource has no addressable page — do not compose a path by hand. When several rows share a name, pick the link by `id`, never by name. |
 | something destructive | Give them the `hint` page from the refusal and stop. A `mutation_refused` (exit 4) is the answer, not an obstacle to route around. |
 
 `explain` prints `MISSING` for a piece nothing curates. Say it is not documented
@@ -95,12 +90,23 @@ guess at runtime.
 - **Session detail views share one URL.** `/session?sessionDetail=<id>` is a
   drawer, the only addressable surface — there is no per-row session link to
   offer beyond that.
+- **Never read the session file, or reuse its session id, outside `bai-agent`.**
+  It exists so the CLI itself can hold the credential; the mutation gate only
+  applies when calls go through the CLI, so bypassing it defeats the point.
+- **The synced data copy holds schema, i18n and docs only — no React source.**
+  Do not grep it for `.tsx`, and never report that emptiness as a fact about
+  the WebUI itself.
 
 ## Cookbook
 
-`references/query-cookbook.md` — 11 documents that validate against this
-checkout's SDL, one per resource, plus the allow-listed mutation and the refused
-destructive one. A test re-validates them, so a stale one fails CI, not a user.
+`<this skill's directory>/references/query-cookbook.md` (next to this file) —
+11 documents that validate against the checkout's SDL, one per resource, plus
+the allow-listed mutation and the refused destructive one. A test re-validates
+them, so a stale one fails CI, not a user. Checkout location:
+`packages/backend.ai-agent-cli/skill/references/query-cookbook.md`; installed:
+`~/.claude/skills/bai-agent/references/query-cookbook.md`, or
+`$CLAUDE_CONFIG_DIR/skills/...` when that is set. Never search the filesystem
+for it.
 
 ## Keeping this in sync (maintainers, in a checkout)
 

--- a/packages/backend.ai-agent-cli/skill/SKILL.md
+++ b/packages/backend.ai-agent-cli/skill/SKILL.md
@@ -25,10 +25,11 @@ in, when to answer versus link, and which neighbour owns what.
 
 ## Preflight
 
-Run `bai-agent doctor --json` once, from wherever you already are — never `cd`
-first. Its `checkout detection` check says whether you are in a checkout or
-running on synced data; its session/auth check says whether you are logged
-in. Run `bai-agent whoami` only when that check is `warn`.
+Run `bai-agent doctor --brief` once, from wherever you already are — never
+`cd` first. It is the one-step preflight: checkout-vs-synced-data and
+session/auth in one line each. Fall back to `bai-agent doctor --json` only
+when you need a specific field out of it. Run `bai-agent whoami` only when
+the auth check is `warn`.
 
 The workflow contract is already loaded: in a checkout it is the `BAI-AGENT`
 block in `CLAUDE.md`; installed, it is `references/agent-block.md`. Read
@@ -58,8 +59,8 @@ A "what does X mean" question never requires logging in — go straight to it.
 | --- | --- |
 | to understand a status value ("what does status X mean") | Try `explain <Type>.<field>=<VALUE>` first — e.g. `explain ComputeSessionNode.status=PENDING`, `explain UserNode.status=before-verification`. Fall back to `explain <Type>.<field>` (no value) or `docs show` for a term or field in general. |
 | to understand a term or field | `explain` (meaning) or `docs show` (the manual). Answer in the words the UI uses, and cite the deployed-docs `url` the CLI returned. |
-| a count, a list, a value | `query` — start from the Cookbook below, adapt, never invent a shape. Summarise the rows; do not paste the raw envelope. |
-| to see it, or act on it | Give the `webui_url` (or `webui_path`) `query` already annotated onto the row, under `data.links`, so the user can open it themselves. Never describe a click path you could report directly. If `data.links` is empty for a result, say the resource has no addressable page — do not compose a path by hand. When several rows share a name, pick the link by `id`, never by name. |
+| a count, a list, a value | Start every live query from `bai-agent cookbook <root field>` (or `--list`) — never search the filesystem for the cookbook; a `schema_mismatch` error names the entry to read. Adapt it, never invent a shape. Summarise the rows; do not paste the raw envelope. |
+| to see it, or act on it | Give the `webui_url` (or `webui_path`) `query` already annotated onto the row, under `data.links`, so the user can open it themselves. When you post-process the `--json` envelope yourself, also print `data.links` — the link must reach the user. Never describe a click path you could report directly. If `data.links` is empty for a result, say the resource has no addressable page — do not compose a path by hand; but a row carrying `webui_link_hint` instead means the id you selected cannot build one, so re-run selecting `row_id`. When several rows share a name, pick the link by `id`, never by name. |
 | something destructive | Give them the `hint` page from the refusal and stop. A `mutation_refused` (exit 4) is the answer, not an obstacle to route around. |
 
 `explain` prints `MISSING` for a piece nothing curates. Say it is not documented
@@ -90,23 +91,21 @@ guess at runtime.
 - **Session detail views share one URL.** `/session?sessionDetail=<id>` is a
   drawer, the only addressable surface — there is no per-row session link to
   offer beyond that.
-- **Never read the session file, or reuse its session id, outside `bai-agent`.**
-  It exists so the CLI itself can hold the credential; the mutation gate only
-  applies when calls go through the CLI, so bypassing it defeats the point.
-- **The synced data copy holds schema, i18n and docs only — no React source.**
-  Do not grep it for `.tsx`, and never report that emptiness as a fact about
-  the WebUI itself.
+
+The block's RULES apply beyond these (session file, empty `data.links`, no
+React source in a synced copy, never `cd` before `doctor`, and more) — read
+them there rather than restated here.
 
 ## Cookbook
 
-`<this skill's directory>/references/query-cookbook.md` (next to this file) —
-11 documents that validate against the checkout's SDL, one per resource, plus
-the allow-listed mutation and the refused destructive one. A test re-validates
-them, so a stale one fails CI, not a user. Checkout location:
-`packages/backend.ai-agent-cli/skill/references/query-cookbook.md`; installed:
-`~/.claude/skills/bai-agent/references/query-cookbook.md`, or
-`$CLAUDE_CONFIG_DIR/skills/...` when that is set. Never search the filesystem
-for it.
+`bai-agent cookbook --list` names every entry; `bai-agent cookbook <n>` and
+`bai-agent cookbook <root field>` print one, prose and document. That command
+is how you read it — it locates the file itself, so never search the
+filesystem for a path and never `cat` one. The entries are 11 documents that
+validate against the SDL, one per resource, plus the allow-listed mutation and
+the refused destructive one; a test re-validates them, so a stale one fails CI,
+not a user. Maintainers edit
+`packages/backend.ai-agent-cli/skill/references/query-cookbook.md`.
 
 ## Keeping this in sync (maintainers, in a checkout)
 

--- a/packages/backend.ai-agent-cli/skill/references/query-cookbook.md
+++ b/packages/backend.ai-agent-cli/skill/references/query-cookbook.md
@@ -157,8 +157,10 @@ query Agents($first: Int!) {
 }
 ```
 
-`--var first=20`. Agents have no detail page yet, so no `webui_path` — point
-the user at the list page instead: `/admin/agent?tab=agents`.
+`--var first=20`. Agents have no detail page yet, so the rows carry no
+`webui_path`; because the root field is list-shaped, `data.links` carries one
+entry for the whole field, pointing at `/admin/agent?tab=agents`. Hand that
+over. A singular root field (`agent(agent_id: …)`) gets no link at all.
 
 ### 6. Resource groups (scaling groups)
 
@@ -285,9 +287,9 @@ pnpm run bai-agent query --allow-mutation --json \
 `createVfolderV2` is one of the three names on
 `packages/backend.ai-agent-cli/src/mutation-allowlist.ts`. The result's
 `data.links` entry is annotated with a `webui_path` / `webui_url` built from
-`vfolder.id`, which is a base64 Relay global id — the Data page wants the raw
-UUID, so that link does **not** open the folder until the id is decoded. Known
-limitation; see "Known limitation" in `packages/backend.ai-agent-cli/README.md`.
+`vfolder.id`: that is a base64 Relay global id (`VFolder:<uuid>`) and the Data
+page wants the raw UUID, so the CLI decodes it first. Hand the user the emitted
+`webui_url` — it opens the folder that was just created.
 
 ### 11. Delete a VFolder — refused on purpose
 

--- a/packages/backend.ai-agent-cli/skill/references/query-cookbook.md
+++ b/packages/backend.ai-agent-cli/skill/references/query-cookbook.md
@@ -44,7 +44,10 @@ query Sessions($first: Int!, $filter: String) {
 
 `--var first=20`. Filter by status with `--var 'filter=status == "RUNNING"'`
 (the manager's filter DSL, not GraphQL). Rows carry `webui_path`
-`/session?sessionDetail=<row_id>`.
+`/session?sessionDetail=<row_id>`. A superadmin sees the whole cluster with
+no `scope_id` at all — the field is optional (add it to `compute_session_nodes`
+only to narrow to one domain/project/user), never required to see everyone
+else's sessions.
 
 ### 2. One session in full
 
@@ -75,8 +78,8 @@ row's `webui_url`).
 ### 3. Virtual folders — cursor mode (`first`)
 
 ```graphql
-query VFolders($first: Int!) {
-  vfolder_nodes(first: $first, order: "-created_at") {
+query VFolders($first: Int!, $filter: String) {
+  vfolder_nodes(first: $first, filter: $filter, order: "-created_at") {
     count
     edges {
       node {
@@ -96,7 +99,9 @@ query VFolders($first: Int!) {
 }
 ```
 
-`--var first=20`. Rows carry `webui_path` `/data?folder=<row_id>`.
+`--var first=20`. Narrow it with `--var 'filter=name == "my-folder"'` — every
+connection's `filter` argument is the manager's filter DSL **string**, not a
+GraphQL input object. Rows carry `webui_path` `/data?folder=<row_id>`.
 
 ## Serving
 
@@ -121,7 +126,9 @@ query Deployments($limit: Int!, $offset: Int!) {
 ```
 
 `--var limit=10 --var offset=0`. `limit` and `offset` are non-null here, so
-this connection has no cursor mode at all. Rows carry `webui_path`
+this connection has no cursor mode at all. `lifecycle_stage` comes back
+prefixed with its enum type name, e.g. `EndpointLifecycle.DESTROYED` — match
+on the suffix, not the raw string. Rows carry `webui_path`
 `/deployments/<endpoint_id>`.
 
 ## Cluster

--- a/packages/backend.ai-agent-cli/src/commands/cookbook.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/cookbook.test.ts
@@ -1,0 +1,228 @@
+import { EXIT } from '../errors.js';
+import { COMMANDS, findCommand } from '../registry.js';
+import { runCli } from '../run.js';
+import { saveSession } from '../session.js';
+import type { CookbookData, CookbookSummary } from './cookbook.js';
+import {
+  cookbookCommandFor,
+  cookbookPath,
+  findEntry,
+  loadCookbook,
+  parseCookbook,
+} from './cookbook.js';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Every command reads the checkout, so the tests run inside one. */
+const cwd = import.meta.dirname;
+
+let out: string[];
+let err: string[];
+
+const run = (argv: string[]) =>
+  runCli({
+    argv,
+    cwd,
+    io: {
+      stdout: (chunk) => out.push(chunk),
+      stderr: (chunk) => err.push(chunk),
+    },
+  });
+
+const jsonOut = <T>() => (JSON.parse(out.join('')) as { data: T }).data;
+const jsonErr = () =>
+  JSON.parse(err.join('')) as {
+    code: string;
+    error: string;
+    hint?: string;
+    suggestions?: string[];
+  };
+
+beforeEach(() => {
+  out = [];
+  err = [];
+});
+
+describe('the cookbook file', () => {
+  it('ships next to the CLI and parses into numbered entries', () => {
+    const { path, entries } = loadCookbook();
+    expect(path).toBe(cookbookPath());
+    expect(path.endsWith('skill/references/query-cookbook.md')).toBe(true);
+    expect(entries.length).toBeGreaterThanOrEqual(8);
+    expect(entries.map((entry) => entry.number)).toEqual(
+      entries.map((_, index) => index + 1),
+    );
+    for (const entry of entries) {
+      expect(entry.title.length, `entry ${entry.number}`).toBeGreaterThan(0);
+      expect(entry.rootFields.length, `entry ${entry.number}`).toBeGreaterThan(
+        0,
+      );
+      expect(entry.body).toContain('```graphql');
+    }
+  });
+
+  it('reads the root fields out of each entry’s document', () => {
+    const { entries } = loadCookbook();
+    expect(findEntry(entries, 'vfolder_nodes')?.number).toBe(3);
+    expect(findEntry(entries, 'adminProjectsV2')?.number).toBe(9);
+    expect(findEntry(entries, '3')?.rootFields).toContain('vfolder_nodes');
+  });
+
+  it('keeps a `###` heading under its `##` section', () => {
+    const entries = parseCookbook(
+      [
+        '# Title',
+        '',
+        '## Sessions',
+        '',
+        '### 1. First',
+        '',
+        'prose',
+        '',
+        '```graphql',
+        'query { user { email } }',
+        '```',
+        '',
+        '## Storage',
+        '',
+        '### 2. Second',
+        '',
+        '```graphql',
+        'query { vfolder_nodes(first: 1) { count } }',
+        '```',
+        '',
+      ].join('\n'),
+    );
+    expect(entries.map((entry) => [entry.number, entry.section])).toEqual([
+      [1, 'Sessions'],
+      [2, 'Storage'],
+    ]);
+    expect(entries[0].rootFields).toEqual(['user']);
+    expect(entries[0].body).not.toContain('## Storage');
+  });
+});
+
+describe('bai-agent cookbook', () => {
+  it('is registered, so --help and manifest carry it', () => {
+    const command = findCommand('cookbook');
+    expect(command).toBeDefined();
+    expect(COMMANDS).toContain(command);
+    expect(command?.flags.map((flag) => flag.flag)).toContain('--list');
+  });
+
+  it('--list prints every entry with its number, title and root fields', async () => {
+    await expect(run(['cookbook', '--list', '--json'])).resolves.toBe(EXIT.ok);
+    const data = jsonOut<Extract<CookbookData, { kind: 'list' }>>();
+    expect(data.entries.length).toBeGreaterThanOrEqual(8);
+    const third = data.entries.find(
+      (entry: CookbookSummary) => entry.number === 3,
+    );
+    expect(third?.rootFields).toContain('vfolder_nodes');
+    expect(third?.title.length).toBeGreaterThan(0);
+  });
+
+  it('lists the entries when no argument is given', async () => {
+    await expect(run(['cookbook'])).resolves.toBe(EXIT.ok);
+    const printed = out.join('');
+    expect(printed).toContain('vfolder_nodes');
+    expect(printed).toContain('adminProjectsV2');
+  });
+
+  it('prints one entry by number, with its heading, prose and document', async () => {
+    await expect(run(['cookbook', '3', '--json'])).resolves.toBe(EXIT.ok);
+    const data = jsonOut<Extract<CookbookData, { kind: 'entry' }>>();
+    expect(data.entry.number).toBe(3);
+    expect(data.entry.rootFields).toContain('vfolder_nodes');
+    expect(data.entry.body).toMatch(/^### 3\. /);
+    expect(data.entry.body).toContain('```graphql');
+    expect(data.entry.body).toContain('vfolder_nodes(first: $first');
+  });
+
+  it('prints the entry a root field belongs to', async () => {
+    await expect(run(['cookbook', 'adminProjectsV2'])).resolves.toBe(EXIT.ok);
+    const printed = out.join('');
+    expect(printed).toContain('entry:');
+    expect(printed).toContain('adminProjectsV2(limit: $limit');
+  });
+
+  it('exits 5 not_found with the list as suggestions', async () => {
+    await expect(run(['cookbook', 'no_such_field', '--json'])).resolves.toBe(
+      EXIT.notFound,
+    );
+    const envelope = jsonErr();
+    expect(envelope.code).toBe('not_found');
+    expect(envelope.hint).toBe('bai-agent cookbook --list');
+    expect(envelope.suggestions?.length).toBeGreaterThanOrEqual(8);
+    expect(envelope.suggestions?.join('\n')).toContain('vfolder_nodes');
+  });
+
+  it('exits 5 for an entry number the cookbook does not have', async () => {
+    await expect(run(['cookbook', '999', '--json'])).resolves.toBe(
+      EXIT.notFound,
+    );
+    expect(jsonErr().code).toBe('not_found');
+  });
+});
+
+describe('cookbookCommandFor', () => {
+  it('names the entry for a root field the cookbook covers', () => {
+    expect(cookbookCommandFor(['vfolder_nodes'])).toBe(
+      'bai-agent cookbook vfolder_nodes',
+    );
+  });
+
+  it('falls back to --list for a root field nothing covers', () => {
+    expect(cookbookCommandFor(['user'])).toBe('bai-agent cookbook --list');
+    expect(cookbookCommandFor([])).toBe('bai-agent cookbook --list');
+  });
+});
+
+describe('query schema_mismatch', () => {
+  const ENDPOINT = 'http://manager.example.com:8090';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.BAI_AGENT_CONFIG_DIR = mkdtempSync(
+      join(tmpdir(), 'bai-agent-cookbook-'),
+    );
+    saveSession({
+      endpoint: ENDPOINT,
+      webui: 'http://manager.example.com:8080',
+      sessionId: 'abcdefghijklmnopqrstuvwxyz012345',
+      savedAt: '2026-09-04T00:00:00.000Z',
+    });
+    fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('points a rejected document at the cookbook entry for its root field', async () => {
+    await expect(
+      run([
+        'query',
+        'query { vfolder_nodes(first: 1) { edges { node { nope_field } } } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.error);
+    expect(fetchMock).not.toHaveBeenCalled();
+    const envelope = jsonErr();
+    expect(envelope.code).toBe('schema_mismatch');
+    expect(envelope.suggestions).toContain('bai-agent cookbook vfolder_nodes');
+    // The validator messages still come first, and the type hint is untouched.
+    expect(envelope.suggestions?.[0]).toContain('nope_field');
+    expect(envelope.hint).toBe('bai-agent schema show VirtualFolderNode');
+  });
+
+  it('falls back to the cookbook list when nothing covers the root field', async () => {
+    await expect(
+      run(['query', 'query { totally_unknown_root_field }', '--json']),
+    ).resolves.toBe(EXIT.error);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(jsonErr().suggestions).toContain('bai-agent cookbook --list');
+  });
+});

--- a/packages/backend.ai-agent-cli/src/commands/cookbook.ts
+++ b/packages/backend.ai-agent-cli/src/commands/cookbook.ts
@@ -1,0 +1,222 @@
+import { defineCommand } from '../command.js';
+import { CliError } from '../errors.js';
+import { CLI_NAME } from '../meta.js';
+import type { RenderOptions } from '../output.js';
+import { list, record, renderBlocks, section, text } from '../output.js';
+import { parseDocument } from '../query/document.js';
+import { shippedSkillDir } from '../skill-install.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The cookbook ships inside the skill directory, next to `SKILL.md`. */
+export const COOKBOOK_FILE = 'references/query-cookbook.md';
+
+export interface CookbookSummary {
+  number: number;
+  title: string;
+  /** The `## …` heading the entry sits under. */
+  section: string;
+  /** Root fields of every GraphQL document in the entry, in document order. */
+  rootFields: string[];
+}
+
+export interface CookbookEntry extends CookbookSummary {
+  /** The heading, its prose and its fenced blocks, verbatim. */
+  body: string;
+}
+
+export type CookbookData =
+  | { kind: 'list'; path: string; entries: CookbookSummary[] }
+  | { kind: 'entry'; path: string; entry: CookbookEntry };
+
+export function cookbookPath(): string {
+  return join(shippedSkillDir(), COOKBOOK_FILE);
+}
+
+const ENTRY_HEADING = /^###\s+(\d+)\.\s+(.+)$/;
+const SECTION_HEADING = /^##\s+(.+)$/;
+const GRAPHQL_BLOCK = /```graphql\n([\s\S]*?)```/g;
+
+function rootFieldsIn(body: string): string[] {
+  const fields: string[] = [];
+  for (const block of body.matchAll(GRAPHQL_BLOCK)) {
+    let parsed;
+    try {
+      parsed = parseDocument(block[1]);
+    } catch {
+      // A block the parser rejects contributes no root field; `skill.test.ts`
+      // is what fails on a cookbook document the SDL outgrew.
+      continue;
+    }
+    for (const operation of parsed.operations) {
+      for (const field of operation.rootFields) {
+        if (!fields.includes(field)) fields.push(field);
+      }
+    }
+  }
+  return fields;
+}
+
+export function parseCookbook(source: string): CookbookEntry[] {
+  const entries: CookbookEntry[] = [];
+  let sectionTitle = '';
+  let open: { number: number; title: string; lines: string[] } | undefined;
+  let openSection = '';
+
+  const flush = (): void => {
+    if (!open) return;
+    const body = open.lines.join('\n').trim();
+    entries.push({
+      number: open.number,
+      title: open.title,
+      section: openSection,
+      rootFields: rootFieldsIn(body),
+      body,
+    });
+    open = undefined;
+  };
+
+  for (const line of source.split('\n')) {
+    const heading = ENTRY_HEADING.exec(line);
+    if (heading) {
+      flush();
+      open = { number: Number(heading[1]), title: heading[2].trim(), lines: [line] };
+      openSection = sectionTitle;
+      continue;
+    }
+    const parent = SECTION_HEADING.exec(line);
+    if (parent) {
+      flush();
+      sectionTitle = parent[1].trim();
+      continue;
+    }
+    if (open) open.lines.push(line);
+  }
+  flush();
+  return entries;
+}
+
+/** A number picks the entry; anything else is matched as a root field. */
+export function findEntry(
+  entries: CookbookEntry[],
+  argument: string,
+): CookbookEntry | undefined {
+  const wanted = argument.trim();
+  if (/^\d+$/.test(wanted)) {
+    return entries.find((entry) => entry.number === Number(wanted));
+  }
+  const lower = wanted.toLowerCase();
+  return entries.find((entry) =>
+    entry.rootFields.some((field) => field.toLowerCase() === lower),
+  );
+}
+
+const summarise = (entry: CookbookEntry): CookbookSummary => ({
+  number: entry.number,
+  title: entry.title,
+  section: entry.section,
+  rootFields: entry.rootFields,
+});
+
+const listLine = (entry: CookbookSummary): string =>
+  [
+    `${entry.number}.`,
+    entry.section ? `[${entry.section}]` : '',
+    entry.title,
+    entry.rootFields.length > 0 ? `— ${entry.rootFields.join(', ')}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+export function loadCookbook(): { path: string; entries: CookbookEntry[] } {
+  const path = cookbookPath();
+  let source: string;
+  try {
+    source = readFileSync(path, 'utf8');
+  } catch (error) {
+    throw new CliError('internal', `Cannot read the cookbook at ${path}.`, {
+      hint: `${CLI_NAME} init --skill`,
+      cause: error,
+    });
+  }
+  return { path, entries: parseCookbook(source) };
+}
+
+/**
+ * The `cookbook` command that opens the entry for a root field — the hint
+ * `query` gives when the checkout's SDL rejects a hand-written document.
+ */
+export function cookbookCommandFor(rootFields: string[]): string {
+  let entries: CookbookEntry[];
+  try {
+    entries = loadCookbook().entries;
+  } catch {
+    return `${CLI_NAME} cookbook --list`;
+  }
+  const match = rootFields.find((field) => findEntry(entries, field));
+  return `${CLI_NAME} cookbook ${match ?? '--list'}`;
+}
+
+function renderEntry(
+  data: Extract<CookbookData, { kind: 'entry' }>,
+  { verbosity }: RenderOptions,
+): string {
+  if (verbosity === 'dense') return data.entry.body;
+  return renderBlocks([
+    record([
+      ['entry', data.entry.number],
+      ['title', data.entry.title],
+      ['section', data.entry.section],
+      ['root fields', data.entry.rootFields.join(', ')],
+      ['path', data.path],
+    ]),
+    section('---'),
+    text(data.entry.body),
+  ]);
+}
+
+export const cookbookCommand = defineCommand<CookbookData>({
+  name: 'cookbook',
+  summary:
+    'Print a ready-to-run query from the skill cookbook, by entry number or root field.',
+  usage: `${CLI_NAME} cookbook [<n> | <root field> | --list] [--json]`,
+  flags: [
+    {
+      flag: '--list',
+      description:
+        'List every entry: number, title and the root field(s) its document uses.',
+      type: 'boolean',
+    },
+  ],
+  maxArgs: 1,
+  run: (context) => {
+    const { path, entries } = loadCookbook();
+    const argument = context.args[0]?.trim();
+    if (!argument || context.flags.list === true) {
+      return { kind: 'list', path, entries: entries.map(summarise) };
+    }
+    const entry = findEntry(entries, argument);
+    if (!entry) {
+      throw new CliError(
+        'not_found',
+        `No cookbook entry numbered or using root field "${argument}".`,
+        {
+          suggestions: entries.map((one) => listLine(summarise(one))),
+          hint: `${CLI_NAME} cookbook --list`,
+        },
+      );
+    }
+    return { kind: 'entry', path, entry };
+  },
+  render: (data, options) => {
+    if (data.kind === 'entry') return renderEntry(data, options);
+    return renderBlocks([
+      section(`${CLI_NAME} cookbook`),
+      record([
+        ['path', data.path],
+        ['entries', data.entries.length],
+      ]),
+      list(data.entries.map(listLine)),
+    ]);
+  },
+});

--- a/packages/backend.ai-agent-cli/src/commands/doctor.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/doctor.test.ts
@@ -1,7 +1,15 @@
+import { EXIT } from '../errors.js';
 import type { DocsPage } from '../search/docs-corpus.js';
 import { parseMarkdown } from '../search/markdown.js';
-import { headingLevelsMatch } from './doctor.js';
-import { describe, expect, it } from 'vitest';
+import { runCli } from '../run.js';
+import type { CheckStatus, DoctorCheck, DoctorData } from './doctor.js';
+import {
+  briefHeadline,
+  doctorCommand,
+  headingLevelsMatch,
+  renderBrief,
+} from './doctor.js';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 const page = (source: string): DocsPage => ({
   slug: 'p',
@@ -32,5 +40,139 @@ describe('headingLevelsMatch', () => {
         page('# A\n### B\n## C\n'),
       ),
     ).toBe(false);
+  });
+});
+
+const check = (
+  group: string,
+  name: string,
+  status: CheckStatus,
+  detail = `${group}/${name}`,
+): DoctorCheck => ({ group, check: name, status, detail });
+
+const doctorData = (checks: DoctorCheck[]): DoctorData => ({
+  brief: true,
+  checks,
+  summary: {
+    total: checks.length,
+    ok: checks.filter((one) => one.status === 'ok').length,
+    warn: checks.filter((one) => one.status === 'warn').length,
+    fail: checks.filter((one) => one.status === 'fail').length,
+  },
+});
+
+const HEALTHY: DoctorCheck[] = [
+  check('runtime', 'node version', 'ok'),
+  check('checkout', 'checkout detection', 'ok', '/repo (version 26.8.0)'),
+  check('checkout', 'synced data', 'ok', 'main at abc123def'),
+  check('docs', 'manual sources', 'ok', '42 en page(s)'),
+  check('docs', 'languages', 'ok'),
+  check('schema', 'sdl parses', 'ok', 'data/schema.graphql parsed'),
+  check('schema', 'marker coverage', 'ok'),
+  check('auth', 'session file', 'ok', 'mode 0600'),
+  check(
+    'auth',
+    'whoami',
+    'ok',
+    'admin@lablup.com (superadmin) at http://m:8090',
+  ),
+  check('mappings', 'mapping files', 'ok'),
+  check('alignment', 'sdl present', 'ok'),
+  check('alignment', 'verdict', 'ok', 'schema matches manager 26.8.0rc1'),
+];
+
+describe('doctor --brief', () => {
+  it('is a registered flag, so --help and manifest show it', () => {
+    expect(doctorCommand.flags.map((flag) => flag.flag)).toContain('--brief');
+    expect(doctorCommand.usage).toContain('--brief');
+  });
+
+  it('leads with auth, then alignment, then the checkout/data lines', () => {
+    const { rows } = briefHeadline(HEALTHY);
+    expect(rows.map(([label]) => label)).toEqual([
+      'auth',
+      'alignment',
+      'checkout',
+      'data',
+      'docs',
+      'schema',
+    ]);
+    expect(rows[0][1]).toContain('admin@lablup.com');
+    expect(rows[1][1]).toContain('26.8.0rc1');
+  });
+
+  it('falls back to the session file when whoami never ran', () => {
+    const { rows } = briefHeadline([
+      check('auth', 'session file', 'warn', 'no session stored'),
+    ]);
+    expect(rows).toEqual([['auth', 'warn — no session stored']]);
+  });
+
+  it('prints only the warn and fail checks under the headline', () => {
+    const rendered = renderBrief(
+      doctorData([
+        ...HEALTHY,
+        check('mappings', 'value coverage', 'warn', 'two values uncurated'),
+        check('runtime', 'i18n index', 'fail', 'nothing labelled'),
+      ]),
+    );
+    expect(rendered).toContain(
+      'warn mappings/value coverage: two values uncurated',
+    );
+    expect(rendered).toContain('fail runtime/i18n index: nothing labelled');
+    expect(rendered).not.toContain('docs/languages');
+    expect(rendered).not.toContain('schema/marker coverage');
+    expect(rendered).toContain('summary: 14 check(s) — 12 ok, 1 warn, 1 fail');
+  });
+
+  it('stays under 40 lines however many checks warn', () => {
+    const noisy = Array.from({ length: 60 }, (_, index) =>
+      check('mappings', `issue ${index}`, 'warn', 'x'.repeat(400)),
+    );
+    const rendered = renderBrief(doctorData([...HEALTHY, ...noisy]));
+    const lines = rendered.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(40);
+    expect(lines.every((line) => line.length <= 200)).toBe(true);
+    expect(rendered).toContain('42 more — bai-agent doctor --json');
+  });
+});
+
+describe('bai-agent doctor --brief end to end', () => {
+  let out: string[];
+
+  const run = (argv: string[]) =>
+    runCli({
+      argv,
+      cwd: import.meta.dirname,
+      io: {
+        stdout: (chunk) => out.push(chunk),
+        stderr: () => {},
+      },
+    });
+
+  beforeEach(() => {
+    out = [];
+  });
+
+  // `--mappings` is the one group that reaches no network.
+  it('renders at most 40 lines of text', async () => {
+    await expect(run(['doctor', '--mappings', '--brief'])).resolves.toBe(
+      EXIT.ok,
+    );
+    const lines = out.join('').trimEnd().split('\n');
+    expect(lines.length).toBeLessThanOrEqual(40);
+    expect(lines.at(-1)).toMatch(/^summary: \d+ check\(s\) — /);
+  });
+
+  it('leaves --json carrying every check', async () => {
+    await run(['doctor', '--mappings', '--brief', '--json']);
+    const brief = JSON.parse(out.join('')) as { data: DoctorData };
+    out = [];
+    await run(['doctor', '--mappings', '--json']);
+    const full = JSON.parse(out.join('')) as { data: DoctorData };
+    expect(brief.data.checks).toEqual(full.data.checks);
+    expect(brief.data.summary).toEqual(full.data.summary);
+    expect(brief.data.brief).toBe(true);
+    expect(full.data.brief).toBe(false);
   });
 });

--- a/packages/backend.ai-agent-cli/src/commands/doctor.ts
+++ b/packages/backend.ai-agent-cli/src/commands/doctor.ts
@@ -658,14 +658,16 @@ const alignmentGroup: CheckGroup = {
     });
 
     const alignment = checkVersionAlignment(
-      { schema: loadSchema(context) },
+      { schema: loadSchema(context), ...(meta ? { schemaTag: meta.tag } : {}) },
       version.manager,
     );
     checks.push({
       group: 'alignment',
       check: 'verdict',
       status: alignment.aligned ? 'ok' : 'warn',
-      detail: `${alignment.summary} (${alignment.checked} marked entries compared)`,
+      detail: `${alignment.summary} (${alignment.checked} marked entries compared${
+        meta ? `, SDL synced from tag ${meta.tag}` : ''
+      })`,
       hint: alignment.hint,
     });
     return checks;

--- a/packages/backend.ai-agent-cli/src/commands/doctor.ts
+++ b/packages/backend.ai-agent-cli/src/commands/doctor.ts
@@ -658,8 +658,17 @@ const alignmentGroup: CheckGroup = {
       detail: `${version.manager} at ${endpoint} (via ${version.source}${session ? '' : ', no session'})`,
     });
 
+    // A tag whose sha256 no longer hashes the SDL describes some other file:
+    // forwarding it would let `schemaTag === managerVersion` declare the SDL
+    // the manager's own and hide every marker finding. The metadata warn above
+    // already reported the mismatch; here the verdict just falls back to the
+    // marker comparison.
+    const trustedTag = meta !== null && shaMatches ? meta.tag : undefined;
     const alignment = checkVersionAlignment(
-      { schema: loadSchema(context), ...(meta ? { schemaTag: meta.tag } : {}) },
+      {
+        schema: loadSchema(context),
+        ...(trustedTag ? { schemaTag: trustedTag } : {}),
+      },
       version.manager,
     );
     checks.push({
@@ -667,7 +676,11 @@ const alignmentGroup: CheckGroup = {
       check: 'verdict',
       status: alignment.aligned ? 'ok' : 'warn',
       detail: `${alignment.summary} (${alignment.checked} marked entries compared${
-        meta ? `, SDL synced from tag ${meta.tag}` : ''
+        meta === null
+          ? ''
+          : shaMatches
+            ? `, SDL synced from tag ${meta.tag}`
+            : `, tag ${meta.tag} ignored: ${SCHEMA_META_FILE} does not describe the SDL on disk`
       })`,
       hint: alignment.hint,
     });

--- a/packages/backend.ai-agent-cli/src/commands/doctor.ts
+++ b/packages/backend.ai-agent-cli/src/commands/doctor.ts
@@ -10,7 +10,8 @@ import {
 import { MAPPINGS_DIR_NAME } from '../mappings/load.js';
 import { resolveMappings } from '../mappings/resolve.js';
 import { CLI_NAME, MIN_NODE_MAJOR } from '../meta.js';
-import { record, renderBlocks, section } from '../output.js';
+import type { Block } from '../output.js';
+import { list, record, renderBlocks, section, text } from '../output.js';
 import type { RepoContext } from '../repo-context.js';
 import {
   CHECKOUT_ENV,
@@ -695,17 +696,109 @@ export function selectGroups(context: RunContext): CheckGroup[] {
 export interface DoctorData {
   checks: DoctorCheck[];
   summary: { total: number; ok: number; warn: number; fail: number };
+  /** Text-only: `--json` carries every check either way. */
+  brief: boolean;
+}
+
+/** `--brief`: the headline checks, then only what warns or fails. */
+export const BRIEF_FLAG = 'brief';
+
+/** Keeps the report one line per check however long a detail grows. */
+const MAX_DETAIL = 140;
+
+/** Enough issues to act on; the rest are one `--json` away. */
+const MAX_BRIEF_ISSUES = 18;
+
+const clamp = (value: string): string =>
+  value.length <= MAX_DETAIL ? value : `${value.slice(0, MAX_DETAIL - 1)}…`;
+
+/**
+ * The lines the brief report leads with, in reading order: is this machine
+ * logged in, is the SDL the manager's, and what data is being read.
+ */
+const BRIEF_HEADLINE: Array<{
+  label: string;
+  group: string;
+  checks: string[];
+}> = [
+  {
+    label: 'auth',
+    group: 'auth',
+    checks: ['whoami', 'session file', 'endpoint'],
+  },
+  { label: 'alignment', group: 'alignment', checks: ['verdict'] },
+  { label: 'checkout', group: 'checkout', checks: ['checkout detection'] },
+  { label: 'data', group: 'checkout', checks: ['synced data'] },
+  { label: 'docs', group: 'docs', checks: ['manual sources'] },
+  { label: 'schema', group: 'schema', checks: ['sdl parses'] },
+];
+
+export function briefHeadline(checks: DoctorCheck[]): {
+  rows: Array<[string, string]>;
+  shown: Set<DoctorCheck>;
+} {
+  const rows: Array<[string, string]> = [];
+  const shown = new Set<DoctorCheck>();
+  for (const { label, group, checks: names } of BRIEF_HEADLINE) {
+    const found = names
+      .map((name) =>
+        checks.find((check) => check.group === group && check.check === name),
+      )
+      .find((check) => check !== undefined);
+    if (!found) continue;
+    rows.push([label, `${found.status} — ${clamp(found.detail)}`]);
+    shown.add(found);
+  }
+  return { rows, shown };
+}
+
+export function renderBrief(data: DoctorData): string {
+  const { rows, shown } = briefHeadline(data.checks);
+  const issues = data.checks.filter(
+    (check) => check.status !== 'ok' && !shown.has(check),
+  );
+  const blocks: Block[] = [section(`${CLI_NAME} doctor --${BRIEF_FLAG}`)];
+  if (rows.length > 0) blocks.push(record(rows));
+  if (issues.length > 0) {
+    blocks.push(
+      section(`Warn / fail, beyond the headline (${issues.length})`),
+      list([
+        ...issues
+          .slice(0, MAX_BRIEF_ISSUES)
+          .map(
+            (check) =>
+              `${check.status} ${check.group}/${check.check}: ${clamp(check.detail)}`,
+          ),
+        ...(issues.length > MAX_BRIEF_ISSUES
+          ? [
+              `${issues.length - MAX_BRIEF_ISSUES} more — ${CLI_NAME} doctor --json`,
+            ]
+          : []),
+      ]),
+    );
+  }
+  const { total, ok, warn, fail } = data.summary;
+  blocks.push(
+    text(`summary: ${total} check(s) — ${ok} ok, ${warn} warn, ${fail} fail`),
+  );
+  return renderBlocks(blocks);
 }
 
 export const doctorCommand = defineCommand<DoctorData>({
   name: 'doctor',
   summary: 'Diagnose the CLI environment and the detected checkout.',
-  usage: `${CLI_NAME} doctor [--${MAPPINGS_GROUP}] [--json]`,
+  usage: `${CLI_NAME} doctor [--${MAPPINGS_GROUP}] [--${BRIEF_FLAG}] [--json]`,
   flags: [
     {
       flag: `--${MAPPINGS_GROUP}`,
       description:
         'Run only the mappings group: validate every mappings/<Type>.yaml and resolve its references.',
+      type: 'boolean',
+    },
+    {
+      flag: `--${BRIEF_FLAG}`,
+      description:
+        'Text output: the auth, alignment and checkout/data lines, then only the checks that warn or fail.',
       type: 'boolean',
     },
   ],
@@ -718,6 +811,7 @@ export const doctorCommand = defineCommand<DoctorData>({
       )
     ).flat();
     return {
+      brief: context.flags[BRIEF_FLAG] === true,
       checks,
       summary: {
         total: checks.length,
@@ -728,6 +822,7 @@ export const doctorCommand = defineCommand<DoctorData>({
     };
   },
   render: (data, { verbosity }) => {
+    if (data.brief) return renderBrief(data);
     const blocks = [section(`${CLI_NAME} doctor`)];
     for (const check of data.checks) {
       blocks.push(
@@ -752,6 +847,9 @@ export const doctorCommand = defineCommand<DoctorData>({
         ['ok', data.summary.ok],
         ['warn', data.summary.warn],
         ['fail', data.summary.fail],
+        ...(verbosity === 'detail'
+          ? ([[BRIEF_FLAG, data.brief]] as Array<[string, boolean]>)
+          : []),
       ]),
     );
     return renderBlocks(blocks);

--- a/packages/backend.ai-agent-cli/src/commands/init.ts
+++ b/packages/backend.ai-agent-cli/src/commands/init.ts
@@ -190,7 +190,7 @@ export const initCommand = defineCommand<InitData>({
     {
       flag: '--skill',
       description:
-        'Install the Claude Code skill into ~/.claude/skills (asked for when neither --skill nor --no-skill is given).',
+        'Install the Claude Code skill into $CLAUDE_CONFIG_DIR/skills, else ~/.claude/skills (asked for when neither --skill nor --no-skill is given).',
       type: 'boolean',
     },
     {

--- a/packages/backend.ai-agent-cli/src/commands/query.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.test.ts
@@ -349,10 +349,101 @@ describe('webui link annotation', () => {
   });
 
   it('leaves an unmapped root field alone', async () => {
-    stubFetch({ data: { user: { email: 'a@b.c' } } });
+    stubFetch({ data: { domain: { name: 'default' } } });
 
     await expect(
-      run(['query', 'query { user { email } }', '--json']),
+      run(['query', 'query { domain(name: "default") { name } }', '--json']),
+    ).resolves.toBe(EXIT.ok);
+    expect(jsonOut().data.links).toEqual([]);
+  });
+});
+
+describe('list-page links', () => {
+  it('points a user_nodes result at the users list page', async () => {
+    stubFetch({
+      data: {
+        user_nodes: {
+          edges: [
+            { node: { id: 'VXNlcjow', username: 'alice' } },
+            { node: { id: 'VXNlcjox', username: 'bob' } },
+          ],
+        },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        'query { user_nodes(first: 2) { edges { node { id username } } } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    const data = jsonOut().data;
+    // One link per root field, not per row, and no id: the page addresses none.
+    expect(data.links).toEqual([
+      {
+        path: 'user_nodes',
+        resource: 'user',
+        webui_path: '/admin/users?tab=users',
+        webui_url: `${WEBUI}/admin/users?tab=users`,
+      },
+    ]);
+    expect(data.result.user_nodes.edges[0].node.webui_path).toBeUndefined();
+  });
+
+  it('points a resource_presets result at the environment preset tab', async () => {
+    stubFetch({ data: { resource_presets: [{ name: 'gpu-1' }] } });
+
+    await expect(
+      run(['query', 'query { resource_presets { name } }', '--json']),
+    ).resolves.toBe(EXIT.ok);
+
+    expect(jsonOut().data.links).toEqual([
+      {
+        path: 'resource_presets',
+        resource: 'resource_preset',
+        webui_path: '/admin/environment?tab=preset',
+        webui_url: `${WEBUI}/admin/environment?tab=preset`,
+      },
+    ]);
+  });
+
+  it('covers the other list-only root fields the manual points at', async () => {
+    stubFetch({
+      data: {
+        agent_list: { items: [{ id: 'agent-1' }] },
+        scaling_groups: [{ name: 'default' }],
+        groups: [{ id: 'g-1' }],
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        `query {
+          agent_list(limit: 1, offset: 0) { items { id } }
+          scaling_groups { name }
+          groups { id }
+        }`,
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    expect(
+      jsonOut().data.links.map((link: any) => [link.resource, link.webui_path]),
+    ).toEqual([
+      ['agent', '/admin/agent?tab=agents'],
+      ['resource_group', '/admin/agent?tab=resourceGroup'],
+      ['project', '/admin/project'],
+    ]);
+  });
+
+  it('emits no list link for a root field that came back empty', async () => {
+    stubFetch({ data: { resource_presets: [] } });
+
+    await expect(
+      run(['query', 'query { resource_presets { name } }', '--json']),
     ).resolves.toBe(EXIT.ok);
     expect(jsonOut().data.links).toEqual([]);
   });

--- a/packages/backend.ai-agent-cli/src/commands/query.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.test.ts
@@ -42,11 +42,18 @@ const jsonErr = () =>
     suggestions?: string[];
   };
 
+/** A per-row uuid — the form the WebUI pages actually take. */
+const rowUuid = (index: number) =>
+  `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+
+const globalId = (type: string, id: string) =>
+  Buffer.from(`${type}:${id}`, 'utf8').toString('base64');
+
 const sessionEdges = (count: number) =>
   Array.from({ length: count }, (_, index) => ({
     node: {
-      id: `Q29tcHV0ZVNlc3Npb246${index}`,
-      row_id: `row-${index}`,
+      id: globalId('ComputeSessionNode', rowUuid(index)),
+      row_id: rowUuid(index),
       name: `session-${index}`,
       status_info: 'x'.repeat(400),
     },
@@ -323,14 +330,85 @@ describe('webui link annotation', () => {
     expect(data.links[0]).toMatchObject({
       path: 'compute_session_nodes.edges[0].node',
       resource: 'session',
-      id: 'row-0',
-      webui_path: '/session?sessionDetail=row-0',
-      webui_url: `${WEBUI}/session?sessionDetail=row-0`,
+      id: rowUuid(0),
+      webui_path: `/session?sessionDetail=${rowUuid(0)}`,
+      webui_url: `${WEBUI}/session?sessionDetail=${rowUuid(0)}`,
     });
     // The annotation is on the node itself, not only in `links`.
     expect(
       data.result.compute_session_nodes.edges[1].node.webui_path,
-    ).toBe('/session?sessionDetail=row-1');
+    ).toBe(`/session?sessionDetail=${rowUuid(1)}`);
+  });
+
+  it('decodes the Relay global id when only `id` was selected', async () => {
+    stubFetch({
+      data: {
+        compute_session_nodes: {
+          edges: [{ node: { id: globalId('ComputeSessionNode', rowUuid(7)) } }],
+        },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        'query { compute_session_nodes(first: 1) { edges { node { id } } } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    // The base64 global id itself opens nothing — the page takes the uuid.
+    expect(jsonOut().data.links[0]).toMatchObject({
+      id: rowUuid(7),
+      webui_path: `/session?sessionDetail=${rowUuid(7)}`,
+    });
+  });
+
+  it('links the created folder of a createVfolderV2 payload', async () => {
+    stubFetch({
+      data: {
+        createVfolderV2: { vfolder: { id: globalId('VFolder', rowUuid(3)) } },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        'mutation { createVfolderV2(input: {name: "x"}) { vfolder { id } } }',
+        '--allow-mutation',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    expect(jsonOut().data.links).toEqual([
+      {
+        path: 'createVfolderV2.vfolder',
+        resource: 'vfolder',
+        id: rowUuid(3),
+        webui_path: `/data?folder=${rowUuid(3)}`,
+        webui_url: `${WEBUI}/data?folder=${rowUuid(3)}`,
+      },
+    ]);
+  });
+
+  it('hints instead of linking when the id resolves to no uuid', async () => {
+    stubFetch({
+      data: { compute_session_nodes: { edges: [{ node: { id: 'row-0' } }] } },
+    });
+
+    await expect(
+      run([
+        'query',
+        'query { compute_session_nodes(first: 1) { edges { node { id } } } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    const data = jsonOut().data;
+    expect(data.links).toEqual([]);
+    const node = data.result.compute_session_nodes.edges[0].node;
+    expect(node.webui_path).toBeUndefined();
+    expect(node.webui_link_hint).toContain('select row_id');
   });
 
   it('prefers --webui over the stored origin', async () => {
@@ -344,7 +422,7 @@ describe('webui link annotation', () => {
       '--json',
     ]);
     expect(jsonOut().data.links[0].webui_url).toBe(
-      'https://ui.example.com/session?sessionDetail=row-0',
+      `https://ui.example.com/session?sessionDetail=${rowUuid(0)}`,
     );
   });
 
@@ -469,6 +547,26 @@ describe('auth', () => {
   });
 });
 
+describe('--json links notice', () => {
+  it('prints a links summary to stderr, not stdout', async () => {
+    stubFetch({ data: { compute_session_nodes: { edges: sessionEdges(1) } } });
+
+    await expect(
+      run([
+        'query',
+        'query { compute_session_nodes(first: 1) { edges { node { id row_id name } } } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    const notice = err.join('');
+    expect(notice).toBe(
+      `links: 1 — session ${WEBUI}/session?sessionDetail=${rowUuid(0)}\n`,
+    );
+    expect(jsonOut().data.links).toHaveLength(1);
+  });
+});
+
 describe('text output', () => {
   it('mirrors the JSON surface', async () => {
     stubFetch({ data: { compute_session_nodes: { edges: sessionEdges(1) } } });
@@ -482,7 +580,7 @@ describe('text output', () => {
 
     const printed = out.join('');
     expect(printed).toContain('operation:');
-    expect(printed).toContain('/session?sessionDetail=row-0');
+    expect(printed).toContain(`/session?sessionDetail=${rowUuid(0)}`);
     expect(printed).toContain('session-0');
   });
 });

--- a/packages/backend.ai-agent-cli/src/commands/query.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.test.ts
@@ -525,6 +525,107 @@ describe('list-page links', () => {
     ).resolves.toBe(EXIT.ok);
     expect(jsonOut().data.links).toEqual([]);
   });
+
+  it('points a Strawberry keypair list at the credentials tab', async () => {
+    stubFetch({
+      data: {
+        adminKeypairsV2: {
+          edges: [{ node: { id: 'S2V5UGFpclYyOjA=', accessKey: 'AKIA' } }],
+          count: 1,
+        },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        'query { adminKeypairsV2(first: 1) { edges { node { id accessKey } } count } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    expect(jsonOut().data.links).toEqual([
+      {
+        path: 'adminKeypairsV2',
+        resource: 'keypair',
+        webui_path: '/admin/users?tab=credentials',
+        webui_url: `${WEBUI}/admin/users?tab=credentials`,
+      },
+    ]);
+  });
+
+  it('points a Strawberry image list at the environment page', async () => {
+    stubFetch({
+      data: {
+        adminImagesV2: {
+          edges: [{ node: { id: 'SW1hZ2VWMjow' } }],
+          count: 1,
+        },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        'query { adminImagesV2(first: 1) { edges { node { id } } count } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+
+    expect(jsonOut().data.links).toEqual([
+      {
+        path: 'adminImagesV2',
+        resource: 'environment',
+        webui_path: '/admin/environment',
+        webui_url: `${WEBUI}/admin/environment`,
+      },
+    ]);
+  });
+
+  it('emits no list link for a connection whose edges came back empty', async () => {
+    stubFetch({ data: { user_nodes: { edges: [], count: 0 } } });
+
+    await expect(
+      run([
+        'query',
+        'query { user_nodes(first: 2) { edges { node { id } } count } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+    expect(jsonOut().data.links).toEqual([]);
+  });
+
+  it('emits no list link for a Graphene list whose items came back empty', async () => {
+    stubFetch({ data: { agent_list: { items: [], total_count: 0 } } });
+
+    await expect(
+      run([
+        'query',
+        'query { agent_list(limit: 1, offset: 0) { items { id } total_count } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+    expect(jsonOut().data.links).toEqual([]);
+  });
+
+  it('keeps the list link when the connection carries rows', async () => {
+    stubFetch({
+      data: {
+        user_nodes: { edges: [{ node: { id: 'VXNlcjow' } }], count: 1 },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        'query { user_nodes(first: 2) { edges { node { id } } count } }',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+    expect(
+      jsonOut().data.links.map((link: any) => link.webui_path),
+    ).toEqual(['/admin/users?tab=users']);
+  });
 });
 
 describe('auth', () => {

--- a/packages/backend.ai-agent-cli/src/commands/query.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.test.ts
@@ -626,6 +626,39 @@ describe('list-page links', () => {
       jsonOut().data.links.map((link: any) => link.webui_path),
     ).toEqual(['/admin/users?tab=users']);
   });
+
+  it('emits no list link for a singular root field', async () => {
+    // `Query.user` returns `User`, the same type `user_nodes` lists — but the
+    // users page is a list of many, and it is admin-only, so a regular account
+    // asking for its own row would have got a link it cannot open.
+    stubFetch({ data: { user: { email: 'alice@example.com' } } });
+
+    await expect(
+      run(['query', 'query { user { email } }', '--json']),
+    ).resolves.toBe(EXIT.ok);
+    expect(jsonOut().data.links).toEqual([]);
+  });
+
+  it('emits no list link for a singular image or keypair either', async () => {
+    stubFetch({
+      data: {
+        image: { name: 'python' },
+        keypair: { access_key: 'AKIA' },
+      },
+    });
+
+    await expect(
+      run([
+        'query',
+        `query {
+          image(reference: "python") { name }
+          keypair(access_key: "AKIA") { access_key }
+        }`,
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.ok);
+    expect(jsonOut().data.links).toEqual([]);
+  });
 });
 
 describe('auth', () => {

--- a/packages/backend.ai-agent-cli/src/commands/query.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.ts
@@ -21,6 +21,7 @@ import {
   validateAgainstSchema,
 } from '../query/document.js';
 import { DEFAULT_MAX_BYTES, jsonBytes, truncateToBudget } from '../query/truncate.js';
+import { cookbookCommandFor } from './cookbook.js';
 import { ENDPOINT_FLAG } from './whoami.js';
 import { readFileSync } from 'node:fs';
 
@@ -91,6 +92,18 @@ function readStdinSync(): string {
   }
 }
 
+const MAX_LINKS_SHOWN = 5;
+
+/** `links: <n> — <resource> <url>[, ...]`, capped at `MAX_LINKS_SHOWN`. */
+function formatLinksNotice(links: QueryLink[]): string {
+  const shown = links
+    .slice(0, MAX_LINKS_SHOWN)
+    .map((link) => `${link.resource} ${link.webui_url ?? link.webui_path}`)
+    .join(', ');
+  const more = links.length > MAX_LINKS_SHOWN ? ', …' : '';
+  return `links: ${links.length} — ${shown}${more}`;
+}
+
 function parseMaxBytes(raw: string | undefined): number {
   if (raw === undefined) return DEFAULT_MAX_BYTES;
   const parsed = Number(raw);
@@ -118,6 +131,23 @@ function refuseMutation(field: string, allowFlagGiven: boolean): CliError {
       ...(page ? [`do it in the WebUI at ${page}`] : []),
     ],
     hint: page ?? `${CLI_NAME} query --help`,
+  });
+}
+
+/**
+ * A document the local SDL rejects is a hand-written one; carry the cookbook
+ * entry for its root field next to the validator messages.
+ */
+function withCookbookPointer(error: unknown, rootFields: string[]): unknown {
+  if (!(error instanceof CliError) || error.code !== 'schema_mismatch') {
+    return error;
+  }
+  return new CliError('schema_mismatch', error.message, {
+    suggestions: [
+      ...(error.suggestions ?? []),
+      cookbookCommandFor(rootFields),
+    ],
+    hint: error.hint,
   });
 }
 
@@ -171,7 +201,14 @@ export const queryCommand = defineCommand<QueryData>({
     const variables = parseVariables(flagList(context.flags, 'var'));
 
     const { document, operations } = parseDocument(source);
-    validateAgainstSchema(executableSchema(repo), document);
+    try {
+      validateAgainstSchema(executableSchema(repo), document);
+    } catch (error) {
+      throw withCookbookPointer(
+        error,
+        operations.flatMap((operation) => operation.rootFields),
+      );
+    }
 
     const allowMutation = context.flags['allow-mutation'] === true;
     const mutations = operations.filter(
@@ -222,6 +259,12 @@ export const queryCommand = defineCommand<QueryData>({
     );
     const cut = truncateToBudget(raw, maxBytes);
     const links = survivingLinks(annotated, cut.value);
+
+    // Text mode renders links in its own block; --json's stdout is a single
+    // envelope, so this is the only place a --json caller sees them at all.
+    if (context.json && links.length > 0) {
+      context.notify(formatLinksNotice(links));
+    }
 
     return {
       endpoint,

--- a/packages/backend.ai-agent-cli/src/commands/query.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.ts
@@ -262,7 +262,14 @@ export const queryCommand = defineCommand<QueryData>({
         list(
           data.links.map(
             (link) =>
-              `${link.path} ${link.resource} ${link.id} ${link.webui_url ?? link.webui_path}`,
+              [
+                link.path,
+                link.resource,
+                link.id,
+                link.webui_url ?? link.webui_path,
+              ]
+                .filter(Boolean)
+                .join(' '),
           ),
         ),
       );

--- a/packages/backend.ai-agent-cli/src/commands/whoami.ts
+++ b/packages/backend.ai-agent-cli/src/commands/whoami.ts
@@ -27,6 +27,8 @@ export interface WhoamiData extends WhoAmI {
   /** Masked; the raw id is never rendered. */
   sessionId: string;
   sessionFile: string;
+  /** The WebUI checkout's own version — not the manager's, not the SDL tag. */
+  repoVersion?: string;
   /** Absent outside a checkout, or when the manager version is unreadable. */
   manager?: ManagerReachability;
   alignment?: VersionAlignment;
@@ -83,6 +85,7 @@ export const whoamiCommand = defineCommand<WhoamiData>({
         endpoint,
         sessionId: maskSessionId(stored.sessionId),
         sessionFile: stored.path,
+        ...(repo.ok ? { repoVersion: repo.context.repoVersion } : {}),
         ...(gate.manager ? { manager: gate.manager } : {}),
         ...(gate.alignment ? { alignment: gate.alignment } : {}),
       };
@@ -104,6 +107,8 @@ export const whoamiCommand = defineCommand<WhoamiData>({
         ['domain', data.domainName],
         ['endpoint', data.endpoint],
         ['manager', data.manager?.managerVersion],
+        ['schemaTag', data.alignment?.schemaTag],
+        ['repoVersion', data.repoVersion],
         ...(verbosity === 'dense'
           ? []
           : ([

--- a/packages/backend.ai-agent-cli/src/init/block.test.ts
+++ b/packages/backend.ai-agent-cli/src/init/block.test.ts
@@ -2,6 +2,7 @@ import { EXIT } from '../errors.js';
 import { COMMANDS } from '../registry.js';
 import { resolveRepoContext } from '../repo-context.js';
 import { runCli } from '../run.js';
+import { installedSkillPath } from '../skill-path.js';
 import {
   AGENTS_MD,
   applyBlock,
@@ -9,7 +10,6 @@ import {
   BLOCK_START,
   CLAUDE_MD,
   findBlockRegion,
-  INSTALLED_SKILL_PATH,
   renderAgentBlock,
   resolveBlockTarget,
 } from './block.js';
@@ -102,12 +102,38 @@ describe('init', () => {
   it('renders the standalone block for an installed skill', () => {
     const block = renderAgentBlock(COMMANDS, { mode: 'standalone' });
     expect(block).toContain('npm i -g backend.ai-agent-cli');
-    expect(block).toContain(INSTALLED_SKILL_PATH);
+    expect(block).toContain(installedSkillPath());
     expect(block).not.toContain('pnpm run bai-agent');
     expect(block).not.toContain('.claude/rules/graphql-pagination.md');
     expect(normalise(renderAgentBlock(COMMANDS))).toBe(
       normalise(renderAgentBlock(COMMANDS, { mode: 'checkout' })),
     );
+  });
+
+  it('names the directory the skill was installed into, not a fixed ~/.claude', () => {
+    const skillPath = '/opt/cfg/skills/bai-agent/SKILL.md';
+    const block = renderAgentBlock(COMMANDS, { mode: 'standalone', skillPath });
+    expect(block).toContain(skillPath);
+    expect(block).toContain(
+      '/opt/cfg/skills/bai-agent/references/query-cookbook.md',
+    );
+    expect(block).not.toContain(installedSkillPath());
+  });
+
+  it('states the preflight, link and session rules the skill relies on', () => {
+    for (const mode of ['checkout', 'standalone'] as const) {
+      const block = renderAgentBlock(COMMANDS, { mode });
+      expect(block).toContain('doctor --json');
+      expect(block).toContain('doctor --brief');
+      expect(block).toContain("only when doctor's session check is `warn`");
+      expect(block).not.toContain('Then `bai-agent whoami`');
+      expect(block).toContain('Empty `data.links`');
+      expect(block).toContain('pick the link by `id`');
+      expect(block).toContain('print `data.links` too');
+      expect(block).toContain('~/.config/backend.ai-agent/sessions');
+      expect(block).toContain('never `cd` first');
+      expect(block).toContain('no React source');
+    }
   });
 
   it('rejects an unknown feature as a usage error', async () => {

--- a/packages/backend.ai-agent-cli/src/init/block.ts
+++ b/packages/backend.ai-agent-cli/src/init/block.ts
@@ -73,13 +73,13 @@ export function renderAgentBlock(
       ? [
           'Agent-facing CLI over a synced Backend.AI WebUI data checkout: the user manual, the GraphQL schema, the i18n stores and — once logged in — the live manager.',
           `CLI: \`${CLI_NAME} <cmd>\` (npm: \`npm i -g backend.ai-agent-cli\`). \`${CLI_NAME} init\` records the endpoint, syncs the data for that manager's version and installs this skill; \`${CLI_NAME} sync\` refreshes the data.`,
-          `Preflight, answer-or-link rules and a ready-to-run query cookbook: the \`${CLI_NAME}\` skill (\`${skillPath}\`).`,
+          `Preflight, answer-or-link rules and a ready-to-run query cookbook: the \`${CLI_NAME}\` skill (\`${skillPath}\`), cookbook at \`${skillPath.replace(/SKILL\.md$/, '')}references/query-cookbook.md\`.`,
         ]
       : [
           'Agent-facing CLI over this checkout: the user manual, the GraphQL schema, the i18n stores and — once logged in — the live manager.',
           `CLI: run every command as \`${PROXY} <cmd>\` from the repository root (shown below as \`${CLI_NAME} ...\`).`,
           `The proxy runs the bundle, so build it first: \`${BUILD}\`. Without the proxy, still from the repository root: \`${DIST} <cmd>\`.`,
-          `Preflight, answer-or-link rules and a ready-to-run query cookbook: the \`${CLI_NAME}\` skill, shipped with the CLI (\`packages/backend.ai-agent-cli/skill/SKILL.md\`) and installed per user by \`${PROXY} init --skill --no-login\`.`,
+          `Preflight, answer-or-link rules and a ready-to-run query cookbook: the \`${CLI_NAME}\` skill, shipped with the CLI (\`packages/backend.ai-agent-cli/skill/SKILL.md\`, cookbook at \`packages/backend.ai-agent-cli/skill/references/query-cookbook.md\`) and installed per user by \`${PROXY} init --skill --no-login\`.`,
         ]),
     '',
     "WORKFLOW — discover, don't guess. Before answering anything about Backend.AI data:",
@@ -89,6 +89,8 @@ export function renderAgentBlock(
     `4. \`${CLI_NAME} query '<document>'\` — ask the manager. Validated against the ${standalone ? 'synced' : "checkout's"} SDL before any network call. Rows come back carrying \`webui_path\` / \`webui_url\` under \`data.links\` — hand that to the user so they can open it themselves.`,
     '',
     `OUTPUT: \`--json\` prints one envelope on stdout — {"apiVersion":"${API_VERSION}","type":…,"data":…}; a failure prints {"apiVersion","error","code","suggestions?","hint?"} on stderr and nothing on stdout. Text is the same data as aligned \`key: value\` records. \`hint\` is a concrete next step — a command to run, or for a refused mutation, the WebUI page to do it on — never prose.`,
+    `\`query\` results: rows are at \`data.result.<rootField>\`, links at \`data.links[]\` (\`webui_path\` / \`webui_url\`); the same fields are also inlined on each linked row.`,
+    "Piping through `| head` hides the exit code and truncates doctor's alignment/session checks — read the JSON `code` field or the exit status instead.",
     `EXIT: ${exitLine()}.`,
     '',
     'RULES:',

--- a/packages/backend.ai-agent-cli/src/init/block.ts
+++ b/packages/backend.ai-agent-cli/src/init/block.ts
@@ -2,6 +2,7 @@ import type { AnyCommand } from '../command.js';
 import { CliError, exitLine } from '../errors.js';
 import { CLI_NAME } from '../meta.js';
 import { API_VERSION } from '../output.js';
+import { installedSkillPath } from '../skill-path.js';
 import type { Stats } from 'node:fs';
 import {
   existsSync,
@@ -44,12 +45,9 @@ export type BlockMode = 'checkout' | 'standalone';
 
 export interface BlockOptions {
   mode?: BlockMode;
-  /** Standalone: where the skill was actually installed (defaults to `~/.claude`). */
+  /** Standalone: where the skill was actually installed; the installer passes it. */
   skillPath?: string;
 }
-
-/** Where the installed skill lives by default, as the standalone block names it. */
-export const INSTALLED_SKILL_PATH = `~/.claude/skills/${CLI_NAME}/SKILL.md`;
 
 const pad = (rows: Array<[string, string]>): string[] => {
   const width = Math.max(0, ...rows.map(([left]) => left.length));
@@ -65,7 +63,7 @@ export function renderAgentBlock(
   options: BlockOptions = {},
 ): string {
   const standalone = options.mode === 'standalone';
-  const skillPath = options.skillPath ?? INSTALLED_SKILL_PATH;
+  const skillPath = options.skillPath ?? installedSkillPath();
   const lines = [
     BLOCK_START,
     `${CLI_NAME} · ${commands.length} commands`,
@@ -83,13 +81,13 @@ export function renderAgentBlock(
         ]),
     '',
     "WORKFLOW — discover, don't guess. Before answering anything about Backend.AI data:",
-    `1. \`${CLI_NAME} doctor\` — ${standalone ? 'synced data' : 'checkout'} and stored session in one pass; exit 0 means the environment is ok. Then \`${CLI_NAME} whoami\` — exit 3 means log in (see RULES).`,
+    `1. \`${CLI_NAME} doctor --brief\` (\`doctor --json\` for a specific field) — run it ONCE: ${standalone ? 'synced data' : 'checkout'} and stored session in one pass; exit 0 means the environment is ok. Run \`${CLI_NAME} whoami\` only when doctor's session check is \`warn\` — exit 3 means log in (see RULES).`,
     `2. \`${CLI_NAME} search "<english UI term>"\` — START HERE: one ranked list over manual + schema + terminology. Every hit carries the \`command:\` that opens it.`,
     `3. \`${CLI_NAME} docs show <id>\` · \`schema show <Type>.<field>\` · \`explain <Type>.<field>=<VALUE>\` — the hit in full. \`schema show\` is what the SDL declares; \`explain\` is what it means to a user.`,
     `4. \`${CLI_NAME} query '<document>'\` — ask the manager. Validated against the ${standalone ? 'synced' : "checkout's"} SDL before any network call. Rows come back carrying \`webui_path\` / \`webui_url\` under \`data.links\` — hand that to the user so they can open it themselves.`,
     '',
     `OUTPUT: \`--json\` prints one envelope on stdout — {"apiVersion":"${API_VERSION}","type":…,"data":…}; a failure prints {"apiVersion","error","code","suggestions?","hint?"} on stderr and nothing on stdout. Text is the same data as aligned \`key: value\` records. \`hint\` is a concrete next step — a command to run, or for a refused mutation, the WebUI page to do it on — never prose.`,
-    `\`query\` results: rows are at \`data.result.<rootField>\`, links at \`data.links[]\` (\`webui_path\` / \`webui_url\`); the same fields are also inlined on each linked row.`,
+    `\`query\` results: rows are at \`data.result.<rootField>\`, links at \`data.links[]\` (\`webui_path\` / \`webui_url\`); the same fields are also inlined on each linked row. When you post-process the envelope (jq/python), print \`data.links\` too — a filter that drops it drops the answer's link.`,
     "Piping through `| head` hides the exit code and truncates doctor's alignment/session checks — read the JSON `code` field or the exit status instead.",
     `EXIT: ${exitLine()}.`,
     '',
@@ -101,6 +99,9 @@ export function renderAgentBlock(
     "- Destructive actions (delete, purge, terminate, revoke) are never run from here. Give the human the WebUI page from the refusal's `hint` and let them press the button.",
     `- Exit 3 \`auth_required\` → \`${CLI_NAME} login --endpoint <url>\`; ${standalone ? `the endpoint is the one \`${CLI_NAME} init\` recorded (\`${CLI_NAME} doctor\` shows it)` : 'take the endpoint and the account from the `webui-connection-info` skill'}. The CLI never handles a password: \`login\` borrows the browser's session, and \`--paste\` covers a browser that cannot reach this machine.`,
     '- Cite what the CLI returned: `search`, `docs show` and `explain` carry a deployed-docs `url`. `explain` prints `MISSING` for a piece nothing curates — report that, never fill it in from memory.',
+    '- Empty `data.links` means the resource has no addressable page: say so, never compose a WebUI path by hand. A row carrying `webui_link_hint` is the other case — the id you selected cannot build a link; re-run selecting `row_id`. When several rows share a name, pick the link by `id`.',
+    `- Never read the session store (\`~/.config/backend.ai-agent/sessions\`) or reuse its session id outside \`${CLI_NAME}\` — the mutation gate only applies to calls that go through the CLI.`,
+    `- Run \`${CLI_NAME}\` from wherever you already are, never \`cd\` first. The synced data copy holds schema, i18n and docs only — no React source, so do not grep it for \`.tsx\`.`,
     standalone
       ? `- Re-run \`${CLI_NAME} init\` after upgrading the CLI; it rewrites this block and the skill.`
       : `- Re-run \`${CLI_NAME} init --features ${FEATURE_AGENTS}\` after any CLI change and re-sync this block.`,

--- a/packages/backend.ai-agent-cli/src/query/links.test.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { annotateLinks, NO_LINK_HINT, resolveLinkId } from './links.js';
+import {
+  annotateLinks,
+  LIST_RESOURCE_BY_TYPE,
+  NO_LINK_HINT,
+  resolveLinkId,
+} from './links.js';
 
 const UUID = '4a3b2c1d-0e9f-4a8b-9c7d-6e5f4a3b2c1d';
 const globalId = (type: string, id: string) =>
@@ -57,5 +62,29 @@ describe('annotateLinks', () => {
     expect(annotateLinks(value, 'session', 'node', undefined)).toEqual([]);
     expect(value.webui_link_hint).toBe(NO_LINK_HINT);
     expect(value.webui_path).toBeUndefined();
+  });
+});
+
+describe('LIST_RESOURCE_BY_TYPE', () => {
+  it('carries both subgraph spellings of every resource it covers', () => {
+    // The Strawberry rows the table used to be missing: `adminKeypairsV2`
+    // resolves to `KeyPairV2` and `adminImagesV2` to `ImageV2`, so without
+    // them the V2 lists got no link although their Graphene twins did.
+    expect(LIST_RESOURCE_BY_TYPE.KeyPairV2).toBe('keypair');
+    expect(LIST_RESOURCE_BY_TYPE.ImageV2).toBe('environment');
+
+    for (const [graphene, strawberry] of [
+      ['User', 'UserV2'],
+      ['KeyPair', 'KeyPairV2'],
+      ['Agent', 'AgentV2'],
+      ['ScalingGroup', 'ResourceGroup'],
+      ['Group', 'ProjectV2'],
+      ['ResourcePreset', 'ResourcePresetV2'],
+      ['Image', 'ImageV2'],
+    ] as const) {
+      expect(LIST_RESOURCE_BY_TYPE[strawberry]).toBe(
+        LIST_RESOURCE_BY_TYPE[graphene],
+      );
+    }
   });
 });

--- a/packages/backend.ai-agent-cli/src/query/links.test.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { annotateLinks, NO_LINK_HINT, resolveLinkId } from './links.js';
+
+const UUID = '4a3b2c1d-0e9f-4a8b-9c7d-6e5f4a3b2c1d';
+const globalId = (type: string, id: string) =>
+  Buffer.from(`${type}:${id}`, 'utf8').toString('base64');
+
+describe('resolveLinkId', () => {
+  it('passes a uuid through, dashed or 32-hex', () => {
+    expect(resolveLinkId('session', UUID)).toBe(UUID);
+    expect(resolveLinkId('vfolder', UUID.replaceAll('-', ''))).toBe(
+      UUID.replaceAll('-', ''),
+    );
+  });
+
+  it('decodes a Relay global id to the uuid the page takes', () => {
+    expect(resolveLinkId('session', globalId('ComputeSessionNode', UUID))).toBe(
+      UUID,
+    );
+    expect(resolveLinkId('vfolder', globalId('VFolder', UUID))).toBe(UUID);
+  });
+
+  it('refuses an id that is neither', () => {
+    expect(resolveLinkId('session', 'row-0')).toBeUndefined();
+    // Base64 that decodes to something with no uuid in it.
+    expect(
+      resolveLinkId('session', globalId('ComputeSessionNode', 'not-a-uuid')),
+    ).toBeUndefined();
+    expect(
+      resolveLinkId('vfolder', Buffer.from(UUID).toString('base64')),
+    ).toBeUndefined();
+  });
+
+  it('keeps the global id for the one page that matches on it', () => {
+    const encoded = globalId('RoleNode', UUID);
+    expect(resolveLinkId('role', encoded)).toBe(encoded);
+  });
+});
+
+describe('annotateLinks', () => {
+  it('links a node carrying only a global id', () => {
+    const value = { id: globalId('ComputeSessionNode', UUID) };
+    const links = annotateLinks(value, 'session', 'node', undefined);
+
+    expect(links).toEqual([
+      {
+        path: 'node',
+        resource: 'session',
+        id: UUID,
+        webui_path: `/session?sessionDetail=${UUID}`,
+      },
+    ]);
+  });
+
+  it('hints instead of linking when the id resolves to nothing', () => {
+    const value = { id: 'row-0' } as Record<string, unknown>;
+    expect(annotateLinks(value, 'session', 'node', undefined)).toEqual([]);
+    expect(value.webui_link_hint).toBe(NO_LINK_HINT);
+    expect(value.webui_path).toBeUndefined();
+  });
+});

--- a/packages/backend.ai-agent-cli/src/query/links.test.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.test.ts
@@ -1,9 +1,13 @@
+import { resolveRepoContext } from '../repo-context.js';
+import { loadSchema } from '../search/schema-sdl.js';
 import { describe, expect, it } from 'vitest';
 import {
   annotateLinks,
   LIST_RESOURCE_BY_TYPE,
+  listResourceForRootField,
   NO_LINK_HINT,
   resolveLinkId,
+  resourceForRootField,
 } from './links.js';
 
 const UUID = '4a3b2c1d-0e9f-4a8b-9c7d-6e5f4a3b2c1d';
@@ -86,5 +90,76 @@ describe('LIST_RESOURCE_BY_TYPE', () => {
         LIST_RESOURCE_BY_TYPE[graphene],
       );
     }
+  });
+});
+
+describe('listResourceForRootField', () => {
+  const schema = loadSchema(resolveRepoContext(import.meta.dirname));
+  const listOf = (field: string) =>
+    listResourceForRootField(schema, 'Query', field);
+
+  it('gives a singular root field no list link', () => {
+    // Each of these resolves to a type that IS in `LIST_RESOURCE_BY_TYPE`, so
+    // the type name alone would link it — but one row is not a list, and most
+    // of those pages are admin-only.
+    for (const field of [
+      'user',
+      'user_from_uuid',
+      'user_node',
+      'keypair',
+      'agent',
+      'group',
+      'image',
+      'resource_preset',
+      'scaling_group',
+    ]) {
+      expect([field, listOf(field)]).toEqual([field, undefined]);
+    }
+  });
+
+  it('still links every list-shaped root field the table covers', () => {
+    const fields = [
+      // GraphQL list types — `[User]`, `[Agent]`, …
+      ['users', 'user'],
+      ['keypairs', 'keypair'],
+      ['agents', 'agent'],
+      ['groups', 'project'],
+      ['groups_by_name', 'project'],
+      ['scaling_groups', 'resource_group'],
+      ['resource_presets', 'resource_preset'],
+      ['images', 'environment'],
+      // Graphene `*List` containers — `items: [X]!`
+      ['user_list', 'user'],
+      ['keypair_list', 'keypair'],
+      ['agent_list', 'agent'],
+      // Relay connections — `edges { node }`
+      ['user_nodes', 'user'],
+      ['agent_nodes', 'agent'],
+      ['group_nodes', 'project'],
+      ['image_nodes', 'environment'],
+      ['adminUsersV2', 'user'],
+      ['myKeypairs', 'keypair'],
+      ['adminKeypairsV2', 'keypair'],
+      ['adminProjectsV2', 'project'],
+      ['domainProjectsV2', 'project'],
+      ['adminResourcePresetsV2', 'resource_preset'],
+      ['adminImagesV2', 'environment'],
+    ] as const;
+
+    expect(fields.map(([field]) => [field, listOf(field)])).toEqual(
+      fields.map(([field, resource]) => [field, resource]),
+    );
+  });
+
+  it('leaves the per-row link of a singular root field alone', () => {
+    // The list-shape rule is `listResourceForRootField`'s alone: a detail page
+    // addresses one row, which is exactly what a singular field returns.
+    expect(resourceForRootField(schema, 'Query', 'compute_session')).toBe(
+      'session',
+    );
+    expect(resourceForRootField(schema, 'Query', 'vfolder_node')).toBe(
+      'vfolder',
+    );
+    expect(resourceForRootField(schema, 'Query', 'endpoint')).toBe('deployment');
   });
 });

--- a/packages/backend.ai-agent-cli/src/query/links.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.ts
@@ -52,6 +52,7 @@ export const LIST_RESOURCE_BY_TYPE: Readonly<Record<string, ListResource>> = {
   UserV2: 'user',
   // keypairs — /admin/users?tab=credentials
   KeyPair: 'keypair',
+  KeyPairV2: 'keypair',
   // agents — /admin/agent?tab=agents
   Agent: 'agent',
   AgentNode: 'agent',
@@ -69,6 +70,7 @@ export const LIST_RESOURCE_BY_TYPE: Readonly<Record<string, ListResource>> = {
   // images — /admin/environment, whose default tab is the image list
   Image: 'environment',
   ImageNode: 'environment',
+  ImageV2: 'environment',
 };
 
 /**
@@ -309,10 +311,24 @@ export function listLink(
   };
 }
 
-const isEmptyRootField = (value: unknown): boolean =>
-  value === null ||
-  value === undefined ||
-  (Array.isArray(value) && value.length === 0);
+/**
+ * Empty enough that a list link would point at rows the result does not have.
+ * Besides a null and a bare `[]`, that covers the two containers the schema
+ * wraps rows in: a Relay connection (`edges`) and a Graphene list (`items`).
+ * Conservative on purpose — an object carrying neither key says nothing about
+ * emptiness, so it keeps its link.
+ */
+const isEmptyRootField = (value: unknown): boolean => {
+  if (value === null || value === undefined) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value !== 'object') return false;
+  const container = value as Record<string, unknown>;
+  for (const key of ['edges', 'items'] as const) {
+    const rows = container[key];
+    if (Array.isArray(rows)) return rows.length === 0;
+  }
+  return false;
+};
 
 /**
  * Annotates each root field of a result whose return type maps to a page: one

--- a/packages/backend.ai-agent-cli/src/query/links.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.ts
@@ -72,12 +72,51 @@ export const LIST_RESOURCE_BY_TYPE: Readonly<Record<string, ListResource>> = {
 };
 
 /**
- * Id fields checked on a node, in **preference** order. `row_id` first: the
+ * Id fields checked on a node, in **preference** order. `row_id` first: most
  * WebUI pages take the raw UUID, not the base64 Relay global id that `id`
  * carries. (The truncator protects the same names — see `UNCUTTABLE_KEYS` —
  * but that list is about what may be cut, not which id wins.)
  */
 export const ID_FIELDS = ['row_id', 'endpoint_id', 'id'] as const;
+
+/**
+ * The id form each detail page's URL param takes. A `uuid` page reads the raw
+ * uuid and opens nothing when handed a global id; `/admin/rbac` matches
+ * `roleDetail` against the node's global `id` (`RBACManagementPage.tsx`).
+ */
+export const ID_FORM: Readonly<Record<LinkedResource, 'uuid' | 'global'>> = {
+  session: 'uuid',
+  vfolder: 'uuid',
+  deployment: 'uuid',
+  model_card: 'uuid',
+  artifact: 'uuid',
+  role: 'global',
+};
+
+/** Annotated on a node whose id cannot produce a link the page would open. */
+export const NO_LINK_HINT =
+  'no WebUI link: this id is neither a uuid nor a Relay global id — select row_id';
+
+const UUID =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})$/i;
+
+const GLOBAL_ID = /^[A-Za-z_][A-Za-z0-9_]*:(.+)$/;
+
+/**
+ * The id to put in a `uuid` page's URL. A Relay global id is base64 of
+ * `<TypeName>:<uuid>`, which those pages reject, so it is decoded; a value
+ * that is neither yields no link rather than one that opens nothing.
+ */
+export function resolveLinkId(
+  resource: LinkedResource,
+  raw: string,
+): string | undefined {
+  if (ID_FORM[resource] === 'global' || UUID.test(raw)) return raw;
+  const inner = GLOBAL_ID.exec(
+    Buffer.from(raw, 'base64').toString('utf8'),
+  )?.[1];
+  return inner !== undefined && UUID.test(inner) ? inner : undefined;
+}
 
 export interface QueryLink {
   /** JSON path of the annotated node inside `data.result`. */
@@ -177,9 +216,11 @@ const idOf = (node: Record<string, unknown>): string | undefined => {
  * Annotates every identifiable node under `value` with `webui_path` (and
  * `webui_url` when an origin is known), **in place**.
  *
- * "Identifiable" is one of `ID_FIELDS` carrying a non-empty string. The walk
- * does not descend into a node it annotated: the first object with an id under
- * a root field IS the row, and its children belong to other types.
+ * "Identifiable" is one of `ID_FIELDS` carrying a non-empty string that
+ * `resolveLinkId` can turn into the id the page takes; a node whose id it
+ * refuses gets `webui_link_hint` instead of a link that opens nothing. The
+ * walk does not descend into a node it saw an id on: the first object with an
+ * id under a root field IS the row, and its children belong to other types.
  */
 export function annotateLinks(
   value: unknown,
@@ -195,8 +236,13 @@ export function annotateLinks(
     }
     if (node === null || typeof node !== 'object') return;
     const object = node as Record<string, unknown>;
-    const id = idOf(object);
-    if (id !== undefined) {
+    const raw = idOf(object);
+    if (raw !== undefined) {
+      const id = resolveLinkId(resource, raw);
+      if (id === undefined) {
+        object.webui_link_hint = NO_LINK_HINT;
+        return;
+      }
       const path_ = resourcePath(refFor(resource, id));
       const link: QueryLink = {
         path,

--- a/packages/backend.ai-agent-cli/src/query/links.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.ts
@@ -1,6 +1,6 @@
 import type { SchemaIndex } from '../search/schema-sdl.js';
-import type { ResourceRef } from '../webui-path.js';
-import { resourcePath, webuiUrl } from '../webui-path.js';
+import type { ListResource, ResourceRef } from '../webui-path.js';
+import { listPath, resourcePath, webuiUrl } from '../webui-path.js';
 
 /** Resource kinds a GraphQL result can be deep-linked to. */
 export type LinkedResource = Extract<
@@ -41,6 +41,37 @@ export const RESOURCE_BY_TYPE: Readonly<Record<string, LinkedResource>> = {
 };
 
 /**
+ * GraphQL type name -> the list page its rows live on, for resources whose page
+ * carries **no** per-row URL param. Consulted only when `RESOURCE_BY_TYPE` has
+ * no row link to give, and it yields ONE link per root field, not per row.
+ */
+export const LIST_RESOURCE_BY_TYPE: Readonly<Record<string, ListResource>> = {
+  // users — /admin/users?tab=users
+  User: 'user',
+  UserNode: 'user',
+  UserV2: 'user',
+  // keypairs — /admin/users?tab=credentials
+  KeyPair: 'keypair',
+  // agents — /admin/agent?tab=agents
+  Agent: 'agent',
+  AgentNode: 'agent',
+  AgentV2: 'agent',
+  // resource groups — /admin/agent?tab=resourceGroup
+  ScalingGroup: 'resource_group',
+  ResourceGroup: 'resource_group',
+  // projects (called groups on the Graphene subgraph) — /admin/project
+  Group: 'project',
+  GroupNode: 'project',
+  ProjectV2: 'project',
+  // resource presets — /admin/environment?tab=preset
+  ResourcePreset: 'resource_preset',
+  ResourcePresetV2: 'resource_preset',
+  // images — /admin/environment, whose default tab is the image list
+  Image: 'environment',
+  ImageNode: 'environment',
+};
+
+/**
  * Id fields checked on a node, in **preference** order. `row_id` first: the
  * WebUI pages take the raw UUID, not the base64 Relay global id that `id`
  * carries. (The truncator protects the same names — see `UNCUTTABLE_KEYS` —
@@ -51,8 +82,9 @@ export const ID_FIELDS = ['row_id', 'endpoint_id', 'id'] as const;
 export interface QueryLink {
   /** JSON path of the annotated node inside `data.result`. */
   path: string;
-  resource: LinkedResource;
-  id: string;
+  resource: LinkedResource | ListResource;
+  /** Absent on a list link: the page has no per-row URL param to carry. */
+  id?: string;
   webui_path: string;
   webui_url?: string;
 }
@@ -67,31 +99,67 @@ const namedFieldType = (
     ?.fields.find((field) => field.name === fieldName)?.namedType;
 
 /**
- * The resource a root field's rows belong to, unwrapping the one level of
- * container the schema uses: a Relay `*Connection` (`edges { node }`) or a
- * Graphene `*List` (`items`).
+ * The row types a root field can resolve to, in match order: the field's own
+ * type, then the one container level the schema uses — a Graphene `*List`
+ * (`items`), a Relay `*Connection` (`edges { node }`), or a single-field
+ * Strawberry `*Payload`, which is unambiguous enough to unwrap.
  */
+function rowTypeCandidates(
+  schema: SchemaIndex,
+  rootTypeName: 'Query' | 'Mutation',
+  fieldName: string,
+): string[] {
+  const named = namedFieldType(schema, rootTypeName, fieldName);
+  if (!named) return [];
+  const candidates = [named];
+
+  const items = namedFieldType(schema, named, 'items');
+  if (items) candidates.push(items);
+
+  const edges = namedFieldType(schema, named, 'edges');
+  const node = edges ? namedFieldType(schema, edges, 'node') : undefined;
+  if (node) candidates.push(node);
+
+  const only = schema.byName.get(named)?.fields;
+  if (only?.length === 1) candidates.push(only[0].namedType);
+
+  return candidates;
+}
+
+const lookupRootField = <T>(
+  table: Readonly<Record<string, T>>,
+  schema: SchemaIndex,
+  rootTypeName: 'Query' | 'Mutation',
+  fieldName: string,
+): T | undefined => {
+  for (const candidate of rowTypeCandidates(schema, rootTypeName, fieldName)) {
+    const hit = table[candidate];
+    if (hit) return hit;
+  }
+  return undefined;
+};
+
+/** The resource a root field's rows deep-link to, one row per link. */
 export function resourceForRootField(
   schema: SchemaIndex,
   rootTypeName: 'Query' | 'Mutation',
   fieldName: string,
 ): LinkedResource | undefined {
-  const named = namedFieldType(schema, rootTypeName, fieldName);
-  if (!named) return undefined;
-  const direct = RESOURCE_BY_TYPE[named];
-  if (direct) return direct;
+  return lookupRootField(RESOURCE_BY_TYPE, schema, rootTypeName, fieldName);
+}
 
-  const items = namedFieldType(schema, named, 'items');
-  if (items && RESOURCE_BY_TYPE[items]) return RESOURCE_BY_TYPE[items];
-
-  const edges = namedFieldType(schema, named, 'edges');
-  const node = edges ? namedFieldType(schema, edges, 'node') : undefined;
-  if (node && RESOURCE_BY_TYPE[node]) return RESOURCE_BY_TYPE[node];
-
-  // Strawberry mutations return a single-field `*Payload` wrapper around the
-  // thing they made, so one field is unambiguous enough to unwrap.
-  const only = schema.byName.get(named)?.fields;
-  return only?.length === 1 ? RESOURCE_BY_TYPE[only[0].namedType] : undefined;
+/** The list page a root field's rows live on, when they have no detail page. */
+export function listResourceForRootField(
+  schema: SchemaIndex,
+  rootTypeName: 'Query' | 'Mutation',
+  fieldName: string,
+): ListResource | undefined {
+  return lookupRootField(
+    LIST_RESOURCE_BY_TYPE,
+    schema,
+    rootTypeName,
+    fieldName,
+  );
 }
 
 const refFor = (resource: LinkedResource, id: string): ResourceRef =>
@@ -178,7 +246,31 @@ export const survivingLinks = (
   links.filter((link) => valueAtPath(truncatedResult, link.path) !== undefined);
 
 /**
- * Annotates each root field of a result whose return type maps to a page.
+ * The list-page link for one root field. Carries no `id` and annotates no row:
+ * the page it points at addresses no single row.
+ */
+export function listLink(
+  resource: ListResource,
+  rootPath: string,
+  webuiOrigin: string | undefined,
+): QueryLink {
+  const path = listPath(resource);
+  return {
+    path: rootPath,
+    resource,
+    webui_path: path,
+    ...(webuiOrigin ? { webui_url: webuiUrl(webuiOrigin, path) } : {}),
+  };
+}
+
+const isEmptyRootField = (value: unknown): boolean =>
+  value === null ||
+  value === undefined ||
+  (Array.isArray(value) && value.length === 0);
+
+/**
+ * Annotates each root field of a result whose return type maps to a page: one
+ * link per row where the page addresses rows, else one link to the list page.
  * Root fields with no mapping are left untouched.
  */
 export function annotateResult(
@@ -193,8 +285,14 @@ export function annotateResult(
     result as Record<string, unknown>,
   )) {
     const resource = resourceForRootField(schema, rootTypeName, field);
-    if (!resource) continue;
-    links.push(...annotateLinks(value, resource, field, webuiOrigin));
+    if (resource) {
+      links.push(...annotateLinks(value, resource, field, webuiOrigin));
+      continue;
+    }
+    const listResource = listResourceForRootField(schema, rootTypeName, field);
+    if (listResource && !isEmptyRootField(value)) {
+      links.push(listLink(listResource, field, webuiOrigin));
+    }
   }
   return links;
 }

--- a/packages/backend.ai-agent-cli/src/query/links.ts
+++ b/packages/backend.ai-agent-cli/src/query/links.ts
@@ -1,4 +1,4 @@
-import type { SchemaIndex } from '../search/schema-sdl.js';
+import type { SchemaField, SchemaIndex } from '../search/schema-sdl.js';
 import type { ListResource, ResourceRef } from '../webui-path.js';
 import { listPath, resourcePath, webuiUrl } from '../webui-path.js';
 
@@ -130,14 +130,26 @@ export interface QueryLink {
   webui_url?: string;
 }
 
-const namedFieldType = (
+const fieldOf = (
   schema: SchemaIndex,
   typeName: string,
   fieldName: string,
-): string | undefined =>
-  schema.byName
-    .get(typeName)
-    ?.fields.find((field) => field.name === fieldName)?.namedType;
+): SchemaField | undefined =>
+  schema.byName.get(typeName)?.fields.find((field) => field.name === fieldName);
+
+/** `[X]`, `[X!]!`, … — a printed type reference carrying a list wrapper. */
+const isListType = (printed: string): boolean => printed.includes('[');
+
+/**
+ * A row type a root field resolves to, plus whether the way there ran through
+ * a list. That is what separates a root field returning MANY rows from one
+ * returning a single object of the same type — `Query.user_nodes` and
+ * `Query.user` both resolve to `User`.
+ */
+interface RowTypeCandidate {
+  typeName: string;
+  listShaped: boolean;
+}
 
 /**
  * The row types a root field can resolve to, in match order: the field's own
@@ -149,20 +161,38 @@ function rowTypeCandidates(
   schema: SchemaIndex,
   rootTypeName: 'Query' | 'Mutation',
   fieldName: string,
-): string[] {
-  const named = namedFieldType(schema, rootTypeName, fieldName);
-  if (!named) return [];
-  const candidates = [named];
+): RowTypeCandidate[] {
+  const root = fieldOf(schema, rootTypeName, fieldName);
+  if (!root) return [];
+  const named = root.namedType;
+  const candidates: RowTypeCandidate[] = [
+    { typeName: named, listShaped: isListType(root.type) },
+  ];
 
-  const items = namedFieldType(schema, named, 'items');
-  if (items) candidates.push(items);
+  const items = fieldOf(schema, named, 'items');
+  if (items) {
+    candidates.push({
+      typeName: items.namedType,
+      listShaped: isListType(items.type),
+    });
+  }
 
-  const edges = namedFieldType(schema, named, 'edges');
-  const node = edges ? namedFieldType(schema, edges, 'node') : undefined;
-  if (node) candidates.push(node);
+  const edges = fieldOf(schema, named, 'edges');
+  const node = edges ? fieldOf(schema, edges.namedType, 'node') : undefined;
+  if (edges && node) {
+    candidates.push({
+      typeName: node.namedType,
+      listShaped: isListType(edges.type),
+    });
+  }
 
   const only = schema.byName.get(named)?.fields;
-  if (only?.length === 1) candidates.push(only[0].namedType);
+  if (only?.length === 1) {
+    candidates.push({
+      typeName: only[0].namedType,
+      listShaped: isListType(only[0].type),
+    });
+  }
 
   return candidates;
 }
@@ -172,9 +202,12 @@ const lookupRootField = <T>(
   schema: SchemaIndex,
   rootTypeName: 'Query' | 'Mutation',
   fieldName: string,
+  /** Skip candidates the root field reaches with no list on the way. */
+  listShapedOnly = false,
 ): T | undefined => {
   for (const candidate of rowTypeCandidates(schema, rootTypeName, fieldName)) {
-    const hit = table[candidate];
+    if (listShapedOnly && !candidate.listShaped) continue;
+    const hit = table[candidate.typeName];
     if (hit) return hit;
   }
   return undefined;
@@ -189,7 +222,14 @@ export function resourceForRootField(
   return lookupRootField(RESOURCE_BY_TYPE, schema, rootTypeName, fieldName);
 }
 
-/** The list page a root field's rows live on, when they have no detail page. */
+/**
+ * The list page a root field's rows live on, when they have no detail page.
+ *
+ * List-shaped root fields only. A list-page link answers "where do these rows
+ * live", which a singular field (`Query.user: User`) never asked; and several
+ * of these pages are admin-only, so a regular account running a query it is
+ * allowed to run would get a link it cannot open.
+ */
 export function listResourceForRootField(
   schema: SchemaIndex,
   rootTypeName: 'Query' | 'Mutation',
@@ -200,6 +240,7 @@ export function listResourceForRootField(
     schema,
     rootTypeName,
     fieldName,
+    true,
   );
 }
 

--- a/packages/backend.ai-agent-cli/src/registry.ts
+++ b/packages/backend.ai-agent-cli/src/registry.ts
@@ -1,4 +1,5 @@
 import type { AnyCommand } from './command.js';
+import { cookbookCommand } from './commands/cookbook.js';
 import { docsCommand } from './commands/docs.js';
 import { doctorCommand } from './commands/doctor.js';
 import { explainCommand } from './commands/explain.js';
@@ -27,6 +28,7 @@ export const COMMANDS: AnyCommand[] = [
   logoutCommand,
   whoamiCommand,
   queryCommand,
+  cookbookCommand,
   explainCommand,
 ];
 

--- a/packages/backend.ai-agent-cli/src/run.test.ts
+++ b/packages/backend.ai-agent-cli/src/run.test.ts
@@ -103,6 +103,7 @@ describe('success envelope', () => {
       'logout',
       'whoami',
       'query',
+      'cookbook',
       'explain',
     ]);
   });

--- a/packages/backend.ai-agent-cli/src/skill-install.test.ts
+++ b/packages/backend.ai-agent-cli/src/skill-install.test.ts
@@ -1,10 +1,11 @@
-import { BLOCK_START, INSTALLED_SKILL_PATH } from './init/block.js';
+import { BLOCK_START } from './init/block.js';
 import { COMMANDS } from './registry.js';
 import {
   AGENT_BLOCK_FILE,
   claudeSkillsDir,
   installSkill,
   installedSkillDir,
+  installedSkillPath,
   shippedSkillDir,
 } from './skill-install.js';
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
@@ -14,9 +15,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('skill install', () => {
   it("resolves the package's own skill/ directory", () => {
-    expect(shippedSkillDir()).toMatch(
-      /[\\/]backend\.ai-agent-cli[\\/]skill$/,
-    );
+    expect(shippedSkillDir()).toMatch(/[\\/]backend\.ai-agent-cli[\\/]skill$/);
     expect(existsSync(join(shippedSkillDir(), 'SKILL.md'))).toBe(true);
   });
 
@@ -25,7 +24,10 @@ describe('skill install', () => {
     expect(claudeSkillsDir({ CLAUDE_CONFIG_DIR: '/cfg' })).toBe(
       join('/cfg', 'skills'),
     );
-    expect(INSTALLED_SKILL_PATH).toBe('~/.claude/skills/bai-agent/SKILL.md');
+    expect(installedSkillPath({})).toBe('~/.claude/skills/bai-agent/SKILL.md');
+    expect(installedSkillPath({ CLAUDE_CONFIG_DIR: '/cfg' })).toBe(
+      join('/cfg', 'skills', 'bai-agent', 'SKILL.md'),
+    );
   });
 
   it('copies the skill, generates the standalone block, and is idempotent', () => {
@@ -44,7 +46,7 @@ describe('skill install', () => {
     expect(block).toContain(BLOCK_START);
     // The block names where the skill actually went, not a fixed ~/.claude.
     expect(block).toContain(join(targetDir, 'SKILL.md'));
-    expect(block).not.toContain(INSTALLED_SKILL_PATH);
+    expect(block).not.toContain(installedSkillPath({}));
     expect(block).toContain('npm i -g backend.ai-agent-cli');
     expect(block).not.toContain('pnpm run bai-agent');
     for (const command of COMMANDS) expect(block).toContain(command.name);

--- a/packages/backend.ai-agent-cli/src/skill-install.ts
+++ b/packages/backend.ai-agent-cli/src/skill-install.ts
@@ -2,6 +2,7 @@ import type { AnyCommand } from './command.js';
 import { CliError } from './errors.js';
 import { renderAgentBlock } from './init/block.js';
 import { CLI_NAME } from './meta.js';
+import { displayPath, installedSkillDir } from './skill-path.js';
 import {
   existsSync,
   mkdirSync,
@@ -11,7 +12,6 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -43,15 +43,12 @@ export function shippedSkillDir(): string {
   );
 }
 
-/** `~/.claude/skills` — or under `$CLAUDE_CONFIG_DIR`, which Claude Code honours. */
-export function claudeSkillsDir(env: Env = process.env): string {
-  const base = env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), '.claude');
-  return join(base, 'skills');
-}
-
-export function installedSkillDir(env: Env = process.env): string {
-  return join(claudeSkillsDir(env), SKILL_NAME);
-}
+export {
+  claudeSkillsDir,
+  displayPath,
+  installedSkillDir,
+  installedSkillPath,
+} from './skill-path.js';
 
 function walk(root: string, dir = root): string[] {
   const files: string[] = [];
@@ -61,12 +58,6 @@ function walk(root: string, dir = root): string[] {
     else files.push(relative(root, path).split(sep).join('/'));
   }
   return files.sort();
-}
-
-/** `~`-relative when under the home directory, as a human would write it. */
-export function displayPath(path: string): string {
-  const home = homedir();
-  return path.startsWith(home + sep) ? `~${path.slice(home.length)}` : path;
 }
 
 export type SkillInstallOutcome = 'installed' | 'updated' | 'unchanged';

--- a/packages/backend.ai-agent-cli/src/skill-path.ts
+++ b/packages/backend.ai-agent-cli/src/skill-path.ts
@@ -1,0 +1,31 @@
+import { CLI_NAME } from './meta.js';
+import { homedir } from 'node:os';
+import { join, sep } from 'node:path';
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Where Claude Code keeps user skills, and how the agent block names the copy
+ * installed there. One home for both, so the block cannot quote a dead path.
+ */
+
+/** `~/.claude/skills` — or under `$CLAUDE_CONFIG_DIR`, which Claude Code honours. */
+export function claudeSkillsDir(env: Env = process.env): string {
+  const base = env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), '.claude');
+  return join(base, 'skills');
+}
+
+export function installedSkillDir(env: Env = process.env): string {
+  return join(claudeSkillsDir(env), CLI_NAME);
+}
+
+/** `~`-relative when under the home directory, as a human would write it. */
+export function displayPath(path: string): string {
+  const home = homedir();
+  return path.startsWith(home + sep) ? `~${path.slice(home.length)}` : path;
+}
+
+/** The installed `SKILL.md`, as the standalone block names it when no install path is given. */
+export function installedSkillPath(env: Env = process.env): string {
+  return displayPath(join(installedSkillDir(env), 'SKILL.md'));
+}

--- a/packages/backend.ai-agent-cli/src/version-align.test.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.test.ts
@@ -9,7 +9,7 @@ import {
   applyVersionAlignmentGate,
   checkVersionAlignment,
 } from './version-align.js';
-import { compareVersions } from './version-order.js';
+import { baseRelease, compareVersions } from './version-order.js';
 import { mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -127,6 +127,21 @@ describe('compareVersions', () => {
   });
 });
 
+describe('baseRelease', () => {
+  it('strips a trailing pre-release run', () => {
+    expect(baseRelease('26.8.0rc1')).toBe('26.8.0');
+    expect(baseRelease('26.8.0a1')).toBe('26.8.0');
+    expect(baseRelease('26.8.0b2')).toBe('26.8.0');
+    expect(baseRelease('26.8.0.dev20260901')).toBe('26.8.0');
+    expect(baseRelease('26.8.0-rc.1')).toBe('26.8.0');
+  });
+
+  it('leaves a plain release alone', () => {
+    expect(baseRelease('26.8.0')).toBe('26.8.0');
+    expect(baseRelease('24.09.0')).toBe('24.09.0');
+  });
+});
+
 describe('checkVersionAlignment', () => {
   const schemaCtx = { schema: fakeSchema() };
 
@@ -170,6 +185,56 @@ describe('checkVersionAlignment', () => {
     expect(
       checkVersionAlignment(schemaCtx, '25.6.0', ['Nope.field']).checked,
     ).toBe(0);
+  });
+
+  it('counts a marker as present when the manager is its own pre-release', () => {
+    const alignment = checkVersionAlignment(schemaCtx, '26.9.0rc1', [
+      'SessionNode.future',
+    ]);
+    expect(alignment.newerCount).toBe(0);
+    expect(alignment.aligned).toBe(true);
+    expect(alignment.hint).toBeUndefined();
+  });
+
+  it('still flags a marker the manager release does not carry yet', () => {
+    const alignment = checkVersionAlignment(schemaCtx, '26.7.0', [
+      'SessionNode.future',
+    ]);
+    expect(alignment.newerCount).toBe(1);
+    expect(alignment.aligned).toBe(false);
+    expect(alignment.hint).toBe('bai-agent schema sync --tag 26.7.0');
+  });
+
+  it('reports a deprecation without calling the schema unaligned', () => {
+    const alignment = checkVersionAlignment(schemaCtx, '26.9.0', [
+      'SessionNode.gone',
+    ]);
+    expect(alignment.aligned).toBe(true);
+    expect(alignment.deprecatedCount).toBe(1);
+    expect(alignment.summary).toContain('deprecated by the manager');
+    expect(alignment.hint).toBeUndefined();
+  });
+
+  it("treats the SDL as the manager's own when the synced tag matches", () => {
+    const alignment = checkVersionAlignment(
+      { schema: fakeSchema(), schemaTag: '26.8.0rc1' },
+      '26.8.0rc1',
+    );
+    expect(alignment.aligned).toBe(true);
+    expect(alignment.newerCount).toBe(0);
+    expect(alignment.schemaTag).toBe('26.8.0rc1');
+    expect(alignment.hint).toBeUndefined();
+  });
+
+  it('never hints a re-sync of the tag the SDL already carries', () => {
+    // A manager older than the SDL's own tag: unaligned, but re-syncing that
+    // same tag is not the fix.
+    const alignment = checkVersionAlignment(
+      { schema: fakeSchema(), schemaTag: '25.6.0' },
+      '25.6.0',
+      ['SessionNode.future'],
+    );
+    expect(alignment.hint).toBeUndefined();
   });
 });
 

--- a/packages/backend.ai-agent-cli/src/version-align.test.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.test.ts
@@ -2,6 +2,7 @@ import { updateConfig } from './config.js';
 import { EXIT } from './errors.js';
 import { clearManagerVersionCache } from './manager.js';
 import { resolveRepoContext } from './repo-context.js';
+import { sha256Of } from './schema-meta.js';
 import { runCli } from './run.js';
 import type { SchemaIndex } from './search/schema-sdl.js';
 import { saveSession } from './session.js';
@@ -10,7 +11,13 @@ import {
   checkVersionAlignment,
 } from './version-align.js';
 import { baseRelease, compareVersions } from './version-order.js';
-import { mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -40,6 +47,45 @@ function fakeCheckout(apiEndpoint?: string): string {
   }
   return root;
 }
+/**
+ * A checkout whose `data/` is real (so `schema.meta.json` can be written into
+ * it) while the SDL itself is the repository's own, symlinked in.
+ */
+function checkoutWithMeta(meta: { tag: string; sha256: string }): string {
+  const real = resolveRepoContext(repoCwd).repoRoot;
+  const root = mkdtempSync(join(tmpdir(), 'bai-agent-meta-checkout-'));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'backend.ai-webui', version: '0.0.0-meta' }),
+  );
+  for (const dir of ['resources', 'packages', 'react']) {
+    symlinkSync(join(real, dir), join(root, dir), 'dir');
+  }
+  mkdirSync(join(root, 'data'));
+  symlinkSync(
+    join(real, 'data/schema.graphql'),
+    join(root, 'data/schema.graphql'),
+    'file',
+  );
+  writeFileSync(
+    join(root, 'data/schema.meta.json'),
+    `${JSON.stringify(
+      {
+        ...meta,
+        fetchedAt: new Date().toISOString(),
+        source: 'https://example.invalid/schema.graphql',
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return root;
+}
+
+/** The hash a fresh `schema sync` would have recorded for the SDL on disk. */
+const committedSchemaSha = (): string =>
+  sha256Of(readFileSync(resolveRepoContext(repoCwd).schemaPath));
+
 const ENDPOINT = 'http://manager.test.invalid:8090';
 const SESSION_ID = 'abcdefghijklmnopqrstuvwxyz012345';
 
@@ -346,6 +392,41 @@ describe('the version gate', () => {
     expect(notices).toEqual([]);
   });
 
+  it('ignores a schema.meta.json tag that no longer hashes the SDL', async () => {
+    // The tag equals the manager version, so trusting it would trip the
+    // `sdlIsTheManagers` short-circuit and hide every marker finding.
+    const cwd = checkoutWithMeta({ tag: '26.8.0', sha256: 'f'.repeat(64) });
+    const { alignment } = await applyVersionAlignmentGate({
+      cwd,
+      schemaCtx: { schema: fakeSchema() },
+      notify: () => {},
+      fetchImpl: fakeManager('26.8.0').impl,
+      endpointFlag: ENDPOINT,
+    });
+    expect(alignment?.schemaTag).toBeUndefined();
+    expect(alignment?.aligned).toBe(false);
+    expect(alignment?.newer.map((finding) => finding.id)).toContain(
+      'SessionNode.future',
+    );
+  });
+
+  it('trusts the recorded tag while it still hashes the SDL', async () => {
+    const cwd = checkoutWithMeta({
+      tag: '26.8.0',
+      sha256: committedSchemaSha(),
+    });
+    const { alignment } = await applyVersionAlignmentGate({
+      cwd,
+      schemaCtx: { schema: fakeSchema() },
+      notify: () => {},
+      fetchImpl: fakeManager('26.8.0').impl,
+      endpointFlag: ENDPOINT,
+    });
+    expect(alignment?.schemaTag).toBe('26.8.0');
+    expect(alignment?.aligned).toBe(true);
+    expect(alignment?.newerCount).toBe(0);
+  });
+
   it('skips introspection silently when the manager has it disabled', async () => {
     const impl = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
       const url = String(input);
@@ -512,5 +593,84 @@ describe('doctor schema alignment', () => {
       alignment.every((check: { status: string }) => check.status !== 'fail'),
     ).toBe(true);
     expect(data.summary.fail).toBe(0);
+  });
+
+  /** Any URL answers; only `/func/` carries a version. */
+  const stubManager = (managerVersion: string) =>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: Parameters<typeof fetch>[0]) =>
+        String(input).endsWith('/func/')
+          ? new Response(
+              JSON.stringify({
+                version: 'v8.20240915',
+                manager: managerVersion,
+              }),
+              { status: 200 },
+            )
+          : new Response(
+              JSON.stringify({
+                data: { __schema: { queryType: { name: 'Query' } } },
+              }),
+              { status: 200 },
+            ),
+      ),
+    );
+
+  const alignmentChecks = (stdout: string) =>
+    (
+      JSON.parse(stdout).data.checks as Array<{
+        group: string;
+        check: string;
+        status: string;
+        detail: string;
+      }>
+    ).filter((check) => check.group === 'alignment');
+
+  const loggedIn = () =>
+    saveSession({
+      endpoint: ENDPOINT,
+      webui: 'https://fr-3770.localhost:1355',
+      sessionId: SESSION_ID,
+      savedAt: new Date().toISOString(),
+    });
+
+  it('falls back to the marker comparison when the recorded tag is stale', async () => {
+    loggedIn();
+    stubManager('25.6.0');
+    const cwd = checkoutWithMeta({ tag: '25.6.0', sha256: 'f'.repeat(64) });
+
+    const { stdout } = await invoke(['doctor', '--json'], cwd);
+    const checks = alignmentChecks(stdout);
+    const meta = checks.find((check) => check.check === 'data/schema.meta.json');
+    const verdict = checks.find((check) => check.check === 'verdict');
+
+    // The separate metadata warn still fires …
+    expect(meta?.status).toBe('warn');
+    expect(meta?.detail).toContain('sha256 does NOT match');
+    // … and the verdict no longer takes the untrusted tag's word for it.
+    expect(verdict?.status).toBe('warn');
+    expect(verdict?.detail).toContain('not aligned with manager 25.6.0');
+    expect(verdict?.detail).toContain('ignored');
+    expect(verdict?.detail).not.toContain('SDL synced from tag');
+  });
+
+  it('keeps the recorded tag in the verdict while it hashes the SDL', async () => {
+    loggedIn();
+    stubManager('25.6.0');
+    const cwd = checkoutWithMeta({
+      tag: '25.6.0',
+      sha256: committedSchemaSha(),
+    });
+
+    const { stdout } = await invoke(['doctor', '--json'], cwd);
+    const checks = alignmentChecks(stdout);
+    const meta = checks.find((check) => check.check === 'data/schema.meta.json');
+    const verdict = checks.find((check) => check.check === 'verdict');
+
+    expect(meta?.status).toBe('ok');
+    expect(verdict?.status).toBe('ok');
+    expect(verdict?.detail).toContain('schema matches manager 25.6.0');
+    expect(verdict?.detail).toContain('SDL synced from tag 25.6.0');
   });
 });

--- a/packages/backend.ai-agent-cli/src/version-align.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.ts
@@ -6,7 +6,7 @@ import { CLI_NAME } from './meta.js';
 import type { Block } from './output.js';
 import { list, record, section } from './output.js';
 import { tryResolveRepoContext } from './repo-context.js';
-import { readSchemaMeta } from './schema-meta.js';
+import { readCommittedSchema, readSchemaMeta } from './schema-meta.js';
 import type {
   MarkerSource,
   SchemaIndex,
@@ -336,14 +336,22 @@ export interface AlignmentGateResult {
   manager?: ManagerReachability;
 }
 
-/** The tag `schema sync` recorded, unless the caller already knows it. */
+/**
+ * The tag `schema sync` recorded, unless the caller already knows it.
+ *
+ * Forwarded only while the recorded `sha256` still hashes the committed SDL:
+ * a stale meta file whose tag happens to equal the manager version would
+ * otherwise trip the `sdlIsTheManagers` short-circuit and hide every finding.
+ */
 function syncedSchemaTag(options: AlignmentGateOptions): string | undefined {
   if (options.schemaCtx.schemaTag !== undefined)
     return options.schemaCtx.schemaTag;
   const resolved = tryResolveRepoContext(options.cwd);
-  return resolved.ok
-    ? (readSchemaMeta(resolved.context)?.tag ?? undefined)
-    : undefined;
+  if (!resolved.ok) return undefined;
+  const meta = readSchemaMeta(resolved.context);
+  if (!meta) return undefined;
+  const sdl = readCommittedSchema(resolved.context);
+  return sdl?.sha256 === meta.sha256 ? meta.tag : undefined;
 }
 
 /**

--- a/packages/backend.ai-agent-cli/src/version-align.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.ts
@@ -5,13 +5,15 @@ import { fetchManagerVersion, probeIntrospection } from './manager.js';
 import { CLI_NAME } from './meta.js';
 import type { Block } from './output.js';
 import { list, record, section } from './output.js';
+import { tryResolveRepoContext } from './repo-context.js';
+import { readSchemaMeta } from './schema-meta.js';
 import type {
   MarkerSource,
   SchemaIndex,
   SchemaMarker,
 } from './search/schema-sdl.js';
 import { loadSession, resolveEndpoint } from './session.js';
-import { compareVersions } from './version-order.js';
+import { baseRelease, compareVersions } from './version-order.js';
 
 /** Every command that runs the gate takes the same flag. */
 export const STRICT_FLAG: FlagSpec = {
@@ -28,6 +30,8 @@ export const STRICT_FLAG: FlagSpec = {
  */
 export interface SchemaAlignmentContext {
   schema: SchemaIndex;
+  /** `data/schema.meta.json`'s tag — the release the SDL was synced from. */
+  schemaTag?: string;
 }
 
 export interface AlignmentFinding {
@@ -40,6 +44,8 @@ export interface AlignmentFinding {
 
 export interface VersionAlignment {
   managerVersion: string;
+  /** The release tag the committed SDL was synced from, when it is recorded. */
+  schemaTag?: string;
   /** Marked entries compared against the manager. */
   checked: number;
   /** Entries the manager is too old to have. */
@@ -48,6 +54,7 @@ export interface VersionAlignment {
   deprecatedCount: number;
   newer: AlignmentFinding[];
   deprecated: AlignmentFinding[];
+  /** Only `newerCount` decides it; a deprecation is informational. */
   aligned: boolean;
   /** The one line `--json`-free callers print on stderr. */
   summary: string;
@@ -157,6 +164,11 @@ function summarize(
  * compared, counting only entries carrying a marker of their own — a type
  * already stands for the fields that inherit from it.
  *
+ * A pre-release manager (`26.8.0rc1`) counts as its own release for markers,
+ * and `schemaCtx.schemaTag` equal to the manager version means the SDL is the
+ * manager's own, so nothing is flagged. Only `Added in` markers ahead of the
+ * manager make it not aligned; a deprecation is reported, not a mismatch.
+ *
  * Pure: it performs no I/O. `applyVersionAlignmentGate` is the wrapper that
  * finds the session, fetches the manager version and reports.
  */
@@ -169,6 +181,14 @@ export function checkVersionAlignment(
     ? selectedEntries(schemaCtx.schema, selectedFields)
     : everyMarkedEntry(schemaCtx.schema);
 
+  const { schemaTag } = schemaCtx;
+  // The SDL came out of the release the manager is running: it IS the
+  // manager's schema, so no marker can be ahead of it.
+  const sdlIsTheManagers =
+    schemaTag !== undefined && schemaTag === managerVersion;
+  // `26.8.0rc1` runs the 26.8.0 code, so an `Added in 26.8.0` marker is there.
+  const managerRelease = baseRelease(managerVersion);
+
   const newer: AlignmentFinding[] = [];
   const deprecated: AlignmentFinding[] = [];
   let checked = 0;
@@ -176,7 +196,11 @@ export function checkVersionAlignment(
     const { addedIn, deprecatedSince } = entry.marker;
     if (!addedIn && !deprecatedSince) continue;
     checked += 1;
-    if (addedIn && compareVersions(addedIn, managerVersion) > 0) {
+    if (
+      !sdlIsTheManagers &&
+      addedIn &&
+      compareVersions(addedIn, managerRelease) > 0
+    ) {
       newer.push({
         id: entry.id,
         version: addedIn,
@@ -185,7 +209,7 @@ export function checkVersionAlignment(
     }
     if (
       deprecatedSince &&
-      compareVersions(deprecatedSince, managerVersion) <= 0
+      compareVersions(deprecatedSince, managerRelease) <= 0
     ) {
       deprecated.push({
         id: entry.id,
@@ -195,30 +219,38 @@ export function checkVersionAlignment(
     }
   }
 
-  const aligned = newer.length === 0 && deprecated.length === 0;
-  const parts = [
-    newer.length > 0
-      ? summarize(newer, newer.length, 'not in the manager yet')
-      : undefined,
+  const aligned = newer.length === 0;
+  const deprecatedNote =
     deprecated.length > 0
       ? summarize(deprecated, deprecated.length, 'deprecated by the manager')
-      : undefined,
-  ].filter(Boolean);
+      : undefined;
+  const summary = aligned
+    ? [`schema matches manager ${managerVersion}`, deprecatedNote]
+        .filter(Boolean)
+        .join('; ')
+    : [
+        `schema is not aligned with manager ${managerVersion}: ${summarize(newer, newer.length, 'not in the manager yet')}`,
+        deprecatedNote,
+      ]
+        .filter(Boolean)
+        .join('; ');
+  // Re-syncing the tag the SDL already carries fixes nothing.
+  const hint =
+    aligned || schemaTag === managerVersion
+      ? undefined
+      : `${CLI_NAME} schema sync --tag ${managerVersion}`;
 
   return {
     managerVersion,
+    ...(schemaTag ? { schemaTag } : {}),
     checked,
     newerCount: newer.length,
     deprecatedCount: deprecated.length,
     newer: newer.slice(0, ALIGNMENT_SAMPLE_LIMIT),
     deprecated: deprecated.slice(0, ALIGNMENT_SAMPLE_LIMIT),
     aligned,
-    summary: aligned
-      ? `schema matches manager ${managerVersion}`
-      : `schema is not aligned with manager ${managerVersion}: ${parts.join('; ')}`,
-    ...(aligned
-      ? {}
-      : { hint: `${CLI_NAME} schema sync --tag ${managerVersion}` }),
+    summary,
+    ...(hint ? { hint } : {}),
   };
 }
 
@@ -238,6 +270,7 @@ export function renderAlignment(alignment: VersionAlignment): Block[] {
     section('Version alignment'),
     record([
       ['manager', alignment.managerVersion],
+      ['schemaTag', alignment.schemaTag],
       ['verdict', alignment.aligned ? 'aligned' : 'not aligned'],
       ['checked', alignment.checked],
       ['newer', alignment.newerCount],
@@ -303,6 +336,16 @@ export interface AlignmentGateResult {
   manager?: ManagerReachability;
 }
 
+/** The tag `schema sync` recorded, unless the caller already knows it. */
+function syncedSchemaTag(options: AlignmentGateOptions): string | undefined {
+  if (options.schemaCtx.schemaTag !== undefined)
+    return options.schemaCtx.schemaTag;
+  const resolved = tryResolveRepoContext(options.cwd);
+  return resolved.ok
+    ? (readSchemaMeta(resolved.context)?.tag ?? undefined)
+    : undefined;
+}
+
 /**
  * The gate `whoami`, `schema show` — and later `query` / `explain` — run.
  *
@@ -327,7 +370,7 @@ export async function applyVersionAlignmentGate(
   }
 
   const alignment = checkVersionAlignment(
-    options.schemaCtx,
+    { ...options.schemaCtx, schemaTag: syncedSchemaTag(options) },
     version.manager,
     options.selectedFields,
   );

--- a/packages/backend.ai-agent-cli/src/version-order.ts
+++ b/packages/backend.ai-agent-cli/src/version-order.ts
@@ -39,3 +39,13 @@ export function compareVersions(a: string, b: string): number {
   }
   return 0;
 }
+
+/**
+ * The release a pre-release belongs to: `26.8.0rc1` -> `26.8.0`. A version
+ * with no trailing pre-release run comes back unchanged.
+ */
+export function baseRelease(version: string): string {
+  const trimmed = version.trim();
+  const match = /^(\d+(?:[._-]\d+)*)[._-]?[a-z][a-z0-9._-]*$/i.exec(trimmed);
+  return match ? match[1] : trimmed;
+}

--- a/packages/backend.ai-agent-cli/src/webui-path.fixture.json
+++ b/packages/backend.ai-agent-cli/src/webui-path.fixture.json
@@ -216,6 +216,30 @@
     "expected": "/admin/users?tab=credentials"
   },
   {
+    "name": "list projects",
+    "ref": {
+      "type": "list",
+      "resource": "project"
+    },
+    "expected": "/admin/project"
+  },
+  {
+    "name": "list resource presets pins the environment page's preset tab",
+    "ref": {
+      "type": "list",
+      "resource": "resource_preset"
+    },
+    "expected": "/admin/environment?tab=preset"
+  },
+  {
+    "name": "list resource groups pins the resources page's tab",
+    "ref": {
+      "type": "list",
+      "resource": "resource_group"
+    },
+    "expected": "/admin/agent?tab=resourceGroup"
+  },
+  {
     "name": "session list with a free-text filter",
     "ref": {
       "type": "list",
@@ -313,6 +337,24 @@
       "statusCategory": "inactive"
     },
     "expected": "/admin/users?tab=credentials&activeType=inactive"
+  },
+  {
+    "name": "project list status uses status",
+    "ref": {
+      "type": "list",
+      "resource": "project",
+      "statusCategory": "inactive"
+    },
+    "expected": "/admin/project?status=inactive"
+  },
+  {
+    "name": "resource preset list drops a filter the page does not parse",
+    "ref": {
+      "type": "list",
+      "resource": "resource_preset",
+      "filter": "name ilike \"%gpu%\""
+    },
+    "expected": "/admin/environment?tab=preset"
   },
   {
     "name": "list combines tab, filter and status in a stable order",

--- a/packages/backend.ai-agent-cli/src/webui-path.test.ts
+++ b/packages/backend.ai-agent-cli/src/webui-path.test.ts
@@ -66,6 +66,11 @@ describe('listPath', () => {
     expect(listPath('session')).toBe('/session');
     expect(listPath('vfolder')).toBe('/data');
     expect(listPath('keypair')).toBe('/admin/users?tab=credentials');
+    expect(listPath('user')).toBe('/admin/users?tab=users');
+    expect(listPath('agent')).toBe('/admin/agent?tab=agents');
+    expect(listPath('project')).toBe('/admin/project');
+    expect(listPath('resource_preset')).toBe('/admin/environment?tab=preset');
+    expect(listPath('resource_group')).toBe('/admin/agent?tab=resourceGroup');
   });
 });
 

--- a/packages/backend.ai-agent-cli/src/webui-path.ts
+++ b/packages/backend.ai-agent-cli/src/webui-path.ts
@@ -22,10 +22,16 @@ export const LIST_RESOURCES_WITH_STATUS = [
   'agent',
   'user',
   'keypair',
+  'project',
 ] as const;
 
 /** List resources whose page has no status param at all. */
-export const LIST_RESOURCES_WITHOUT_STATUS = ['model_card', 'environment'] as const;
+export const LIST_RESOURCES_WITHOUT_STATUS = [
+  'model_card',
+  'environment',
+  'resource_preset',
+  'resource_group',
+] as const;
 
 export type ListResourceWithStatus =
   (typeof LIST_RESOURCES_WITH_STATUS)[number];
@@ -34,8 +40,9 @@ export type ListResourceWithoutStatus =
 export type ListResource = ListResourceWithStatus | ListResourceWithoutStatus;
 
 /**
- * A reference to something the UI can open. `agent`, `user` and `keypair` have
- * list entries but no detail member: their pages carry no per-row URL param.
+ * A reference to something the UI can open. `agent`, `user`, `keypair`,
+ * `project`, `resource_preset` and `resource_group` have list entries but no
+ * detail member: their pages carry no per-row URL param.
  */
 export type ResourceRef =
   | { type: 'session'; id: string; view?: SessionView }
@@ -69,7 +76,8 @@ interface ListPageSpec {
   pathname: string;
   /** Params that select the resource's surface on a shared page (e.g. a tab). */
   fixedParams?: Readonly<Record<string, string>>;
-  filterParam: string;
+  /** Absent when the page parses no free-text filter — a `filter` is dropped. */
+  filterParam?: string;
   statusParam?: string;
 }
 
@@ -122,6 +130,23 @@ export const LIST_PAGES: Readonly<Record<ListResource, ListPageSpec>> = {
     fixedParams: { tab: 'credentials' },
     filterParam: 'filter',
     statusParam: 'activeType',
+  },
+  project: {
+    // Single-tab page, so no tab param — `ProjectPage.tsx` parses `filter`
+    // and a `status` of active | inactive.
+    pathname: '/admin/project',
+    filterParam: 'filter',
+    statusParam: 'status',
+  },
+  resource_preset: {
+    // Presets are the environment page's second tab (`EnvironmentPage.tsx`).
+    pathname: '/admin/environment',
+    fixedParams: { tab: 'preset' },
+  },
+  resource_group: {
+    // Resource groups are the resources page's third tab (`ResourcesPage.tsx`).
+    pathname: '/admin/agent',
+    fixedParams: { tab: 'resourceGroup' },
   },
 };
 
@@ -188,7 +213,7 @@ export const resourceLocation = (ref: ResourceRef): ResourceLocation => {
       const params: Array<[string, string]> = Object.entries(
         spec.fixedParams ?? {},
       );
-      if (ref.filter !== undefined) {
+      if (ref.filter !== undefined && spec.filterParam) {
         params.push([spec.filterParam, ref.filter]);
       }
       if (ref.statusCategory !== undefined && spec.statusParam) {


### PR DESCRIPTION
Relates to #9273 (FR-3781) — covers that issue's "deep links fall back to the raw `id` for Strawberry types whose id is a Relay global id" bullet. Its search-ranking, client-directive, `--max-bytes` and root-field-alias items are **not** in this PR, so it stays open.

Fixes found by running an A/B benchmark of the `bai-agent` CLI + Claude Code skill: 24 questions × {no CLI, CLI} × {Sonnet, Opus}, answers scored blind against ground truth captured from the live manager. Two rounds of fixes, each re-measured. Full reports and traces are in the benchmark bundle (not in this repo).

## What changed

**`fix(agent-cli)` — `99805546c`**

- **Version alignment: stop the pre-release false positive.** `checkVersionAlignment` compared `Added in X.Y.Z` markers against the manager version with PEP-440 ordering, so a `26.8.0rc1` manager flagged all 147 `Added in 26.8.0` markers as "not in the manager yet" — even when the local SDL *was* that rc's own release asset. Now markers compare against the manager's base release, a `schema.meta.json` tag equal to the manager version short-circuits to aligned, the `schema sync --tag <v>` hint is never emitted for the tag already synced, and deprecations alone no longer flip `aligned` to false. `whoami` prints `schemaTag` and `repoVersion` as separate rows so they stop being read as the manager version.
- **`query` emits list-page links.** `data.links` was populated only for types with a per-row page, so `user_nodes`, agents, projects, resource presets and resource groups came back with `links: []` and the model hand-wrote paths (`/admin/user`, `/resource-policy`, `/admin/user?tab=project` — all wrong). Each of those root fields now carries one list-page link; routes confirmed against `react/src/routes.tsx` and the page components.
- **Skill / agent block.** One-step preflight, absolute cookbook location, `explain <Type>.<field>=<VALUE>` first for status values, never compose a path when `data.links` is empty, never reuse the session id outside the CLI, the synced copy has no React source. Agent block gains the `--json` envelope shape and the `| head` exit-code trap.

**`feat(agent-cli)` — `199fa1e1f`**

- **Relay global ids decoded before building a link.** `ID_FIELDS` fell back to `id`, which on Graphene/Strawberry node types is a base64 global id; the WebUI pages read a raw uuid, so `/data?folder=<base64>` and `/session?sessionDetail=<base64>` were dead links presented as working ones. `resolveLinkId` now returns a uuid as-is, decodes `<TypeName>:<uuid>`, and otherwise emits **no link** plus a `webui_link_hint` telling the caller to select `row_id`. `role` deliberately keeps its global id — `RBACManagementPage.tsx` looks roles up by it.
- **The installed agent block names the real skill directory.** `INSTALLED_SKILL_PATH` was hard-coded to `~/.claude/skills/...`, so an install under `$CLAUDE_CONFIG_DIR` produced a path nothing could read. Resolution moved to `src/skill-path.ts` and honours `$CLAUDE_CONFIG_DIR`. The block also carries the rules that previously lived only in `SKILL.md` (session file, empty `data.links`, post-processing, no React source) and drops the standalone `whoami` step — `whoami` runs only when doctor's session check warns.
- **`doctor --brief`** — auth and alignment first, warn/fail only, under 40 lines; `--json` unchanged.
- **`bai-agent cookbook [--list | <n> | <root field>]`** — prints a cookbook entry so an agent never searches the filesystem for the file; a `schema_mismatch` error now names the entry to read for the root field it tried.
- **`query --json` prints a one-line `links:` notice on stderr**, so links survive `jq`/`python` post-processing of the envelope.

## Measured effect

Same VM, same manager (26.8.0rc1), one blind panel of three judges over 24 questions × 8 answers (192 runs). Correctness 0–5, citation/link 0–3.

| condition | correctness | runs flagged for hallucination (/48) | citation·link | cost / question | wall |
|---|---|---|---|---|---|
| no CLI | 4.08 | 9 | 1.26 | $0.291 | 73 s |
| CLI, before this PR | 4.50 | 9 | 2.20 | $0.337 | 63 s |
| CLI, first commit | 4.76 | 4 | 2.50 | $0.281 | 52 s |
| CLI, both commits | 4.75 | 2 | 2.60 | $0.267 | 50 s |

Concretely: the alignment caveat disappeared from every answer (5 answers carried a wrong one before), hand-written WebUI paths went to zero, and on three "create a folder / preset / project folder" tasks the WebUI link the assistant handed back went from 2/6 correct to 6/6. Turn count and cost fell because the preflight and cookbook lookups stopped being exploratory.

## Verification

- `pnpm --filter backend.ai-agent-cli test` — 511 tests, 33 files
- `bash scripts/verify.sh` — `=== ALL PASS ===` (Relay, lint, format, tsc, agent-cli tsc, terminology)
- `AGENTS.md` (`CLAUDE.md` symlink) regenerated with `pnpm run bai-agent init --features agents --write`; the diff is inside the `BAI-AGENT` markers only
- Live-checked against the manager: `doctor --brief` 15 lines with `alignment: ok`, `cookbook --list` 11 entries, `cookbook nope` → exit 5, `query` on `compute_session_nodes` yields a uuid session link plus the stderr notice

## Reports

The A/B benchmark this PR came out of, written up:

- **CLI vs no CLI** — https://claude.ai/code/artifact/c28252c5-10c5-4df3-adba-c321449afd69
- **Version comparison (original CLI → this PR → #9446)** — https://claude.ai/code/artifact/51d9ff2d-9da0-48cf-bd92-8ebc7ba68d9e

Both are private Claude artifacts — they open for whoever they are shared with, not for anonymous readers. The markdown source and the raw material behind them (192 run traces, judge scores, the ground truth captured from the manager, and the verification of every object the create-task runs made) live on the dev box under `~/bai-agent-ab-report/` on `jongeun`'s account.

Method in one line: 24 questions x {no CLI, original CLI, each patched CLI} x {Sonnet, Opus}, one run per cell, answers scored blind by a three-judge panel against ground truth captured from the live manager.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FYN5tF1QadeQiSeZ5XBfV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FYN5tF1QadeQiSeZ5XBfV
