### PR TITLE
test(FR-3873): cover the missing-sToken branch of the /applauncher route

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 322 / 470 features covered (69%)**
+**Overall (in-scope routes): 334 / 489 features covered (68%)**
 
 | Page                     | Route                                            | Features | Covered | Status  |
 | ------------------------ | ------------------------------------------------ | :------: | :-----: | :-----: |
@@ -53,7 +53,7 @@
 | Admin Deployment Preset  | `/admin/deployments/deployment-presets/new`      |    4     |    4    | ✅ 100% |
 | Runtime Parameters       | `/admin/deployments?tab=runtime-variant-presets` |    5     |    5    | ✅ 100% |
 | Project-Agnostic Scope   | `/admin/*` (except `admin-dashboard`)            |    5     |    5    | ✅ 100% |
-| **Total**                |                                                  | **490**  | **333** | **68%** |
+| **Total**                |                                                  | **489**  | **334** | **68%** |
 
 ---
 

--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 334 / 489 features covered (68%)**
+**Overall (in-scope routes): 340 / 497 features covered (68%)**
 
 | Page                     | Route                                            | Features | Covered | Status  |
 | ------------------------ | ------------------------------------------------ | :------: | :-----: | :-----: |
@@ -53,7 +53,7 @@
 | Admin Deployment Preset  | `/admin/deployments/deployment-presets/new`      |    4     |    4    | ✅ 100% |
 | Runtime Parameters       | `/admin/deployments?tab=runtime-variant-presets` |    5     |    5    | ✅ 100% |
 | Project-Agnostic Scope   | `/admin/*` (except `admin-dashboard`)            |    5     |    5    | ✅ 100% |
-| **Total**                |                                                  | **489**  | **334** | **68%** |
+| **Total**                |                                                  | **497**  | **340** | **68%** |
 
 ---
 

--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-09-04
+> **Last Updated:** 2026-09-08
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 317 / 462 features covered (68%)**
+**Overall (in-scope routes): 322 / 470 features covered (69%)**
 
 | Page                     | Route                                            | Features | Covered | Status  |
 | ------------------------ | ------------------------------------------------ | :------: | :-----: | :-----: |
@@ -44,6 +44,7 @@
 | Reservoir                | `/reservoir`, `/reservoir/:artifactId`           |    18    |    0    |  ❌ 0%  |
 | Branding                 | `/branding`                                      |    14    |    0    |  ❌ 0%  |
 | App Launcher             | (modal)                                          |    19    |   11    | 🔶 58%  |
+| Edu App Launcher         | `/applauncher`, `/edu-applauncher`               |    8     |    5    | 🔶 63%  |
 | Chat                     | `/chat/:id?`                                     |    7     |    7    | ✅ 100% |
 | Plugin System            | (config-based)                                   |    12    |   12    | ✅ 100% |
 | RBAC Management          | `/rbac`                                          |    22    |   21    | 🔶 95%  |
@@ -52,7 +53,7 @@
 | Admin Deployment Preset  | `/admin/deployments/deployment-presets/new`      |    4     |    4    | ✅ 100% |
 | Runtime Parameters       | `/admin/deployments?tab=runtime-variant-presets` |    5     |    5    | ✅ 100% |
 | Project-Agnostic Scope   | `/admin/*` (except `admin-dashboard`)            |    5     |    5    | ✅ 100% |
-| **Total**                |                                                  | **482**  | **328** | **68%** |
+| **Total**                |                                                  | **490**  | **333** | **68%** |
 
 ---
 
@@ -1003,6 +1004,27 @@
 
 ---
 
