### PR TITLE
feat(FR-47): disable resource presets that the selected agent cannot fit

### DIFF
--- a/react/src/components/AgentSelect.tsx
+++ b/react/src/components/AgentSelect.tsx
@@ -76,7 +76,17 @@ interface Props {
     label?: React.ReactNode;
     value?: string | number | null;
   }) => React.ReactNode;
+  /**
+   * Reports the remaining slots (available - occupied) of every loaded agent,
+   * so a caller can gate its own UI on the picked agent's capacity.
+   */
+  onRemainingSlotsChange?: (
+    remainingSlotsByAgentId: AgentRemainingSlotsMap,
+  ) => void;
 }
+
+/** Remaining slots per agent id, e.g. `{ 'agent-1': { cpu: 2, mem: 1024 } }`. */
+export type AgentRemainingSlotsMap = Record<string, Record<string, number>>;
 
 const AgentSelect: React.FC<Props> = ({
   fetchKey,
@@ -88,6 +98,7 @@ const AgentSelect: React.FC<Props> = ({
   placeholder,
   disabled,
   labelRender: _labelRender,
+  onRemainingSlotsChange,
   ...selectProps
 }) => {
   'use memo';
@@ -148,46 +159,62 @@ const AgentSelect: React.FC<Props> = ({
     },
   );
 
-  const agentOptions: Array<BAIComplexSelectOption> = _.compact(
-    _.map(agent_summary_list?.items, (agent) => {
-      if (!agent?.id) return null;
-      const availableSlotsInfo: {
-        [key in string]: string;
-      } = JSON.parse(agent?.available_slots ?? '{}');
-      const occupiedSlotsInfo: {
-        [key in string]: string;
-      } = JSON.parse(agent?.occupied_slots ?? '{}');
-      const remainingSlotsInfo: {
-        [key in string]: number;
-      } = _.mapValues(availableSlotsInfo, (value, key) => {
-        if (key.endsWith('.shares')) {
-          return parseFloat(value) - parseFloat(occupiedSlotsInfo[key] ?? 0);
-        } else {
-          return parseInt(value) - parseInt(occupiedSlotsInfo[key] ?? 0);
-        }
-      });
+  const remainingSlotsByAgentId: AgentRemainingSlotsMap = _.fromPairs(
+    _.compact(
+      _.map(agent_summary_list?.items, (agent) => {
+        if (!agent?.id) return null;
+        const availableSlotsInfo: {
+          [key in string]: string;
+        } = JSON.parse(agent?.available_slots ?? '{}');
+        const occupiedSlotsInfo: {
+          [key in string]: string;
+        } = JSON.parse(agent?.occupied_slots ?? '{}');
+        const remainingSlotsInfo: {
+          [key in string]: number;
+        } = _.mapValues(availableSlotsInfo, (value, key) => {
+          if (key.endsWith('.shares')) {
+            return parseFloat(value) - parseFloat(occupiedSlotsInfo[key] ?? 0);
+          } else {
+            return parseInt(value) - parseInt(occupiedSlotsInfo[key] ?? 0);
+          }
+        });
+        return [agent.id, remainingSlotsInfo] as [
+          string,
+          Record<string, number>,
+        ];
+      }),
+    ),
+  );
 
-      return {
-        // P26-3: the label is the string that fills the trigger, the
-        // accessible name and the live region; the figures go in `extra`.
-        label: agent.id,
-        value: agent.id,
-        extra: (
-          <BAIFlex direction="row" gap={'xxs'}>
-            {_.map(remainingSlotsInfo, (slot, key) => {
-              return (
-                <BAIResourceNumberWithIcon
-                  key={key}
-                  // @ts-ignore
-                  type={key}
-                  value={slot.toString()}
-                  hideTooltip
-                />
-              );
-            })}
-          </BAIFlex>
-        ),
-      };
+  const reportRemainingSlots = useEffectEvent(() => {
+    onRemainingSlotsChange?.(remainingSlotsByAgentId);
+  });
+  useEffect(() => {
+    reportRemainingSlots();
+  }, [remainingSlotsByAgentId]);
+
+  const agentOptions: Array<BAIComplexSelectOption> = _.map(
+    _.toPairs(remainingSlotsByAgentId),
+    ([agentId, remainingSlotsInfo]) => ({
+      // P26-3: the label is the string that fills the trigger, the
+      // accessible name and the live region; the figures go in `extra`.
+      label: agentId,
+      value: agentId,
+      extra: (
+        <BAIFlex direction="row" gap={'xxs'}>
+          {_.map(remainingSlotsInfo, (slot, key) => {
+            return (
+              <BAIResourceNumberWithIcon
+                key={key}
+                // @ts-ignore
+                type={key}
+                value={slot.toString()}
+                hideTooltip
+              />
+            );
+          })}
+        </BAIFlex>
+      ),
     }),
   );
 

--- a/react/src/components/AgentSelect.tsx
+++ b/react/src/components/AgentSelect.tsx
@@ -159,31 +159,35 @@ const AgentSelect: React.FC<Props> = ({
     },
   );
 
+  // One pass over the server's items: the options keep its order, the map is
+  // only a lookup derived from the same list.
+  const loadedAgents = _.compact(
+    _.map(agent_summary_list?.items, (agent) => {
+      if (!agent?.id) return null;
+      const availableSlotsInfo: {
+        [key in string]: string;
+      } = JSON.parse(agent?.available_slots ?? '{}');
+      const occupiedSlotsInfo: {
+        [key in string]: string;
+      } = JSON.parse(agent?.occupied_slots ?? '{}');
+      const remainingSlotsInfo: {
+        [key in string]: number;
+      } = _.mapValues(availableSlotsInfo, (value, key) => {
+        if (key.endsWith('.shares')) {
+          return parseFloat(value) - parseFloat(occupiedSlotsInfo[key] ?? 0);
+        } else {
+          return parseInt(value) - parseInt(occupiedSlotsInfo[key] ?? 0);
+        }
+      });
+      return { id: agent.id, remainingSlotsInfo };
+    }),
+  );
+
   const remainingSlotsByAgentId: AgentRemainingSlotsMap = _.fromPairs(
-    _.compact(
-      _.map(agent_summary_list?.items, (agent) => {
-        if (!agent?.id) return null;
-        const availableSlotsInfo: {
-          [key in string]: string;
-        } = JSON.parse(agent?.available_slots ?? '{}');
-        const occupiedSlotsInfo: {
-          [key in string]: string;
-        } = JSON.parse(agent?.occupied_slots ?? '{}');
-        const remainingSlotsInfo: {
-          [key in string]: number;
-        } = _.mapValues(availableSlotsInfo, (value, key) => {
-          if (key.endsWith('.shares')) {
-            return parseFloat(value) - parseFloat(occupiedSlotsInfo[key] ?? 0);
-          } else {
-            return parseInt(value) - parseInt(occupiedSlotsInfo[key] ?? 0);
-          }
-        });
-        return [agent.id, remainingSlotsInfo] as [
-          string,
-          Record<string, number>,
-        ];
-      }),
-    ),
+    _.map(loadedAgents, ({ id, remainingSlotsInfo }) => [
+      id,
+      remainingSlotsInfo,
+    ]),
   );
 
   const reportRemainingSlots = useEffectEvent(() => {
@@ -194,12 +198,12 @@ const AgentSelect: React.FC<Props> = ({
   }, [remainingSlotsByAgentId]);
 
   const agentOptions: Array<BAIComplexSelectOption> = _.map(
-    _.toPairs(remainingSlotsByAgentId),
-    ([agentId, remainingSlotsInfo]) => ({
+    loadedAgents,
+    ({ id, remainingSlotsInfo }) => ({
       // P26-3: the label is the string that fills the trigger, the
       // accessible name and the live region; the figures go in `extra`.
-      label: agentId,
-      value: agentId,
+      label: id,
+      value: id,
       extra: (
         <BAIFlex direction="row" gap={'xxs'}>
           {_.map(remainingSlotsInfo, (slot, key) => {

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -196,4 +196,116 @@ describe('getAllocatablePresetNames', () => {
     // Only compare with resource limits
     expect(result).toEqual(['cpu1_mem2g']);
   });
+
+  describe('with a selected agent', () => {
+    const noResourceLimits: MergedResourceLimits = {
+      cpu: {},
+      mem: {},
+      accelerators: {},
+    };
+    const GiB = 1024 ** 3;
+    // The manager reports both preset `mem` and agent slots as byte strings.
+    const agentPresets: Array<ResourcePreset> = [
+      {
+        name: 'cpu4_mem8g_cuda2',
+        resource_slots: {
+          cpu: '4',
+          mem: String(8 * GiB),
+          'cuda.shares': '2',
+        },
+        shared_memory: String(GiB),
+        allocatable: true,
+      },
+      {
+        name: 'cpu2_mem4g_cuda1',
+        resource_slots: {
+          cpu: '2',
+          mem: String(4 * GiB),
+          'cuda.shares': '1',
+        },
+        shared_memory: String(GiB),
+        allocatable: true,
+      },
+      {
+        name: 'cpu1_mem2g',
+        resource_slots: { cpu: '1', mem: String(2 * GiB) },
+        shared_memory: String(GiB),
+        allocatable: true,
+      },
+    ];
+
+    it('keeps only the presets that fit the remaining slots of the agent', () => {
+      const result = getAllocatablePresetNames(
+        agentPresets,
+        noResourceLimits,
+        undefined,
+        { cpu: 2, mem: 4 * GiB, 'cuda.shares': 1 },
+      );
+      expect(result).toEqual(['cpu2_mem4g_cuda1', 'cpu1_mem2g']);
+    });
+
+    it('excludes a preset asking for a slot the agent does not provide', () => {
+      const result = getAllocatablePresetNames(
+        agentPresets,
+        noResourceLimits,
+        undefined,
+        { cpu: 8, mem: 64 * GiB },
+      );
+      expect(result).toEqual(['cpu1_mem2g']);
+    });
+
+    it('ignores shmem, which is carved out of the session memory', () => {
+      const result = getAllocatablePresetNames(
+        [
+          {
+            name: 'cpu1_mem2g_shmem1g',
+            resource_slots: {
+              cpu: '1',
+              mem: String(2 * GiB),
+              shmem: String(GiB),
+            },
+            shared_memory: String(GiB),
+            allocatable: true,
+          },
+        ],
+        noResourceLimits,
+        undefined,
+        { cpu: 1, mem: 2 * GiB },
+      );
+      expect(result).toEqual(['cpu1_mem2g_shmem1g']);
+    });
+
+    it('excludes every preset when the agent has no room left', () => {
+      const result = getAllocatablePresetNames(
+        agentPresets,
+        noResourceLimits,
+        undefined,
+        { cpu: 0, mem: 0, 'cuda.shares': 0 },
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('still applies the resource limits on top of the agent slots', () => {
+      const result = getAllocatablePresetNames(
+        agentPresets,
+        { cpu: { max: 2 }, mem: {}, accelerators: {} },
+        undefined,
+        { cpu: 16, mem: 64 * GiB, 'cuda.shares': 16 },
+      );
+      expect(result).toEqual(['cpu2_mem4g_cuda1', 'cpu1_mem2g']);
+    });
+
+    it('returns the unfiltered list when no agent is pinned', () => {
+      const result = getAllocatablePresetNames(
+        agentPresets,
+        noResourceLimits,
+        undefined,
+      );
+      expect(result).toEqual([
+        'cpu4_mem8g_cuda2',
+        'cpu2_mem4g_cuda1',
+        'cpu1_mem2g',
+      ]);
+    });
+  });
 });

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -254,6 +254,40 @@ describe('getAllocatablePresetNames', () => {
       expect(result).toEqual(['cpu1_mem2g']);
     });
 
+    it('keeps a preset whose accelerator request is zero on an agent without that slot', () => {
+      // `check-presets` zero-fills every preset with all cluster-known slot
+      // types, so on a heterogeneous cluster a CPU preset still carries
+      // `cuda.shares: "0"` while a CPU-only agent reports no `cuda.shares`.
+      const result = getAllocatablePresetNames(
+        [
+          {
+            name: 'cpu1_mem2g',
+            resource_slots: {
+              cpu: '1',
+              mem: String(2 * GiB),
+              'cuda.shares': '0',
+            },
+            shared_memory: String(GiB),
+            allocatable: true,
+          },
+          {
+            name: 'cpu1_mem2g_cuda1',
+            resource_slots: {
+              cpu: '1',
+              mem: String(2 * GiB),
+              'cuda.shares': '1',
+            },
+            shared_memory: String(GiB),
+            allocatable: true,
+          },
+        ],
+        noResourceLimits,
+        undefined,
+        { cpu: 4, mem: 8 * GiB },
+      );
+      expect(result).toEqual(['cpu1_mem2g']);
+    });
+
     it('ignores shmem, which is carved out of the session memory', () => {
       const result = getAllocatablePresetNames(
         [

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../hooks/useResourceLimitAndRemaining';
 import { theme } from '../../theme-shim';
 import { ProjectContext } from '../../types/projectContext';
-import AgentSelect from '../AgentSelect';
+import AgentSelect, { type AgentRemainingSlotsMap } from '../AgentSelect';
 import {
   Image,
   ImageEnvironmentFormInput,
@@ -52,7 +52,13 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { RotateCw } from 'lucide-react';
-import React, { Suspense, useEffect, useMemo, useTransition } from 'react';
+import React, {
+  Suspense,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -309,6 +315,16 @@ const ResourceAllocationFormItems: React.FC<
     form,
     preserve: true,
   });
+  const currentAgentInForm = Form.useWatch(['agent'], {
+    form,
+    preserve: true,
+  });
+
+  // Reported by `AgentSelect`, which already computes it for its option rows.
+  // Merged rather than replaced: the select re-queries with a search filter, so
+  // a narrowed result must not drop the agent the form still holds.
+  const [agentRemainingSlots, setAgentRemainingSlots] =
+    useState<AgentRemainingSlotsMap>({});
 
   const [{ currentImageMinM, remaining, resourceLimits, checkPresetInfo }] =
     useResourceLimitAndRemaining({
@@ -394,13 +410,30 @@ const ResourceAllocationFormItems: React.FC<
     }
   }, [supportedAcceleratorTypesInRGByImage, form, currentResourceValue]);
 
+  // A concrete single agent bounds the allocation further than the
+  // keypair/group/resource-group limits do. "auto" and multi-agent picks are
+  // scheduled across agents, so they keep the unfiltered preset list.
+  const selectedAgentNames = _.compact(_.castArray(currentAgentInForm));
+  const selectedAgentRemainingSlots =
+    enableAgentSelect &&
+    selectedAgentNames.length === 1 &&
+    selectedAgentNames[0] !== 'auto'
+      ? agentRemainingSlots[selectedAgentNames[0]]
+      : undefined;
+
   const allocatablePresetNames = useMemo(() => {
     return getAllocatablePresetNames(
       checkPresetInfo?.presets,
       resourceLimits,
       currentImage,
+      selectedAgentRemainingSlots,
     );
-  }, [checkPresetInfo?.presets, resourceLimits, currentImage]);
+  }, [
+    checkPresetInfo?.presets,
+    resourceLimits,
+    currentImage,
+    selectedAgentRemainingSlots,
+  ]);
 
   const runShmemAutomationRule = (M_plus_S: string) => {
     // if M+S > 4G, S can be 1G regard to current image's minimum mem(M)
@@ -1530,6 +1563,12 @@ const ResourceAllocationFormItems: React.FC<
                   fetchKey={agentFetchKey}
                   mode={supportMultiAgents ? 'multiple' : undefined}
                   fallbackToAuto
+                  onRemainingSlotsChange={(next) =>
+                    setAgentRemainingSlots((prev) => {
+                      const merged = { ...prev, ...next };
+                      return _.isEqual(prev, merged) ? prev : merged;
+                    })
+                  }
                   labelRender={
                     supportMultiAgents
                       ? ({ label, value }) => {
@@ -1821,6 +1860,8 @@ export const getAllocatablePresetNames = (
   presets: Array<ResourcePreset> | undefined,
   resourceLimits: MergedResourceLimits,
   currentImage: Image,
+  /** Remaining slots of the single agent the session is pinned to, if any. */
+  agentRemainingSlots?: Record<string, number>,
 ) => {
   const currentImageAcceleratorLimits = _.filter(
     currentImage?.resource_limits,
@@ -1902,7 +1943,27 @@ export const getAllocatablePresetNames = (
       );
     }
   }).map((preset) => preset.name);
-  return currentImageAcceleratorLimits.length === 0
-    ? bySliderLimit
-    : _.intersection(bySliderLimit, byImageAcceleratorLimits);
+  const byResourceLimit =
+    currentImageAcceleratorLimits.length === 0
+      ? bySliderLimit
+      : _.intersection(bySliderLimit, byImageAcceleratorLimits);
+
+  if (!agentRemainingSlots) {
+    return byResourceLimit;
+  }
+
+  const byAgentRemainingSlots = _.filter(presets, (preset) => {
+    return _.every(preset.resource_slots, (_value, key) => {
+      // shmem comes out of the session's own mem, so the agent doesn't slot it.
+      if (key === 'shmem') return true;
+      const remaining = agentRemainingSlots[key];
+      // A slot the agent doesn't offer at all can never be allocated on it.
+      if (_.isUndefined(remaining)) return false;
+      return key === 'mem'
+        ? compareNumberWithUnits(preset.resource_slots[key], remaining) <= 0
+        : (_.toNumber(preset.resource_slots[key]) || 0) <= remaining;
+    });
+  }).map((preset) => preset.name);
+
+  return _.intersection(byResourceLimit, byAgentRemainingSlots);
 };

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1956,12 +1956,15 @@ export const getAllocatablePresetNames = (
     return _.every(preset.resource_slots, (_value, key) => {
       // shmem comes out of the session's own mem, so the agent doesn't slot it.
       if (key === 'shmem') return true;
-      const remaining = agentRemainingSlots[key];
-      // A slot the agent doesn't offer at all can never be allocated on it.
-      if (_.isUndefined(remaining)) return false;
+      const requested = preset.resource_slots[key];
+      // `check-presets` zero-fills every preset with every cluster-known slot
+      // type, while an agent only reports the slots it physically has. So a
+      // missing slot means 0 remaining, not "disqualify the preset": compare
+      // numerically and let a zero request pass.
+      const remaining = agentRemainingSlots[key] ?? 0;
       return key === 'mem'
-        ? compareNumberWithUnits(preset.resource_slots[key], remaining) <= 0
-        : (_.toNumber(preset.resource_slots[key]) || 0) <= remaining;
+        ? compareNumberWithUnits(requested, remaining) <= 0
+        : (_.toNumber(requested) || 0) <= remaining;
     });
   }).map((preset) => preset.name);
 


### PR DESCRIPTION
Resolves #2836 (FR-47)

## What changed

The session launcher lets a user pin a session to a specific agent when `hideAgents` is `false`, but the resource preset list ignored that choice: presets were enabled purely from the keypair / project / resource-group limits and the image's accelerator limits. A user could pick an agent with 2 free CPU cores and still be offered an 8-core preset as if it were allocatable.

- `AgentSelect` already computes each agent's remaining slots (`available_slots - occupied_slots`) to render the figures beside every option. That map is no longer local: it is reported through a new optional `onRemainingSlotsChange` prop. No new query, no duplicated arithmetic. The option list and the map are built from a single pass over `agent_summary_list.items`, so the server's order and any duplicate ids are preserved in the options.
- `ResourceAllocationFormItems` watches the `agent` field and, when **exactly one concrete agent** is selected, passes that agent's remaining slots to `getAllocatablePresetNames`.
- `getAllocatablePresetNames` takes an optional 4th argument and intersects its existing result with the presets that fit on that agent.

## Design decisions

- **`auto` and multi-agent selections keep the unfiltered list.** Those sessions are scheduled across agents (`multi-agents` support), so no single agent bounds them. Filtering applies only to a single concrete pick.
- **A slot missing from the agent counts as 0 remaining, not as an automatic disqualification.** The manager's `check-presets` zero-fills every preset with *all* cluster-known slot types (`ResourceSlot.normalize_slots_by_known_slots`), while an agent's `available_slots` only carries the slots it physically has. On a heterogeneous cluster that means every preset carries `cuda.shares: "0"` and a CPU-only agent has no `cuda.shares` key at all — so the comparison is numeric (`requested <= remaining ?? 0`): a zero request passes, a real accelerator request on an agent without that accelerator does not.
- **`shmem` is skipped**, matching the existing slider-limit branch — it is carved out of the session's own memory rather than slotted by the agent.
- **The reported map is merged, not replaced.** `AgentSelect` re-queries with a server-side search filter, so a narrowed result must not silently drop the agent the form still holds. The merge is guarded by `_.isEqual` so an unchanged result does not re-render.
- **The user's current preset is not re-selected** when the agent changes. The auto-select effect only runs while `allocationPreset === 'auto-select'`, so an already-chosen preset stays chosen and simply renders disabled — no silent reallocation under the user.

## Known limits

- **A preset chosen before the agent is narrowed stays selected.** It renders disabled and the resource sliders keep their values, so the session can still be submitted with an allocation the pinned agent cannot fit — the scheduler rejects it rather than the form. Clearing or re-running the allocation on an agent change is a product call, deliberately left out of this PR.
- **`AgentSelect` loads only the first page (`pageSize: 50`) plus whatever the server-side search filter returns.** If the form holds an agent that was never loaded, the map has no entry for it and the preset list falls back to the unfiltered set — graceful, but not a guarantee for clusters with more than 50 schedulable agents in a resource group.

## Tests

- `pnpm exec vitest run src/components/SessionFormItems/ResourceAllocationFormItems.test.ts` → **21 passed**, including 7 new cases for the agent argument: fits/does-not-fit, a real accelerator request on an agent lacking that slot, a **zero-valued** accelerator slot on an agent lacking that slot (the `check-presets` zero-fill case above), `shmem` ignored, a full agent, resource limits still applied on top, and the unfiltered path when no agent is pinned.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

No CSS/token changes, no GraphQL tag changes (the existing `AgentSelectQuery` already selects `available_slots` / `occupied_slots`), no new i18n strings.

## Review notes

- Open the session launcher on a deployment with `hideAgents = false`, pick an agent whose remaining CPU is smaller than some presets, and open the preset dropdown: presets that do not fit are disabled and sorted last.
- Switch the agent back to **Auto select** (or select several agents where `multi-agents` is supported) — the preset list returns to the keypair/group-limited set.
- On a heterogeneous cluster, pick a CPU-only agent and confirm the CPU presets stay enabled while the accelerator presets are disabled.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
