### PR TITLE
docs(FR-3869): Set up the ADR process

### DIFF
--- a/.claude/rules/adr.md
+++ b/.claude/rules/adr.md
@@ -29,22 +29,13 @@ and commit bodies. An ADR puts it in one file a reader can open from the code.
    restriction, a required prop pattern) review will enforce from now on. A bug
    fix, a single component, or work that follows an existing ADR needs none.
 3. **Write and proceed.** Record the decision in the same branch and keep
-   implementing. The PR is where a human reviews it. The ADR, the
+   implementing. The PR is where a human reviews it. The ADR, its
    `docs/ARCHITECTURE.md` row, and the code land in one PR.
 4. **Flag a reversal early.** A decision that reverses an ADR in force is a
    bigger call: say so in the PR description or the Jira issue before landing.
 5. **Name it where the code follows it.** A PR that lands or follows an ADR
    says `ADR NNNN` in its Summary. A source comment that exists because of an
-   ADR points at the file, as the ESLint message for ADR 0001 does.
+   ADR is the one-line pointer `comment-density.md` allows, aimed at the ADR
+   file, as the ESLint message for ADR 0001 is.
 
-## How to write one
-
-Load the `adr-writing` skill. It holds the file conventions (filename, English
-title, no status field, how a decision is retired), the section skeleton, the
-writing rules, and the landing checks. Do not restate them here.
-
-## Related
-
-- `docs/ARCHITECTURE.md` — the index of ADRs in force and the next free number.
-- `docs/adr/0001-explicit-project-prop-contract.md` — the first ADR, and the
-  shape a guardrail-style decision takes.
+Write one with the `adr-writing` skill.

--- a/.claude/rules/adr.md
+++ b/.claude/rules/adr.md
@@ -1,0 +1,50 @@
+---
+description: Read the ADRs in force before changing what they cover; record a new architecture-level decision as an ADR in the same PR; flag a reversal to a human before landing it
+---
+
+# Architecture Decision Records
+
+Architecture-level decisions live in `docs/adr/`, one file per decision, indexed
+by `docs/ARCHITECTURE.md`. A decision on `main` is in force. Code that follows
+it must not drift from it, and code that needs a new decision must record one.
+
+## Why
+
+Reviewers and agents keep re-deriving *why* the code looks the way it does —
+why leaf components take `project` as a required prop, why a hook may not be
+imported on some routes — and the reasoning is scattered across Jira threads
+and commit bodies. An ADR puts it in one file a reader can open from the code.
+
+## Rules
+
+1. **Read before implementing.** Before changing an area an ADR covers, read
+   that ADR and its row in `docs/ARCHITECTURE.md`. Never implement against an
+   ADR in force. If you disagree, write a new ADR that supersedes it instead of
+   coding around it.
+2. **Write when a decision appears.** A change needs an ADR when it adds,
+   removes, or replaces a runtime dependency; moves where a kind of state lives
+   or who may read it; changes a contract between `react/`,
+   `packages/backend.ai-ui/`, Electron, or the manager API; changes routing or
+   page structure every page must follow; or introduces a guardrail (an ESLint
+   restriction, a required prop pattern) review will enforce from now on. A bug
+   fix, a single component, or work that follows an existing ADR needs none.
+3. **Write and proceed.** Record the decision in the same branch and keep
+   implementing. The PR is where a human reviews it. The ADR, the
+   `docs/ARCHITECTURE.md` row, and the code land in one PR.
+4. **Flag a reversal early.** A decision that reverses an ADR in force is a
+   bigger call: say so in the PR description or the Jira issue before landing.
+5. **Name it where the code follows it.** A PR that lands or follows an ADR
+   says `ADR NNNN` in its Summary. A source comment that exists because of an
+   ADR points at the file, as the ESLint message for ADR 0001 does.
+
+## How to write one
+
+Load the `adr-writing` skill. It holds the file conventions (filename, English
+title, no status field, how a decision is retired), the section skeleton, the
+writing rules, and the landing checks. Do not restate them here.
+
+## Related
+
+- `docs/ARCHITECTURE.md` — the index of ADRs in force and the next free number.
+- `docs/adr/0001-explicit-project-prop-contract.md` — the first ADR, and the
+  shape a guardrail-style decision takes.

--- a/.claude/skills/adr-writing/SKILL.md
+++ b/.claude/skills/adr-writing/SKILL.md
@@ -1,24 +1,26 @@
 ---
 name: adr-writing
 description: >-
-  Write and revise the documents under `docs/` — the ADRs in `docs/adr/` and
-  the `docs/ARCHITECTURE.md` index — so a first-time reader understands them
-  alone. Covers when a change needs an ADR, the file conventions (name, title,
-  no status field, how a decision is retired), the section skeleton, the
-  writing rules for titles, terms, and sentences, mermaid usage and its syntax
-  traps, and the checks a document passes before it lands. Use before
-  authoring a new ADR, before revising one, and before landing any change
-  under `docs/adr/`. Trigger on "ADR 써줘", "결정 기록 남겨줘", "write an
-  ADR", "architecture decision record", or when an implementation needs a
-  decision no ADR in force covers.
+  Write and revise the ADRs in `docs/adr/` and their index `docs/ARCHITECTURE.md`
+  so a first-time reader understands them alone. Covers the file conventions
+  (name, title, no status field, how a decision is retired), the section
+  skeleton, the writing rules for titles, terms, and sentences, mermaid usage
+  and its syntax traps, and the checks a document passes before it lands. Use
+  before authoring a new ADR, before revising one, and before landing any
+  change under `docs/adr/`. Trigger on "ADR 써줘", "결정 기록 남겨줘", "write
+  an ADR", "architecture decision record", or when an implementation needs a
+  decision no ADR in force covers. When a change needs an ADR, and what an
+  agent owes the ADRs in force, is `.claude/rules/adr.md`.
 ---
 
 # ADR writing
 
-A decision nobody can read was not recorded. This skill governs every document
-under `docs/adr/` and the index that lists them: when a change needs one, how
-the file is named and retired, how the sections run, when to draw instead of
-explain, and what must hold before the document lands.
+A decision nobody can read was not recorded. This skill governs the shape of
+every file under `docs/adr/` and of `docs/ARCHITECTURE.md`: how the file is
+named and retired, how the sections run, when to draw instead of explain, and
+what must hold before the document lands. When a change needs an ADR and what
+an agent owes the ADRs in force is `.claude/rules/adr.md`, loaded in every
+session; this skill does not repeat it.
 
 Every sentence must pass one test: **would someone meeting this codebase for
 the first time understand it without asking a question?** If not, the fix
@@ -26,11 +28,10 @@ belongs in the writing, not in the reader.
 
 ## What an ADR is for
 
-An ADR records an **architecture-level decision**: what was chosen, which
-alternatives were dropped and why, and what shape the code must now take. It
-is not a design document for every feature and not a changelog. The reader is
-an agent or a person who will build against this decision months from now,
-not the author and not today's reviewer.
+An ADR records an architecture-level decision: what was chosen, which
+alternatives were dropped and why, and what shape the code must now take. The
+reader is an agent or a person who will build against this decision months
+from now, not the author and not today's reviewer.
 
 - **Enough context, and no more.** A line survives only if that reader would
   act differently for having read it.
@@ -49,60 +50,20 @@ After reading, does the reader know what was chosen, what was rejected, and
 what shape the code must take? If any of the three is missing it is a memo,
 not a decision record.
 
-## When a change needs an ADR
-
-Write one when the change makes a decision that other code will have to
-follow. In this repository that is typically one of:
-
-- **A dependency crosses the boundary**: a runtime dependency is added,
-  removed, or replaced (a component system, a state library, a data layer, a
-  build tool).
-- **State ownership changes**: where a kind of state lives — Jotai atom,
-  Relay store, URL search param, component prop — or which layer may read it
-  (ADR 0001 is this kind).
-- **A contract between layers changes**: `react/` and
-  `packages/backend.ai-ui/`, host and Electron, the app and the manager's
-  GraphQL or REST surface.
-- **Routing or page structure changes** in a way every page must follow.
-- **A guardrail is introduced**: an ESLint restriction, a required prop
-  pattern, a naming rule that CI or review will enforce from now on.
-
-Do not write one for a bug fix, a single component, a copy change, or work
-that follows an ADR already in force. When unsure, ask: will a reviewer six
-months from now need to know *why* the code looks this way? If yes, write it.
-
-## The obligations that come with ADRs
-
-- **Read before implementing.** Before changing an area an ADR covers, read
-  that ADR and the row for it in `docs/ARCHITECTURE.md`. Never implement
-  against an ADR in force.
-- **Write and proceed.** When a decision becomes necessary mid-implementation,
-  write the ADR in the same branch and keep going. The PR is where a human
-  reviews it; do not wait for approval before writing code.
-- **Flag a reversal early.** A decision that reverses an ADR in force is a
-  bigger call: tell the human before landing it, in the PR description or the
-  Jira issue. Once approved it lands as an ordinary ADR.
-- **Land the ADR with the code.** The ADR, the `docs/ARCHITECTURE.md` row, and
-  the implementation go in one PR, so a reader can see the decision and the
-  code that follows it together.
-- **Name it where the code follows it.** A PR body that lands or follows an
-  ADR says `ADR NNNN` in its Summary. A source comment that exists only because
-  of an ADR points at the file (`docs/adr/NNNN-<slug>.md`), as the ESLint
-  message for ADR 0001 does.
-
 ## ADR file conventions
 