+### 26b. Edu App Launcher (`/applauncher`, `/edu-applauncher`)
+
+**Test files:** [`e2e/app-launcher/edu-applauncher-stoken.spec.ts`](app-launcher/edu-applauncher-stoken.spec.ts)
+
+External portals (LMS) open these routes with a signed `sToken` plus the app and session to launch. The spec is fully mock-driven (`config.toml`, `/func/`, `/server/login-check`, `/server/token-login`) and needs no cluster; the sToken-authenticated happy path is validated by an out-of-tree manager `AUTHORIZE` hook plugin and cannot be minted in-tree.
+
+| Feature                                                                  | Status | Test                                                                                                      |
+| ------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------- |
+| Invalid sToken → boundary error card (`/edu-applauncher`)                | ✅     | ``invalid sToken on `/edu-applauncher` surfaces the boundary error card``                                 |
+| Invalid sToken → same error card on `/applauncher` (legacy alias)        | ✅     | ``invalid sToken on `/applauncher` (legacy alias) surfaces the same error card``                          |
+| Non-sToken URL params preserved in the error state                       | ✅     | `error state keeps non-sToken URL params intact (app, session_id)`                                        |
+| eduApp URL params forwarded to `token_login`                             | ✅     | `eduApp URL params (app, session_id, api_version, date, endpoint) all reach the token_login body`         |
+| Missing sToken → missing-token error card, no `token_login` call         | ✅     | ``User cannot launch an app from `/applauncher` without an sToken and sees the missing-token error card`` |
+| Launch app for an existing `session_id` while already logged in (#9488)  | ❌     | -                                                                                                         |
+| Create a session from `session_template` and launch (#9490)              | ❌     | -                                                                                                         |
+| sToken-authenticated launch (needs an out-of-tree AUTHORIZE hook plugin) | ❌     | -                                                                                                         |
+
+**Coverage: 🔶 5/8 features**
+
+---
+
 ### 27. Chat (`/chat/:id?`)
 
 **Test files:** [`e2e/chat/chat.spec.ts`](chat/chat.spec.ts), [`e2e/chat/chat-sync.spec.ts`](chat/chat-sync.spec.ts), [`e2e/chat/chat-attachment.spec.ts`](chat/chat-attachment.spec.ts)
@@ -1307,17 +1329,18 @@ These are core user workflows that affect the largest number of users.
 
 ### Priority 3: Nice to Have - Edge Cases, Admin Tools
 
-| #   | Page/Feature                                                        | Reason                                                                                    | Estimated Complexity |
-| --- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| 7   | **Endpoint Detail - Auto-scaling & Tokens** (`/serving/:serviceId`) | 14 features with 5 modals. Complex admin feature, but lower user count.                   | High                 |
-| 8   | **Session - Filtering, Drawer** (`/session`)                        | Session list already has creation/lifecycle coverage. SessionDetailDrawer is significant. | Low                  |
-| 9   | **Environment - Presets** (`/environment`)                          | 4 uncovered features for Resource Presets tab. Each with CRUD modals.                     | Medium               |
-| 10  | **Resources - Resource Groups** (`/agent`)                          | 5 uncovered features with 3 modals (create/edit/info). Agent drawer also untested.        | Medium               |
-| 11  | **Model Store** (`/model-store`)                                    | Browse/search models. ModelCardModal for detail. Read-only interface.                     | Low                  |
-| 12  | **Scheduler** (`/scheduler`)                                        | 6 features. Pending session queue monitoring. Admin tool.                                 | Low                  |
-| 13  | **Branding** (`/branding`)                                          | 14 features. Theme/logo customization. Admin tool.                                        | Medium               |
-| 14  | **Storage Host Settings** (`/storage-settings/:hostname`)           | Niche admin feature.                                                                      | Low                  |
-| 15  | **Chat** (`/chat/:id?`)                                             | ✅ Covered. Mock-based tests for chat UI, history, multi-pane, sync.                      | -                    |
+| #   | Page/Feature                                                        | Reason                                                                                                     | Estimated Complexity |
+| --- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- |
+| 7   | **Endpoint Detail - Auto-scaling & Tokens** (`/serving/:serviceId`) | 14 features with 5 modals. Complex admin feature, but lower user count.                                    | High                 |
+| 8   | **Session - Filtering, Drawer** (`/session`)                        | Session list already has creation/lifecycle coverage. SessionDetailDrawer is significant.                  | Low                  |
+| 9   | **Environment - Presets** (`/environment`)                          | 4 uncovered features for Resource Presets tab. Each with CRUD modals.                                      | Medium               |
+| 10  | **Resources - Resource Groups** (`/agent`)                          | 5 uncovered features with 3 modals (create/edit/info). Agent drawer also untested.                         | Medium               |
+| 11  | **Model Store** (`/model-store`)                                    | Browse/search models. ModelCardModal for detail. Read-only interface.                                      | Low                  |
+| 12  | **Scheduler** (`/scheduler`)                                        | 6 features. Pending session queue monitoring. Admin tool.                                                  | Low                  |
+| 13  | **Branding** (`/branding`)                                          | 14 features. Theme/logo customization. Admin tool.                                                         | Medium               |
+| 14  | **Storage Host Settings** (`/storage-settings/:hostname`)           | Niche admin feature.                                                                                       | Low                  |
+| 15  | **Chat** (`/chat/:id?`)                                             | ✅ Covered. Mock-based tests for chat UI, history, multi-pane, sync.                                       | -                    |
+| 16  | **Edu App Launcher - cluster-backed launch** (`/applauncher`)       | Already-logged-in `session_id` launch (#9488) and `session_template` creation (#9490) need a live cluster. | Medium               |
 
 ---
 
@@ -1396,6 +1419,7 @@ To efficiently build new E2E tests, these POMs should be created:
 | `/branding`                            |        ❌        |      ❌      |    P3    |
 | `/chat/:id?`                           |        ✅        |      ✅      |    -     |
 | App Launcher (modal)                   |        🔶        |      ❌      |    -     |
+| `/applauncher`, `/edu-applauncher`     |        🔶        |      ❌      |    -     |
 | Plugin System (config-based)           |        ✅        |      ❌      |    -     |
 | `/admin-serving?tab=auto-scaling-rule` |        🔶        |      ❌      |    -     |
 

--- a/e2e/app-launcher/edu-applauncher-stoken.spec.ts
+++ b/e2e/app-launcher/edu-applauncher-stoken.spec.ts
@@ -21,9 +21,7 @@
  * `stoken-login.spec.ts`: a customer-specific auth plugin is required
  * to mint real sTokens.
  *
- * The missing-token branch is covered below at route level; the
- * sToken-authenticated path stays out of scope because sToken validation
- * lives entirely manager-side in an out-of-tree AUTHORIZE hook plugin.
+ * The missing-token branch is covered below at route level.
  */
 import { webuiEndpoint } from '../utils/test-util';
 import { expect, test, type Page } from '@playwright/test';

--- a/e2e/app-launcher/edu-applauncher-stoken.spec.ts
+++ b/e2e/app-launcher/edu-applauncher-stoken.spec.ts
@@ -20,6 +20,10 @@
  * Valid-token happy-path is out of scope here for the same reason as
  * `stoken-login.spec.ts`: a customer-specific auth plugin is required
  * to mint real sTokens.
+ *
+ * The missing-token branch is covered below at route level; the
+ * sToken-authenticated path stays out of scope because sToken validation
+ * lives entirely manager-side in an out-of-tree AUTHORIZE hook plugin.
  */
 import { webuiEndpoint } from '../utils/test-util';
 import { expect, test, type Page } from '@playwright/test';
@@ -252,6 +256,45 @@ test.describe(
         date,
         endpoint,
       });
+    });
+
+    /**
+     * Route-level guard for the `missing-token` branch: `/applauncher`
+     * mounts the boundary unconditionally with `sToken ?? ''`, so a launcher
+     * URL that lost its token must reach the error card instead of the
+     * launcher, and must not POST an empty token to the webserver.
+     */
+    test('User sees the missing-token error card when opening `/applauncher` without an sToken', async ({
+      page,
+    }) => {
+      await installBoundaryProbeMocks(page);
+
+      let tokenLoginCalled = false;
+      await page.route('**/server/token-login', async (route) => {
+        tokenLoginCalled = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(AUTH_FAILED_INERT_RESPONSE),
+        });
+      });
+
+      // Full LMS signing envelope, minus `sToken` / `stoken`.
+      const params = new URLSearchParams({
+        api_version: 'v9.20250722',
+        date: '2026-04-22T07:58:04.609420+00:00',
+        endpoint: '127.0.0.1',
+        session_id: 'd847ee6f-be1c-4e40-8cc4-0cb182f4ceff',
+        app: 'jupyterlab',
+      });
+      await page.goto(`${webuiEndpoint}/applauncher?${params.toString()}`);
+
+      // The heading distinguishes this card from the token-invalid one,
+      // which shares the Retry button.
+      await expect(
+        page.getByRole('heading', { name: 'No sign-in token was provided.' }),
+      ).toBeVisible({ timeout: 15_000 });
+      expect(tokenLoginCalled).toBe(false);
     });
   },
 );

