### PR TITLE
fix(FR-3107): scope dashboard My Sessions counts to the current user

### DIFF
--- a/react/src/__generated__/DashboardPageQuery.graphql.ts
+++ b/react/src/__generated__/DashboardPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<58f93c107decec6964d1b2e9b48a951f>>
+ * @generated SignedSource<<2b567f455f816ff0c7223af555b6c557>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,10 +12,14 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type DashboardPageQuery$variables = {
   agentNodeFilter: string;
+  batchFilter?: string | null | undefined;
+  inferenceFilter?: string | null | undefined;
+  interactiveFilter?: string | null | undefined;
   isSuperAdmin: boolean;
   resourceGroup?: string | null | undefined;
   scopeId?: any | null | undefined;
   skipTotalResourceWithinResourceGroup: boolean;
+  systemFilter?: string | null | undefined;
 };
 export type DashboardPageQuery$data = {
   readonly AgentStatsFragment?: {
@@ -40,107 +44,125 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "isSuperAdmin"
+  "name": "batchFilter"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "resourceGroup"
+  "name": "inferenceFilter"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scopeId"
+  "name": "interactiveFilter"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "isSuperAdmin"
+},
+v5 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "resourceGroup"
+},
+v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "scopeId"
+},
+v7 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "skipTotalResourceWithinResourceGroup"
 },
-v5 = [
-  {
-    "kind": "Variable",
-    "name": "scopeId",
-    "variableName": "scopeId"
-  }
-],
-v6 = {
+v8 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "systemFilter"
+},
+v9 = {
+  "kind": "Variable",
+  "name": "scopeId",
+  "variableName": "scopeId"
+},
+v10 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v7 = {
+v11 = {
   "kind": "Variable",
   "name": "scope_id",
   "variableName": "scopeId"
 },
-v8 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "count",
   "storageKey": null
 },
-v9 = [
-  (v8/*: any*/)
+v13 = [
+  (v12/*: any*/)
 ],
-v10 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v11 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "row_id",
   "storageKey": null
 },
-v12 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v13 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status",
   "storageKey": null
 },
-v14 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "priority",
   "storageKey": null
 },
-v15 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status_info",
   "storageKey": null
 },
-v16 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "occupied_slots",
   "storageKey": null
 },
-v17 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tag",
   "storageKey": null
 },
-v18 = [
+v22 = [
   {
     "alias": null,
     "args": null,
@@ -156,21 +178,21 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "idle_checks",
   "storageKey": null
 },
-v20 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "scaling_group",
   "storageKey": null
 },
-v21 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -187,21 +209,21 @@ v21 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v10/*: any*/),
-          (v11/*: any*/),
-          (v12/*: any*/),
-          (v13/*: any*/)
+          (v14/*: any*/),
+          (v15/*: any*/),
+          (v16/*: any*/),
+          (v17/*: any*/)
         ],
         "storageKey": null
       }
     ],
     "storageKey": null
   },
-  (v8/*: any*/)
+  (v12/*: any*/)
 ],
