### PR TITLE
feat(FR-35): add a refresh button to the session launcher environment selector

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.test.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.test.tsx
@@ -150,6 +150,15 @@ describe('ImageEnvironmentSelectFormItems refresh control', () => {
       'ImageEnvironmentSelectFormItemsQuery',
     );
 
+    // The refetch runs inside a transition, so the already-rendered selects
+    // stay on screen instead of suspending the launcher step.
+    expect(screen.queryByText('loading')).not.toBeInTheDocument();
+    expect(
+      screen
+        .getAllByRole('button')
+        .some((button) => button.textContent === 'pytorch'),
+    ).toBe(true);
+
     await resolveImageQuery(environment, ['pytorch', 'tensorflow']);
 
     // The trigger keeps the selection the refresh must not disturb, so the

--- a/react/src/components/ImageEnvironmentSelectFormItems.test.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.test.tsx
@@ -63,6 +63,28 @@ vi.mock('../hooks', async (importOriginal) => {
   };
 });
 
+/**
+ * With no image metadata and `supports() === false`, the component groups by
+ * `registry/name`, so the option a reader sees is named after `name` alone.
+ */
+const image = (name: string) => ({
+  id: `${name}-1.0`,
+  name,
+  humanized_name: name,
+  tag: '1.0-py3',
+  registry: 'cr.backend.ai',
+  architecture: 'x86_64',
+  digest: `sha256:${name}`,
+  installed: true,
+  resource_limits: [],
+  labels: [],
+  namespace: name,
+  base_image_name: name,
+  tags: [],
+  version: '1.0',
+  supported_accelerators: [],
+});
+
 const renderFormItems = (
   environment: RelayMockEnvironment,
   showRefreshButton?: boolean,
@@ -79,10 +101,18 @@ const renderFormItems = (
     </RelayEnvironmentProvider>,
   );
 
-const resolveImageQuery = async (environment: RelayMockEnvironment) => {
+const resolveImageQuery = async (
+  environment: RelayMockEnvironment,
+  imageNames?: Array<string>,
+) => {
   await act(async () => {
     environment.mock.resolveMostRecentOperation((operation) =>
-      MockPayloadGenerator.generate(operation),
+      MockPayloadGenerator.generate(
+        operation,
+        imageNames
+          ? { Query: () => ({ images: imageNames.map(image) }) }
+          : undefined,
+      ),
     );
   });
 };
@@ -98,16 +128,18 @@ describe('ImageEnvironmentSelectFormItems refresh control', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('re-executes the image query when clicked', async () => {
+  it('re-executes the image query when clicked and offers the newly returned image', async () => {
     const environment = createMockEnvironment();
     renderFormItems(environment, true);
-    await resolveImageQuery(environment);
+    await resolveImageQuery(environment, ['pytorch']);
 
     const refreshButton = await screen.findByRole('button', {
       name: 'button.Refresh',
     });
     // The initial query is already resolved, so nothing is in flight.
     expect(environment.mock.getAllOperations()).toHaveLength(0);
+    // An image committed after the launcher opened is not in the store yet.
+    expect(screen.queryByText('tensorflow')).not.toBeInTheDocument();
 
     await userEvent.click(refreshButton);
 
@@ -117,5 +149,20 @@ describe('ImageEnvironmentSelectFormItems refresh control', () => {
     expect(environment.mock.getMostRecentOperation().fragment.node.name).toBe(
       'ImageEnvironmentSelectFormItemsQuery',
     );
+
+    await resolveImageQuery(environment, ['pytorch', 'tensorflow']);
+
+    // The trigger keeps the selection the refresh must not disturb, so the
+    // refreshed list is only visible once the dropdown is open.
+    const environmentTrigger = screen
+      .getAllByRole('button')
+      .find((button) => button.textContent === 'pytorch');
+    expect(environmentTrigger).toBeDefined();
+    await userEvent.click(environmentTrigger as HTMLElement);
+
+    expect(
+      await screen.findByRole('option', { name: 'tensorflow' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'pytorch' })).toBeInTheDocument();
   });
 });

--- a/react/src/components/ImageEnvironmentSelectFormItems.test.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.test.tsx
@@ -1,0 +1,121 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import { Form } from '../form-engine';
+import ImageEnvironmentSelectFormItems from './ImageEnvironmentSelectFormItems';
+import '@testing-library/jest-dom';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * FR-35 — the refresh control re-fetches the image list in place, so an image
+ * committed after the launcher opened becomes selectable without a reload.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  };
+});
+
+vi.mock('./ImageMetaIcon', () => ({ default: () => null }));
+
+// Nothing under test depends on the resolved app mode, so pin it instead of
+// mounting `ThemeModeProvider`.
+vi.mock('../hooks/useThemeMode', () => ({
+  useThemeMode: () => ({ isDarkMode: false }),
+}));
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useBackendAIImageMetaData: () => [
+      null,
+      {
+        getBaseVersion: (name: string) => name,
+        getImageMeta: () => ({ key: '', tags: [] }),
+        getTags: () => [],
+        tagAlias: (value: string) => value,
+      },
+    ],
+    useSuspendedBackendaiClient: () => ({
+      _config: {
+        showNonInstalledImages: false,
+        allow_manual_image_name_for_session: false,
+      },
+      supports: () => false,
+    }),
+  };
+});
+
+const renderFormItems = (
+  environment: RelayMockEnvironment,
+  showRefreshButton?: boolean,
+) =>
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <Form>
+        <Suspense fallback={<div>loading</div>}>
+          <ImageEnvironmentSelectFormItems
+            showRefreshButton={showRefreshButton}
+          />
+        </Suspense>
+      </Form>
+    </RelayEnvironmentProvider>,
+  );
+
+const resolveImageQuery = async (environment: RelayMockEnvironment) => {
+  await act(async () => {
+    environment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation),
+    );
+  });
+};
+
+describe('ImageEnvironmentSelectFormItems refresh control', () => {
+  it('is hidden unless the consumer asks for it', async () => {
+    const environment = createMockEnvironment();
+    renderFormItems(environment);
+    await resolveImageQuery(environment);
+
+    expect(
+      screen.queryByRole('button', { name: 'button.Refresh' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('re-executes the image query when clicked', async () => {
+    const environment = createMockEnvironment();
+    renderFormItems(environment, true);
+    await resolveImageQuery(environment);
+
+    const refreshButton = await screen.findByRole('button', {
+      name: 'button.Refresh',
+    });
+    // The initial query is already resolved, so nothing is in flight.
+    expect(environment.mock.getAllOperations()).toHaveLength(0);
+
+    await userEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(environment.mock.getAllOperations()).toHaveLength(1);
+    });
+    expect(environment.mock.getMostRecentOperation().fragment.node.name).toBe(
+      'ImageEnvironmentSelectFormItemsQuery',
+    );
+  });
+});

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -34,6 +34,7 @@ import TextHighlighter from './TextHighlighter';
 import { AstryxFormTextInput } from './astryxFormControls';
 import { Badge } from '@astryxdesign/core/Badge';
 import { Divider } from '@astryxdesign/core/Divider';
+import { IconButton } from '@astryxdesign/core/IconButton';
 import {
   badgeVariantForTagColor,
   BAIDoubleTag,
@@ -44,9 +45,17 @@ import {
   BAISelectOptionItem as SelectOption,
   BAISelectOptionGroup as SelectOptGroup,
   BAIText,
+  useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { RotateCw } from 'lucide-react';
+import React, {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -78,11 +87,13 @@ interface ImageEnvironmentSelectFormItemsProps {
   filter?: (image: Image) => boolean;
   showPrivate?: boolean;
   searchPrefill?: string;
+  /** Show a refresh button that re-fetches the image list. */
+  showRefreshButton?: boolean;
 }
 
 const ImageEnvironmentSelectFormItems: React.FC<
   ImageEnvironmentSelectFormItemsProps
-> = ({ filter, showPrivate, searchPrefill }) => {
+> = ({ filter, showPrivate, searchPrefill, showRefreshButton }) => {
   'use memo';
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
   const environments = Form.useWatch('environments', { form, preserve: true });
@@ -134,6 +145,9 @@ const ImageEnvironmentSelectFormItems: React.FC<
     [searchPrefill],
   );
 
+  const [isRefetchPending, startRefetchTransition] = useTransition();
+  const [imageFetchKey, updateImageFetchKey] = useUpdatableState('initial');
+
   const imageEnvironmentSelectFormItemsVariables = baiClient?._config
     ?.showNonInstalledImages
     ? {}
@@ -172,7 +186,9 @@ const ImageEnvironmentSelectFormItems: React.FC<
     `,
     imageEnvironmentSelectFormItemsVariables,
     {
-      fetchPolicy: 'store-and-network',
+      fetchPolicy:
+        imageFetchKey === 'initial' ? 'store-and-network' : 'network-only',
+      fetchKey: imageFetchKey,
     },
   );
 
@@ -415,16 +431,34 @@ const ImageEnvironmentSelectFormItems: React.FC<
           style={{ marginBottom: 0 }}
           name={['environments', 'environment']}
           label={
-            <BAIText
-              copyable={{
-                text: getImageFullName(
-                  form.getFieldValue(['environments', 'image']),
-                ),
-              }}
-            >
-              {t('session.launcher.Environments')} /{' '}
-              {t('session.launcher.Version')}
-            </BAIText>
+            <BAIFlex direction="row" align="center" gap="xxs">
+              <BAIText
+                copyable={{
+                  text: getImageFullName(
+                    form.getFieldValue(['environments', 'image']),
+                  ),
+                }}
+              >
+                {t('session.launcher.Environments')} /{' '}
+                {t('session.launcher.Version')}
+              </BAIText>
+              {showRefreshButton ? (
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  icon={<RotateCw size="1em" />}
+                  label={t('button.Refresh')}
+                  tooltip={t('button.Refresh')}
+                  isLoading={isRefetchPending}
+                  onClick={(e) => {
+                    // The row lives inside the item's `<label htmlFor>`, whose
+                    // default action would move focus into the select.
+                    e.preventDefault();
+                    startRefetchTransition(() => updateImageFetchKey());
+                  }}
+                />
+              ) : null}
+            </BAIFlex>
           }
           rules={[
             {

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1151,7 +1151,7 @@ const SessionLauncherPage = () => {
                       return null;
                     }}
                   >
-                    <ImageEnvironmentSelectFormItems />
+                    <ImageEnvironmentSelectFormItems showRefreshButton />
                   </ErrorBoundary>
                   <Form.Item label={t('session.launcher.EnvironmentVariable')}>
                     <EnvVarFormList


### PR DESCRIPTION
Resolves #2906 (FR-35)

The session launcher's Environment / Version selector fetched the image list
once on mount (`useLazyLoadQuery` with `store-and-network` and no fetch key).
An image committed or pushed while the launcher was open only became selectable
after a full page reload.

## What changed

- `ImageEnvironmentSelectFormItems` gains an opt-in `showRefreshButton` prop.
  When set, a ghost refresh `IconButton` renders in the Environment / Version
  label row, next to the existing copy control.
- Clicking it bumps a `useUpdatableState` fetch key inside a `useTransition`,
  so the query re-runs with `network-only` while the already-rendered selects
  stay on screen instead of suspending the launcher step. The initial mount
  keeps `store-and-network`.
- `SessionLauncherPage` passes the new prop.

## Design decisions

- **Opt-in, not always on.** The component is also mounted by
  `DeploymentAddRevisionModal`; that call site is left untouched, so the button
  appears only where the issue asks for it.
- **`preventDefault()` on the click.** The label row is rendered inside the form
  item's `<label htmlFor>`, whose default action moves focus into the select —
  the same reason the form engine's own tooltip trigger prevents it.
- **No new i18n key.** The existing `button.Refresh` (en/ko and the other 20
  locales) covers the label and the tooltip, so `make i18n` was not needed.
- **The auto-select effect is untouched.** It keys off
  `environments.version` / `manual`, not the image list, so a refresh does not
  rewrite or reset the user's current selection.

## Tests

- New `react/src/components/ImageEnvironmentSelectFormItems.test.tsx` (2 cases,
  relay-test-utils mock environment): the button is absent without the prop, and
  clicking it puts a second `ImageEnvironmentSelectFormItemsQuery` in flight.
  `pnpm exec vitest run src/components/ImageEnvironmentSelectFormItems.test.tsx`
  → 2 passed.
- No e2e run (requires a live cluster).

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Open the session launcher, reach the Environment step, and confirm the refresh
  icon sits to the right of the "Environments / Version" label.
- Commit a new customized image (or `docker push` one) with the launcher open,
  click refresh, and confirm the new image shows up in the Environment list
  without reloading the page.
- With an environment/version already picked, click refresh and confirm the
  selection is preserved and the step does not flash a loading fallback.
- Open Deployments → Add revision and confirm that selector still has **no**
  refresh button.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