--- a/e2e/app-launcher/edu-applauncher-stoken.spec.ts
+++ b/e2e/app-launcher/edu-applauncher-stoken.spec.ts
@@ -262,7 +262,7 @@ test.describe(
      * URL that lost its token must reach the error card instead of the
      * launcher, and must not POST an empty token to the webserver.
      */
-    test('User sees the missing-token error card when opening `/applauncher` without an sToken', async ({
+    test('User cannot launch an app from `/applauncher` without an sToken and sees the missing-token error card', async ({
       page,
     }) => {
       await installBoundaryProbeMocks(page);


### PR DESCRIPTION
Resolves #5850 (FR-3873)

Adds one E2E test to the existing `e2e/app-launcher/edu-applauncher-stoken.spec.ts`, covering the `/applauncher` route when the launcher URL arrives **without** an `sToken`, and inventories the `/applauncher` / `/edu-applauncher` routes in `e2e/E2E_COVERAGE_REPORT.md`.

## What changed

- `e2e/app-launcher/edu-applauncher-stoken.spec.ts` — one new test, last in the existing `EduAppLauncher sToken boundary` describe block (tags `@regression @app-launcher @functional` already correct), plus one line on the file's top doc-comment recording that the missing-token branch is now covered at route level. Test name follows the `[Actor] can/cannot [action] [condition]` shape from `e2e/E2E-TEST-NAMING-GUIDELINES.md`.
- `e2e/E2E_COVERAGE_REPORT.md` — new section **26b. Edu App Launcher (`/applauncher`, `/edu-applauncher`)**. The FR-2616 spec had never been inventoried, so the whole route was absent from the report: the section lists the five existing tests as ✅ and three ❌ rows (the two cluster-backed follow-ups #9488 / #9490 and the out-of-tree sToken-authenticated path), and the Coverage Summary row, **Total** (497 features / 340 covered), the **Overall** line, the quick-reference matrix, a Priority 3 entry for #9488 / #9490 and the Last Updated date are recomputed per `.github/instructions/e2e.instructions.md`. The Total and Overall lines are now the exact sum of the 37 Coverage Summary rows; the pre-existing drift on `main` (a stated total that did not match its own rows) is corrected as part of this, per Copilot's review.

The test reuses the file's existing `installBoundaryProbeMocks()` scaffolding (mocked `config.toml`, `/func/` ping, `/server/login-check` → `authenticated: false`), registers `**/server/token-login` purely as a call probe, navigates to `/applauncher` with the full LMS signing envelope (`api_version`, `date`, `endpoint`, `session_id`, `app`) minus `sToken`, and asserts:

1. `page.getByRole('heading', { name: 'No sign-in token was provided.' })` is visible — that literal is `sTokenLoginBoundary.ErrorMissingTokenTitle` in `resources/i18n/en.json`, and `BAICard` renders a string `title` as a real `<h5>`, so it is role-addressable. Asserting only the Retry button would not distinguish this card from the already-covered token-invalid card, which shares it.
2. `token_login` was never called — `STokenLoginBoundary` decides `missing-token` before contacting the webserver (`if (!alreadyLoggedIn && !sToken)`), so a regression that POSTed an empty token would fail here.

## Why only this slice of the issue

The issue lists four cases. Case 3 (invalid sToken) and URL-param forwarding are already covered by the four existing tests in this file. The missing-token branch had only component-level coverage (`react/src/components/STokenLoginBoundary.test.tsx`); the **route wiring** at `react/src/routes.tsx` (`const [sToken] = useSToken()` → `sToken ?? ''`) was untested. That is what this PR adds.

**Follow-up: #9488, #9490** — the two remaining cases are now tracked as their own issues, so they do not disappear when this PR closes #5850.

**Case 1 (existing `session_id` → app proxy URL resolved) is feasible and is deliberately left as a follow-up (#9488), not declared impossible.** `STokenLoginBoundary` has an explicit already-logged-in fast path (`alreadyLoggedIn = !!(await client.check_login())`, and the guard is `!alreadyLoggedIn && !sToken`), `EduAppLauncher` accepts `sToken?: string | null`, and its Path A (`EduAppLauncher.tsx:713`, `const sessionId = extraParams.session_id || null`) never reads `sToken` at all. So `loginAsUser(page, request)` + a real session + `/applauncher?session_id=<id>&app=…` would exercise it — the same shape `e2e/app-launcher/app-launcher-launch.spec.ts:79` already uses. It needs a live Backend.AI cluster, which is not available in this working environment, so it is not included here. It would also need the launch spec's existing guards (serial mode, no-agent/timeout skip).

**Case 2 (session creation from a `session_template`)** is descoped to #9490 because it needs a configured session-template fixture plus agent capacity, not because of any client-side limitation.

What genuinely *cannot* be tested here is the **sToken-authenticated** happy path: the WebUI never validates an sToken. `packages/backend.ai-client/src/client.ts:1172` POSTs it verbatim to `/server/token-login`; the webserver (`web/server.py:682`) forwards it to `_authorize_via_anonymous_session`, and the manager (`services/auth/service.py:277-281`) hands it to an `AUTHORIZE` hook plugin that lives out of tree. Minting a valid sToken therefore requires a customer-specific plugin — the same constraint this spec's header has recorded since FR-2616.

Two ideas from the issue that are dead ends and are not implemented: `endpoint-unresolved` is unreachable in a browser (`useResolvedApiEndpoint` deliberately does not cache an empty resolution, so the component re-suspends forever), and an "invalid `endpoint` param" test is meaningless because the URL's `endpoint=` is LMS signing-envelope data, not the API endpoint.

## Notes

- **No new spec file.** The issue proposes `e2e/app-launcher/app-launcher-url-flow.spec.ts`; creating it would duplicate ~90 lines of mock scaffolding that already exist in `edu-applauncher-stoken.spec.ts`.
- No `.ant-*` locator, no `waitForLoadState` / `waitForTimeout`, no `isVisible().catch()` fallback, no `test.fixme` stub, no serial mode.
- The nightly `e2e-healer` workflow currently runs only `e2e/auth/login.spec.ts` (`.github/workflows/e2e-healer.md:85-87` — the full-suite line is commented out), so this test executes on manual/full runs.
- Commits are authored by the PR owner with `Co-Authored-By` / `Claude-Session` trailers so `license/cla` resolves.
- Review history: Copilot round 1 (coverage report omission, test naming) fixed in 7f739eb; rounds 2 and 3 (report totals not matching the rows) fixed in b7c5c0de0 and 34c1ce84a; Copilot recommended approval on 34c1ce84a.

**Checklist:** (if applicable)

- [ ] Documentation — n/a, no user-facing change
- [ ] Minium required manager version — n/a
- [x] Specific setting for review — the spec is fully mock-driven; it needs only a served WebUI at `E2E_WEBUI_ENDPOINT`, no Backend.AI cluster and no login
- [x] Minimum requirements to check during review — `bash scripts/verify.sh`
- [x] Test case(s) to demonstrate the difference of before/after — this PR is the test case

## Verification

`bash scripts/verify.sh` (tail), re-run on `7f739eb` after the coverage-report update and the rename:

```
=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0
  warn-only terminology findings: 1
  near-duplicate findings (report): 0
  unknown-noun findings (report): 0
--- Terminology: PASS ---

=== Terminology self-test (report-only here; hard gate in CI) ===
non-English terminology precision self-test (FR-3051)
  rows under test: 12 non-en avoid row(s), 3 negative control(s)
  PASS — 696 assertion(s) hold.

=== ALL PASS ===
```

The single warn-only terminology finding (`BAIResourceUnitGrid^ChangeGroupColor`) is pre-existing and unrelated. `prettier --check` passes on both changed files.

Astryx token gate, `make i18n` and `pnpm relay` were not needed — no CSS, theme token, `var(--…)`, translation key or GraphQL document is touched.

The spec **was** executed locally against a Vite dev server (`E2E_WEBUI_ENDPOINT=http://127.0.0.1:9081`), which is all it needs:

```
$ npx playwright test e2e/app-launcher/edu-applauncher-stoken.spec.ts --project=chromium
  5 passed (2.9m)
```

All five tests in the file pass, including the new one. The two additional failures in that run are the suite-wide `cleanup` teardown project (`global-cleanup.teardown.ts`), which logs in as admin against a real cluster — unavailable in this environment and unrelated to this change. Re-running only the new test:

```
$ npx playwright test e2e/app-launcher/edu-applauncher-stoken.spec.ts --project=chromium --grep "missing-token error card"
  1 passed (2.4m)
```

The later commits changed only a doc-comment, the test's name and the Markdown report, so the Playwright run above was not repeated; `bash scripts/verify.sh` was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VB9nrvZ2VxL9u3Bc1zhDbB