### PR TITLE
feat(FR-1973): default the session launcher to the minimum required allocation

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -10,6 +10,7 @@ import {
 import { Image } from '../ImageEnvironmentSelectFormItems';
 import {
   getAllocatablePresetNames,
+  getAutoSelectedAllocationPreset,
   getUnifiedSlotNameFromTag,
   isUnifiedAcceleratorSlot,
 } from './ResourceAllocationFormItems';
@@ -195,5 +196,54 @@ describe('getAllocatablePresetNames', () => {
     );
     // Only compare with resource limits
     expect(result).toEqual(['cpu1_mem2g']);
+  });
+});
+
+describe('getAutoSelectedAllocationPreset', () => {
+  it('starts on "minimum-required" when custom resource allocation is allowed', () => {
+    expect(
+      getAutoSelectedAllocationPreset({
+        allocatablePresetNames: ['small', 'medium', 'large'],
+        enableResourcePresets: true,
+        allowCustomResourceAllocation: true,
+      }),
+    ).toBe('minimum-required');
+  });
+
+  it('starts on "minimum-required" even when no preset is allocatable', () => {
+    expect(
+      getAutoSelectedAllocationPreset({
+        allocatablePresetNames: [],
+        enableResourcePresets: true,
+        allowCustomResourceAllocation: true,
+      }),
+    ).toBe('minimum-required');
+  });
+
+  it('falls back to the alphabetically first allocatable preset when "minimum-required" is not offered', () => {
+    expect(
+      getAutoSelectedAllocationPreset({
+        allocatablePresetNames: ['small', 'medium', 'large'],
+        enableResourcePresets: true,
+        allowCustomResourceAllocation: false,
+      }),
+    ).toBe('large');
+  });
+
+  it('returns null when presets are disabled or none is allocatable and "minimum-required" is not offered', () => {
+    expect(
+      getAutoSelectedAllocationPreset({
+        allocatablePresetNames: ['small'],
+        enableResourcePresets: false,
+        allowCustomResourceAllocation: false,
+      }),
+    ).toBeNull();
+    expect(
+      getAutoSelectedAllocationPreset({
+        allocatablePresetNames: [],
+        enableResourcePresets: true,
+        allowCustomResourceAllocation: false,
+      }),
+    ).toBeNull();
   });
 });

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -664,16 +664,24 @@ const ResourceAllocationFormItems: React.FC<
           )
         ) {
           // if the current preset is available in the current resource group, do nothing.
-        } else if (enableResourcePresets && allocatablePresetNames[0]) {
-          const autoSelectedPreset = _.sortBy(allocatablePresetNames)[0];
-          form.setFieldsValue({
-            allocationPreset: autoSelectedPreset,
-          });
-          updateResourceFieldsBasedOnPreset(autoSelectedPreset);
         } else {
-          // if the current preset is not available in the current resource group, set to "minimum-required".
-          if (baiClient._config.allowCustomResourceAllocation) {
-            form.setFieldValue('allocationPreset', 'minimum-required');
+          const autoSelectedPreset = getAutoSelectedAllocationPreset({
+            allocatablePresetNames,
+            enableResourcePresets,
+            allowCustomResourceAllocation:
+              baiClient._config.allowCustomResourceAllocation,
+          });
+          if (autoSelectedPreset === 'minimum-required') {
+            // resource fields are filled by the image-driven effect below.
+            form.setFieldsValue({
+              allocationPreset: 'minimum-required',
+              enabledAutomaticShmem: true,
+            });
+          } else if (autoSelectedPreset) {
+            form.setFieldsValue({
+              allocationPreset: autoSelectedPreset,
+            });
+            updateResourceFieldsBasedOnPreset(autoSelectedPreset);
           } else {
             form.setFieldValue('allocationPreset', null);
           }
@@ -1816,6 +1824,27 @@ const MemoizedResourceAllocationFormItems = React.memo(
 );
 
 export default MemoizedResourceAllocationFormItems;
+
+// The preset the launcher starts with (FR-1973). `minimum-required` is only
+// rendered when `allowCustomResourceAllocation` is on, so without it the
+// fallback has to stay a real preset or the field becomes unselectable.
+export const getAutoSelectedAllocationPreset = ({
+  allocatablePresetNames,
+  enableResourcePresets,
+  allowCustomResourceAllocation,
+}: {
+  allocatablePresetNames: Array<string>;
+  enableResourcePresets?: boolean;
+  allowCustomResourceAllocation?: boolean;
+}): string | null => {
+  if (allowCustomResourceAllocation) {
+    return 'minimum-required';
+  }
+  if (enableResourcePresets && allocatablePresetNames[0]) {
+    return _.sortBy(allocatablePresetNames)[0];
+  }
+  return null;
+};
 
 export const getAllocatablePresetNames = (
   presets: Array<ResourcePreset> | undefined,


### PR DESCRIPTION
Resolves #5146 (FR-1973)

## What changed

The session launcher's initial allocation preset was `_.sortBy(allocatablePresetNames)[0]` — the alphabetically first allocatable preset ('small' in a default install, but whatever happens to sort first in a site's own preset list). That silently over-allocates for a user who just wants to start a session, and the pick is arbitrary rather than a curated default.

The launcher now starts on **Minimum allocation** (`minimum-required`), which allocates exactly what the selected image declares as its minimum. Nothing else about the field changes: the user can still switch to any preset or to Custom.

## Design decisions

- **The old alphabetical pick stays as the fallback.** `ResourcePresetSelect` renders the `minimum-required` option only when `baiClient._config.allowCustomResourceAllocation` is on. On a deployment with it off, defaulting to `minimum-required` would leave the select showing a value it does not list, so those deployments keep the previous behaviour (first allocatable preset, else `null`).
- **`enabledAutomaticShmem` is set to `true`** alongside the preset, mirroring what `ResourcePresetSelect`'s `onChange` already does for the `minimum-required` case. The resource fields themselves are filled by the existing image-driven effect, not here.
- **Prefilled forms are untouched.** The effect still returns early when the form already holds `custom` / `minimum-required` or a preset that is allocatable in the current resource group, so session-template and re-launch prefill keep their preset. `FileBrowserButton*` already hardcoded `allocationPreset: 'minimum-required'` and is unaffected.
- The selection moved into an exported pure helper, `getAutoSelectedAllocationPreset`, so both config branches are unit-testable without rendering the form.

## Tests

- Added 4 cases to `react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts` covering `getAutoSelectedAllocationPreset`: custom-allocation on (with and without allocatable presets), custom-allocation off (alphabetical fallback), and the `null` cases.
- `pnpm exec vitest run src/components/SessionFormItems/ResourceAllocationFormItems.test.ts` — 18 passed.
- `pnpm exec vitest run src/components/SessionFormItems/ResourceAllocationFormItems.contract.test.tsx` — 2 passed (unchanged).

## Verification

`bash scripts/verify.sh`:

```
=== ALL PASS ===
```

## Review notes

- Open **Start session** on a deployment with `allowCustomResourceAllocation = true`: the Resource presets field should land on *Minimum allocation*, and CPU/RAM/accelerator should match the selected image's minimum (change the image and confirm the numbers follow).
- Set `allowCustomResourceAllocation = false` in `config.toml` and reload: the field should still land on the alphabetically first allocatable preset, exactly as before — *Minimum allocation* is not even offered there.
- Re-launch an existing session and open a session template: both should still arrive with their own preset selected, not with *Minimum allocation*.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup) — `allowCustomResourceAllocation` in `config.toml` toggles the two branches
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