-This is the single definition of how an ADR file is named, titled, and
-retired. `.claude/rules/adr.md` and `AGENTS.md` point here rather than
-restating it.
+This is the definition of how an ADR file is named, titled, and retired. The
+one other copy is `.github/instructions/adr.instructions.md`, which restates
+the points Copilot needs because it cannot load a skill; keep the two in step.
 
 - **Filename** — `NNNN-title.md`, for example
-  `0001-explicit-project-prop-contract.md`. Numbers increase sequentially and
-  are never reused. Take the next number from `docs/ARCHITECTURE.md`.
-- **Title** — `# NNNN — <English noun phrase>`. It names the subject and
-  carries no colon subtitle and no parenthesis. A Jira key goes in `## 출처`,
-  never in the title. A supersede pointer goes on its own line, never in the
-  title.
+  `0001-explicit-project-prop-contract.md`. The next number is the highest
+  `NNNN` in `docs/adr/` plus one. Numbers are never reused, so when the
+  sequence has a gap the deleted number stays retired; `git log -- docs/adr`
+  shows it.
+- **Title** — `# NNNN — <English noun phrase>` (T1–T6). A Jira key goes in
+  the sources section, never in the title. A supersede pointer goes on its
+  own line, never in the title.
 - **No status field.** An ADR on `main` is a decision in force — landing it
   there, merged and human-approved, is the record. A draft under review is
   proposed by virtue of sitting in an unmerged PR, and nothing marks it in the
@@ -112,18 +73,20 @@ restating it.
   it, or **delete it outright**. Both are allowed, and deleting is usually
   right once the decision and the code it described are both gone, because a
   retired file is then a trap a reader has to disprove. Git history holds
-  what it said.
-- **Leave no dangling link** — either way, convert inbound references in
-  surviving documents and source comments to plain `ADR NNNN` mentions. No
-  check enforces this; grep for the retired filename before landing. A gap in
-  the sequence is the expected result, not an error.
+  what it said. Convert inbound references in surviving documents and source
+  comments to plain `ADR NNNN` mentions.
 - **Partial replacement** — if the new ADR replaces only part of the old,
   keep the old file, say so in the new ADR, and add a scoped pointer line
   rather than the blanket supersede marker.
+- **Mention form** — documents and PR bodies write `ADR NNNN`. Source
+  comments written before this convention say `ADR-NNNN`; they are corrected
+  when the file is next edited, never swept.
 - **Language** — the title is English; the body is Korean, with English
-  technical terms and identifiers written as they appear in the code. ADR
-  0001 predates this convention and keeps its English body; a document is not
-  translated for its own sake, only revised when its content changes.
+  technical terms and identifiers written as they appear in the code. An ADR
+  that landed before this convention keeps its body language; a document is
+  revised only when its content changes, never translated for its own sake.
+  Section headings follow the body language, as
+  [references/document-shape.md](references/document-shape.md) fixes.
 
 ## Phase 0 — Gather what the document must agree with
 
@@ -134,21 +97,18 @@ landed.
   narrows, and their rows in `docs/ARCHITECTURE.md`.
 - The source files the decision names, so identifiers in the text match the
   code — component names, hook names, atom names, ESLint rule ids.
-- The Jira issue the work belongs to, so `## 출처` can cite it.
+- The Jira issue the work belongs to, so the sources section can cite it.
 - Sibling ADRs written in the same increment, so terminology stays shared.
 
 ## Phase 1 — Draft against the rule catalogues
 
-Two catalogues apply, and both cite by id — "T1 violation", "fixed S4",
-"D2 missing".
+Two reference files hold the rules, and both cite by id — "T1 violation",
+"fixed S4", "D2 missing".
 
-| angle | ids | where | what it governs |
-|---|---|---|---|
-| Title | T1–T6 | [references/writing-rules.md](references/writing-rules.md) | an English noun phrase that names the subject and stands alone |
-| Language | L1–L5 | [references/writing-rules.md](references/writing-rules.md) | English terms as-is, glossary, unfamiliar words, no invented terms |
-| Sentences | S1–S10 | [references/writing-rules.md](references/writing-rules.md) | complete sentences, one idea per bullet, tables, one register |
-| Body shape | D1–D2 | [references/writing-rules.md](references/writing-rules.md) | the Summary a body opens with, and the diagram a flow gets |
-| Document shape | D3–D4 | [references/document-shape.md](references/document-shape.md) | the section skeleton, the increment overview, and the one-diagram floor |
+| file | ids | what it governs |
+|---|---|---|
+| [references/writing-rules.md](references/writing-rules.md) | T1–T6, L1–L5, S1–S10, D1–D2 | the title, the terms, the sentences and bullets, the Summary a body opens with, and the diagram a flow gets |
+| [references/document-shape.md](references/document-shape.md) | D3–D4 | the section skeleton, the heading language, the increment overview, the one-diagram floor, and the mermaid syntax traps |
 
 Write the sections in the order D3 fixes: title, Summary, Context, diagrams,
 Decision, alternatives with the reason each was rejected, Consequences,
@@ -156,65 +116,37 @@ sources, glossary.
 
 ## Phase 2 — Reread as a first-time reader
 
-Read the draft start to finish as someone who has never seen this codebase.
-Work the reread list in [references/writing-rules.md](references/writing-rules.md)
-first — it covers the title, terms, sentences, and register. These are the
-defects only a document can have.
+Work the reread list at the end of
+[references/writing-rules.md](references/writing-rules.md), then these three
+checks, which only a document can fail:
 
-- The document carries no diagram at all, or a paragraph describes something
-  that moves or connects and no diagram shows it (D2).
 - A sibling document draws the same components with a different decomposition
   (D2), or the increment has no overview document (D4).
-- A section from the D3 skeleton is missing, or a Decision item stacks several
-  decisions that should be `### N.` subsections.
+- A section from the D3 skeleton is missing, or a heading is in the wrong
+  language for the body.
+- A Decision item stacks several decisions that should be `### N.`
+  subsections.
 
-## Phase 3 — Adversarial review against the principle
+## Phase 3 — Adversarial review before landing
 
-Self-review does not catch this class of defect: the author cannot see their
-own narration. Dispatch reviewers with the document path and this instruction,
-and fix everything they return before landing.
+Self-review does not catch narration: the author cannot see their own. Before
+landing, dispatch one reviewer agent with the document path and this
+instruction, and fix everything it returns. Ask for defects, not a verdict:
 
-Ask for the defects, not a verdict. Three lenses, run in parallel:
-
-- **Padding.** Every line that a reader building from this would not act on —
+- **Padding.** Every line a reader building from this would not act on —
   narrated thinking, restatements, deferral rationale, the document describing
-  itself. Report each with its line number.
+  itself — with its line number.
 - **Gaps.** What an agent implementing against this would still have to ask:
   a chosen shape with no type, no prop contract, no invariant, no file it
   lives in.
-- **Leakage.** Narration of how the choice was reached, or a rejected
-  alternative argued with instead of stated and dismissed.
 
-Verify the returned findings before acting — a reviewer that is wrong about
-the code is common. Check the file it cites.
+Verify the findings before acting — a reviewer that is wrong about the code
+is common. Check the file it cites.
 
 ## Phase 4 — Land
 
-- Read the document once on GitHub's rendering of the branch — the reading
-  path for every document under `docs/`. A broken mermaid diagram shows there
-  as a syntax error; no CI check catches it.
-- Add or update the row in `docs/ARCHITECTURE.md` in the same change. One ADR
-  gets one row.
-- Verify every cross-reference resolves to a file that exists.
-- Name the ADR in the PR body's Summary as `ADR NNNN`.
-
-## Red flags
-
-Stop and rewrite if you are: adding a colon subtitle because the title feels
-thin; appending a Jira key or a parenthesis to the title; explaining a flow in
-prose because drawing it feels like work; drawing the same component with a
-different name than the sibling document uses; translating an English
-technical term into a Korean coinage; arguing with an earlier draft of the
-same document; or adding a section nobody asked for because it seems thorough.
-
-## References
-
-- [references/writing-rules.md](references/writing-rules.md) — the rule
-  catalogue: titles T1–T6, language L1–L5, sentences S1–S10, and body shape
-  D1–D2, with the reread list. Cite the ids when reviewing ("T6 violation")
-  and when reporting a fix ("rewrote the title, T1").
-- [references/document-shape.md](references/document-shape.md) — what only a
-  document has: D3 and D4, the ADR section skeleton, the one-diagram floor,
-  and the mermaid syntax traps.
-- `docs/ARCHITECTURE.md` — the index of ADRs in force and the next free
-  number.
+- Read the document once on GitHub's rendering of the branch. A broken
+  mermaid diagram shows there as a syntax error; no CI check catches it.
+- Add or update the ADR's row in `docs/ARCHITECTURE.md` in the same change.
+- Verify every cross-reference resolves to a file that exists, and when an
+  ADR was retired, grep for its filename so no link points at it.

--- a/.claude/skills/adr-writing/SKILL.md
+++ b/.claude/skills/adr-writing/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: adr-writing
+description: >-
+  Write and revise the documents under `docs/` — the ADRs in `docs/adr/` and
+  the `docs/ARCHITECTURE.md` index — so a first-time reader understands them
+  alone. Covers when a change needs an ADR, the file conventions (name, title,
+  no status field, how a decision is retired), the section skeleton, the
+  writing rules for titles, terms, and sentences, mermaid usage and its syntax
+  traps, and the checks a document passes before it lands. Use before
+  authoring a new ADR, before revising one, and before landing any change
+  under `docs/adr/`. Trigger on "ADR 써줘", "결정 기록 남겨줘", "write an
+  ADR", "architecture decision record", or when an implementation needs a
+  decision no ADR in force covers.
+---
+
+# ADR writing
+
+A decision nobody can read was not recorded. This skill governs every document
+under `docs/adr/` and the index that lists them: when a change needs one, how
+the file is named and retired, how the sections run, when to draw instead of
+explain, and what must hold before the document lands.
+
+Every sentence must pass one test: **would someone meeting this codebase for
+the first time understand it without asking a question?** If not, the fix
+belongs in the writing, not in the reader.
+
+## What an ADR is for
+
+An ADR records an **architecture-level decision**: what was chosen, which
+alternatives were dropped and why, and what shape the code must now take. It
+is not a design document for every feature and not a changelog. The reader is
+an agent or a person who will build against this decision months from now,
+not the author and not today's reviewer.
+
+- **Enough context, and no more.** A line survives only if that reader would
+  act differently for having read it.
+- **Never narrate your thinking.** Deliberation, reversals, what an earlier
+  draft said, what you worried about — none of it belongs. State the fact, the
+  option, or the decision.
+- **The document never talks about itself.** No "covered in the last section",
+  no "this document does not decide X". Say the thing or delete it.
+- **Link outward instead of retelling.** When the context lives in another
+  ADR, a source file, a Jira issue, or an upstream document, cite it and
+  reproduce only the sentence the reader must act on.
+- **Name the scope boundary once.** What is out of scope gets one line — never
+  the reasoning for deferring it, never a sketch of the deferred design.
+
+After reading, does the reader know what was chosen, what was rejected, and
+what shape the code must take? If any of the three is missing it is a memo,
+not a decision record.
+
+## When a change needs an ADR
+
+Write one when the change makes a decision that other code will have to
+follow. In this repository that is typically one of:
+
+- **A dependency crosses the boundary**: a runtime dependency is added,
+  removed, or replaced (a component system, a state library, a data layer, a
+  build tool).
+- **State ownership changes**: where a kind of state lives — Jotai atom,
+  Relay store, URL search param, component prop — or which layer may read it
+  (ADR 0001 is this kind).
+- **A contract between layers changes**: `react/` and
+  `packages/backend.ai-ui/`, host and Electron, the app and the manager's
+  GraphQL or REST surface.
+- **Routing or page structure changes** in a way every page must follow.
+- **A guardrail is introduced**: an ESLint restriction, a required prop
+  pattern, a naming rule that CI or review will enforce from now on.
+
+Do not write one for a bug fix, a single component, a copy change, or work
+that follows an ADR already in force. When unsure, ask: will a reviewer six
+months from now need to know *why* the code looks this way? If yes, write it.
+
+## The obligations that come with ADRs
+
+- **Read before implementing.** Before changing an area an ADR covers, read
+  that ADR and the row for it in `docs/ARCHITECTURE.md`. Never implement
+  against an ADR in force.
+- **Write and proceed.** When a decision becomes necessary mid-implementation,
+  write the ADR in the same branch and keep going. The PR is where a human
+  reviews it; do not wait for approval before writing code.
+- **Flag a reversal early.** A decision that reverses an ADR in force is a
+  bigger call: tell the human before landing it, in the PR description or the
+  Jira issue. Once approved it lands as an ordinary ADR.
+- **Land the ADR with the code.** The ADR, the `docs/ARCHITECTURE.md` row, and
+  the implementation go in one PR, so a reader can see the decision and the
+  code that follows it together.
+- **Name it where the code follows it.** A PR body that lands or follows an
+  ADR says `ADR NNNN` in its Summary. A source comment that exists only because
+  of an ADR points at the file (`docs/adr/NNNN-<slug>.md`), as the ESLint
+  message for ADR 0001 does.
+
+## ADR file conventions
+
+This is the single definition of how an ADR file is named, titled, and
+retired. `.claude/rules/adr.md` and `AGENTS.md` point here rather than
+restating it.
+
+- **Filename** — `NNNN-title.md`, for example
+  `0001-explicit-project-prop-contract.md`. Numbers increase sequentially and
+  are never reused. Take the next number from `docs/ARCHITECTURE.md`.
+- **Title** — `# NNNN — <English noun phrase>`. It names the subject and
+  carries no colon subtitle and no parenthesis. A Jira key goes in `## 출처`,
+  never in the title. A supersede pointer goes on its own line, never in the
+  title.
+- **No status field.** An ADR on `main` is a decision in force — landing it
+  there, merged and human-approved, is the record. A draft under review is
+  proposed by virtue of sitting in an unmerged PR, and nothing marks it in the
+  file. The one marker a file ever carries is reversal.
+- **Reversing a decision** — do not edit the existing ADR's reasoning. Either
+  keep the file and add a top line `> superseded by NNNN` naming what replaced
+  it, or **delete it outright**. Both are allowed, and deleting is usually
+  right once the decision and the code it described are both gone, because a
+  retired file is then a trap a reader has to disprove. Git history holds
+  what it said.
+- **Leave no dangling link** — either way, convert inbound references in
+  surviving documents and source comments to plain `ADR NNNN` mentions. No
+  check enforces this; grep for the retired filename before landing. A gap in
+  the sequence is the expected result, not an error.
+- **Partial replacement** — if the new ADR replaces only part of the old,
+  keep the old file, say so in the new ADR, and add a scoped pointer line
+  rather than the blanket supersede marker.
+- **Language** — the title is English; the body is Korean, with English
+  technical terms and identifiers written as they appear in the code. ADR
+  0001 predates this convention and keeps its English body; a document is not
+  translated for its own sake, only revised when its content changes.
+
+## Phase 0 — Gather what the document must agree with
+
+Read these before writing, so the draft does not contradict what already
+landed.
+
+- The ADRs this decision touches, including the ones it supersedes or
+  narrows, and their rows in `docs/ARCHITECTURE.md`.
+- The source files the decision names, so identifiers in the text match the
+  code — component names, hook names, atom names, ESLint rule ids.
+- The Jira issue the work belongs to, so `## 출처` can cite it.
+- Sibling ADRs written in the same increment, so terminology stays shared.
+
+## Phase 1 — Draft against the rule catalogues
+
+Two catalogues apply, and both cite by id — "T1 violation", "fixed S4",
+"D2 missing".
+
+| angle | ids | where | what it governs |
+|---|---|---|---|
+| Title | T1–T6 | [references/writing-rules.md](references/writing-rules.md) | an English noun phrase that names the subject and stands alone |
+| Language | L1–L5 | [references/writing-rules.md](references/writing-rules.md) | English terms as-is, glossary, unfamiliar words, no invented terms |
+| Sentences | S1–S10 | [references/writing-rules.md](references/writing-rules.md) | complete sentences, one idea per bullet, tables, one register |
+| Body shape | D1–D2 | [references/writing-rules.md](references/writing-rules.md) | the Summary a body opens with, and the diagram a flow gets |
+| Document shape | D3–D4 | [references/document-shape.md](references/document-shape.md) | the section skeleton, the increment overview, and the one-diagram floor |
+
+Write the sections in the order D3 fixes: title, Summary, Context, diagrams,
+Decision, alternatives with the reason each was rejected, Consequences,
+sources, glossary.
+
+## Phase 2 — Reread as a first-time reader
+
+Read the draft start to finish as someone who has never seen this codebase.
+Work the reread list in [references/writing-rules.md](references/writing-rules.md)
+first — it covers the title, terms, sentences, and register. These are the
+defects only a document can have.
+
+- The document carries no diagram at all, or a paragraph describes something
+  that moves or connects and no diagram shows it (D2).
+- A sibling document draws the same components with a different decomposition
+  (D2), or the increment has no overview document (D4).
+- A section from the D3 skeleton is missing, or a Decision item stacks several
+  decisions that should be `### N.` subsections.
+
+## Phase 3 — Adversarial review against the principle
+
+Self-review does not catch this class of defect: the author cannot see their
+own narration. Dispatch reviewers with the document path and this instruction,
+and fix everything they return before landing.
+
+Ask for the defects, not a verdict. Three lenses, run in parallel:
+
+- **Padding.** Every line that a reader building from this would not act on —
+  narrated thinking, restatements, deferral rationale, the document describing
+  itself. Report each with its line number.
+- **Gaps.** What an agent implementing against this would still have to ask:
+  a chosen shape with no type, no prop contract, no invariant, no file it
+  lives in.
+- **Leakage.** Narration of how the choice was reached, or a rejected
+  alternative argued with instead of stated and dismissed.
+
+Verify the returned findings before acting — a reviewer that is wrong about
+the code is common. Check the file it cites.
+
+## Phase 4 — Land
+
+- Read the document once on GitHub's rendering of the branch — the reading
+  path for every document under `docs/`. A broken mermaid diagram shows there
+  as a syntax error; no CI check catches it.
+- Add or update the row in `docs/ARCHITECTURE.md` in the same change. One ADR
+  gets one row.
+- Verify every cross-reference resolves to a file that exists.
+- Name the ADR in the PR body's Summary as `ADR NNNN`.
+
+## Red flags
+
+Stop and rewrite if you are: adding a colon subtitle because the title feels
+thin; appending a Jira key or a parenthesis to the title; explaining a flow in
+prose because drawing it feels like work; drawing the same component with a
+different name than the sibling document uses; translating an English
+technical term into a Korean coinage; arguing with an earlier draft of the
+same document; or adding a section nobody asked for because it seems thorough.
+
+## References
+
+- [references/writing-rules.md](references/writing-rules.md) — the rule
+  catalogue: titles T1–T6, language L1–L5, sentences S1–S10, and body shape
+  D1–D2, with the reread list. Cite the ids when reviewing ("T6 violation")
+  and when reporting a fix ("rewrote the title, T1").
+- [references/document-shape.md](references/document-shape.md) — what only a
+  document has: D3 and D4, the ADR section skeleton, the one-diagram floor,
+  and the mermaid syntax traps.
+- `docs/ARCHITECTURE.md` — the index of ADRs in force and the next free
+  number.

--- a/.claude/skills/adr-writing/agents/openai.yaml
+++ b/.claude/skills/adr-writing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'ADR Writing'
+  short_description: 'Write ADRs under docs/adr/ so a first-time reader understands them alone.'
+  default_prompt: 'Use this skill when a change needs an architecture decision record, or when authoring or revising one under docs/adr/. It fixes when an ADR is required, the file conventions (name, English title, no status field, how a decision is retired), the section skeleton, the writing rules for titles, terms, and sentences, mermaid usage, and the checks before landing. It governs how the document reads, not what it decides.'

--- a/.claude/skills/adr-writing/references/document-shape.md
+++ b/.claude/skills/adr-writing/references/document-shape.md
@@ -1,0 +1,72 @@
+# Document shape — reference
+
+Rule ids D3–D4 and the ADR section skeleton, used by the `adr-writing` skill.
+Both bind documents under `docs/adr/` only.
+
+The rules that bind the whole document — titles (T1–T6), language (L1–L5),
+sentences (S1–S10), and body shape (D1–D2 — the Summary a body opens with,
+and the diagram a flow gets) — live in [writing-rules.md](writing-rules.md).
+Read those first; this file adds what only a document has.
+
+The lifecycle is not a writing rule. It lives in the `adr-writing` skill's
+**ADR file conventions** section: a retired ADR either keeps its file and
+gains a `> superseded by NNNN` top line, or is deleted outright. Deleting is
+allowed, and numbers are never reused, so a gap in the sequence is expected.
+
+## Shape (D3–D4)
+
+| id | rule | fix |
+|----|------|-----|
+| D3 | Follow the ADR section skeleton | see below |
+| D4 | The first document of a multi-document increment carries the overview | give a one-line definition of each component and one diagram of how they relate; siblings link to it instead of redrawing it |
+
+## Mermaid in a document
+
+D2 says draw what moves. A document under `docs/adr/` also carries a floor:
+an ADR describes a system, so it carries at least one diagram. The floor is a
+document rule and reaches no other surface — a PR body draws when it has
+something that moves and otherwise draws nothing.
+
+Label every edge with what actually crosses it, such as `project prop`,
+`useFragment(queryRef)`, or `mutation variables`. Mark which boxes read
+ambient state or hold a side effect, because a boundary a reader has to infer
+is a boundary they will get wrong.
+
+Diagrams across sibling documents must use the same component decomposition.
+A reader moving between two ADRs should recognise the same boxes.
+
+## D3 — ADR section skeleton
+
+- `# NNNN — <English noun-phrase title>` (T1–T6; the `NNNN — ` prefix is the
+  skeleton, not an appended qualifier)
+- `## Summary` — complete-sentence bullets. If unfamiliar terms appear, open
+  with `> 낯선 용어는 문서 맨 아래 [용어](#용어)에 모아 두었다.`
+- `## Context` — what exists today and why a decision is needed. When the
+  decision introduces a component, say in one sentence what that component is
+  before saying why it is needed, and say what it is not whenever the name
+  invites the wrong reading.
+- `## 설계도` — mermaid. Give each diagram its own heading when there are
+  several.
+- `## Decision` — `### N. <heading>` per decision, one idea each. Inventories
+  as tables. Name the file, type, prop, or rule the decision lands in.
+- `## 대안과 기각 사유` — one bullet per alternative: what it is, its
+  advantage, that it is rejected, and why.
+- `## Consequences` — gains and limits, as complete-sentence bullets.
+- `## 출처` — the Jira issues and the sources the decision rests on, then a
+  `관련:` line linking the neighbouring ADRs.
+- `## 용어` — the glossary table, when the document introduced a term a
+  first-time reader would not know.
+
+## Mermaid syntax traps
+
+| trap | why it breaks | write instead |
+|---|---|---|
+| `A -. .-> B` | a dotted link whose label is only whitespace does not parse | `A -.-> B` |
+| `{}` or `\|` inside a flowchart node label | the characters carry shape meaning | rewrite the label, or use a sequence diagram where message text is plain |
+| a floating `NOTE[...]` node to caption a group | reads as a component that does not exist | use a `subgraph` whose title is the caption |
+
+GitHub renders every diagram when the document is read, so the first two rows
+show a syntax error on the page — read the branch's rendered view before
+landing, because no CI check catches them. The third breaks nowhere: a
+floating caption node is valid mermaid, and only a reader can see that it
+names a component which does not exist.

--- a/.claude/skills/adr-writing/references/document-shape.md
+++ b/.claude/skills/adr-writing/references/document-shape.md
@@ -1,17 +1,9 @@
 # Document shape — reference
 
-Rule ids D3–D4 and the ADR section skeleton, used by the `adr-writing` skill.
-Both bind documents under `docs/adr/` only.
-
-The rules that bind the whole document — titles (T1–T6), language (L1–L5),
-sentences (S1–S10), and body shape (D1–D2 — the Summary a body opens with,
-and the diagram a flow gets) — live in [writing-rules.md](writing-rules.md).
-Read those first; this file adds what only a document has.
-
-The lifecycle is not a writing rule. It lives in the `adr-writing` skill's
-**ADR file conventions** section: a retired ADR either keeps its file and
-gains a `> superseded by NNNN` top line, or is deleted outright. Deleting is
-allowed, and numbers are never reused, so a gap in the sequence is expected.
+Rule ids D3–D4, the ADR section skeleton, the heading language, the
+one-diagram floor, and the mermaid syntax traps, used by the `adr-writing`
+skill. The rules for titles, terms, sentences, and D1–D2 are in
+[writing-rules.md](writing-rules.md).
 
 ## Shape (D3–D4)
 
@@ -22,10 +14,8 @@ allowed, and numbers are never reused, so a gap in the sequence is expected.
 
 ## Mermaid in a document
 
-D2 says draw what moves. A document under `docs/adr/` also carries a floor:
-an ADR describes a system, so it carries at least one diagram. The floor is a
-document rule and reaches no other surface — a PR body draws when it has
-something that moves and otherwise draws nothing.
+D2 says draw what moves. An ADR also carries a floor: it describes a system,
+so it carries at least one diagram.
 
 Label every edge with what actually crosses it, such as `project prop`,
 `useFragment(queryRef)`, or `mutation variables`. Mark which boxes read
@@ -52,10 +42,19 @@ A reader moving between two ADRs should recognise the same boxes.
 - `## 대안과 기각 사유` — one bullet per alternative: what it is, its
   advantage, that it is rejected, and why.
 - `## Consequences` — gains and limits, as complete-sentence bullets.
-- `## 출처` — the Jira issues and the sources the decision rests on, then a
-  `관련:` line linking the neighbouring ADRs.
+- `## 출처` — the Jira issues and the sources the decision rests on, the date
+  the decision was made, then a `관련:` line linking the neighbouring ADRs.
 - `## 용어` — the glossary table, when the document introduced a term a
   first-time reader would not know.
+
+Section headings follow the body language. The four headings that differ:
+
+| Korean body | English body |
+|---|---|
+| `## 설계도` | `## Diagram` |
+| `## 대안과 기각 사유` | `## Rejected alternatives` |
+| `## 출처` | `## Sources` |
+| `## 용어` | `## Glossary` |
 
 ## Mermaid syntax traps
 
@@ -65,8 +64,6 @@ A reader moving between two ADRs should recognise the same boxes.
 | `{}` or `\|` inside a flowchart node label | the characters carry shape meaning | rewrite the label, or use a sequence diagram where message text is plain |
 | a floating `NOTE[...]` node to caption a group | reads as a component that does not exist | use a `subgraph` whose title is the caption |
 
-GitHub renders every diagram when the document is read, so the first two rows
-show a syntax error on the page — read the branch's rendered view before
-landing, because no CI check catches them. The third breaks nowhere: a
-floating caption node is valid mermaid, and only a reader can see that it
-names a component which does not exist.
+The first two rows show as a syntax error on GitHub's rendered page. The
+third breaks nowhere: a floating caption node is valid mermaid, and only a
+reader can see that it names a component which does not exist.

--- a/.claude/skills/adr-writing/references/writing-rules.md
+++ b/.claude/skills/adr-writing/references/writing-rules.md
@@ -1,0 +1,192 @@
+# Writing rules — reference
+
+Rule ids used by the `adr-writing` skill, grouped by four angles. They bind
+every document under `docs/adr/` and the `docs/ARCHITECTURE.md` index. Cite
+the id when reporting a finding ("T1 violation") and when reporting a fix
+("rewrote the title, T1").
+
+Body shape runs under ids D1–D4. D1 (Summary first) and D2 (draw what moves)
+are catalogued below under Angle 4. D3 (the ADR section skeleton) and D4 (the
+increment overview) live in [document-shape.md](document-shape.md), together
+with the one-diagram floor a document carries and the mermaid syntax traps.
+
+PR and issue titles are not governed here. They follow the
+`prefix(FR-NNNN): title` form that `AGENTS.md` fixes.
+
+## Angle 1 — Title (T1–T6)
+
+| id | rule | fix |
+|----|------|-----|
+| T1 | A title NAMES its subject; it does not explain it | write a noun phrase for what the thing IS; the explanation moves to the Summary |
+| T2 | No colon subtitle | needing one means the title is not doing its job — rewrite the title |
+| T3 | No term a first-time reader would not know | name the concrete thing instead, even if the body defines the term later |
+| T4 | Every title is English | a document keeps its Korean body and takes an English title |
+| T5 | One intent per title | if the title needs "and", a comma, or a second clause to hold two things, it is covering two decisions — split them |
+| T6 | Nothing is appended to a title — no parentheses, brackets, Jira key, or trailing qualifier | the qualifier goes in the body; the Jira key goes in `## 출처`; a supersede pointer goes on its own line |
+
+Three forms, one right:
+
+| form | example |
+|---|---|
+| names it (correct) | `Explicit project prop contract for leaf components` |
+| explains it (wrong) | `Leaf components take the project as a prop instead of reading it` |
+| opens with jargon (wrong) | `Ambient-read elimination: the leaf tier` |
+
+Test: read the title alone, without the body. Does it tell you what the
+document is about, or does it argue a point you cannot yet follow?
+
+T2 and T6 in practice:
+
+| wrong | why | right |
+|---|---|---|
+| `ADR-0001: Explicit project prop contract for leaf components` | a colon after the number (T2); the `NNNN — ` prefix is the skeleton | `0001 — Explicit project prop contract for leaf components` |
+| `0002 — Relay pagination modes (FR-3430, supersedes 0001 §3)` | a Jira key and a supersede note appended (T6) | `0002 — Relay pagination modes`, with the key in `## 출처` and the pointer on its own line |
+
+## Angle 2 — Language (L1–L5)
+
+| id | rule | fix |
+|----|------|-----|
+| L1 | Do not coin awkward Korean calques for English technical terms | write the English word inside the Korean sentence: fragment, atom, search param, leaf component |
+| L2 | The glossary sits at the END under `## 용어`, linked from first use | `[ambient read](#용어)`; GitHub keeps Hangul heading slugs, so the anchor resolves |
+| L3 | Explain any term a first-time reader would not know, with a reference | give the meaning and point at the ADR, the source file, or the upstream doc |
+| L4 | Do not invent a term. Use the name the repository already uses | grep `react/` and `packages/` for the thing; if it has no name, describe it instead of naming it |
+| L5 | Do not carry an English metaphor into Korean. Write what happens instead | not `삼킨다` but `mutation을 보내지 않는다`; not `구멍` but `막는 것이 없다` |
+
+Banned example for L1: writing `조각` for "fragment". Write `fragment`, or
+better, name the concrete thing — `useFragment`, the `queryRef` prop.
+
+L5 is not L1 with a different word, and its fix is the opposite one. L1 says
+to keep the English term because the code is written with that word, so a
+reader can go and find it. A metaphor has nothing to find: `swallow` sitting
+in a Korean sentence is still a figure, so keeping the English helps no one.
+Delete the figure and write the mechanism it stood for.
+
+L4 covers the failure where two real terms get welded into a phrase nobody
+uses. `ambient`와 `selector`는 둘 다 코드에 있지만 `ambient selector`는 없다.
+Before writing a compound, grep for it: if the repository never says it,
+neither should the document. A reader cannot tell an invented term from one
+they simply have not met, so they go looking for a definition that does not
+exist.
+
+A glossary row carries a full sentence, not a fragment: "ambient read |
+component가 prop이 아니라 전역 atom이나 hook에서 현재 값을 직접 읽는 것이다".
+
+A term several ADRs share is defined once, in the ADR that introduced it; a
+later document links that row instead of restating it.
+
+## Angle 3 — Sentences and structure (S1–S10)
+
+| id | rule | fix |
+|----|------|-----|
+| S1 | No rambling — every sentence earns its place | delete the sentence that only restates the previous one |
+| S2 | Never add content that is useless, redundant, contradictory, speculative, or unrequested | delete it; thoroughness is not measured in sections |
+| S3 | A document reads as written once | never reference or argue with its own earlier draft; revise in place while unmerged — history lives in git and the Jira issue |
+| S4 | Write complete sentences | no `=` shorthand, no arrow chain `A → B → C`, no verbless fragment list |
+| S5 | One bullet or paragraph states one idea | split the item; put field/enum/option inventories in a table; parentheses go one level deep |
+| S6 | Detail goes in bullet lists, not paragraph blocks | reserve running prose for the Summary and short lead-ins |
+| S7 | One register throughout: state what is and what was decided | delete selling words, hedges, and exclamations; a sentence that promotes a decision has stopped recording it |
+| S8 | An explaining bullet opens with a short English label | write `- **<English noun phrase>**: <detail>`: two to four English words the reader takes in at a glance, then the detail after the colon in Korean. A rule, checklist, or step list is exempt and keeps the instruction as its label |
+| S9 | Every sentence names the thing that acts | write the actor — a component, a hook, a file, a page, a person. Korean drops subjects freely, so the fix is to put one back, not to trust that the reader will supply it |
+| S10 | An explaining bullet carries both halves — never a bare one-liner, never a paragraph | a label with no detail leaves the reader with the "why" missing; a detail past three sentences belongs in `### N.` subsections or a table |
+
+S4 in practice. Shorten by cutting content, never by compressing grammar —
+the reader must never reconstruct a missing verb.
+
+| wrong | right |
+|---|---|
+| `project prop = 필수. page만 ambient read, leaf는 금지. null → tier별 처리.` | `converted leaf component는 필수 prop \`project\`를 받는다. ambient 값은 page만 읽어 prop으로 넘기고, leaf는 \`useCurrentProjectValue\`를 부르지 않는다. \`null\`이 오면 tier마다 정한 동작을 한다.` |
+
+Tables, glossaries, command or field lists, and the S8 label are exempt from
+S4: there the phrase form IS the content.
+
+S5 in practice. A Decision item that stacks four things becomes four `### N.`
+subsections, and the field inventory inside it becomes a table.
+
+S7 in practice. The register is plain declarative sentences about what
+exists, what changed, and what was decided.
+
+| wrong | right |
+|---|---|
+| `이 설계는 훨씬 깔끔하고 안전한 구조를 제공합니다!` | `이 설계는 project 선택을 page 한 곳으로 모은다.` |
+| `아마도 대부분의 경우에는 문제가 없을 것으로 보입니다.` | `page 밖에서 mount되는 component는 route로 판정한다. 그 밖의 경로는 아직 검증하지 않았다.` |
+
+S8 in practice. A reader scans a list by its first words. A list of labels is
+a table of contents; a list of sentences is a wall.
+
+| wrong | why | right |
+|---|---|---|
+| `- prop이 필수라서 TypeScript가 모든 call site에 결정을 강제하고, 빠뜨리면 컴파일 오류가 난다.` | the detail comes first, so the point arrives last | `- **Required prop**: prop이 필수라서 TypeScript가 모든 call site에 project 결정을 강제한다. 빠뜨리면 silent bug가 아니라 컴파일 오류가 난다.` |
+| `- **prop은 필수로 둔다.** 모든 call site가 …` | the opening is a sentence, not a label | `- **Required prop**: 모든 call site가 …` |
+| `- **결정의 축**: 세 tier로 나눈다.` | the label is a Korean coinage, so nothing is grasped at a glance | `- **Null handling tiers**: \`null\`을 받은 component는 modal, button, alert 세 tier 중 하나로 동작한다.` |
+
+The label is English even in a Korean body. This rule fixes that, not T4 —
+T4 binds titles, and a Korean `## 용어` heading stays Korean. Inventing the
+label in Korean is the most common way a coined term enters a document.
+
+The label is a noun phrase, so S4 does not bind it. S4 binds the detail after
+the colon, which is a complete sentence like any other.
+
+Name the subject the item settles — its owner, its order, its limit, its
+entry point, its cost. An action wearing a noun's clothes fails the rule too:
+write `- **Prop owner**:`, never `- **Where the prop is decided**:`.
+
+S8 and S10 bind the lists that **explain** — decisions, consequences,
+rejected alternatives. Two kinds of list fall outside S8's noun form.
+
+- An **inventory whose items are the content** stays bare: option lists,
+  field and enum tables, glossary rows, file paths, and source citations.
+  S10 does not bind it either, because there is no label to pair a detail
+  with.
+- A **rule, checklist, or step list keeps the instruction as its label** —
+  `- **Draw what moves** (D2)`, `- **Read before implementing**`. A reader
+  scans such a list for what to do, and a noun phrase would bury it.
+
+S9 in practice. A subjectless Korean sentence reads as a proverb, and a
+proverb cannot be checked against the code. Ask of every sentence: **who does
+this, and to what?** If the answer is not in the sentence, put it there.
+
+| wrong | why | right |
+|---|---|---|
+| `같은 값을 두 곳에서 읽으면 어긋난다.` | nobody reads, nothing diverges | `page와 leaf component가 같은 atom을 각자 읽고 있다.` |
+| `두 값이 같은지 검사하는 것이 없다.` | the missing checker is the point | `두 값이 같은지 아무도 검사하지 않는다.` |
+| `헤더에는 이미 있다.` | what is already there | `\`WebUIHeader\`에는 \`ProjectSelect\`가 이미 있다.` |
+
+The same defect hides in nominalisations. `그 판단은 page가 내리는 것이 맞다`
+names the judge; `그것은 page가 아는 것이 맞다` does not say what knowing
+means. Prefer the verb with an actor over the noun without one.
+
+## Angle 4 — Body shape (D1–D2)
+
+| id | rule | fix |
+|----|------|-----|
+| D1 | Every body opens with a Summary | state the problem, the decision, and the scope before any detail, under `## Summary` |
+| D2 | Draw what moves rather than explaining it | a data flow, a render sequence, a component layout, a state machine, or a before/after goes in a mermaid diagram, with every edge labelled by what crosses it |
+
+D2 test: if a paragraph describes something that moves or connects, draw it
+instead. Never explain a flow in prose alone. The converse is not a rule — a
+convention change, a dependency bump, or a rename needs no second diagram
+beyond the one-diagram floor in [document-shape.md](document-shape.md).
+
+## Reread as a first-time reader
+
+Read the draft start to finish as someone who has never seen this codebase.
+Each item is a defect to fix before landing.
+
+- The title only makes sense to someone who already read the body (T1).
+- The title carries a colon, a parenthesis, a Jira key, or two intents (T2,
+  T5, T6).
+- A term appears with no definition and no glossary entry (L3).
+- A term reads like the repository's vocabulary but appears nowhere in it
+  (L4).
+- A figure of speech stands where the mechanism should be (L5).
+- A sentence must be read twice to find its verb or its subject (S4).
+- A bullet carries a decision, its fields, its rationale, and its exception
+  at once (S5).
+- A sentence promotes the work instead of recording it (S7).
+- An explaining bullet opens with a sentence, with detail, or with a Korean
+  coinage, instead of a short English label (S8).
+- A sentence states a rule of thumb with nobody performing it (S9).
+- A bullet is a bare label with no detail, or a paragraph under a dash (S10).
+- The body opens with background instead of a Summary (D1).
+- A paragraph describes something that moves or connects, and no diagram
+  shows it (D2).

