### PR TITLE
refactor(FR-3418): migrate BAIAdminResourceGroupSelect to adminResourceGroups

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f61dc7b60b11c952e23ba36b8b623a93>>
+ * @generated SignedSource<<ef152d2696065fbbf098dc4a464b53c0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -112,7 +112,7 @@ return {
     "name": "BAIAdminResourceGroupSelectPaginationQuery",
     "selections": [
       {
-        "alias": "resourceGroups",
+        "alias": null,
         "args": (v1/*: any*/),
         "concreteType": "ResourceGroupConnection",
         "kind": "LinkedField",
@@ -205,29 +205,29 @@ return {
         "storageKey": null
       },
       {
-        "alias": "resourceGroups",
+        "alias": null,
         "args": (v1/*: any*/),
         "filters": [
           "filter"
         ],
         "handle": "connection",
-        "key": "BAIAdminResourceGroupSelect_resourceGroups",
+        "key": "BAIAdminResourceGroupSelect_adminResourceGroups",
         "kind": "LinkedHandle",
         "name": "adminResourceGroups"
       }
     ]
   },
   "params": {
-    "cacheID": "b5cedd03adfaf9887155fd93e5fcbf4e",
+    "cacheID": "3a8a567467e18a8f1de11de8fae76d69",
     "id": null,
     "metadata": {},
     "name": "BAIAdminResourceGroupSelectPaginationQuery",
     "operationKind": "query",
-    "text": "query BAIAdminResourceGroupSelectPaginationQuery(\n  $after: String\n  $filter: ResourceGroupFilter\n  $first: Int = 10\n) {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv on Query {\n  resourceGroups: adminResourceGroups(first: $first, after: $after, filter: $filter) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query BAIAdminResourceGroupSelectPaginationQuery(\n  $after: String\n  $filter: ResourceGroupFilter\n  $first: Int = 10\n) {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv on Query {\n  adminResourceGroups(first: $first, after: $after, filter: $filter) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b1be0cd7d12414c29b4121b745f0815d";
+(node as any).hash = "06343f7c21be5c30322e3d95f1f1ea3e";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<16819de3ceab898d01fff5e4a99f2913>>
+ * @generated SignedSource<<f61dc7b60b11c952e23ba36b8b623a93>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -112,11 +112,11 @@ return {
     "name": "BAIAdminResourceGroupSelectPaginationQuery",
     "selections": [
       {
-        "alias": null,
+        "alias": "resourceGroups",
         "args": (v1/*: any*/),
         "concreteType": "ResourceGroupConnection",
         "kind": "LinkedField",
-        "name": "resourceGroups",
+        "name": "adminResourceGroups",
         "plural": false,
         "selections": [
           {
@@ -205,7 +205,7 @@ return {
         "storageKey": null
       },
       {
-        "alias": null,
+        "alias": "resourceGroups",
         "args": (v1/*: any*/),
         "filters": [
           "filter"
@@ -213,21 +213,21 @@ return {
         "handle": "connection",
         "key": "BAIAdminResourceGroupSelect_resourceGroups",
         "kind": "LinkedHandle",
-        "name": "resourceGroups"
+        "name": "adminResourceGroups"
       }
     ]
   },
   "params": {
-    "cacheID": "1a90a27c601f1d11dcd17163dbcfabbe",
+    "cacheID": "b5cedd03adfaf9887155fd93e5fcbf4e",
     "id": null,
     "metadata": {},
     "name": "BAIAdminResourceGroupSelectPaginationQuery",
     "operationKind": "query",
-    "text": "query BAIAdminResourceGroupSelectPaginationQuery(\n  $after: String\n  $filter: ResourceGroupFilter\n  $first: Int = 10\n) {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv on Query {\n  resourceGroups(first: $first, after: $after, filter: $filter) @since(version: \"26.1.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query BAIAdminResourceGroupSelectPaginationQuery(\n  $after: String\n  $filter: ResourceGroupFilter\n  $first: Int = 10\n) {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment_G9cLv on Query {\n  resourceGroups: adminResourceGroups(first: $first, after: $after, filter: $filter) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "97c2e022b1e40671b4d0311dbd4912ec";
+(node as any).hash = "b1be0cd7d12414c29b4121b745f0815d";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelect_resourceGroupsFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelect_resourceGroupsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f54303809f24743231756ff3635d6e4b>>
+ * @generated SignedSource<<34d025fc8aed10976a41f308a78be12e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -181,6 +181,6 @@ return {
 };
 })();
 
-(node as any).hash = "97c2e022b1e40671b4d0311dbd4912ec";
+(node as any).hash = "b1be0cd7d12414c29b4121b745f0815d";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelect_resourceGroupsFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminResourceGroupSelect_resourceGroupsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<34d025fc8aed10976a41f308a78be12e>>
+ * @generated SignedSource<<3a337741405974f2956c83b0521d7bcc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type BAIAdminResourceGroupSelect_resourceGroupsFragment$data = {
-  readonly resourceGroups: {
+  readonly adminResourceGroups: {
     readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
@@ -31,7 +31,7 @@ import BAIAdminResourceGroupSelectPaginationQuery_graphql from './BAIAdminResour
 
 const node: ReaderFragment = (function(){
 var v0 = [
-  "resourceGroups"
+  "adminResourceGroups"
 ];
 return {
   "argumentDefinitions": [
@@ -77,7 +77,7 @@ return {
   "name": "BAIAdminResourceGroupSelect_resourceGroupsFragment",
   "selections": [
     {
-      "alias": "resourceGroups",
+      "alias": "adminResourceGroups",
       "args": [
         {
           "kind": "Variable",
@@ -87,7 +87,7 @@ return {
       ],
       "concreteType": "ResourceGroupConnection",
       "kind": "LinkedField",
-      "name": "__BAIAdminResourceGroupSelect_resourceGroups_connection",
+      "name": "__BAIAdminResourceGroupSelect_adminResourceGroups_connection",
       "plural": false,
       "selections": [
         {
@@ -181,6 +181,6 @@ return {
 };
 })();
 
-(node as any).hash = "b1be0cd7d12414c29b4121b745f0815d";
+(node as any).hash = "06343f7c21be5c30322e3d95f1f1ea3e";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
@@ -85,9 +85,13 @@ const BAIAdminResourceGroupSelect: React.FC<
           filter: { type: "ResourceGroupFilter" }
         )
         @refetchable(queryName: "BAIAdminResourceGroupSelectPaginationQuery") {
-          resourceGroups(first: $first, after: $after, filter: $filter)
+          resourceGroups: adminResourceGroups(
+            first: $first
+            after: $after
+            filter: $filter
+          )
             @connection(key: "BAIAdminResourceGroupSelect_resourceGroups")
-            @since(version: "26.1.0") {
+            @since(version: "26.2.0") {
             count
             edges {
               node {

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
@@ -85,12 +85,8 @@ const BAIAdminResourceGroupSelect: React.FC<
           filter: { type: "ResourceGroupFilter" }
         )
         @refetchable(queryName: "BAIAdminResourceGroupSelectPaginationQuery") {
-          resourceGroups: adminResourceGroups(
-            first: $first
-            after: $after
-            filter: $filter
-          )
-            @connection(key: "BAIAdminResourceGroupSelect_resourceGroups")
+          adminResourceGroups(first: $first, after: $after, filter: $filter)
+            @connection(key: "BAIAdminResourceGroupSelect_adminResourceGroups")
             @since(version: "26.2.0") {
             count
             edges {
@@ -108,7 +104,7 @@ const BAIAdminResourceGroupSelect: React.FC<
   const selectedKeys = _.compact(_.castArray(controllableValue ?? []));
 
   const options = _.compact(
-    _.map(data.resourceGroups?.edges, (item) =>
+    _.map(data.adminResourceGroups?.edges, (item) =>
       item?.node?.name
         ? { value: item.node.name, label: item.node.name }
         : null,
@@ -134,7 +130,7 @@ const BAIAdminResourceGroupSelect: React.FC<
       multiple={multiple}
       isLoading={isLoading}
       isLoadingNext={isLoadingNext}
-      total={data.resourceGroups?.count ?? undefined}
+      total={data.adminResourceGroups?.count ?? undefined}
       options={options}
       value={labeledValue}
       onChange={(next) => {

--- a/react/src/__generated__/AgentSettingModalQuery.graphql.ts
+++ b/react/src/__generated__/AgentSettingModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85acc6198648fc05a01890b02abf090c>>
+ * @generated SignedSource<<3214eb7707210b78d3d5e2abcc62b135>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,7 +50,7 @@ return {
     "name": "AgentSettingModalQuery",
     "selections": [
       {
-        "alias": "resourceGroups",
+        "alias": null,
         "args": (v0/*: any*/),
         "concreteType": "ResourceGroupConnection",
         "kind": "LinkedField",
@@ -143,25 +143,25 @@ return {
         "storageKey": "adminResourceGroups(first:10)"
       },
       {
-        "alias": "resourceGroups",
+        "alias": null,
         "args": (v0/*: any*/),
         "filters": [
           "filter"
         ],
         "handle": "connection",
-        "key": "BAIAdminResourceGroupSelect_resourceGroups",
+        "key": "BAIAdminResourceGroupSelect_adminResourceGroups",
         "kind": "LinkedHandle",
         "name": "adminResourceGroups"
       }
     ]
   },
   "params": {
-    "cacheID": "c402f205f655f900f2fdfed6924d9f5f",
+    "cacheID": "46beb32231d26fa312aba8940c79553d",
     "id": null,
     "metadata": {},
     "name": "AgentSettingModalQuery",
     "operationKind": "query",
-    "text": "query AgentSettingModalQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  resourceGroups: adminResourceGroups(first: 10) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query AgentSettingModalQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  adminResourceGroups(first: 10) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/AgentSettingModalQuery.graphql.ts
+++ b/react/src/__generated__/AgentSettingModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<16c489e5b11d027acbb51266d2272c70>>
+ * @generated SignedSource<<85acc6198648fc05a01890b02abf090c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,11 +50,11 @@ return {
     "name": "AgentSettingModalQuery",
     "selections": [
       {
-        "alias": null,
+        "alias": "resourceGroups",
         "args": (v0/*: any*/),
         "concreteType": "ResourceGroupConnection",
         "kind": "LinkedField",
-        "name": "resourceGroups",
+        "name": "adminResourceGroups",
         "plural": false,
         "selections": [
           {
@@ -140,10 +140,10 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": "resourceGroups(first:10)"
+        "storageKey": "adminResourceGroups(first:10)"
       },
       {
-        "alias": null,
+        "alias": "resourceGroups",
         "args": (v0/*: any*/),
         "filters": [
           "filter"
@@ -151,17 +151,17 @@ return {
         "handle": "connection",
         "key": "BAIAdminResourceGroupSelect_resourceGroups",
         "kind": "LinkedHandle",
-        "name": "resourceGroups"
+        "name": "adminResourceGroups"
       }
     ]
   },
   "params": {
-    "cacheID": "cde03dadbfc6ce076a4fad8dcc7fb9ff",
+    "cacheID": "c402f205f655f900f2fdfed6924d9f5f",
     "id": null,
     "metadata": {},
     "name": "AgentSettingModalQuery",
     "operationKind": "query",
-    "text": "query AgentSettingModalQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  resourceGroups(first: 10) @since(version: \"26.1.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query AgentSettingModalQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  resourceGroups: adminResourceGroups(first: 10) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/RoleFormModalResourceGroupQuery.graphql.ts
+++ b/react/src/__generated__/RoleFormModalResourceGroupQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca647247e5ea5d27f732666c80ddf411>>
+ * @generated SignedSource<<274ce1ae94acebf79725f5574381cfb3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,11 +50,11 @@ return {
     "name": "RoleFormModalResourceGroupQuery",
     "selections": [
       {
-        "alias": null,
+        "alias": "resourceGroups",
         "args": (v0/*: any*/),
         "concreteType": "ResourceGroupConnection",
         "kind": "LinkedField",
-        "name": "resourceGroups",
+        "name": "adminResourceGroups",
         "plural": false,
         "selections": [
           {
@@ -140,10 +140,10 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": "resourceGroups(first:10)"
+        "storageKey": "adminResourceGroups(first:10)"
       },
       {
-        "alias": null,
+        "alias": "resourceGroups",
         "args": (v0/*: any*/),
         "filters": [
           "filter"
@@ -151,17 +151,17 @@ return {
         "handle": "connection",
         "key": "BAIAdminResourceGroupSelect_resourceGroups",
         "kind": "LinkedHandle",
-        "name": "resourceGroups"
+        "name": "adminResourceGroups"
       }
     ]
   },
   "params": {
-    "cacheID": "7651e21381517ec3783fe48265a90ad0",
+    "cacheID": "fedd97e9616a70fc6cd3b9f22cf59d02",
     "id": null,
     "metadata": {},
     "name": "RoleFormModalResourceGroupQuery",
     "operationKind": "query",
-    "text": "query RoleFormModalResourceGroupQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  resourceGroups(first: 10) @since(version: \"26.1.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query RoleFormModalResourceGroupQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  resourceGroups: adminResourceGroups(first: 10) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/RoleFormModalResourceGroupQuery.graphql.ts
+++ b/react/src/__generated__/RoleFormModalResourceGroupQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<274ce1ae94acebf79725f5574381cfb3>>
+ * @generated SignedSource<<da468024d567e8bb33d11b396ae24e87>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,7 +50,7 @@ return {
     "name": "RoleFormModalResourceGroupQuery",
     "selections": [
       {
-        "alias": "resourceGroups",
+        "alias": null,
         "args": (v0/*: any*/),
         "concreteType": "ResourceGroupConnection",
         "kind": "LinkedField",
@@ -143,25 +143,25 @@ return {
         "storageKey": "adminResourceGroups(first:10)"
       },
       {
-        "alias": "resourceGroups",
+        "alias": null,
         "args": (v0/*: any*/),
         "filters": [
           "filter"
         ],
         "handle": "connection",
-        "key": "BAIAdminResourceGroupSelect_resourceGroups",
+        "key": "BAIAdminResourceGroupSelect_adminResourceGroups",
         "kind": "LinkedHandle",
         "name": "adminResourceGroups"
       }
     ]
   },
   "params": {
-    "cacheID": "fedd97e9616a70fc6cd3b9f22cf59d02",
+    "cacheID": "92caa24d9f102ece23d6e349aca8cd2e",
     "id": null,
     "metadata": {},
     "name": "RoleFormModalResourceGroupQuery",
     "operationKind": "query",
-    "text": "query RoleFormModalResourceGroupQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  resourceGroups: adminResourceGroups(first: 10) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query RoleFormModalResourceGroupQuery {\n  ...BAIAdminResourceGroupSelect_resourceGroupsFragment\n}\n\nfragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query {\n  adminResourceGroups(first: 10) @since(version: \"26.2.0\") {\n    count\n    edges {\n      node {\n        id\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Resolves #8475 (FR-3418)

`BAIAdminResourceGroupSelect` was the last source-level user of the deprecated
`resourceGroups` connection (`data/schema.graphql`: *"Use admin_resource_groups
instead. This API will be removed after v26.3.0. See BEP-1041 for migration
guide."*). This points its pagination fragment at the successor
`adminResourceGroups`, which has an identical argument list and returns the same
`ResourceGroupConnection`.

### Design decisions

- **Selected under its own name, no alias.** The field is selected as `adminResourceGroups(...)`
  (the `resourceGroups:` alias was dropped per review). The `@connection` key follows the field —
  `BAIAdminResourceGroupSelect_adminResourceGroups`, since Relay requires the key suffix to match
  the selected field or alias — and the component's two `data.resourceGroups` reads become
  `data.adminResourceGroups`. The fragment name and both call sites (`RoleFormModal`,
  `AgentSettingModal`) are untouched, so the diff is the component file and its regenerated artifacts.
- **`@since` raised 26.1.0 → 26.2.0**, matching the version in which
  `adminResourceGroups` was added.
- **Pagination stays cursor mode** (`first`/`after`) — `usePaginationFragment`
  requires it, and mixing in `limit`/`offset` would be rejected at runtime by the
  V2 connections (`.claude/rules/graphql-pagination.md`).

### Minimum manager version

This select's minimum manager version rises **26.1.0 → 26.2.0**. On a 26.1.x
manager the `@since` transformer strips the field from the document and the picker
renders an empty list — the same graceful-degradation path it already had, one
minor higher. Worth a release-note line.

## Tests

- `pnpm run relay` — regenerated the four affected artifacts (2 in `backend.ai-ui`,
  2 in `react`, from the two call-site queries).
- `bash scripts/verify.sh` — Relay, Lint, Format, TypeScript, Astryx gates, terminology.
- No new unit test: the change is the `graphql` tag plus the two matching `data.*` reads;
  the component's logic is unchanged.

## Verification

```
=== ALL PASS ===
```

## Review notes

- The real review surface is the `graphql` tag and the two `data.adminResourceGroups` reads in
  `packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx`;
  the `__generated__` churn is `pnpm relay` output (see `.claude/rules/review-ignored-paths.md`).
- Confirm the connection handle key in the generated artifacts is
  `"key": "BAIAdminResourceGroupSelect_adminResourceGroups"` (renamed with the field; the
  Relay store is in-memory, so nothing persisted depends on the old key) and `loadNext` keeps working.
- Manually: open **Admin → Roles → role form** (resource-group scope picker) and the
  **agent setting modal**, against a manager ≥ 26.2.0. The list, the type-to-search
  (`name contains` refetch) and scroll-to-load-more should behave exactly as before.
- `grep -rn 'resourceGroups(' react/src packages/backend.ai-ui/src` now returns no hits.

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version — 26.1.0 → 26.2.0 for this component
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — manager ≥ 26.2.0
- [ ] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ

