### PR TITLE
style(FR-3871): reword DEGRADED as a replica shortfall in ko/ja/th/vi

### DIFF
--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -153,7 +153,7 @@
     "SelectDeployment": "デプロイメントを選択"
   },
   "comp:BAIDeploymentStatusTag": {
-    "Degraded": "低下中",
+    "Degraded": "レプリカ不足",
     "Deploying": "デプロイ中",
     "Healthy": "正常",
     "NotChecked": "未確認",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -153,7 +153,7 @@
     "SelectDeployment": "배포를 선택해주세요"
   },
   "comp:BAIDeploymentStatusTag": {
-    "Degraded": "저하됨",
+    "Degraded": "복제본 부족",
     "Deploying": "배포 중",
     "Healthy": "정상",
     "NotChecked": "미확인",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -153,7 +153,7 @@
     "SelectDeployment": "เลือกการปรับใช้"
   },
   "comp:BAIDeploymentStatusTag": {
-    "Degraded": "ลดลง",
+    "Degraded": "เรพลิกาไม่ครบ",
     "Deploying": "กำลังปรับใช้",
     "Healthy": "ปกติ",
     "NotChecked": "ยังไม่ตรวจสอบ",
@@ -287,9 +287,9 @@
     "PreferredDomainName": "โดเมนที่ต้องการ",
     "Project": "โปรเจกต์",
     "ProjectID": "รหัสโปรเจกต์",
-    "ReplicaSummary": "จำนวนสำเนา",
-    "ReplicaSummaryTooltip": "จำนวนสำเนาที่กำลังทำงานเทียบกับจำนวนสำเนาที่ต้องการ",
-    "Replicas": "จำนวนสำเนา",
+    "ReplicaSummary": "จำนวนเรพลิกา",
+    "ReplicaSummaryTooltip": "จำนวนเรพลิกาที่กำลังทำงานเทียบกับจำนวนเรพลิกาที่ต้องการ",
+    "Replicas": "จำนวนเรพลิกา",
     "ResourceGroup": "กลุ่มทรัพยากร",
     "RevisionNumber": "ฉบับแก้ไข",
     "RevisionNumberTooltip": "หมายเลขฉบับแก้ไขปัจจุบันของการปรับใช้",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -153,7 +153,7 @@
     "SelectDeployment": "Chọn triển khai"
   },
   "comp:BAIDeploymentStatusTag": {
-    "Degraded": "Bị suy giảm",
+    "Degraded": "Không đủ bản sao",
     "Deploying": "Đang triển khai",
     "Healthy": "Bình thường",
     "NotChecked": "Chưa kiểm tra",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1271,7 +1271,7 @@
       "SkipToReview": "レビューへスキップ"
     },
     "status": {
-      "Degraded": "低下",
+      "Degraded": "レプリカ不足",
       "Deploying": "デプロイ中",
       "Healthy": "正常",
       "NotChecked": "未確認",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1271,7 +1271,7 @@
       "SkipToReview": "검토로 건너뛰기"
     },
     "status": {
-      "Degraded": "저하됨",
+      "Degraded": "복제본 부족",
       "Deploying": "배포 중",
       "Healthy": "정상",
       "NotChecked": "미확인",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1271,7 +1271,7 @@
       "SkipToReview": "ข้ามไปยังการตรวจสอบ"
     },
     "status": {
-      "Degraded": "เสื่อมสภาพ",
+      "Degraded": "เรพลิกาไม่ครบ",
       "Deploying": "กำลังปรับใช้",
       "Healthy": "ปกติ",
       "NotChecked": "ยังไม่ตรวจสอบ",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1271,7 +1271,7 @@
       "SkipToReview": "Chuyển đến xem lại"
     },
     "status": {
-      "Degraded": "Suy giảm",
+      "Degraded": "Không đủ bản sao",
       "Deploying": "Đang triển khai",
       "Healthy": "Bình thường",
       "NotChecked": "Chưa kiểm tra",


### PR DESCRIPTION
Resolves #8652 (FR-3871)

Adopts option 1 from the issue: the **shortfall** framing for `DEGRADED`, so
WebUI and FastTrack render the same enum the same way in ko/ja/th/vi.

`DEGRADED` on a deployment means the active replica count fell below the desired
count. The four translations rendered the English term of art literally, as a
*decline from a prior level* — a claim the status does not make when zero
replicas ever came up. The new wording names the subject (replicas) and the
condition (not enough), which also reads correctly at `0 / N`.

**i18n strings only — no code changes.**

## Before / after

### 1. `comp:BAIDeploymentStatusTag.Degraded` — `packages/backend.ai-ui/src/locale/`

| locale | before | after |
|---|---|---|
| ko | 저하됨 | 복제본 부족 |
| ja | 低下中 | レプリカ不足 |
| th | ลดลง | เรพลิกาไม่ครบ |
| vi | Bị suy giảm | Không đủ bản sao |

### 2. `deployment.status.Degraded` — `resources/i18n/`

A parallel label set for the same enum. It is currently **orphaned** — no call
site reads `deployment.status.Degraded` (only `deployment.status.Terminated` is
referenced, from `AdminDeployment.tsx`, `DeploymentReplicasCard.tsx`,
`DeploymentListPage.tsx`, `ProjectAdminDeploymentsPage.tsx`) — but it is kept in
sync so it does not become a second, contradictory wording the moment something
picks it up.

| locale | before | after |
|---|---|---|
| ko | 저하됨 | 복제본 부족 |
| ja | 低下 | レプリカ不足 |
| th | เสื่อมสภาพ | เรพลิกาไม่ครบ |
| vi | Suy giảm | Không đủ bản sao |

### 3. th replica-noun alignment — `packages/backend.ai-ui/src/locale/th.json`

`comp:BAIModelDeploymentNodes`, the replica-count column the tag sits beside.
`สำเนา` → `เรพลิกา` only; nothing else in these strings changed, and no trailing
punctuation was added.

| key | before | after |
|---|---|---|
| `ReplicaSummary` | จำนวนสำเนา | จำนวนเรพลิกา |
| `Replicas` | จำนวนสำเนา | จำนวนเรพลิกา |
| `ReplicaSummaryTooltip` | จำนวนสำเนาที่กำลังทำงานเทียบกับจำนวนสำเนาที่ต้องการ | จำนวนเรพลิกาที่กำลังทำงานเทียบกับจำนวนเรพลิกาที่ต้องการ |

> The issue points at these keys as living under `comp:BAIDeploymentStatusTag`;
> they are actually in `comp:BAIModelDeploymentNodes` (th.json:290-292). The line
> numbers were right, the section label was not.

## Terminology

`packages/backend.ai-webui-docs/terminology.json:206-218` defines the `replica`
concept and approves **ko 복제본 / ja レプリカ / th เรพลิกา** as the preferred
non-English renderings. The avoid-list at `:687-694` bans **ko 레플리카** in
favour of 복제본 ("Use the Korean translation, not the transliteration"), which
FR-3082 (#7785) swept through the tree. The new ko/ja strings use the approved
nouns directly.

## The th deviation from the reporter's table

The issue proposes th **สำเนาไม่ครบ**; this PR uses **เรพลิกาไม่ครบ**.

`สำเนา` is the ordinary Thai word for *copy* (as in "save a copy"), not the
approved replica noun. terminology.json approves `เรพลิกา`, and
`resources/i18n/th.json` already uses `เรพลิกา` **33×** — including the sibling
`replicaStatus.tooltip.*` strings. The only *replica-sense* `สำเนา` anywhere in
the Thai stores were the three BUI strings in section 3 above, now aligned. The
four remaining `สำเนา` in `resources/i18n/th.json` (`:267` ×2, `:314`, `:2949`)
are all the ordinary *copy* sense — "save as a copy", "redundant copies" — and
are correctly left alone.

So the deviation keeps the tag and the count beside it naming the same noun,
which is exactly the property the issue asks for; it just picks the noun the
termbase already settled on.

**vi keeps the reporter's `bản sao`** even though it carries the same
copy/replica ambiguity as th `สำเนา`: terminology.json has no `vi` row for
`replica` (its `languages` are en/ko/ja/th), and the vi stores already use
`bản sao` as the replica noun store-wide (BUI `Số bản sao`, `resources/i18n/vi.json`
`:1081`, `:1131-1133`, `:1148`). With no termbase entry to override it,
store-consistency is the tiebreaker, and `Không đủ bản sao` matches the
adjacent count column exactly as the issue asks.

## Not touched, deliberately

- **`replicaStatus.*` (every locale).** A different tier with a different
  meaning: the health checker cannot reach an individual replica, and it is
  temporarily dropped from the active pool (`resources/i18n/ko.json`
  `replicaStatus.tooltip.Degraded`: "헬스 체커가 이 복제본에 접근할 수 없습니다.
  활성 풀에서 일시적으로 제외됩니다."). "Degraded" is accurate there — a reachable
  replica did become unreachable — so the literal wording stays.
- **`react/src/components/ReplicaStatusTag.tsx`.** Its `DEGRADED` →
  `replicaStatus.Degraded` mapping (line 48) is the **only translated `Degraded`
  that actually renders today**, and it keeps ko 저하됨.

  This means ko 저하됨 (replica tier) and ko 복제본 부족 (deployment tier) will
  coexist **on purpose**. They are two different statuses about two different
  objects, and the issue's closing note — that shortfall wording needs care once
  lifecycle and health render as separate fields — is precisely why the
  per-replica health tier should *not* inherit the deployment-level phrasing.
- **`en.json` anywhere.** English `Degraded` is the term of art; the issue says
  so explicitly.
- **The other 17 BUI locales** (`en` plus the 16 non-English ones — de, el, es,
  fi, fr, id, it, mn, ms, pl, pt, pt-BR, ru, tr, zh-CN, zh-TW). Out of scope for
  this issue, which is scoped to the four locales FastTrack already moved.
- **`packages/backend.ai-webui-docs/`.** No prose change needed; the termbase
  already says what this PR conforms to.

## Finding: `DEGRADED` is currently unreachable through `BAIDeploymentStatusTag`

Worth recording, because it bounds the user-visible effect of this PR to zero
today.

All three call sites feed `metadata.status`:

- `packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx:190`
- `react/src/components/DeploymentBasicInfoCard.tsx:92`
- `react/src/pages/DeploymentDetailPage.tsx:421` (via `deploymentStatus`, assigned
  from `deployment.metadata.status` at `:242`)

…and `metadata.status` is typed `DeploymentStatus`, which in
`data/schema.graphql:6155-6164` has **six** members — `PENDING`, `SCALING`,
`DEPLOYING`, `READY`, `STOPPING`, `STOPPED` — and **no `DEGRADED`**. The
component's `BAIDeploymentStatus` union still carries the health values
(`HEALTHY`/`UNHEALTHY`/`DEGRADED`/`NOT_CHECKED`) from when the tag was a
consolidated lifecycle+health tag, but the tag now renders under a **Lifecycle**
column while health moved to the Replica/Route surfaces.

So this PR is a correctness fix for the string, landed ahead of the enum: if
`DEGRADED` is ever routed back into this tag (or another product reads these
keys, as FastTrack does), it reads right from the start. It is also why the
issue's warning about `[Deploying] [replica shortfall]` cannot bite here yet.

## Out of scope — follow-up

`resources/i18n/th.json` still has a **แบบจำลอง** ("model") replica-noun residue,
a third spelling for the same concept: `:1133` (`DesiredReplicasTooltip`), `:1162`
(`ModelFolderTooltip`), `:2051` (`AdditionalMountsTooltip`), plus the
`adminDeploymentPreset`, `autoScalingRule` and `data.modelStore` blocks
(`Replicas`, `MinReplicas`, `MaxReplicas`, `StepSizeTooltip`, `ReplicaNumber`, …).
Aligning those on `เรพลิกา` touches auto-scaling and preset surfaces this issue
does not cover, so it is left for a dedicated pass rather than smuggled in here.

**Checklist:** (if applicable)

- [ ] Documentation — no change needed; `terminology.json` already approves the wording used.
- [ ] Minium required manager version — n/a, no API surface touched.
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup) — n/a.
- [x] Minimum requirements to check during review — see below.
- [x] Test case(s) to demonstrate the difference of before/after — before/after tables above.

### Minimum requirements to check during review

1. Only the 11 string values in the tables above changed; the diff is 8 JSON files, `11 insertions(+), 11 deletions(-)`, no `.ts`/`.tsx` touched.
2. No `replicaStatus.*` key, no `en.json`, and none of the other 17 BUI locales appear in the diff.
3. `scripts/check-terminology-i18n.mjs` (blocking gate, run inside `verify.sh`) reports **0 blocking findings**.

## Verification

`bash scripts/verify.sh` — tail:

```
CHECK 1 — terminology drift (i18n VALUES + docs prose vs avoid[])
  warn  [packages/backend.ai-ui/src/locale/en] comp:BAIResourceUnitGrid^ChangeGroupColor (context: for project)
        term "group" -> use "project" (Ambiguous)
        value: Change group color

  CHECK 1 summary: 0 blocking, 1 warn-only.

=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0
  warn-only terminology findings: 1
  near-duplicate findings (report): 0
  unknown-noun findings (report): 0
--- Terminology: PASS ---

=== Terminology self-test (report-only here; hard gate in CI) ===
non-English terminology precision self-test (FR-3051)
  rows under test: 12 non-en avoid row(s), 3 negative control(s)
  PASS — 696 assertion(s) hold.

=== ALL PASS ===
```

The single warn-only terminology finding is pre-existing, in `en.json`, and
unrelated to this PR (`comp:BAIResourceUnitGrid^ChangeGroupColor`). It is
warn-only and does not gate.

`pnpm --filter backend.ai-ui test`:

```
 Test Files  75 passed | 1 skipped (76)
      Tests  1966 passed | 1 skipped (1967)
```

The suite passes, but note that no test asserts these translated values —
`BAIDeploymentStatusTag.test.tsx` only exercises the status predicates and never
renders a label. The check that actually covers this diff is the terminology
gate above (0 blocking).

Not run, and why: the Astryx token gate (no CSS, theme token or `var(--…)`
change), `make i18n` (no new or removed keys — values only), and `pnpm relay`
(no `graphql` tag touched; `verify.sh` recompiles Relay regardless and it passes).

The commit was re-authored to the PR owner (content unchanged, `Co-Authored-By` /
`Claude-Session` trailers kept) so `license/cla` can resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VB9nrvZ2VxL9u3Bc1zhDbB