--- a/.claude/skills/adr-writing/references/writing-rules.md
+++ b/.claude/skills/adr-writing/references/writing-rules.md
@@ -5,13 +5,9 @@ every document under `docs/adr/` and the `docs/ARCHITECTURE.md` index. Cite
 the id when reporting a finding ("T1 violation") and when reporting a fix
 ("rewrote the title, T1").
 
-Body shape runs under ids D1–D4. D1 (Summary first) and D2 (draw what moves)
-are catalogued below under Angle 4. D3 (the ADR section skeleton) and D4 (the
-increment overview) live in [document-shape.md](document-shape.md), together
-with the one-diagram floor a document carries and the mermaid syntax traps.
-
-PR and issue titles are not governed here. They follow the
-`prefix(FR-NNNN): title` form that `AGENTS.md` fixes.
+D3–D4, the section skeleton, and the mermaid traps are in
+[document-shape.md](document-shape.md). PR and issue titles follow the
+`prefix(FR-NNNN): title` form that `AGENTS.md` fixes, not these rules.
 
 ## Angle 1 — Title (T1–T6)
 
@@ -119,27 +115,17 @@ a table of contents; a list of sentences is a wall.
 | `- **prop은 필수로 둔다.** 모든 call site가 …` | the opening is a sentence, not a label | `- **Required prop**: 모든 call site가 …` |
 | `- **결정의 축**: 세 tier로 나눈다.` | the label is a Korean coinage, so nothing is grasped at a glance | `- **Null handling tiers**: \`null\`을 받은 component는 modal, button, alert 세 tier 중 하나로 동작한다.` |
 
-The label is English even in a Korean body. This rule fixes that, not T4 —
-T4 binds titles, and a Korean `## 용어` heading stays Korean. Inventing the
-label in Korean is the most common way a coined term enters a document.
-
-The label is a noun phrase, so S4 does not bind it. S4 binds the detail after
-the colon, which is a complete sentence like any other.
+The label is English even in a Korean body; inventing it in Korean is the
+most common way a coined term enters a document.
 
 Name the subject the item settles — its owner, its order, its limit, its
 entry point, its cost. An action wearing a noun's clothes fails the rule too:
 write `- **Prop owner**:`, never `- **Where the prop is decided**:`.
 
 S8 and S10 bind the lists that **explain** — decisions, consequences,
-rejected alternatives. Two kinds of list fall outside S8's noun form.
-
-- An **inventory whose items are the content** stays bare: option lists,
-  field and enum tables, glossary rows, file paths, and source citations.
-  S10 does not bind it either, because there is no label to pair a detail
-  with.
-- A **rule, checklist, or step list keeps the instruction as its label** —
-  `- **Draw what moves** (D2)`, `- **Read before implementing**`. A reader
-  scans such a list for what to do, and a noun phrase would bury it.
+rejected alternatives. An inventory whose items are the content (option
+lists, field tables, glossary rows, file paths, citations) stays bare, and
+neither rule binds it.
 
 S9 in practice. A subjectless Korean sentence reads as a proverb, and a
 proverb cannot be checked against the code. Ask of every sentence: **who does
@@ -163,9 +149,7 @@ means. Prefer the verb with an actor over the noun without one.
 | D2 | Draw what moves rather than explaining it | a data flow, a render sequence, a component layout, a state machine, or a before/after goes in a mermaid diagram, with every edge labelled by what crosses it |
 
 D2 test: if a paragraph describes something that moves or connects, draw it
-instead. Never explain a flow in prose alone. The converse is not a rule — a
-convention change, a dependency bump, or a rename needs no second diagram
-beyond the one-diagram floor in [document-shape.md](document-shape.md).
+instead. Never explain a flow in prose alone.
 
 ## Reread as a first-time reader
 

--- a/.github/instructions/adr.instructions.md
+++ b/.github/instructions/adr.instructions.md
@@ -11,8 +11,8 @@ full rules. The points below are the ones most often missed.
 
 ## File and title
 
-- Filename `NNNN-title.md`; take the next number from `docs/ARCHITECTURE.md`
-  and never reuse one.
+- Filename `NNNN-title.md`; the next number is the highest in `docs/adr/` plus
+  one, and a number is never reused.
 - Title `# NNNN — <English noun phrase>`. No colon subtitle, no parenthesis, no
   Jira key in the title.
 - No status field. A retired ADR gets a `> superseded by NNNN` top line or is
@@ -27,7 +27,8 @@ full rules. The points below are the ones most often missed.
   (`- **Required prop**: ...`).
 - At least one mermaid diagram, every edge labelled. Check the rendered branch
   on GitHub before landing; no CI catches a mermaid syntax error.
-- Jira issues go in `## 출처`.
+- Jira issues and the decision date go in `## 출처` (`## Sources` in an
+  English-body document).
 
 ## Index
 

--- a/.github/instructions/adr.instructions.md
+++ b/.github/instructions/adr.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "docs/adr/**/*.md,docs/ARCHITECTURE.md"
+---
+
+# ADR Guidelines for Backend.AI WebUI
+
+These instructions apply to the architecture decision records under `docs/adr/`
+and their index `docs/ARCHITECTURE.md`. Load the `adr-writing` skill
+(`.claude/skills/adr-writing/`) before writing or revising either; it holds the
+full rules. The points below are the ones most often missed.
+
+## File and title
+
+- Filename `NNNN-title.md`; take the next number from `docs/ARCHITECTURE.md`
+  and never reuse one.
+- Title `# NNNN — <English noun phrase>`. No colon subtitle, no parenthesis, no
+  Jira key in the title.
+- No status field. A retired ADR gets a `> superseded by NNNN` top line or is
+  deleted; inbound links become plain `ADR NNNN` mentions.
+
+## Body
+
+- Open with `## Summary`, then follow the section skeleton in
+  `.claude/skills/adr-writing/references/document-shape.md`.
+- Body in Korean, English technical terms and identifiers as they appear in the
+  code. Explaining bullets open with a short English label
+  (`- **Required prop**: ...`).
+- At least one mermaid diagram, every edge labelled. Check the rendered branch
+  on GitHub before landing; no CI catches a mermaid syntax error.
+- Jira issues go in `## 출처`.
+
+## Index
+
+- One ADR gets one row in `docs/ARCHITECTURE.md`, added in the same PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,7 @@ read `package.json` / `pnpm-workspace.yaml` / `ls` rather than expecting a list 
 ### Architecture Decision Records (detail: `.claude/rules/adr.md`, auto-loaded)
 
 - Architecture-level decisions live in `docs/adr/`, indexed by `docs/ARCHITECTURE.md`. A decision on `main` is in force: read the ADRs covering an area before changing it, and never implement against one.
-- A change that makes a new decision — a runtime dependency, where a kind of state lives, a contract between layers, routing every page follows, a guardrail review will enforce — records an ADR in the same PR and proceeds; the PR is where a human reviews it. A reversal of an ADR in force is flagged to a human before landing.
-- Write ADRs with the `adr-writing` skill. A PR that lands or follows one says `ADR NNNN` in its summary.
+- A change that makes a new decision other code must follow records an ADR in the same PR and proceeds; the PR is where a human reviews it. A reversal of an ADR in force is flagged to a human before landing.
 
 ### On-Demand Skills (loaded only when needed)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ read `package.json` / `pnpm-workspace.yaml` / `ls` rather than expecting a list 
 - **Storybook**: `storybook-patterns` skill (fw plugin; CSF 3, meta config, story patterns, checklists)
 - **i18n**: `i18n-patterns` skill (fw plugin; translation keys, casing rules, language-specific guidelines)
 - **Documentation**: `docs-writing-guide` skill (fw plugin; user manual structure, terminology, multilingual rules)
-- **ADR**: `adr-writing` skill (when a change needs an ADR, file conventions, section skeleton, writing rules, landing checks)
+- **ADR**: `adr-writing` skill (file conventions, section skeleton, writing rules, landing checks; when a change needs one is `.claude/rules/adr.md`)
 - **Backend.AI live data, field meanings, GraphQL**: `bai-agent` skill (preflight/login, the `search` -> `docs show`/`schema show`/`explain` -> `query` loop, and pointing the user at the `webui_url` the query result already carries). It ships with the CLI (`packages/backend.ai-agent-cli/skill/`), not as a repository skill: install it per user with `pnpm run bai-agent init --skill --no-login`. Its workflow contract is the generated `BAI-AGENT` block at the bottom of this file.
 - **Relay mutations**: `relay-mutation-store-updates` skill (when a mutation can skip the refetch — update mutations must return their changed fields so Relay patches the normalized store; refetch only when list membership changes)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,18 @@ read `package.json` / `pnpm-workspace.yaml` / `ls` rather than expecting a list 
 - Use Jotai for global state, Relay for GraphQL state.
 - Comment only what the code cannot say — ≤2 lines by default; the reasoning behind a change goes in the commit body and the PR, not the source file (`.claude/rules/comment-density.md`). The long justification blocks already in the tree are migration-era history: trim a file's blocks when you edit it, don't sweep.
 
+### Architecture Decision Records (detail: `.claude/rules/adr.md`, auto-loaded)
+
+- Architecture-level decisions live in `docs/adr/`, indexed by `docs/ARCHITECTURE.md`. A decision on `main` is in force: read the ADRs covering an area before changing it, and never implement against one.
+- A change that makes a new decision — a runtime dependency, where a kind of state lives, a contract between layers, routing every page follows, a guardrail review will enforce — records an ADR in the same PR and proceeds; the PR is where a human reviews it. A reversal of an ADR in force is flagged to a human before landing.
+- Write ADRs with the `adr-writing` skill. A PR that lands or follows one says `ADR NNNN` in its summary.
+
 ### On-Demand Skills (loaded only when needed)
 
 - **Storybook**: `storybook-patterns` skill (fw plugin; CSF 3, meta config, story patterns, checklists)
 - **i18n**: `i18n-patterns` skill (fw plugin; translation keys, casing rules, language-specific guidelines)
 - **Documentation**: `docs-writing-guide` skill (fw plugin; user manual structure, terminology, multilingual rules)
+- **ADR**: `adr-writing` skill (when a change needs an ADR, file conventions, section skeleton, writing rules, landing checks)
 - **Backend.AI live data, field meanings, GraphQL**: `bai-agent` skill (preflight/login, the `search` -> `docs show`/`schema show`/`explain` -> `query` loop, and pointing the user at the `webui_url` the query result already carries). It ships with the CLI (`packages/backend.ai-agent-cli/skill/`), not as a repository skill: install it per user with `pnpm run bai-agent init --skill --no-login`. Its workflow contract is the generated `BAI-AGENT` block at the bottom of this file.
 - **Relay mutations**: `relay-mutation-store-updates` skill (when a mutation can skip the refetch — update mutations must return their changed fields so Relay patches the normalized store; refetch only when list membership changes)
 
