### PR TITLE
feat(FR-347): show associated projects on the container registry list

### DIFF
--- a/react/src/__generated__/ContainerRegistryListQuery.graphql.ts
+++ b/react/src/__generated__/ContainerRegistryListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<932c8525c83cc9568f3aafc94900516f>>
+ * @generated SignedSource<<2d37ba9a0a1dbfeeb0fd30b73bff9234>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,7 +22,16 @@ export type ContainerRegistryListQuery$data = {
     readonly count: number | null | undefined;
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly allowed_groups: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly id: string;
+              readonly name: string | null | undefined;
+            } | null | undefined;
+          } | null | undefined>;
+        } | null | undefined;
         readonly id: string;
+        readonly is_global: boolean | null | undefined;
         readonly name: string | null | undefined;
         readonly password: string | null | undefined;
         readonly project: string | null | undefined;
@@ -168,10 +177,17 @@ v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "count",
+  "name": "is_global",
   "storageKey": null
 },
 v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v18 = {
   "alias": null,
   "args": [
     {
@@ -247,18 +263,54 @@ return {
                   (v12/*: any*/),
                   (v13/*: any*/),
                   (v14/*: any*/),
-                  (v15/*: any*/)
+                  (v15/*: any*/),
+                  (v16/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GroupConnection",
+                    "kind": "LinkedField",
+                    "name": "allowed_groups",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "GroupEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "GroupNode",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v6/*: any*/),
+                              (v9/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v16/*: any*/)
+          (v17/*: any*/)
         ],
         "storageKey": null
       },
-      (v17/*: any*/)
+      (v18/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -315,13 +367,7 @@ return {
                     "name": "extra",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "is_global",
-                    "storageKey": null
-                  },
+                  (v16/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -365,24 +411,24 @@ return {
             ],
             "storageKey": null
           },
-          (v16/*: any*/)
+          (v17/*: any*/)
         ],
         "storageKey": null
       },
-      (v17/*: any*/)
+      (v18/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "2c290294552cc0caa3dd687d9720335e",
+    "cacheID": "ad591a73bcc0a558fd6fd978f617aa4a",
     "id": null,
     "metadata": {},
     "name": "ContainerRegistryListQuery",
     "operationKind": "query",
-    "text": "query ContainerRegistryListQuery(\n  $domain: String!\n  $filter: String\n  $order: String\n  $first: Int\n  $offset: Int\n) {\n  container_registry_nodes(filter: $filter, order: $order, first: $first, offset: $offset) @since(version: \"24.09.0\") {\n    edges {\n      node {\n        ...ContainerRegistryEditorModalFragment\n        id\n        row_id\n        registry_name\n        name\n        url\n        type\n        project\n        username\n        password\n        ssl_verify\n      }\n    }\n    count\n  }\n  domain(name: $domain) {\n    name\n    allowed_docker_registries\n  }\n}\n\nfragment ContainerRegistryEditorModalFragment on ContainerRegistryNode {\n  id\n  row_id\n  name\n  registry_name\n  url\n  type\n  project\n  username\n  ssl_verify\n  extra @since(version: \"24.09.3\")\n  is_global @since(version: \"24.09.0\")\n  allowed_groups @since(version: \"25.3.0\") {\n    edges {\n      node {\n        id\n        row_id\n        name\n      }\n    }\n  }\n}\n"
+    "text": "query ContainerRegistryListQuery(\n  $domain: String!\n  $filter: String\n  $order: String\n  $first: Int\n  $offset: Int\n) {\n  container_registry_nodes(filter: $filter, order: $order, first: $first, offset: $offset) @since(version: \"24.09.0\") {\n    edges {\n      node {\n        ...ContainerRegistryEditorModalFragment\n        id\n        row_id\n        registry_name\n        name\n        url\n        type\n        project\n        username\n        password\n        ssl_verify\n        is_global @since(version: \"24.09.0\")\n        allowed_groups @since(version: \"25.3.0\") {\n          edges {\n            node {\n              id\n              name\n            }\n          }\n        }\n      }\n    }\n    count\n  }\n  domain(name: $domain) {\n    name\n    allowed_docker_registries\n  }\n}\n\nfragment ContainerRegistryEditorModalFragment on ContainerRegistryNode {\n  id\n  row_id\n  name\n  registry_name\n  url\n  type\n  project\n  username\n  ssl_verify\n  extra @since(version: \"24.09.3\")\n  is_global @since(version: \"24.09.0\")\n  allowed_groups @since(version: \"25.3.0\") {\n    edges {\n      node {\n        id\n        row_id\n        name\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "83d2445a2d783eb91f99f02f22559918";
+(node as any).hash = "1ed0301691acd30d1c460506b33c806e";
 
 export default node;

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -26,6 +26,7 @@ import {
   BAINameActionCell,
   BAIPropertyFilter,
   BAITable,
+  BAITagList,
   INITIAL_FETCH_KEY,
   badgeVariantForTagColor,
   filterOutNullAndUndefined,
@@ -136,6 +137,15 @@ const ContainerRegistryList: React.FC<{
                 username
                 password
                 ssl_verify
+                is_global @since(version: "24.09.0")
+                allowed_groups @since(version: "25.3.0") {
+                  edges {
+                    node {
+                      id
+                      name
+                    }
+                  }
+                }
               }
             }
             count
@@ -335,6 +345,24 @@ const ContainerRegistryList: React.FC<{
           />
         ) : null;
       },
+    },
+    {
+      key: 'allowed_groups',
+      title: t('registry.AllowedProjects'),
+      render: (_value, record) =>
+        // `is_global` and `allowed_groups` are stripped by managers older than
+        // 24.09.0 / 25.3.0, so both branches must tolerate `undefined`.
+        record.is_global ? (
+          t('environment.AllProjects')
+        ) : (
+          <BAITagList
+            variant="text"
+            maxInline={1}
+            items={_.compact(
+              _.map(record.allowed_groups?.edges, (edge) => edge?.node?.name),
+            )}
+          />
+        ),
     },
     {
       key: 'username',


### PR DESCRIPTION
Resolves #3010 (FR-347)

The container registry create/edit modal has let admins pick the projects a registry is allowed in since FR-2171, but the **list** gave no way to see the result — an admin had to open every registry's modal one by one to learn which projects it was associated with. This PR adds the missing half.

## What changed

- `ContainerRegistryListQuery` now selects `is_global @since("24.09.0")` and `allowed_groups @since("25.3.0") { edges { node { id name } } }` on each registry node.
- A new **Allowed Projects** column sits between *Project* and *Username*, rendered with `BAITagList` (`variant="text"`, `maxInline={1}`): the first project name shows inline and the remainder collapse into a hover `+N` popup — the same dense-cell pattern `BAIAdminUserV2Table` uses.
- A registry with `is_global` renders `All projects` instead of the tag list, matching the modal's `is_global` semantics (when global, no association rows exist).

## Design decisions

- **No new i18n keys.** The column title reuses `registry.AllowedProjects` (the modal's own label) and the global case reuses `environment.AllProjects`, so the wording stays identical to what the modal already shows.
- **Minimal per-row selection** (`id`, `name` only, no pagination args) to keep the added per-row resolver cheap.
- **Version tolerance**: both fields are `@since`-gated, so older managers strip them and they arrive `undefined` — `record.is_global` falls through to the tag list, whose items are `_.compact(...)` of an empty edge list, so the cell renders the `-` empty state rather than crashing.
- The column joins the column-settings modal automatically (`useHiddenColumnKeysSetting` derives its key set from the `columns` array), so no extra registration was needed.
- The editor modal is untouched.

## Tests

- `bash scripts/verify.sh` (Relay compile + drift check, lint, format, TypeScript, Astryx/theme gates, terminology).
- No unit test added: the change is a declarative column definition with no branching logic beyond the `is_global` ternary, and `ContainerRegistryList` has no existing test harness.
- No e2e run (requires a live cluster).

## Verification

```
=== ALL PASS ===
```

## Review notes

- Open **Administration → Registries**: the table should show an *Allowed Projects* column after *Project*. A registry associated with several projects shows the first name plus a `+N` chip; hovering the chip lists the rest.
- Set a registry to *Set as Global Registry* in the edit modal and save — its cell should read *All projects*. Uncheck it and pick two projects — the cell should show `first-project +1`.
- Against a manager older than 25.3.0 the column should render `-` (fields stripped by `@since`) rather than erroring; the column can also be hidden from the gear/column-settings modal.

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version — `is_global` 24.09.0, `allowed_groups` 25.3.0 (both `@since`-gated, degrade to the empty state below that)
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — an admin account and at least one container registry associated with 2+ projects
- [ ] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