-v22 = [
-  (v10/*: any*/),
-  (v13/*: any*/),
+v26 = [
+  (v14/*: any*/),
+  (v17/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -209,8 +231,8 @@ v22 = [
     "name": "available_slots",
     "storageKey": null
   },
-  (v16/*: any*/),
-  (v20/*: any*/)
+  (v20/*: any*/),
+  (v24/*: any*/)
 ];
 return {
   "fragment": {
@@ -219,19 +241,47 @@ return {
       (v1/*: any*/),
       (v2/*: any*/),
       (v3/*: any*/),
-      (v4/*: any*/)
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
     "name": "DashboardPageQuery",
     "selections": [
       {
-        "args": (v5/*: any*/),
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "batchFilter",
+            "variableName": "batchFilter"
+          },
+          {
+            "kind": "Variable",
+            "name": "inferenceFilter",
+            "variableName": "inferenceFilter"
+          },
+          {
+            "kind": "Variable",
+            "name": "interactiveFilter",
+            "variableName": "interactiveFilter"
+          },
+          (v9/*: any*/),
+          {
+            "kind": "Variable",
+            "name": "systemFilter",
+            "variableName": "systemFilter"
+          }
+        ],
         "kind": "FragmentSpread",
         "name": "SessionCountDashboardItemFragment"
       },
       {
-        "args": (v5/*: any*/),
+        "args": [
+          (v9/*: any*/)
+        ],
         "kind": "FragmentSpread",
         "name": "RecentlyCreatedSessionFragment"
       },
@@ -304,11 +354,15 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v3/*: any*/),
-      (v2/*: any*/),
+      (v6/*: any*/),
+      (v5/*: any*/),
+      (v7/*: any*/),
       (v4/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/),
       (v1/*: any*/),
-      (v0/*: any*/)
+      (v2/*: any*/),
+      (v8/*: any*/)
     ],
     "kind": "Operation",
     "name": "DashboardPageQuery",
@@ -317,72 +371,72 @@ return {
         "alias": "myInteractive",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
+            "variableName": "interactiveFilter"
           },
-          (v6/*: any*/),
-          (v7/*: any*/)
+          (v10/*: any*/),
+          (v11/*: any*/)
         ],
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
         "name": "compute_session_nodes",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v13/*: any*/),
         "storageKey": null
       },
       {
         "alias": "myBatch",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+            "variableName": "batchFilter"
           },
-          (v6/*: any*/),
-          (v7/*: any*/)
+          (v10/*: any*/),
+          (v11/*: any*/)
         ],
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
         "name": "compute_session_nodes",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v13/*: any*/),
         "storageKey": null
       },
       {
         "alias": "myInference",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+            "variableName": "inferenceFilter"
           },
-          (v6/*: any*/),
-          (v7/*: any*/)
+          (v10/*: any*/),
+          (v11/*: any*/)
         ],
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
         "name": "compute_session_nodes",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v13/*: any*/),
         "storageKey": null
       },
       {
         "alias": "myUpload",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
+            "variableName": "systemFilter"
           },