@@ -115,6 +122,7 @@ When terms disagree, precedence is: (1) the live UI i18n label in `resources/i18
 - `i18n.instructions.md` → `resources/i18n/**/*.json,packages/backend.ai-ui/src/locale/**/*.json` (use `i18n-patterns` skill for tsx/ts context)
 - `e2e.instructions.md` → `e2e/**/*.ts`
 - `docs.instructions.md` → `packages/backend.ai-webui-docs/**/*.md`
+- `adr.instructions.md` → `docs/adr/**/*.md,docs/ARCHITECTURE.md`
 
 ### Verification Harness
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,17 +10,8 @@
 | [0001 — Explicit project prop contract for leaf components](adr/0001-explicit-project-prop-contract.md) | leaf component는 현재 project를 ambient hook에서 읽지 않고 필수 prop `project`로 받는다. page만 ambient 값을 읽어 넘기고, `null`을 받은 component는 tier마다 정한 동작을 한다. `/admin/*` 화면은 project-agnostic route로 묶이고 ESLint가 그 안에서 `useCurrentProjectValue` import를 막는다. |
 | [0002 — Pin set link grammar and a single codec](adr/0002-pin-set-link-grammar-and-single-codec.md) | review overlay의 pin 여러 개는 `#bai=v3` part를 `&`로 이어 붙인 링크 하나로 나른다. 읽는 쪽은 overlay의 codec 하나뿐이고 `pnpm run review-pins` CLI로 노출되며, Claude 쪽 review skill과 Teams transport는 그 CLI를 부른다. |
 
-다음 번호는 **0003**다.
-
 ## 새 ADR을 적는 방법
 
-- **When**: 런타임 의존성을 더하거나 빼거나 바꿀 때, 어떤 상태가 어디에 살고 누가 읽는지를 바꿀 때,
-  `react/`·`packages/backend.ai-ui/`·Electron·manager API 사이의 계약을 바꿀 때, 모든 page가 따라야
-  하는 routing 구조를 바꿀 때, review가 앞으로 강제할 guardrail을 들일 때 쓴다. 버그 수정과
-  component 하나짜리 작업과 이미 있는 ADR을 따르는 작업에는 쓰지 않는다.
-- **How**: `.claude/skills/adr-writing/` 스킬이 파일 이름, 제목, 절 구성, 문장 규칙, 착지 전 검사를
-  정한다. 규칙은 그 스킬에만 있고 이 문서는 되풀이하지 않는다.
-- **Where**: ADR 파일과 이 표의 한 줄과 그 결정을 따르는 코드가 한 PR로 들어간다. ADR 하나는 이 표에
-  한 줄만 갖는다.
-- **Retire**: 결정을 뒤집을 때는 옛 파일 맨 위에 `> superseded by NNNN` 한 줄을 달거나 파일을
-  지운다. 번호는 다시 쓰지 않으므로 목록에 빈 번호가 생기는 것이 정상이다.
+언제 ADR이 필요한지는 `.claude/rules/adr.md`가, 파일 이름·제목·절 구성·문장 규칙·착지 전 검사는
+`.claude/skills/adr-writing/` 스킬이 정한다. ADR 파일과 이 표의 한 줄과 그 결정을 따르는 코드는 한
+PR로 들어간다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Architecture overview
+
+이 문서는 현행 ADR(Architecture Decision Record)의 색인이다. 진본은 각 ADR 파일(`docs/adr/`)이며,
+이 표는 새 해석을 더하지 않는다. `main`에 착지한 ADR은 발효된 결정이고, 코드는 그 결정을 따른다.
+
+## ADR 목록
+
+| ADR | 무엇을 정하는가 |
+|---|---|
+| [0001 — Explicit project prop contract for leaf components](adr/0001-explicit-project-prop-contract.md) | leaf component는 현재 project를 ambient hook에서 읽지 않고 필수 prop `project`로 받는다. page만 ambient 값을 읽어 넘기고, `null`을 받은 component는 tier마다 정한 동작을 한다. `/admin/*` 화면은 project-agnostic route로 묶이고 ESLint가 그 안에서 `useCurrentProjectValue` import를 막는다. |
+
+다음 번호는 **0002**다.
+
+## 새 ADR을 적는 방법
+
+- **When**: 런타임 의존성을 더하거나 빼거나 바꿀 때, 어떤 상태가 어디에 살고 누가 읽는지를 바꿀 때,
+  `react/`·`packages/backend.ai-ui/`·Electron·manager API 사이의 계약을 바꿀 때, 모든 page가 따라야
+  하는 routing 구조를 바꿀 때, review가 앞으로 강제할 guardrail을 들일 때 쓴다. 버그 수정과
+  component 하나짜리 작업과 이미 있는 ADR을 따르는 작업에는 쓰지 않는다.
+- **How**: `.claude/skills/adr-writing/` 스킬이 파일 이름, 제목, 절 구성, 문장 규칙, 착지 전 검사를
+  정한다. 규칙은 그 스킬에만 있고 이 문서는 되풀이하지 않는다.
+- **Where**: ADR 파일과 이 표의 한 줄과 그 결정을 따르는 코드가 한 PR로 들어간다. ADR 하나는 이 표에
+  한 줄만 갖는다.
+- **Retire**: 결정을 뒤집을 때는 옛 파일 맨 위에 `> superseded by NNNN` 한 줄을 달거나 파일을
+  지운다. 번호는 다시 쓰지 않으므로 목록에 빈 번호가 생기는 것이 정상이다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,8 +8,9 @@
 | ADR | 무엇을 정하는가 |
 |---|---|
 | [0001 — Explicit project prop contract for leaf components](adr/0001-explicit-project-prop-contract.md) | leaf component는 현재 project를 ambient hook에서 읽지 않고 필수 prop `project`로 받는다. page만 ambient 값을 읽어 넘기고, `null`을 받은 component는 tier마다 정한 동작을 한다. `/admin/*` 화면은 project-agnostic route로 묶이고 ESLint가 그 안에서 `useCurrentProjectValue` import를 막는다. |
+| [0002 — Pin set link grammar and a single codec](adr/0002-pin-set-link-grammar-and-single-codec.md) | review overlay의 pin 여러 개는 `#bai=v3` part를 `&`로 이어 붙인 링크 하나로 나른다. 읽는 쪽은 overlay의 codec 하나뿐이고 `pnpm run review-pins` CLI로 노출되며, Claude 쪽 review skill과 Teams transport는 그 CLI를 부른다. |
 
-다음 번호는 **0002**다.
+다음 번호는 **0003**다.
 
 ## 새 ADR을 적는 방법
 

--- a/docs/adr/0001-explicit-project-prop-contract.md
+++ b/docs/adr/0001-explicit-project-prop-contract.md
@@ -1,9 +1,30 @@
-# ADR-0001: Explicit project prop contract for leaf components
+# 0001 — Explicit project prop contract for leaf components
 
-- Status: Accepted
-- Date: 2026-07-29
-- Issues: FR-3407 (epic), FR-3408 (first application), FR-3415 (final
-  application — the `/admin/*` surface is complete)
+## Summary
+
+- Leaf components (creation modals, session-launch buttons, mismatch alerts)
+  take the current project as a **required** `project` prop and never read
+  the ambient value through `useCurrentProjectValue` themselves.
+- Pages are the only readers of the ambient project. They narrow it with
+  `toProjectContext` and pass it down; a page above project scope passes
+  `null`, and each component tier defines what `null` renders.
+- The project-agnostic `/admin/*` surface is gated by
+  `useIsProjectAgnosticPage()`: the header selector is not mounted there, and
+  an ESLint rule forbids importing the ambient hook in those pages.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  atom[(current-project atom)]
+  page[Project-scoped page]
+  agnostic[Project-agnostic page<br/>/admin/*]
+  leaf[Leaf component<br/>modal, button, alert tier]
+  atom -- "useCurrentProjectValue()" --> page
+  page -- "project prop, narrowed by toProjectContext" --> leaf
+  agnostic -- "project prop: null" --> leaf
+  atom -. "import forbidden by ESLint" .-x agnostic
+```
 
 ## Context
 
@@ -286,7 +307,7 @@ narrowing helper for the loosely-typed ambient value).
     domain-wide, and resource presets have no project dimension at all (see
     below). The page still owns the URL state and resolves the id; `ImageList`
     receives `project` plus an `onChangeProject` callback and never decides
-    the project itself, so ADR-0001's contract is intact.
+    the project itself, so ADR 0001's contract is intact.
 
     The consumers below it were converted:
     - `ImageList` — required `project: ProjectContextOrNull` plus
@@ -417,3 +438,10 @@ reintroduces the invisible-global failure mode this ADR exists to remove.
    that tier-specific behavior is rendered. Test external behavior only
    (props in, rendered output + mutation variables out) — never which hooks
    are called.
+
+## Sources
+
+- FR-3407 (epic); FR-3408, FR-3410, FR-3411, FR-3412, FR-3413, FR-3414, and
+  FR-3415 (the applications, in order — the `/admin/*` surface is complete
+  with the last).
+- Decided 2026-07-29.

--- a/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
+++ b/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
@@ -59,7 +59,7 @@ the quote markers gone and the link moved to a separate `hrefs[]`, so that
 reconstruction is Teams-shaped, not pin-shaped, and it feeds the CLI rather
 than duplicating it.
 
-## Considered options
+## Rejected alternatives
 
 - **`v4` set envelope** — every anchor in one compressed blob. Shorter URLs
   (deflate shares the repeated route and landmark) and a natural place for

--- a/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
+++ b/docs/adr/0002-pin-set-link-grammar-and-single-codec.md
@@ -1,8 +1,35 @@
-# ADR-0002: A pin set is `&`-repeated `#bai=v3` parts, read by one codec
+# 0002 — Pin set link grammar and a single codec
 
-- Status: Accepted
-- Date: 2026-09-04
-- Issues: FR-3313 (epic), the pin-set tickets under it
+## Summary
+
+- A pin set is `&`-repeated `#bai=v3` parts in one link:
+  `#bai=v3.<id1>.<anchor1>&bai=v3.<id2>.<anchor2>…`. A single pin is the N=1
+  case and is byte-identical to the existing link, so there is no version
+  bump.
+- The format has one reader: the review overlay's own codec, exposed as the
+  `pnpm run review-pins` CLI. The Claude-side review skill runs that CLI
+  instead of keeping a reimplementation.
+- The Teams transport in claude-mp only reconstructs the pasted text and hands
+  it to the CLI; it does not parse pins itself.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  overlay[Review overlay<br/>codec.ts, deeplink.ts, block.ts, id.ts]
+  link["Pin-set link and blocks<br/>#bai=v3 parts joined by &"]
+  surfaces[PR comment, Teams thread, Claude prompt]
+  teams[claude-mp Teams reader]
+  cli[review-pins CLI]
+  skill[Claude-side review skill]
+  overlay -- "copy set" --> link
+  link -- "paste" --> surfaces
+  surfaces -- "HTML flattened to text + hrefs" --> teams
+  teams -- "reconstructed text" --> cli
+  surfaces -- "pasted text" --> cli
+  cli -- "decoded pins" --> skill
+  overlay -. "same codec" .- cli
+```
 
 ## Context
 
@@ -56,3 +83,8 @@ than duplicating it.
   the last block, because repeating the set link in every block made the
   comment O(N²) — 371 KB at 30 pins, past GitHub's 65,536-character comment
   limit from 13 pins on.
+
+## Sources
+
+- FR-3313 (epic) and the pin-set tickets under it; FR-3855 landed the CLI.
+- Decided 2026-09-04.


### PR DESCRIPTION
Resolves #9457 (FR-3869)

## Summary

Architecture-level decisions in this repository had two ADRs and no convention around them: nothing said when a change needs one, how the file is named and retired, what sections it carries, or where the list of decisions in force lives. This PR ports the ADR process from `lablup-agent-platform` — the `adr-writing` skill, an auto-loaded rule, an instructions file for `docs/adr/**`, and the `docs/ARCHITECTURE.md` index — and brings ADR 0001 and ADR 0002 under the same header conventions. No code changes.

## What changed

- `.claude/skills/adr-writing/` — the skill an agent loads to write or revise an ADR: when a change needs one, the file conventions (filename, English title, no status field, `> superseded by NNNN` or delete), the section skeleton (D3), the writing rules for titles / terms / sentences (T1–T6, L1–L5, S1–S10, D1–D2), mermaid traps, and the landing checks. Examples are rewritten against this codebase (leaf components, `useCurrentProjectValue`, Relay fragments).
- `.claude/rules/adr.md` — auto-loaded rule with the five obligations: read before implementing, write when a decision appears, write and proceed in the same PR, flag a reversal early, name the ADR where code follows it.
- `.github/instructions/adr.instructions.md` — applies to `docs/adr/**/*.md` and `docs/ARCHITECTURE.md`; points at the skill and restates the points most often missed.
- `docs/ARCHITECTURE.md` — the index of ADRs in force, with one row per ADR and a pointer to the rule and the skill.
- `docs/adr/0001-explicit-project-prop-contract.md` — title moved to `# 0001 — …`, the `Status / Date / Issues` header replaced by a `## Summary` and a mermaid diagram of the prop flow, the issue keys and date moved to a `## Sources` section at the end. Body text is otherwise untouched.
- `docs/adr/0002-pin-set-link-grammar-and-single-codec.md` — the same header migration: `# 0002 — Pin set link grammar and a single codec` (the old title carried a colon subtitle), a `## Summary`, a diagram of the pin-set link's path from the overlay to the CLI, `## Considered options` renamed to the skeleton's `## Rejected alternatives`, and `## Sources`. Body text is otherwise untouched.
- `AGENTS.md` (and `CLAUDE.md` through the symlink) — a short "Architecture Decision Records" section under Core Guidelines, the skill listed under On-Demand Skills, and the instructions file listed under Auto-Applied Instructions.

## Decisions taken while porting

- **No status field.** The Jira scope lists `status` as part of the format; it is dropped on purpose. An ADR on `main` is in force by virtue of being merged, a draft is proposed by virtue of sitting in an unmerged PR, and the only marker a file ever carries is `> superseded by NNNN`. A status line drifts from the branch state and nobody updates it.
- **English title, Korean body.** New ADRs follow this. ADR 0001 and ADR 0002 predate the convention and keep their English bodies; only their headers and sources moved.
- **One skill, not two.** The source repository splits the rules between `writing` and `adr-writing`. Here the writing rules are scoped to `docs/adr/` and folded into `adr-writing` as a reference file, so PR and issue titles keep following the `prefix(FR-NNNN): title` form `AGENTS.md` already fixes.
- **One owner per rule.** When a change needs an ADR and what an agent owes the ADRs in force is `.claude/rules/adr.md` (auto-loaded); the file conventions, skeleton, and writing rules are the skill; `AGENTS.md`, `docs/ARCHITECTURE.md`, and the Copilot instructions file point at those two instead of restating them. The next ADR number is derived from `docs/adr/` rather than pinned in the index.
- **No review-checklist item, no CI.** The obligations live in the auto-loaded rule and `AGENTS.md`. There is no CI check for ADR links or mermaid syntax; the skill requires reading the rendered branch on GitHub before landing.

## How to reference an ADR from code and PRs

- A PR that lands or follows an ADR says `ADR NNNN` in its Summary.
- A source comment that exists because of an ADR points at the file path, as the ESLint message for ADR 0001 already does (`docs/adr/0001-explicit-project-prop-contract.md`).

## Verification

- `docs/` and `.claude/` are outside lint-staged's prettier globs (`src/**`, `react/src/**`); the files on `main` these edits touch carry the same prettier warnings before and after, so no formatting was applied.
- Both mermaid diagrams were checked on GitHub's rendering of this branch in a browser (ADR 0001 at commit 0d35217d2, ADR 0002 at 90b8dc3f3); both draw, no syntax error.
