### PR TITLE
feat(FR-34): start a session from a My Environments image

### DIFF
--- a/react/src/components/CustomizedImageList.test.tsx
+++ b/react/src/components/CustomizedImageList.test.tsx
@@ -1,0 +1,127 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import CustomizedImageList from './CustomizedImageList';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * FR-34: each customized image row offers a shortcut into the session
+ * launcher with that image already chosen, carried by the `formValues` query
+ * param the launcher already reads.
+ */
+
+const webuiNavigate = vi.fn();
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useBackendAIImageMetaData: () => [
+      null,
+      {
+        getBaseVersion: () => '',
+        getBaseImages: () => [],
+        getBaseImage: () => '',
+        tagAlias: (value: string) => value,
+        getTags: () => [],
+      },
+    ],
+    useSuspendedBackendaiClient: () => ({
+      supports: () => true,
+    }),
+    useWebUINavigate: () => webuiNavigate,
+  };
+});
+
+vi.mock('../hooks/useRouteScope', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useRouteScope')>();
+  return {
+    ...originalModule,
+    useProjectPath: () => (key: string) => `/project/default/${key}`,
+  };
+});
+
+vi.mock('./TableColumnsSettingModal', () => ({ default: () => null }));
+
+const IMAGE = {
+  id: 'image-1',
+  registry: 'cr.backend.ai',
+  namespace: 'testing/ngc-pytorch',
+  name: 'testing/ngc-pytorch',
+  tag: '23.09-py3-customized_abc',
+  architecture: 'aarch64',
+  humanized_name: 'ngc-pytorch',
+  digest: 'sha256:deadbeef',
+  labels: [],
+  supported_accelerators: [],
+  base_image_name: 'ngc-pytorch',
+  tags: [],
+  version: '23.09',
+};
+
+const FULL_NAME =
+  'cr.backend.ai/testing/ngc-pytorch:23.09-py3-customized_abc@aarch64';
+
+const renderList = () => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  environment.mock.queueOperationResolver((operation) =>
+    MockPayloadGenerator.generate(operation, {
+      ImageNode: () => IMAGE,
+    }),
+  );
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback={null}>
+        <CustomizedImageList />
+      </Suspense>
+    </RelayEnvironmentProvider>,
+  );
+  return { environment };
+};
+
+describe('CustomizedImageList session shortcut (FR-34)', () => {
+  beforeEach(() => {
+    webuiNavigate.mockClear();
+  });
+
+  it('navigates to the session launcher with the row image preselected', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    const startButton = await screen.findByRole('button', {
+      name: 'session.launcher.StartNewSession',
+    });
+    await user.click(startButton);
+
+    await waitFor(() => expect(webuiNavigate).toHaveBeenCalledTimes(1));
+    const url = new URL(webuiNavigate.mock.calls[0][0], 'https://localhost');
+    expect(url.pathname).toBe('/project/default/session/start');
+    expect(url.searchParams.get('step')).toBe('0');
+    expect(JSON.parse(url.searchParams.get('formValues') ?? '{}')).toEqual({
+      environments: { version: FULL_NAME },
+    });
+  });
+});

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -14,8 +14,10 @@ import { getImageFullName, localeCompare } from '../helper';
 import {
   useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
+  useWebUINavigate,
 } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { theme } from '../theme-shim';
 import AliasedImageDoubleTags from './AliasedImageDoubleTags';
 import { ImageTags } from './ImageTags';
@@ -36,7 +38,7 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { Trash2, RotateCw, Search, Settings } from 'lucide-react';
+import { Trash2, RotateCw, Search, Settings, PlayIcon } from 'lucide-react';
 import React, { useMemo, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -50,6 +52,8 @@ const CustomizedImageList: React.FC = () => {
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const baiClient = useSuspendedBackendaiClient();
+  const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const supportExtendedImageInfo =
     baiClient?.supports('extended-image-info') ?? false;
 
@@ -233,6 +237,26 @@ const CustomizedImageList: React.FC = () => {
       key: 'control',
       render: (_text, row) => (
         <BAIFlex direction="row" align="stretch" justify="center" gap="xxs">
+          <IconButton
+            variant="ghost"
+            className="bai-action-accent"
+            icon={<PlayIcon size="1em" />}
+            label={t('session.launcher.StartNewSession')}
+            tooltip={t('session.launcher.StartNewSession')}
+            onClick={() => {
+              const params = new URLSearchParams();
+              params.set('step', '0');
+              params.set(
+                'formValues',
+                JSON.stringify({
+                  environments: { version: getImageFullName(row) || '' },
+                }),
+              );
+              webuiNavigate(
+                `${buildProjectPath('session/start')}?${params.toString()}`,
+              );
+            }}
+          />
           {/* antd `type="text" danger` -> ghost IconButton + the shared
               `.bai-name-action-cell-danger` tint: Astryx IconButton has no
               `color` prop (P5) and `destructive` is a solid fill, too loud for

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -180,8 +180,13 @@ const ImageEnvironmentSelectFormItems: React.FC<
     _.map(
       _.groupBy(
         _.filter(images, (image) => {
+          // A customized image can carry `ai.backend.features: private`;
+          // dropping the already-selected one would silently swap the pick.
+          const isSelected =
+            !!environments?.version &&
+            getImageFullName(image) === environments.version;
           return (
-            (showPrivate ? true : !isPrivateImage(image)) &&
+            (showPrivate || !isPrivateImage(image) || isSelected) &&
             (filter ? filter(image) : true)
           );
         }),


### PR DESCRIPTION
Resolves #2908 (FR-34)

## What changed

The **My Environments** table (customized images) only offered a Delete action, so launching a session with a self-committed image meant navigating to the launcher and hunting the image down in the environment select.

- `react/src/components/CustomizedImageList.tsx` — each row's Control column now leads with a **Start new session** ghost `IconButton` (`PlayIcon`). It navigates to `session/start` with `step=0` and a `formValues` JSON carrying `{ environments: { version: <full image name> } }`, exactly the query-param shape `StartPage` already uses and `SessionLauncherPage` already merges into its initial form values. `useProjectPath` keeps the link project-scoped, matching the page it is launched from.
- `react/src/components/ImageEnvironmentSelectFormItems.tsx` — the environment select keeps a **private** image visible when it is the currently selected `environments.version`.

## Design decisions

- **No new i18n key.** `session.launcher.StartNewSession` ("Start new session" / "새 세션 시작") already exists in every catalogue and is the same wording the launcher page itself uses.
- **Why the select change.** `SessionLauncherPage` mounts `ImageEnvironmentSelectFormItems` without `showPrivate`, so images labelled `ai.backend.features: private` are filtered out. Customized images committed before the manager stopped tagging them private (`commit_session.py`: *"Remove PRIVATE label for customized images"*) still carry the label, and the auto-select effect would then silently fall back to the first available image — the user asks for image A and lands on image B. Rather than turning `showPrivate` on for the whole launcher (which would expose every private image), the filter now makes one exception: the image that is *already selected* is never hidden. The general list is unchanged, and once the user picks something else the private image drops out again.
- The accent tint (`bai-action-accent`) matches the sibling `ImageList` control column.

## Tests

- New `react/src/components/CustomizedImageList.test.tsx` — renders the list against a mocked Relay environment and asserts that clicking the row action navigates to `/project/default/session/start` with `step=0` and a `formValues` payload naming the row's full image name (`registry/namespace:tag@arch`).
- `cd react && pnpm exec vitest run src/components/CustomizedImageList.test.tsx` → 1 file passed, 1 test passed.

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Open **My Environments** (`/my-environment`) with at least one committed image; the Control column now shows a play icon before the trash icon. Clicking it should land on the session launcher at step 0 with that exact image (registry, namespace, tag, architecture) already chosen in Environments.
- Check the URL it navigates to: `…/session/start?step=0&formValues={"environments":{"version":"…"}}` — the project segment should be the project you were browsing.
- If you have an older customized image that still carries `ai.backend.features: private`, confirm it now resolves in the launcher instead of falling back to the first image in the list — and that it is still absent from the environment dropdown when you open the launcher fresh.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
