### PR TITLE
fix(FR-3280): serve a 404 page for unsupported docs locales

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -97,6 +97,7 @@ export { buildWebDocument } from "./html-builder-web.js";
 export type {
   LanguagePeer,
   LanguagePickerPageOptions,
+  NotFoundPageOptions,
   PageAssets,
   PageSeoContext,
   PageVersionContext,
@@ -110,6 +111,7 @@ export {
   buildHomePage,
   buildIndexPage,
   buildLanguagePickerPage,
+  buildNotFoundPage,
   buildRootRedirectIndexPage,
   buildWebPage,
 } from "./website-builder.js";

--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -22,6 +22,7 @@ import {
   buildIndexPage,
   buildLangRedirectStubPage,
   buildLanguagePickerPage,
+  buildNotFoundPage,
   buildRootRedirectIndexPage,
   buildWebPage,
   type WebPageContext,
@@ -1957,6 +1958,109 @@ describe("buildLangRedirectStubPage — FR-3247 per-language redirect stubs", ()
       /<title>Docs<\/title>\n {2}<meta name="robots" content="noindex" \/>/,
     );
     assert.doesNotMatch(html, /og:|twitter:/);
+  });
+});
+
+describe("buildNotFoundPage — FR-3280 unmatched-path fallback", () => {
+  const baseLanguages = [
+    { lang: "en", label: "English" },
+    { lang: "ko", label: "한국어" },
+    { lang: "ja", label: "日本語" },
+    { lang: "th", label: "ภาษาไทย" },
+  ];
+
+  const versioned = () =>
+    buildNotFoundPage({
+      title: "Backend.AI WebUI User Guide",
+      productName: "Backend.AI WebUI",
+      languages: baseLanguages,
+      basePath: "latest",
+    });
+
+  it("links every supported language under the /latest/ alias", () => {
+    const html = versioned();
+    for (const { lang, label } of baseLanguages) {
+      assert.match(html, new RegExp(`href="/latest/${lang}/"`));
+      assert.ok(html.includes(label), `missing label ${label}`);
+    }
+  });
+
+  it("links the /latest/ alias itself as the documentation home", () => {
+    assert.match(versioned(), /href="\/latest\/"/);
+  });
+
+  it("uses site-root-absolute hrefs only — the page is served under the requested path", () => {
+    const html = versioned();
+    assert.doesNotMatch(html, /href="\.\//);
+    assert.doesNotMatch(html, /href="\.\.\//);
+  });
+
+  it("does not redirect: no inline script and no meta refresh", () => {
+    const html = versioned();
+    assert.doesNotMatch(html, /<script/i);
+    assert.doesNotMatch(html, /http-equiv="refresh"/i);
+  });
+
+  it("is noindex and announces the 404", () => {
+    const html = versioned();
+    assert.match(html, /<meta name="robots" content="noindex" \/>/);
+    assert.match(html, />404</);
+    assert.match(html, /Page not found/);
+  });
+
+  it("drops the alias segment in flat mode (no basePath)", () => {
+    const html = buildNotFoundPage({
+      title: "Docs",
+      productName: "Docs",
+      languages: baseLanguages,
+    });
+    assert.match(html, /href="\/en\/"/);
+    assert.doesNotMatch(html, /href="\/latest\//);
+  });
+
+  it("HTML-escapes the title, product name and language labels", () => {
+    const html = buildNotFoundPage({
+      title: "<script>alert(1)</script>",
+      productName: "A & B",
+      languages: [{ lang: "en", label: "<b>English</b>" }],
+    });
+    assert.doesNotMatch(html, /<script/i);
+    assert.match(html, /&lt;b&gt;English&lt;\/b&gt;/);
+    assert.match(html, /A &amp; B/);
+  });
+
+  it("rejects an empty language list and path-breakout inputs", () => {
+    assert.throws(
+      () =>
+        buildNotFoundPage({
+          title: "Docs",
+          productName: "Docs",
+          languages: [],
+        }),
+      /must contain at least one entry/,
+    );
+    for (const bad of ["..", ".", "../x", "a/b", ".hidden"]) {
+      assert.throws(
+        () =>
+          buildNotFoundPage({
+            title: "Docs",
+            productName: "Docs",
+            languages: baseLanguages,
+            basePath: bad,
+          }),
+        /invalid basePath/,
+        `expected ${JSON.stringify(bad)} to be rejected`,
+      );
+    }
+    assert.throws(
+      () =>
+        buildNotFoundPage({
+          title: "Docs",
+          productName: "Docs",
+          languages: [{ lang: "../x", label: "x" }],
+        }),
+      /invalid lang/,
+    );
   });
 });
 

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -2687,7 +2687,7 @@ export function buildNotFoundPage(opts: NotFoundPageOptions): string {
     <p class="nf__code">404</p>
     <h1 class="nf__title">Page not found</h1>
     <p class="nf__body">The page you requested does not exist in ${safeProduct}. If you followed a link with a language code we do not publish, pick a language below instead.</p>
-    <p class="nf__heading">Available languages</p>
+    <h2 class="nf__heading">Available languages</h2>
     <ul class="nf__list">
 ${langItems}
     </ul>

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -2604,3 +2604,95 @@ ${redirectPageSeoBlock(title, opts.seo)}  <meta name="robots" content="noindex" 
 </body>
 </html>`;
 }
+
+/**
+ * Build the site-root `dist/web/404.html` fallback page (FR-3280).
+ *
+ * The hosting layer serves this page for any path that matched no
+ * rule and no file — most visibly an unsupported locale such as
+ * `/latest/fr/`, which previously returned a zero-byte 404 body.
+ *
+ * Two constraints follow from "served at an arbitrary URL": every href
+ * must be site-root-absolute (a relative one would resolve against the
+ * bogus path), and the page must not redirect — an unmatched path has
+ * no correct destination to send the reader to, so it states what
+ * happened and lets them choose.
+ */
+export interface NotFoundPageOptions {
+  title: string;
+  productName: string;
+  languages: Array<{ lang: string; label: string }>;
+  /**
+   * Single path segment the language links are mounted under, e.g.
+   * `latest` for `/latest/<lang>/` (the version-agnostic alias). Leave
+   * undefined for flat-mode builds, where `/<lang>/` is the real
+   * content.
+   */
+  basePath?: string;
+}
+
+export function buildNotFoundPage(opts: NotFoundPageOptions): string {
+  const { title, productName, languages, basePath } = opts;
+  if (languages.length === 0) {
+    throw new Error(
+      `buildNotFoundPage: \`languages\` must contain at least one entry`,
+    );
+  }
+  if (
+    basePath !== undefined &&
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(basePath)
+  ) {
+    throw new Error(
+      `buildNotFoundPage: invalid basePath ${JSON.stringify(basePath)}`,
+    );
+  }
+  const hrefBase = basePath ? `/${basePath}/` : "/";
+  const safeTitle = escapeHtml(title);
+  const safeProduct = escapeHtml(productName);
+  const langItems = languages
+    .map((l) => {
+      if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(l.lang)) {
+        throw new Error(
+          `buildNotFoundPage: invalid lang ${JSON.stringify(l.lang)}`,
+        );
+      }
+      return `      <li><a class="nf__lang" hreflang="${escapeHtml(l.lang)}" lang="${escapeHtml(l.lang)}" href="${hrefBase}${escapeHtml(l.lang)}/">${escapeHtml(l.label)}</a></li>`;
+    })
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Page not found &mdash; ${safeTitle}</title>
+  <meta name="robots" content="noindex" />
+  <style>
+    :root { color-scheme: light dark; --nf-fg: #1c1e21; --nf-muted: #606770; --nf-bg: #ffffff; --nf-border: #ebedf0; --nf-link: #1868db; }
+    @media (prefers-color-scheme: dark) {
+      :root { --nf-fg: #e3e3e3; --nf-muted: #a8a8a8; --nf-bg: #1b1b1d; --nf-border: #333338; --nf-link: #7ab0ff; }
+    }
+    body { margin: 0; background: var(--nf-bg); color: var(--nf-fg); font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; }
+    .nf { max-width: 34rem; margin: 4rem auto; padding: 2rem; border: 1px solid var(--nf-border); border-radius: .5rem; }
+    .nf__code { margin: 0; font-size: .875rem; font-weight: 700; letter-spacing: .08em; color: var(--nf-muted); }
+    .nf__title { margin: .25rem 0 .5rem 0; font-size: 1.5rem; }
+    .nf__body { margin: 0 0 1.5rem 0; color: var(--nf-muted); font-size: .9375rem; line-height: 1.6; }
+    .nf__heading { margin: 0 0 .5rem 0; font-size: .8125rem; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; color: var(--nf-muted); }
+    .nf__list { list-style: none; padding: 0; margin: 0 0 1.5rem 0; display: flex; flex-direction: column; gap: .5rem; }
+    a { color: var(--nf-link); }
+  </style>
+</head>
+<body>
+  <main class="nf">
+    <p class="nf__code">404</p>
+    <h1 class="nf__title">Page not found</h1>
+    <p class="nf__body">The page you requested does not exist in ${safeProduct}. If you followed a link with a language code we do not publish, pick a language below instead.</p>
+    <p class="nf__heading">Available languages</p>
+    <ul class="nf__list">
+${langItems}
+    </ul>
+    <p class="nf__body"><a href="${hrefBase}">Go to ${safeTitle}</a></p>
+  </main>
+</body>
+</html>`;
+}

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -20,6 +20,7 @@ import {
   buildHomePage,
   buildRootRedirectIndexPage,
   buildLangRedirectStubPage,
+  buildNotFoundPage,
   applyImageAttributes,
 } from "./website-builder.js";
 import { buildSearchIndex } from "./search-index-builder.js";
@@ -862,6 +863,26 @@ export async function generateWebsite(
     console.log(
       `Written: index.html (root redirect${loadedVersions.latest ? ` → ${loadedVersions.latest.label}` : ""})`,
     );
+
+    // Site-root 404 fallback (FR-3280). The hosting layer serves it for
+    // every path that matched no rule and no file — an unsupported
+    // locale like `/latest/fr/` above all — which previously returned an
+    // empty body. Its links are site-root-absolute because the page is
+    // served under the requested (wrong) URL, not under `/404.html`.
+    fs.writeFileSync(
+      path.join(distBase, "404.html"),
+      buildNotFoundPage({
+        title,
+        productName,
+        languages: peerLangsForRedirect,
+        basePath:
+          loadedVersions.enabled && loadedVersions.latest
+            ? "latest"
+            : undefined,
+      }),
+      "utf-8",
+    );
+    console.log(`Written: 404.html (unmatched-path fallback)`);
   }
 
   // Per-language redirect stubs (FR-3247). Versioned mode only: emit

--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -177,6 +177,13 @@ aws amplify update-app --app-id <APP_ID> \
 Do **not** reintroduce version numbers (e.g. `/26.4/`) into rule targets
 — that recreates the manual-reapplication step this design removed.
 
+> **Pending one-time reapplication (FR-3280).** The rule set gained a
+> trailing `/<*>` → `/404.html` (status `404`) catch-all so unmatched
+> paths — an unsupported locale such as `/latest/fr/` above all — serve
+> the build's 404 page instead of an empty body. Until someone applies
+> the rules once by the procedure above, the live site keeps returning
+> the blank 404; deploying the build alone is not enough.
+
 ---
 
 ## What is NOT a runbook step

--- a/packages/backend.ai-webui-docs/amplify-redirects.json
+++ b/packages/backend.ai-webui-docs/amplify-redirects.json
@@ -32,6 +32,14 @@
     "    wildcards. Slug-level mapping is impossible (the Sphinx manual",
     "    and this site have entirely different page slugs), so they land",
     "    on the per-language index. Supersedes FR-2742's per-slug idea.",
+    "  - The trailing /<*> → /404.html rule (FR-3280) is AWS's documented",
+    "    custom-404 pattern: `status: 404` makes it fire only when the",
+    "    request matched no earlier rule AND no file in the artifact, so",
+    "    it cannot shadow real pages or assets. It MUST stay last —",
+    "    Amplify evaluates rules in order. The target page is emitted by",
+    "    the docs build (`404.html`), lists the supported languages and",
+    "    does not redirect, because an unmatched path (e.g. an",
+    "    unsupported locale like /latest/fr/) has no correct destination.",
     "  - Bare language paths (/ko, /ko/) get EXPLICIT rules per language:",
     "    Amplify matches sources literally (no trailing-slash",
     "    normalization) and /<lang>/<*> is not guaranteed to match the",
@@ -115,6 +123,11 @@
       "source": "/th/<*>",
       "target": "/latest/th/",
       "status": "302"
+    },
+    {
+      "source": "/<*>",
+      "target": "/404.html",
+      "status": "404"
     }
   ]
 }


### PR DESCRIPTION
Resolves #8209 (FR-3280)

## What changed

An unsupported locale in a docs URL returned HTTP 404 with a **zero-byte body** — the reported blank page. Reproduced against the live site: `/latest/fr/`, `/fr/` and `/latest/de/index.html` all return 404 with `content-length: 0`, while `/latest/en/` returns 200. Two things were missing: the docs build emitted no 404 page, and `amplify-redirects.json` enumerates only `en/ko/ja/th` with no catch-all.

- **`buildNotFoundPage()`** (`packages/backend.ai-docs-toolkit/src/website-builder.ts`) emits `dist/web/404.html`, written by `website-generator.ts` alongside the existing root-redirect and `/latest/` alias pages. It states that the page does not exist, lists every supported language, and links to the documentation home.
- **`amplify-redirects.json`** gains a trailing `/<*>` → `/404.html` rule with status `404`.

## Design decisions

- **Static page, no redirect.** The issue offered "404 page *or* redirect to the nearest supported locale". An unmatched path has no correct destination — `/latest/fr/foo` is not the French version of anything — so bouncing the reader to `/latest/en/` would hide the mistake and lose the URL. The page names the problem and lets them choose.
- **Site-root-absolute hrefs.** The hosting layer serves `404.html` under the *requested* (wrong) URL, so relative hrefs would resolve against that bogus path. All links are `/latest/…`, release-invariant per the rule file's header (no version numbers in targets).
- **Self-contained styles.** The page inlines its own small stylesheet instead of pulling the hashed site CSS: it must render correctly from any path, including one where asset resolution is exactly what failed.
- **Catch-all ordering.** `status: 404` is AWS's documented custom-404 pattern — the rule fires only when no earlier rule matched *and* no file exists in the artifact, so it cannot shadow real pages or assets, and it returns 404 (not 200) so asset misses stay honest errors. It is appended **last**; Amplify evaluates rules in order, so the per-language rules still win.
- Flat-mode builds (no versions) get `/<lang>/` links instead of `/latest/<lang>/`; the toolkit is shared, so the alias segment is an option, not a constant.

## ⚠️ Requires one Amplify console action to reach the live site

`amplify-redirects.json` is **not read by Amplify Hosting** (see the file's own header). This PR changes the rule **set**, which is the one case the release runbook says needs manual (re)application:

```bash
aws amplify update-app --app-id <APP_ID> \
  --custom-rules "$(jq -c '.customRules' packages/backend.ai-webui-docs/amplify-redirects.json)"
```

…or paste the `customRules` array in "App settings → Rewrites and redirects → Open text editor". Until the docs/DevOps owner does this once, the live site keeps returning the blank 404 even after the build deploys. Noted in `RELEASE-RUNBOOK.md` so it is not lost.

## Tests

- `pnpm --filter backend.ai-docs-toolkit exec tsx --test src/website-builder.test.ts` → **96 pass, 0 fail** (8 new cases: language links under the alias, home link, root-absolute-only hrefs, no redirect script/meta, `noindex` + 404 copy, flat-mode fallback, HTML escaping, and rejection of empty language lists / path-breakout `basePath` and `lang`).
- Real build: `pnpm --filter backend.ai-webui-docs run build:web:en` → `Written: 404.html (unmatched-path fallback)`; the emitted page contains only `href="/latest/en/"` and `href="/latest/"`.

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Build the site (`pnpm --filter backend.ai-webui-docs run build:web:en`) and open `dist/web/404.html` from a nested path (e.g. serve `dist/web` and visit `/latest/fr/`) — the links must still resolve to `/latest/…`, which is what the root-absolute hrefs buy.
- Check rule ordering in `amplify-redirects.json`: the new `/<*>` entry must be the **last** element of `customRules`, or the per-language redirects stop firing.
- Confirm the runbook wording matches what you'd actually want DevOps to do — this is the one manual step between merge and the bug actually being gone on `webui.docs.backend.ai`.

**Checklist:** (if applicable)

- [x] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
