### PR TITLE
feat(FR-3862): move the review overlay dock with the keyboard

### DIFF
--- a/react/vite-plugins/review-overlay/client/dock.test.ts
+++ b/react/vite-plugins/review-overlay/client/dock.test.ts
@@ -695,6 +695,232 @@ describe('createSetDock', () => {
     });
   });
 
+  // FR-3862. The grip was a bare `<span>` with only pointer listeners, so the
+  // dock could not be moved without a mouse. Every keyboard move goes through
+  // the same `clamp`/`savePos` the drag does.
+  describe('moving the dock with the keyboard', () => {
+    const grip = () => node<HTMLButtonElement>('.grip');
+    const press = (key: string, shiftKey = false) => {
+      const evt = new KeyboardEvent('keydown', {
+        key,
+        shiftKey,
+        bubbles: true,
+        cancelable: true,
+      });
+      grip().dispatchEvent(evt);
+      return evt;
+    };
+    const point = (type: string, x: number, y: number) =>
+      grip().dispatchEvent(
+        new MouseEvent(type, {
+          clientX: x,
+          clientY: y,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    const dragTo = (x: number, y: number) => {
+      point('pointerdown', 0, 0);
+      point('pointermove', x, y);
+      point('pointerup', x, y);
+    };
+    const left = () => node('.setdock').style.left;
+    const top = () => node('.setdock').style.top;
+    /** 1024 - 260 wide - 12 inset, and 768 - 160 stand-in height - 12. */
+    const CORNER = { left: 752, top: 596 };
+
+    it('is a button with an accessible name, not a bare span', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      expect(grip().tagName).toBe('BUTTON');
+      expect(grip().type).toBe('button');
+      expect(grip().getAttribute('aria-label')).toBeTruthy();
+      expect(grip().title).toBe(grip().getAttribute('aria-label'));
+    });
+
+    // Dev-only chrome floating over the app: it takes a tab stop while the
+    // reviewer can see it, and gives it back the moment it is out of sight.
+    it('is a tab stop only while the dock is on screen', () => {
+      expect(grip().tabIndex).toBe(-1);
+
+      dock.render([pin('c_a', 'a')]);
+      expect(grip().tabIndex).toBe(0);
+
+      dock.setCollapsed(true);
+      expect(grip().tabIndex).toBe(-1);
+
+      dock.setCollapsed(false);
+      expect(grip().tabIndex).toBe(0);
+
+      dock.render([]);
+      expect(grip().tabIndex).toBe(-1);
+    });
+
+    it('steps away from the default corner with an arrow key', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowLeft');
+
+      expect(left()).toBe(`${CORNER.left - 8}px`);
+      expect(top()).toBe(`${CORNER.top}px`);
+      expect(node('.setdock').style.right).toBe('auto');
+      expect(node('.setdock').style.bottom).toBe('auto');
+    });
+
+    it('moves on every arrow, and the presses accumulate', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowUp');
+      press('ArrowUp');
+      press('ArrowLeft');
+
+      expect(left()).toBe(`${CORNER.left - 8}px`);
+      expect(top()).toBe(`${CORNER.top - 16}px`);
+    });
+
+    it('takes a bigger step with Shift held', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowLeft', true);
+
+      expect(left()).toBe(`${CORNER.left - 64}px`);
+    });
+
+    // Otherwise the page scrolls under a dock that is moving over it.
+    it('takes the arrow key rather than letting the page scroll', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      expect(press('ArrowDown').defaultPrevented).toBe(true);
+    });
+
+    it('leaves a modified arrow to the browser', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      const evt = new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      grip().dispatchEvent(evt);
+
+      expect(evt.defaultPrevented).toBe(false);
+      expect(left()).toBe('');
+    });
+
+    it('keeps a keyboard move inside the viewport', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      for (let i = 0; i < 10; i++) press('ArrowRight', true);
+      for (let i = 0; i < 20; i++) press('ArrowDown', true);
+
+      // The same edges the drag clamps to: 1024 - 260 - 8, 768 - 160 - 8.
+      expect(left()).toBe('756px');
+      expect(top()).toBe('600px');
+    });
+
+    // A drag holds an unclamped position on purpose, so a window that grows
+    // again gives it back. An arrow steps from what is on screen instead.
+    it('comes back off the edge on the very next press', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      for (let i = 0; i < 10; i++) press('ArrowRight', true);
+      press('ArrowLeft');
+
+      expect(left()).toBe('748px');
+    });
+
+    // The pointer saves on release, not on every move; Enter is the release.
+    it('keeps the position for the tab once the move is committed', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowLeft');
+      expect(sessionStorage.getItem(DOCK_POS_KEY)).toBeNull();
+
+      press('Enter');
+
+      expect(sessionStorage.getItem(DOCK_POS_KEY)).toBe(
+        JSON.stringify({ left: CORNER.left - 8, top: CORNER.top }),
+      );
+    });
+
+    it('commits when the grip loses focus', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowUp');
+      grip().dispatchEvent(new FocusEvent('blur'));
+
+      expect(sessionStorage.getItem(DOCK_POS_KEY)).toBe(
+        JSON.stringify({ left: CORNER.left, top: CORNER.top - 8 }),
+      );
+    });
+
+    // Enter is what activates a button; it must not also reach the page.
+    it('takes the committing Enter', () => {
+      dock.render([pin('c_a', 'a')]);
+      press('ArrowUp');
+
+      expect(press('Enter').defaultPrevented).toBe(true);
+    });
+
+    it('puts the dock back where the move started when Escape cancels', () => {
+      dock.render([pin('c_a', 'a')]);
+      dragTo(300, 200);
+
+      press('ArrowLeft', true);
+      press('ArrowUp', true);
+      expect(left()).toBe('236px');
+
+      press('Escape');
+
+      expect(left()).toBe('300px');
+      expect(top()).toBe('200px');
+      expect(sessionStorage.getItem(DOCK_POS_KEY)).toBe(
+        JSON.stringify({ left: 300, top: 200 }),
+      );
+    });
+
+    // The corner is a position like any other: a dock that never moved has to
+    // be able to get all the way back to it.
+    it('cancels back to the default corner it started from', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowLeft');
+      press('ArrowUp', true);
+      expect(left()).toBe(`${CORNER.left - 8}px`);
+
+      press('Escape');
+
+      expect(left()).toBe('');
+      expect(top()).toBe('');
+      expect(node('.setdock').style.right).toBe('');
+      expect(sessionStorage.getItem(DOCK_POS_KEY)).toBeNull();
+    });
+
+    // Escape after the move is committed is not the app's Escape to eat.
+    it('leaves Escape alone when no keyboard move is running', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      expect(press('Escape').defaultPrevented).toBe(false);
+
+      press('ArrowLeft');
+      press('Enter');
+
+      expect(press('Escape').defaultPrevented).toBe(false);
+      expect(left()).toBe(`${CORNER.left - 8}px`);
+    });
+
+    it('drops the keyboard move a drag takes over from', () => {
+      dock.render([pin('c_a', 'a')]);
+
+      press('ArrowLeft');
+      dragTo(300, 200);
+      press('Escape');
+
+      expect(left()).toBe('300px');
+    });
+  });
+
   // A set spans pages, and an off-page pin has no card — the row is the only
   // thing it has on screen.
   describe('a pin on another page', () => {

--- a/react/vite-plugins/review-overlay/client/dock.ts
+++ b/react/vite-plugins/review-overlay/client/dock.ts
@@ -28,6 +28,23 @@ const DOCK_WIDTH = 260;
 const DOCK_HEIGHT = 160;
 /** Margin the dock keeps to every viewport edge, dragged or default. */
 const EDGE_PAD = 8;
+/** The corner the CSS parks an unmoved dock at, as `right`/`bottom`. */
+const EDGE_INSET = 12;
+/** One arrow press: the dock's own spacing unit. */
+const KEY_STEP = EDGE_PAD;
+/** Shift+arrow — eight of those, so a 1280px viewport is 20 presses wide. */
+const KEY_STEP_BIG = EDGE_PAD * 8;
+
+/** Named for what it DOES (R8.1), and dragging is no longer the only way. */
+const GRIP_LABEL = 'Move the dock (drag, or arrow keys)';
+
+/** Which edge each arrow pushes the dock towards. */
+const ARROWS: Readonly<Record<string, DockPos | undefined>> = {
+  ArrowLeft: { left: -1, top: 0 },
+  ArrowRight: { left: 1, top: 0 },
+  ArrowUp: { left: 0, top: -1 },
+  ArrowDown: { left: 0, top: 1 },
+};
 
 export interface DockPos {
   left: number;
@@ -91,8 +108,9 @@ const rowNote = (pin: SetPin): string =>
 
 const STYLE = `
   .setdock {
-    position: fixed; right: 12px; bottom: 12px; z-index: 2147483000;
-    display: none; flex-direction: column; width: 260px;
+    position: fixed; right: ${EDGE_INSET}px; bottom: ${EDGE_INSET}px;
+    z-index: 2147483000;
+    display: none; flex-direction: column; width: ${DOCK_WIDTH}px;
     background: var(--bai-review-surface); color: var(--bai-review-text);
     border: 1px solid var(--bai-review-border); border-radius: 8px;
     box-shadow: 0 4px 18px var(--bai-review-shadow);
@@ -110,8 +128,16 @@ const STYLE = `
     flex: none; display: flex; align-items: center; cursor: grab;
     color: var(--bai-review-text-dim); touch-action: none;
     -webkit-user-select: none; user-select: none;
+    border: 0; background: none; padding: 0; font: inherit; border-radius: 4px;
   }
   .setdock.dragging .grip { cursor: grabbing; }
+  /* Nothing of the app's focus styling crosses the shadow boundary, so every
+     focusable in here is invisible to a keyboard without its own ring. */
+  .setdock .grip:focus-visible,
+  .setdock .act:focus-visible,
+  .setdock .rowlabel:focus-visible {
+    outline: 2px solid var(--bai-review-accent); outline-offset: 1px;
+  }
   .setdock .title {
     font-weight: 600; margin-right: auto; display: flex; align-items: center;
     gap: 4px;
@@ -253,10 +279,13 @@ export function createSetDock(options: SetDockOptions) {
   dock.className = 'setdock';
   const head = document.createElement('div');
   head.className = 'head';
-  const grip = document.createElement('span');
+  const grip = document.createElement('button');
+  grip.type = 'button';
   grip.className = 'grip';
+  // A dock nobody has revealed yet is not a tab stop; `render` opens it.
+  grip.tabIndex = -1;
   grip.append(icon('grip-vertical'));
-  grip.title = 'Drag the dock';
+  setLabel(grip, GRIP_LABEL);
   const title = document.createElement('span');
   title.className = 'title';
   title.append(icon('map-pin'));
@@ -307,9 +336,17 @@ export function createSetDock(options: SetDockOptions) {
     };
   }
 
-  /** `right`/`bottom` are the CSS default; a placed dock has to drop them. */
-  function moveTo(next: DockPos) {
+  /** `right`/`bottom` are the CSS default; a placed dock has to drop them, and
+   *  `null` — the corner a cancelled keyboard move goes back to — restores them. */
+  function moveTo(next: DockPos | null) {
     wanted = next;
+    if (!next) {
+      dock.style.left = '';
+      dock.style.top = '';
+      dock.style.right = '';
+      dock.style.bottom = '';
+      return;
+    }
     const at = clamp(next);
     dock.style.left = `${at.left}px`;
     dock.style.top = `${at.top}px`;
@@ -318,21 +355,41 @@ export function createSetDock(options: SetDockOptions) {
   }
 
   function savePos() {
-    if (!wanted) return;
     try {
-      sessionStorage.setItem(DOCK_POS_KEY, JSON.stringify(wanted));
+      if (wanted) sessionStorage.setItem(DOCK_POS_KEY, JSON.stringify(wanted));
+      else sessionStorage.removeItem(DOCK_POS_KEY);
     } catch {
-      // Storage off or full: the dock still sits where it was dragged.
+      // Storage off or full: the dock still sits where it was put.
     }
+  }
+
+  /** Where an unmoved dock sits — what an arrow key steps away from. */
+  function cornerPos(): DockPos {
+    const box = dock.getBoundingClientRect();
+    if (box.width || box.height) return { left: box.left, top: box.top };
+    // jsdom, and a dock still `display: none`: no layout to read.
+    return {
+      left: window.innerWidth - (dock.offsetWidth || DOCK_WIDTH) - EDGE_INSET,
+      top: window.innerHeight - (dock.offsetHeight || DOCK_HEIGHT) - EDGE_INSET,
+    };
   }
 
   /** Grab offset inside the dock, so it does not jump to the cursor. */
   let grab: { dx: number; dy: number } | null = null;
 
+  /**
+   * Where the keyboard move in flight began, so Escape can undo the whole run
+   * of presses and not just the last one. `at` is `null` for the default
+   * corner, which is a position like any other.
+   */
+  let keyFrom: { at: DockPos | null } | null = null;
+
   grip.addEventListener('pointerdown', (evt) => {
     if (evt.button) return;
     const box = dock.getBoundingClientRect();
     grab = { dx: evt.clientX - box.left, dy: evt.clientY - box.top };
+    // The pointer takes over: there is no keyboard move left to cancel.
+    keyFrom = null;
     // Without this the gesture becomes a text selection, and react-grab's
     // select mode would read it as a pick.
     evt.preventDefault();
@@ -366,6 +423,55 @@ export function createSetDock(options: SetDockOptions) {
   };
   grip.addEventListener('pointerup', endDrag);
   grip.addEventListener('pointercancel', endDrag);
+
+  /** Lifting the pointer commits; so do Enter, and tabbing away. */
+  const endKeyMove = () => {
+    if (!keyFrom) return;
+    keyFrom = null;
+    savePos();
+  };
+
+  grip.addEventListener('keydown', (evt) => {
+    if (evt.key === 'Escape' || evt.key === 'Enter') {
+      if (!keyFrom) return;
+      // Enter is the button's own activation key; neither may reach the page.
+      evt.preventDefault();
+      evt.stopPropagation();
+      if (evt.key === 'Enter') {
+        endKeyMove();
+        return;
+      }
+      const { at } = keyFrom;
+      keyFrom = null;
+      moveTo(at);
+      savePos();
+      return;
+    }
+    const arrow = ARROWS[evt.key];
+    if (!arrow || evt.metaKey || evt.ctrlKey || evt.altKey) return;
+    // Otherwise the page scrolls under a dock that is moving over it.
+    evt.preventDefault();
+    evt.stopPropagation();
+    keyFrom ??= { at: wanted };
+    const step = evt.shiftKey ? KEY_STEP_BIG : KEY_STEP;
+    // Stepping from what is on screen, not from an unclamped drag: a dock
+    // held against an edge has to come back on the very next press.
+    const from = wanted ? clamp(wanted) : cornerPos();
+    moveTo(
+      clamp({
+        left: from.left + arrow.left * step,
+        top: from.top + arrow.top * step,
+      }),
+    );
+  });
+
+  grip.addEventListener('blur', endKeyMove);
+
+  /** Hidden or folded the dock is `display: none`; say so in the tab order too. */
+  const syncTabStop = () => {
+    const list = dock.classList;
+    grip.tabIndex = list.contains('shown') && !list.contains('folded') ? 0 : -1;
+  };
 
   /**
    * Folded, the dock is `display: none` and measures the stand-in box, so a
@@ -412,6 +518,7 @@ export function createSetDock(options: SetDockOptions) {
     if (ids !== listed) setConfirming(false);
     listed = ids;
     dock.classList.toggle('shown', pins.length > 0);
+    syncTabStop();
     titleText.textContent = `${pins.length} ${pins.length === 1 ? 'pin' : 'pins'}`;
     setText(clear, `Clear all (${pins.length})`);
     confirmText.textContent = `Clear all ${pins.length}?`;
@@ -509,6 +616,7 @@ export function createSetDock(options: SetDockOptions) {
      */
     setCollapsed(next: boolean) {
       dock.classList.toggle('folded', next);
+      syncTabStop();
       if (!next) reclamp();
     },
     /** Tests and hot reloads: one dock lives as long as the page. */


### PR DESCRIPTION
Resolves #9449 (FR-3862)

Follow-up from the ready gate on FR-3858 ([#9440](https://github.com/lablup/backend.ai-webui/pull/9440), Copilot thread on `client/dock.ts`). The set dock's grip was a bare `<span>` with a `title` and pointer listeners only — no `tabindex`, no `role` — so a keyboard-only reviewer could not move the dock off whatever it was covering.

A keyboard move now runs through the **same** `clamp()` and the same `savePos()` the pointer drag uses, so the dock cannot be parked off-screen and the position persists identically (`sessionStorage`, per tab).

## Design decisions

The ticket left five decisions open. What was settled, and why:

1. **The grip is a real `<button type="button">`, not `role="button"` + `tabindex`.** Nothing in the drag path needed a `<span>`: `setPointerCapture`, `touch-action: none` and the `preventDefault()` on `pointerdown` all work on a button. The UA button chrome is reset in the same rule that already carried the grip's cursor and user-select (`border: 0; background: none; padding: 0; font: inherit`), which is the pattern `.act` and `.rowlabel` in this stylesheet already use.
2. **Accessible name says what the control does: `Move the dock (drag, or arrow keys)`.** The old `Drag the dock` is a lie to the audience that just gained access, and R8.1 in this file names a control for the action, not the mechanism. Set through the existing `setLabel` helper, so `title` and `aria-label` stay in step.
3. **Step: 8px per arrow, 64px with Shift.** 8 is `EDGE_PAD` — the dock's own spacing unit, and the margin it keeps to every viewport edge — so a press is one "unit" of the dock's own geometry rather than an invented number. Shift is eight of those: 20 presses crosses a 1280px viewport, which is coarse enough to be useful without overshooting a 260px-wide dock.
4. **Escape cancels the whole run of presses; Enter and blur commit.** `keyFrom` records the position the *first* arrow stepped away from, so Escape undoes the run, not the last press. The default corner is one of those positions: `moveTo(null)` drops the inline `left/top/right/bottom` and lets the CSS corner take over again, and `savePos()` clears the stored key to match. Committing on blur mirrors the pointer, which commits on release.
   **`pointercancel` is deliberately left as it was** — it still commits where the dock landed. Turning it into a true cancel would be a behaviour change to the pointer path that this ticket did not ask for; a cancelled pointer is usually the OS taking the pointer away mid-gesture, and the dock is already visibly there. Worth a separate ticket if we disagree.
5. **An arrow steps from the *clamped* position, a drag keeps the unclamped one.** A drag deliberately holds the raw position so a window that shrinks and grows again gives the reviewer's spot back. For the keyboard that would be a trap: 10 presses into a wall would need 10 presses back out before anything moved. The arrow handler steps from `clamp(wanted)` and stores the clamped result, so the dock comes off the edge on the very next press.
6. **Tab order: only while the dock is on screen.** `shown`/`folded` are both `display: none`, which already removes the grip from the tab order — but that is CSS keeping an accessibility promise, silently. `syncTabStop()` sets `tabIndex` explicitly from those two classes (in `render` and `setCollapsed`), so the dev-only overlay never adds a tab stop the reviewer cannot see, and a future fold-by-opacity cannot regress it. Initial state is `-1`; the dock starts hidden.
7. **The shadow root gets its own `:focus-visible` ring** (2px `--bai-review-accent`, 1px offset). None of the app's focus styling crosses the shadow boundary. Applied to `.grip`, `.act` and `.rowlabel` together rather than the grip alone — the dock's other buttons and its row labels are already focusable and equally ringless, and one grip with a ring among them would read as the odd one out.

Also folded in while touching the stylesheet: the `12px` corner inset and the `260px` width are now interpolated from `EDGE_INSET` / `DOCK_WIDTH`, the constants the jsdom clamp and the new keyboard base position already read. They used to be duplicated literals.

## Tests

`react/vite-plugins/review-overlay/client/dock.test.ts`, new `describe('moving the dock with the keyboard')` — 14 cases: the grip is a `<button>` with a matching `title`/`aria-label`; the tab stop appears and disappears with `render` / `setCollapsed`; arrow steps and accumulation; the Shift step; `preventDefault` on the arrow (no page scroll under a moving dock) and a modified arrow left to the browser; clamping at every edge and the come-back-on-the-next-press property; nothing persisted until Enter or blur; Escape back to a dragged position and back to the default corner; Escape left alone when no move is running; a drag taking over from a keyboard move.

The existing pointer-drag tests are unchanged. Whole overlay suite: **578 passed (23 files)**.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

(First run in a fresh worktree failed the `Astryx theme build` step with `No "exports" main defined in .../node_modules/backend.ai-ui/package.json` — the workspace package had never been built there. `pnpm --filter backend.ai-ui run build` fixed it; unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhVNGfg7euLLTisbzTPMjk
