### PR TITLE
chore(FR-2985): drop the wholesale bui-language Vitest mock

### DIFF
--- a/react/__test__/buiLanguage.mock.js
+++ b/react/__test__/buiLanguage.mock.js
@@ -1,6 +1,0 @@
-// Mock for src/helper/bui-language.ts
-// This avoids importing antd/es/locale which requires ESM transformation
-module.exports = {
-  buiLanguages: {},
-  buiTranslations: {},
-};

--- a/react/src/helper/bui-language.test.ts
+++ b/react/src/helper/bui-language.test.ts
@@ -1,0 +1,29 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { buiLanguages } from './bui-language';
+import { SUPPORTED_LANGUAGES } from './resolveInitialLanguage';
+import { describe, expect, it } from 'vitest';
+
+// This module used to be replaced wholesale by a hand-written Vitest mock
+// (FR-2985). The assertions below fail loudly if the real `backend.ai-ui/locale/*`
+// modules stop resolving, instead of taking out every test that loads
+// `DefaultProviders`.
+describe('buiLanguages', () => {
+  it('covers exactly the supported languages', () => {
+    expect(Object.keys(buiLanguages).sort()).toEqual(
+      [...SUPPORTED_LANGUAGES].sort(),
+    );
+  });
+
+  it('loads a real BAILocale for every supported language', () => {
+    SUPPORTED_LANGUAGES.forEach((language) => {
+      const locale = buiLanguages[language];
+      expect(locale.lang, language).toBeTruthy();
+      expect(Object.keys(locale.astryxLocale ?? {}), language).not.toHaveLength(
+        0,
+      );
+    });
+  });
+});

--- a/react/src/helper/bui-language.ts
+++ b/react/src/helper/bui-language.ts
@@ -40,8 +40,7 @@ import zh_TW from 'backend.ai-ui/locale/zh_TW';
 // The `satisfies` clause below is a compile-time guard that keeps this map
 // in exact two-way sync with `SUPPORTED_LANGUAGES` in
 // `helper/resolveInitialLanguage.ts` (a missing key or an extra key is a
-// type error). Type-only import, so the Vitest mock of this module is
-// unaffected.
+// type error).
 export const buiLanguages = {
   de: de_DE,
   el: el_GR,

--- a/react/vitest.config.ts
+++ b/react/vitest.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
       // Workspace package alias (dev-source path, matching the Jest
       // moduleNameMapper entry for `backend.ai-ui`).
       { find: /^backend\.ai-ui\/dist(\/|$)/, replacement: buiSrc + '$1' },
+      // The `./locale/*` subpath export points at `dist/`, which CI never
+      // builds before running this suite — resolve it to source instead.
+      { find: /^backend\.ai-ui\/locale\//, replacement: buiSrc + '/locale/' },
       { find: /^backend\.ai-ui$/, replacement: buiSrc },
       // `backend.ai-client` is mocked in tests (see __test__/backendAiClient.mock.js).
       // The Jest moduleNameMapper handled this explicitly; we use an alias instead.
@@ -55,11 +58,6 @@ export default defineConfig({
       {
         find: /^.+\.(css|less|scss|sass)(\?raw)?$/,
         replacement: resolve(__dirname, '__test__/rawCss.mock.js'),
-      },
-      // `bui-language` helper was mocked by Jest. Replicate the mapping.
-      {
-        find: /^.*\/helper\/bui-language$/,
-        replacement: resolve(__dirname, '__test__/buiLanguage.mock.js'),
       },
     ],
   },


### PR DESCRIPTION
Resolves #7614 (FR-2985)

`react/vitest.config.ts` aliased every `*/helper/bui-language` import to a hand-written mock, so the module's export shape had to be maintained in two places. Any new export in the real module was silently `undefined` under Vitest and took out every test file that transitively loads `DefaultProviders` — the failure PR #7595 hit. The mock has since drifted the other way as well: it still exported `buiTranslations`, which the real module dropped in FR-2986.

The mock's stated reason — *"avoids importing antd/es/locale which requires ESM transformation"* — is obsolete: antd was removed from the repo in FR-3482, and `bui-language.ts` now imports 21 small `backend.ai-ui/locale/*` modules that each hold a language code plus a JSON catalog. That makes option 1 from the issue (drop the mock) the right fix.

**What changed**

- Deleted the `/^.*\/helper\/bui-language$/` alias and `react/__test__/buiLanguage.mock.js`; tests now load the real module — one source of truth.
- Added a `backend.ai-ui/locale/` → BUI `src/locale/` alias. Required, not cosmetic: the package's `./locale/*` subpath export resolves to `dist/`, and the `react-vitest` job in `.github/workflows/vitest-react.yml` never builds BUI. Without it the suite would fail in CI while passing locally.
- Added `react/src/helper/bui-language.test.ts`, so a future resolution break fails by name instead of killing three unrelated suites at load time.
- Dropped a stale sentence in `bui-language.ts` that referred to the deleted mock.

**Design decision:** the `.svg`, CSS and `backend.ai-client` aliases in the same config are left alone. They stand in for non-JS assets and a network client — things a test runner genuinely cannot load — not a plain data module with a hand-copied export shape. Only the `bui-language` case had the drift problem the issue describes.

## Tests

Full `react` Vitest suite, run with `packages/backend.ai-ui/dist` moved aside so it matches the CI condition (no BUI build step):

```
Test Files  130 passed (130)
     Tests  2270 passed (2270)
  Duration  83.78s
```

Before the change (mock in place, dist present): `130 passed / 2270 passed`, `Duration 122.68s`. The runs were on the same machine but the "before" one was cold, so read this as *no regression* rather than a 30% win — the point is that loading the real 21 locale modules costs nothing measurable.

New file `src/helper/bui-language.test.ts`: 2 passed.

## Verification

```
bash scripts/verify.sh
=== ALL PASS ===
```

## Review notes

- The load-bearing line is the new `backend.ai-ui/locale/` alias. To confirm it is doing the work, `mv packages/backend.ai-ui/dist /tmp/x && (cd react && pnpm exec vitest run)` — that is the CI environment; it passes.
- The three suites the issue named (`src/hooks/backendai.test.tsx`, `src/hooks/useResourceLimitAndRemaining.test.ts`, `src/components/SessionFormItems/ResourceAllocationFormItems.test.ts`) are in the green run above; they load `DefaultProviders` transitively.
- Coverage will shift slightly: `src/helper/bui-language.ts` is now executed rather than aliased away, so the coverage-report comment moves a little.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