-          (v6/*: any*/),
-          (v7/*: any*/)
+          (v10/*: any*/),
+          (v11/*: any*/)
         ],
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
         "name": "compute_session_nodes",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v13/*: any*/),
         "storageKey": null
       },
       {
@@ -403,7 +457,7 @@ return {
             "name": "order",
             "value": "-created_at"
           },
-          (v7/*: any*/)
+          (v11/*: any*/)
         ],
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
@@ -426,10 +480,10 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v10/*: any*/),
-                  (v11/*: any*/),
-                  (v12/*: any*/),
-                  (v13/*: any*/),
+                  (v14/*: any*/),
+                  (v15/*: any*/),
+                  (v16/*: any*/),
+                  (v17/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -458,8 +512,8 @@ return {
                     "name": "agent_ids",
                     "storageKey": null
                   },
-                  (v14/*: any*/),
-                  (v15/*: any*/),
+                  (v18/*: any*/),
+                  (v19/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -495,7 +549,7 @@ return {
                     "name": "terminated_at",
                     "storageKey": null
                   },
-                  (v16/*: any*/),
+                  (v20/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -503,7 +557,7 @@ return {
                     "name": "requested_slots",
                     "storageKey": null
                   },
-                  (v17/*: any*/),
+                  (v21/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -542,7 +596,7 @@ return {
                                 "name": "cluster_role",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -572,7 +626,7 @@ return {
                                     "name": "architecture",
                                     "storageKey": null
                                   },
-                                  (v12/*: any*/),
+                                  (v16/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -580,7 +634,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "tags",
                                     "plural": true,
-                                    "selections": (v18/*: any*/),
+                                    "selections": (v22/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -590,7 +644,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "labels",
                                     "plural": true,
-                                    "selections": (v18/*: any*/),
+                                    "selections": (v22/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -607,12 +661,12 @@ return {
                                     "name": "namespace",
                                     "storageKey": null
                                   },
-                                  (v17/*: any*/),
-                                  (v10/*: any*/)
+                                  (v21/*: any*/),
+                                  (v14/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -627,8 +681,8 @@ return {
                                 "name": "cluster_idx",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
-                              (v15/*: any*/),
+                              (v17/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -652,7 +706,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/),
+                  (v23/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -675,7 +729,7 @@ return {
                         "name": "email",
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -717,21 +771,21 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
-                              (v12/*: any*/),
-                              (v10/*: any*/)
+                              (v15/*: any*/),
+                              (v16/*: any*/),
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v8/*: any*/)
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/),
-                  (v19/*: any*/),
+                  (v24/*: any*/),
+                  (v23/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -746,7 +800,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependees",
                     "plural": false,
-                    "selections": (v21/*: any*/),
+                    "selections": (v25/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -756,7 +810,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependents",
                     "plural": false,
-                    "selections": (v21/*: any*/),
+                    "selections": (v25/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -773,7 +827,7 @@ return {
                     "name": "commit_status",
                     "storageKey": null
                   },
-                  (v14/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -848,7 +902,7 @@ return {
                     "kind": "LinkedField",
                     "name": "items",
                     "plural": true,
-                    "selections": (v22/*: any*/),
+                    "selections": (v26/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -902,13 +956,13 @@ return {
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
-                        "selections": (v22/*: any*/),
+                        "selections": (v26/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v8/*: any*/)
+                  (v12/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -969,16 +1023,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "65f08df63c477b79d883977167e514f4",
+    "cacheID": "abaa697c9808913e7c0a976312d4d8be",
     "id": null,
     "metadata": {},
     "name": "DashboardPageQuery",
     "operationKind": "query",
-    "text": "query DashboardPageQuery(\n  $scopeId: ScopeField\n  $resourceGroup: String\n  $skipTotalResourceWithinResourceGroup: Boolean!\n  $isSuperAdmin: Boolean!\n  $agentNodeFilter: String!\n) {\n  ...SessionCountDashboardItemFragment_3vJUag\n  ...RecentlyCreatedSessionFragment_3vJUag\n  ...TotalResourceWithinResourceGroupFragment_2otDCj @skip(if: $skipTotalResourceWithinResourceGroup)\n  ...AgentStatsFragment @include(if: $isSuperAdmin)\n}\n\nfragment AgentStatsFragment on Query {\n  agentStats @since(version: \"25.15.0\") {\n    totalResource {\n      free\n      used\n      capacity\n    }\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditSessionPriorityModalFragment on ComputeSessionNode {\n  id\n  name\n  priority @since(version: \"24.09.0\")\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment RecentlyCreatedSessionFragment_3vJUag on Query {\n  compute_session_nodes(first: 5, order: \"-created_at\", filter: \"status == \\\"running\\\"\", scope_id: $scopeId) {\n    edges {\n      node {\n        id\n        ...SessionNodesFragment\n      }\n    }\n  }\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionAccessKeyFragment on ComputeSessionNode {\n  access_key\n  user_id\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionCountDashboardItemFragment_3vJUag on Query {\n  myInteractive: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"interactive\\\"\", scope_id: $scopeId) {\n    count\n  }\n  myBatch: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"batch\\\"\", scope_id: $scopeId) {\n    count\n  }\n  myInference: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"inference\\\"\", scope_id: $scopeId) {\n    count\n  }\n  myUpload: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"system\\\"\", scope_id: $scopeId) {\n    count\n  }\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n  ...SessionAccessKeyFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  priority @since(version: \"24.09.0\")\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  ...EditSessionPriorityModalFragment\n  ...SessionAccessKeyFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment TotalResourceWithinResourceGroupFragment_2otDCj on Query {\n  agent_summary_list(limit: 1000, offset: 0, status: \"ALIVE\", scaling_group: $resourceGroup, filter: \"schedulable == true\") @skip(if: $isSuperAdmin) {\n    items {\n      id\n      status\n      available_slots\n      occupied_slots\n      scaling_group\n    }\n    total_count\n  }\n  agent_nodes(filter: $agentNodeFilter, first: 100) @include(if: $isSuperAdmin) @since(version: \"24.12.0\") {\n    edges {\n      node {\n        id\n        status\n        available_slots\n        occupied_slots\n        scaling_group\n      }\n    }\n    count\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query DashboardPageQuery(\n  $scopeId: ScopeField\n  $resourceGroup: String\n  $skipTotalResourceWithinResourceGroup: Boolean!\n  $isSuperAdmin: Boolean!\n  $agentNodeFilter: String!\n  $interactiveFilter: String\n  $batchFilter: String\n  $inferenceFilter: String\n  $systemFilter: String\n) {\n  ...SessionCountDashboardItemFragment_3INTnW\n  ...RecentlyCreatedSessionFragment_3vJUag\n  ...TotalResourceWithinResourceGroupFragment_2otDCj @skip(if: $skipTotalResourceWithinResourceGroup)\n  ...AgentStatsFragment @include(if: $isSuperAdmin)\n}\n\nfragment AgentStatsFragment on Query {\n  agentStats @since(version: \"25.15.0\") {\n    totalResource {\n      free\n      used\n      capacity\n    }\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditSessionPriorityModalFragment on ComputeSessionNode {\n  id\n  name\n  priority @since(version: \"24.09.0\")\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment RecentlyCreatedSessionFragment_3vJUag on Query {\n  compute_session_nodes(first: 5, order: \"-created_at\", filter: \"status == \\\"running\\\"\", scope_id: $scopeId) {\n    edges {\n      node {\n        id\n        ...SessionNodesFragment\n      }\n    }\n  }\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionAccessKeyFragment on ComputeSessionNode {\n  access_key\n  user_id\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionCountDashboardItemFragment_3INTnW on Query {\n  myInteractive: compute_session_nodes(first: 0, filter: $interactiveFilter, scope_id: $scopeId) {\n    count\n  }\n  myBatch: compute_session_nodes(first: 0, filter: $batchFilter, scope_id: $scopeId) {\n    count\n  }\n  myInference: compute_session_nodes(first: 0, filter: $inferenceFilter, scope_id: $scopeId) {\n    count\n  }\n  myUpload: compute_session_nodes(first: 0, filter: $systemFilter, scope_id: $scopeId) {\n    count\n  }\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n  ...SessionAccessKeyFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  priority @since(version: \"24.09.0\")\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  ...EditSessionPriorityModalFragment\n  ...SessionAccessKeyFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment TotalResourceWithinResourceGroupFragment_2otDCj on Query {\n  agent_summary_list(limit: 1000, offset: 0, status: \"ALIVE\", scaling_group: $resourceGroup, filter: \"schedulable == true\") @skip(if: $isSuperAdmin) {\n    items {\n      id\n      status\n      available_slots\n      occupied_slots\n      scaling_group\n    }\n    total_count\n  }\n  agent_nodes(filter: $agentNodeFilter, first: 100) @include(if: $isSuperAdmin) @since(version: \"24.12.0\") {\n    edges {\n      node {\n        id\n        status\n        available_slots\n        occupied_slots\n        scaling_group\n      }\n    }\n    count\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c569b4f4d4f8ee32a4f369157d8a1348";
+(node as any).hash = "66db8ba378294c96067135854af0550f";
 
 export default node;

--- a/react/src/__generated__/SessionCountDashboardItemFragment.graphql.ts
+++ b/react/src/__generated__/SessionCountDashboardItemFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cf99f63c7dc61f9285ea240ec223073c>>
+ * @generated SignedSource<<1c18b2c1f6d2c47cad007156e1e69829>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -55,9 +55,29 @@ v2 = [
 return {
   "argumentDefinitions": [
     {
+      "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\"",
+      "kind": "LocalArgument",
+      "name": "batchFilter"
+    },
+    {
+      "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\"",
+      "kind": "LocalArgument",
+      "name": "inferenceFilter"
+    },
+    {
+      "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\"",
+      "kind": "LocalArgument",
+      "name": "interactiveFilter"
+    },
+    {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "scopeId"
+    },
+    {
+      "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\"",
+      "kind": "LocalArgument",
+      "name": "systemFilter"
     }
   ],
   "kind": "Fragment",
@@ -74,9 +94,9 @@ return {
       "alias": "myInteractive",
       "args": [
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "filter",
-          "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
+          "variableName": "interactiveFilter"
         },
         (v0/*: any*/),
         (v1/*: any*/)
@@ -92,9 +112,9 @@ return {
       "alias": "myBatch",
       "args": [
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "filter",
-          "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+          "variableName": "batchFilter"
         },
         (v0/*: any*/),
         (v1/*: any*/)
@@ -110,9 +130,9 @@ return {
       "alias": "myInference",
       "args": [
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "filter",
-          "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+          "variableName": "inferenceFilter"
         },
         (v0/*: any*/),
         (v1/*: any*/)
@@ -128,9 +148,9 @@ return {
       "alias": "myUpload",
       "args": [
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "filter",
-          "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
+          "variableName": "systemFilter"
         },
         (v0/*: any*/),
         (v1/*: any*/)
@@ -148,6 +168,6 @@ return {
 };
 })();
 
-(node as any).hash = "19e666cf346850c01eda18c6889928ae";
+(node as any).hash = "62fd6c06a208e3f17511370116de6c21";
 
 export default node;

--- a/react/src/__generated__/SessionCountDashboardItemRefetchQuery.graphql.ts
+++ b/react/src/__generated__/SessionCountDashboardItemRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f6883a616899087b74a9d782ced06f4f>>
+ * @generated SignedSource<<922d3470225c508d75bffab3c753b94f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,11 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SessionCountDashboardItemRefetchQuery$variables = {
+  batchFilter?: string | null | undefined;
+  inferenceFilter?: string | null | undefined;
+  interactiveFilter?: string | null | undefined;
   scopeId?: any | null | undefined;
+  systemFilter?: string | null | undefined;
 };
 export type SessionCountDashboardItemRefetchQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"SessionCountDashboardItemFragment">;
@@ -24,9 +28,29 @@ export type SessionCountDashboardItemRefetchQuery = {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
+    "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\"",
+    "kind": "LocalArgument",
+    "name": "batchFilter"
+  },
+  {
+    "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\"",
+    "kind": "LocalArgument",
+    "name": "inferenceFilter"
+  },
+  {
+    "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\"",
+    "kind": "LocalArgument",
+    "name": "interactiveFilter"
+  },
+  {
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "scopeId"
+  },
+  {
+    "defaultValue": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\"",
+    "kind": "LocalArgument",
+    "name": "systemFilter"
   }
 ],
 v1 = {
@@ -59,8 +83,28 @@ return {
         "args": [
           {
             "kind": "Variable",
+            "name": "batchFilter",
+            "variableName": "batchFilter"
+          },
+          {
+            "kind": "Variable",
+            "name": "inferenceFilter",
+            "variableName": "inferenceFilter"
+          },
+          {
+            "kind": "Variable",
+            "name": "interactiveFilter",
+            "variableName": "interactiveFilter"
+          },
+          {
+            "kind": "Variable",
             "name": "scopeId",
             "variableName": "scopeId"
+          },
+          {
+            "kind": "Variable",
+            "name": "systemFilter",
+            "variableName": "systemFilter"
           }
         ],
         "kind": "FragmentSpread",
@@ -80,9 +124,9 @@ return {
         "alias": "myInteractive",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
+            "variableName": "interactiveFilter"
           },
           (v1/*: any*/),
           (v2/*: any*/)
@@ -98,9 +142,9 @@ return {
         "alias": "myBatch",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+            "variableName": "batchFilter"
           },
           (v1/*: any*/),
           (v2/*: any*/)
@@ -116,9 +160,9 @@ return {
         "alias": "myInference",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+            "variableName": "inferenceFilter"
           },
           (v1/*: any*/),
           (v2/*: any*/)
@@ -134,9 +178,9 @@ return {
         "alias": "myUpload",
         "args": [
           {
-            "kind": "Literal",
+            "kind": "Variable",
             "name": "filter",
-            "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
+            "variableName": "systemFilter"
           },
           (v1/*: any*/),
           (v2/*: any*/)
@@ -151,16 +195,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4e2a7d64eccfa5e512354e770190e051",
+    "cacheID": "e6cc3327cd077002dec6704b3313653a",
     "id": null,
     "metadata": {},
     "name": "SessionCountDashboardItemRefetchQuery",
     "operationKind": "query",
-    "text": "query SessionCountDashboardItemRefetchQuery(\n  $scopeId: ScopeField\n) {\n  ...SessionCountDashboardItemFragment_3vJUag\n}\n\nfragment SessionCountDashboardItemFragment_3vJUag on Query {\n  myInteractive: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"interactive\\\"\", scope_id: $scopeId) {\n    count\n  }\n  myBatch: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"batch\\\"\", scope_id: $scopeId) {\n    count\n  }\n  myInference: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"inference\\\"\", scope_id: $scopeId) {\n    count\n  }\n  myUpload: compute_session_nodes(first: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"system\\\"\", scope_id: $scopeId) {\n    count\n  }\n}\n"
+    "text": "query SessionCountDashboardItemRefetchQuery(\n  $batchFilter: String = \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"batch\\\"\"\n  $inferenceFilter: String = \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"inference\\\"\"\n  $interactiveFilter: String = \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"interactive\\\"\"\n  $scopeId: ScopeField\n  $systemFilter: String = \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"system\\\"\"\n) {\n  ...SessionCountDashboardItemFragment_3INTnW\n}\n\nfragment SessionCountDashboardItemFragment_3INTnW on Query {\n  myInteractive: compute_session_nodes(first: 0, filter: $interactiveFilter, scope_id: $scopeId) {\n    count\n  }\n  myBatch: compute_session_nodes(first: 0, filter: $batchFilter, scope_id: $scopeId) {\n    count\n  }\n  myInference: compute_session_nodes(first: 0, filter: $inferenceFilter, scope_id: $scopeId) {\n    count\n  }\n  myUpload: compute_session_nodes(first: 0, filter: $systemFilter, scope_id: $scopeId) {\n    count\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "19e666cf346850c01eda18c6889928ae";
+(node as any).hash = "62fd6c06a208e3f17511370116de6c21";
 
 export default node;

--- a/react/src/components/SessionCountDashboardItem.tsx
+++ b/react/src/components/SessionCountDashboardItem.tsx
@@ -35,41 +35,57 @@ const SessionCountDashboardItem: React.FC<SessionCountDashboardItemProps> = ({
 
   const [data, refetch] = useRefetchableFragment(
     graphql`
-        fragment  SessionCountDashboardItemFragment on Query
-        @argumentDefinitions(
-          scopeId: { type: "ScopeField" }
-        ) 
-        @refetchable(queryName: "SessionCountDashboardItemRefetchQuery") {
-          myInteractive: compute_session_nodes(
-            first: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
-            scope_id: $scopeId
-          ) {
-            count
-          }
-          myBatch: compute_session_nodes(
-            first: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
-            scope_id: $scopeId
-          ) {
-            count
-          }
-          myInference: compute_session_nodes(
-            first: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
-            scope_id: $scopeId
-          ) {
-            count
-          }
-          myUpload: compute_session_nodes(
-            first: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
-            scope_id: $scopeId
-          ) {
-            count
-          }
+      fragment SessionCountDashboardItemFragment on Query
+      @argumentDefinitions(
+        scopeId: { type: "ScopeField" }
+        interactiveFilter: {
+          type: "String"
+          defaultValue: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
         }
-      `,
+        batchFilter: {
+          type: "String"
+          defaultValue: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+        }
+        inferenceFilter: {
+          type: "String"
+          defaultValue: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+        }
+        systemFilter: {
+          type: "String"
+          defaultValue: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
+        }
+      )
+      @refetchable(queryName: "SessionCountDashboardItemRefetchQuery") {
+        myInteractive: compute_session_nodes(
+          first: 0
+          filter: $interactiveFilter
+          scope_id: $scopeId
+        ) {
+          count
+        }
+        myBatch: compute_session_nodes(
+          first: 0
+          filter: $batchFilter
+          scope_id: $scopeId
+        ) {
+          count
+        }
+        myInference: compute_session_nodes(
+          first: 0
+          filter: $inferenceFilter
+          scope_id: $scopeId
+        ) {
+          count
+        }
+        myUpload: compute_session_nodes(
+          first: 0
+          filter: $systemFilter
+          scope_id: $scopeId
+        ) {
+          count
+        }
+      }
+    `,
     queryRef,
   );
 

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -28,7 +28,7 @@ import TotalResourceWithinResourceGroup, {
 import { breadcrumbExtraAtom } from '../components/breadcrumbExtraAtom';
 import { dashboardEditModeAtom } from '../components/dashboardEditModeAtom';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
-import { useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
@@ -44,6 +44,7 @@ import {
   BAIUnmountAfterClose,
   filterOutEmpty,
   INITIAL_FETCH_KEY,
+  mergeFilterValues,
   useFetchKey,
   useInterval,
 } from 'backend.ai-ui';
@@ -68,6 +69,7 @@ const DashboardPage: React.FC = () => {
   const currentProject = useCurrentProjectValue();
   const currentResourceGroup = useCurrentResourceGroupValue();
   const userRole = useCurrentUserRole();
+  const [currentUser] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
   const webuiNavigate = useWebUINavigate();
   const buildProjectPath = useProjectPath();
@@ -143,6 +145,15 @@ const DashboardPage: React.FC = () => {
 
   const isAgentStatsSupported = baiClient.supports('agent-stats');
 
+  // This panel is strictly personal: admins/monitors hold read permission on
+  // every project session, so without the user filter it would count theirs too.
+  const mySessionCountFilter = (type: string) =>
+    mergeFilterValues([
+      'status != "TERMINATED" & status != "CANCELLED"',
+      `type == "${type}"`,
+      `user_id == "${currentUser.uuid}"`,
+    ]);
+
   const queryRef = useLazyLoadQuery<DashboardPageQuery>(
     graphql`
       query DashboardPageQuery(
@@ -151,8 +162,19 @@ const DashboardPage: React.FC = () => {
         $skipTotalResourceWithinResourceGroup: Boolean!
         $isSuperAdmin: Boolean!
         $agentNodeFilter: String!
+        $interactiveFilter: String
+        $batchFilter: String
+        $inferenceFilter: String
+        $systemFilter: String
       ) {
-        ...SessionCountDashboardItemFragment @arguments(scopeId: $scopeId)
+        ...SessionCountDashboardItemFragment
+          @arguments(
+            scopeId: $scopeId
+            interactiveFilter: $interactiveFilter
+            batchFilter: $batchFilter
+            inferenceFilter: $inferenceFilter
+            systemFilter: $systemFilter
+          )
         ...RecentlyCreatedSessionFragment @arguments(scopeId: $scopeId)
         ...TotalResourceWithinResourceGroupFragment
           @skip(if: $skipTotalResourceWithinResourceGroup)
@@ -171,6 +193,10 @@ const DashboardPage: React.FC = () => {
       skipTotalResourceWithinResourceGroup: !isAvailableTotalResourcePanel,
       isSuperAdmin: _.isEqual(userRole, 'superadmin'),
       agentNodeFilter: `schedulable == true & status == "ALIVE" & scaling_group == "${currentResourceGroup}"`,
+      interactiveFilter: mySessionCountFilter('interactive'),
+      batchFilter: mySessionCountFilter('batch'),
+      inferenceFilter: mySessionCountFilter('inference'),
+      systemFilter: mySessionCountFilter('system'),
     },
     {
       fetchPolicy:
@@ -206,11 +232,7 @@ const DashboardPage: React.FC = () => {
             <SessionCountDashboardItem
               queryRef={queryRef}
               isRefetching={isRefetching}
-              title={
-                _.isEqual(userRole, 'superadmin')
-                  ? t('session.ActiveSessions')
-                  : t('session.MySessions')
-              }
+              title={t('session.MySessions')}
             />
           </Suspense>
         ),


### PR DESCRIPTION
Resolves #7843 (FR-3107)

## Problem

The project dashboard's session-count panel queried `compute_session_nodes` with only `scope_id: project:<id>` and no user restriction. Backend RBAC grants admins and monitors read permission on every session in a project, so for those roles the panel titled **My Sessions** counted every project member's sessions. This is the same root cause FR-3092 fixed for the `/session` list page (PR #7838).

## What changed

`react/src/components/SessionCountDashboardItem.tsx`

- `SessionCountDashboardItemFragment` now takes the four per-type filters as `@argumentDefinitions` (`interactiveFilter`, `batchFilter`, `inferenceFilter`, `systemFilter`), each defaulting to the literal it previously hardcoded. GraphQL cannot concatenate strings, so the filter has to be built at the call site and passed in.

`react/src/pages/DashboardPage.tsx`

- Builds each filter with `mergeFilterValues([...])` — the not-finished status filter, the type filter, and `user_id == "<current user uuid>"` from `useCurrentUserInfo()` — exactly the idiom `ComputeSessionListPage.tsx` uses, and passes them through the existing `@arguments` spread.
- The panel title no longer branches on the role. It was `session.ActiveSessions` for superadmins and `session.MySessions` for everyone else; now that the counts are personal for every role, "Active Sessions" would be false, so it always reads `session.MySessions` (an existing key — no new i18n strings).

`react/src/pages/AdminDashboardPage.tsx` is **not** touched: it passes no filter arguments, so the fragment defaults apply and its superadmin-only "Active Sessions" panel stays project-wide. The generated `AdminDashboardPageQuery.graphql.ts` is unchanged, which confirms this.

## Design decisions

- **Recently Created Sessions is deliberately left project-scoped.** The issue also mentions that panel, but its own tooltip promises "in the current project" (`resources/i18n/en.json` → `RecentlyCreatedSessionsTooltip`), so narrowing it would contradict shipped copy. If the product owner wants it personal too, that is a separate change including the tooltip.
- **The superadmin title change is the one visible behaviour change.** It is safe now that a superadmin-only `AdminDashboardPage` exists at the admin-scope `/dashboard` route and renders the same fragment as "Active Sessions" — the project-wide view has its own home. The alternative (keep "Active Sessions" and leave superadmin counts project-wide) would leave the superadmin dashboard inconsistent with every other role, so it was not taken.
- No backend change is needed: `user_id == "<uuid>"` on `compute_session_nodes` is already in production via FR-3092.

## Tests

- `bash scripts/verify.sh` (Relay compile + generated-artifact sync, Lint, Format, TypeScript, plus the repository gates).
- `pnpm run relay` — regenerated `SessionCountDashboardItemFragment`, its refetch query, and `DashboardPageQuery`; committed.
- No unit test added: the change is a query-variable wiring with no standalone logic, and `mergeFilterValues` already has its own tests (`packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx`). The FR-3092 precedent added none either.

## Verification

```
=== ALL PASS ===
```

## Review notes

- Sign in as an **admin or monitor** in a project where another user has running sessions, open `/dashboard`, and confirm the "My Sessions" Interactive/Batch/Inference/System counts now match only your own sessions (cross-check against `/session`, which FR-3092 already scoped).
- As a **superadmin**, open the admin-scope dashboard and confirm its "Active Sessions" panel still shows project-wide counts — the fragment defaults must still apply there.
- Wait through one 15s interval refetch (and press the panel's refresh button) and confirm the counts do not widen back: `refetch({})` reuses the parent query's fragment variables, so the user filter must survive.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
