### PR TITLE
fix(FR-2911): gate trash-bin permanent delete on delete_vfolder permission

### DIFF
--- a/react/src/components/VFolderNodes.test.tsx
+++ b/react/src/components/VFolderNodes.test.tsx
@@ -399,3 +399,44 @@ describe('VFolderNodes trash-bin row actions name why they are blocked (FR-3722)
     ).toHaveLength(2);
   }, 10000);
 });
+
+/**
+ * FR-2911: a read-only invitee's shared folder carries no `delete_vfolder`
+ * permission, so the trash bin's permanent delete must be blocked for the
+ * same reason "Move to trash" already is.
+ */
+describe('VFolderNodes trash-bin permanent delete requires delete permission (FR-2911)', () => {
+  beforeEach(() => {
+    mockObservedWidth = 600;
+    mockBaiClient.vfolder.delete_from_trash_bin.mockClear();
+  });
+
+  it('disables Delete with the no-permission reason when delete_vfolder is missing', async () => {
+    const user = userEvent.setup();
+    renderTable(undefined, null, {
+      status: 'delete-pending',
+      permissions: ['read_attribute', 'read_content', 'mount_ro'],
+    });
+
+    const deleteButton = await screen.findByRole('button', {
+      name: 'data.folders.Delete',
+    });
+    expect(deleteButton).toHaveAttribute('aria-disabled', 'true');
+
+    await user.hover(deleteButton);
+    expect(
+      await screen.findByText('data.folders.NoDeletePermission'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+    expect(mockBaiClient.vfolder.delete_from_trash_bin).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('keeps Delete enabled when delete_vfolder is granted', async () => {
+    renderTable(undefined, null, { status: 'delete-pending' });
+
+    expect(
+      await screen.findByRole('button', { name: 'data.folders.Delete' }),
+    ).toBeEnabled();
+  }, 10000);
+});

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -269,9 +269,11 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
                   projectFolderAdminHint ??
                   t('data.folders.NoDeletePermission'),
               }
-            : vfolder?.status !== 'delete-pending'
-              ? { reason: t('data.folders.DeletionAlreadyStarted') }
-              : false,
+            : !hasDeletePermission
+              ? { reason: t('data.folders.NoDeletePermission') }
+              : vfolder?.status !== 'delete-pending'
+                ? { reason: t('data.folders.DeletionAlreadyStarted') }
+                : false,
           onClick: onDeleteForever,
         }
       : null,


### PR DESCRIPTION
Resolves #7458 (FR-2911)

A virtual folder shared **read-only** shows up in the recipient's `/data` list, and — once moved to the trash bin — its row offered a fully enabled **Delete** (permanent) action. The recipient could therefore destroy someone else's folder forever.

`VFolderNodes` already computes `hasDeletePermission` (`permissions` contains `delete_vfolder`) and applies it to the **Move to trash** action. The trash-bin **Delete** action gated only on the project-folder lock (`isProjectFolderManagedElsewhere`) and on `status !== 'delete-pending'` — never on the permission. This PR adds the missing branch.

The permission genuinely distinguishes the case: the manager maps `VFolderPermission.READ_ONLY` to `{READ_ATTRIBUTE, READ_CONTENT, MOUNT_RO}` and grants `DELETE_VFOLDER` only to owners/admins (`src/ai/backend/manager/models/vfolder/row.py`), so the node's `permissions` field already tells the UI the recipient may not delete.

### Design decisions

- The new branch sits **after** `isProjectFolderManagedElsewhere` and **before** the status check, so a read-only recipient reads "No delete permission" rather than the less accurate "Deletion already started". This mirrors the ordering of the existing Move-to-trash chain.
- Reuses the existing `data.folders.NoDeletePermission` key — no new strings, no i18n or Relay changes (`permissions` is already selected in `VFolderNodesFragment`).
- **Out of scope: `VFolderNodesV2.tsx`** (the admin data page). It has the same shape, but the V2 `VFolder` type exposes no entity-level permission list — only `accessControl.permission` (RO / RW / RW_DELETE) — and that surface already carries a `TODO(needs-backend)`. Gating it would be a separate, differently-shaped change; the user-facing `/data` page is the one an unprivileged recipient actually reaches.
- The bulk path was already correct (`BAIVFolderDeleteButton` filters on `delete_vfolder`, and the trash tab offers only bulk *Restore*), so this row action was the last unguarded permanent-delete affordance in the user page.

### Backend follow-up (not in this PR)

`VFolderService.delete_forever` in the manager carries a literal `# TODO: Implement proper permission checking and business logic` and does not verify `DELETE_VFOLDER` before purging. This PR removes the affordance from the UI; a server-side check is still needed to close the hole for direct API callers. Worth filing on the manager side.

## Tests

- Added `VFolderNodes trash-bin permanent delete requires delete permission (FR-2911)` to `react/src/components/VFolderNodes.test.tsx`: a `delete-pending` folder whose `permissions` omit `delete_vfolder` renders **Delete** as `aria-disabled`, shows `data.folders.NoDeletePermission` on hover, and never calls `delete_from_trash_bin`; the granted case stays enabled.
- `pnpm exec vitest run src/components/VFolderNodes.test.tsx` → **7 passed (7)**.

## Verification

```
bash scripts/verify.sh
...
=== ALL PASS ===
```

## Review notes

- Log in as a user who received a **read-only** shared folder, move it to the trash bin, and confirm the row's **Delete** button is disabled with the "No delete permission" tooltip (and that it also names that reason when the row narrows into the More menu).
- As the folder **owner**, confirm nothing changed: Delete stays enabled while `delete-pending`, and still says "Deletion already started" for `delete-ongoing`.
- Confirm the admin data page (`VFolderNodesV2`) is untouched — that gap is called out above as out of scope.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
