### PR TITLE
fix(FR-3522): offer folder rename only to principals the manager allows

### DIFF
--- a/react/src/components/EditableVFolderNameV2.test.tsx
+++ b/react/src/components/EditableVFolderNameV2.test.tsx
@@ -21,9 +21,10 @@ import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockE
 
 /**
  * Contract tests for the ownership/role-based rename gate (ADR-0001,
- * FR-3413). Rename is allowed for the folder owner, super admins, or when
- * the page-passed `project` matches the folder's own ownership project —
- * never derived from the ambient current project. External behavior only:
+ * FR-3413). Rename is allowed for the folder owner, super admins, or a
+ * project admin of the page-passed `project` when it matches the folder's
+ * own ownership project (FR-3522) — never derived from the ambient current
+ * project. External behavior only:
  * the presence/absence of the rename (edit) trigger in the rendered output.
  */
 
@@ -66,8 +67,9 @@ vi.mock('../hooks/backendai', async (importOriginal) => {
   };
 });
 
-// Super-admin status is pinned per test scenario.
+// Super-admin status and project-admin scopes are pinned per test scenario.
 let mockIsSuperAdmin = false;
+let mockProjectAdminIds: string[] = [];
 vi.mock('../hooks/useCurrentUserProjectRoles', async (importOriginal) => {
   const originalModule =
     await importOriginal<
@@ -78,7 +80,7 @@ vi.mock('../hooks/useCurrentUserProjectRoles', async (importOriginal) => {
     useCurrentUserProjectRoles: () => ({
       isSuperAdmin: mockIsSuperAdmin,
       domainAdminDomains: [],
-      projectAdminIds: [],
+      projectAdminIds: mockProjectAdminIds,
     }),
   };
 });
@@ -182,6 +184,7 @@ const findEditTrigger = async () => {
 describe('EditableVFolderNameV2 rename gate (ADR-0001, FR-3413)', () => {
   beforeEach(() => {
     mockIsSuperAdmin = false;
+    mockProjectAdminIds = [];
   });
 
   it('lets the folder owner rename regardless of project context (project null)', async () => {
@@ -203,13 +206,35 @@ describe('EditableVFolderNameV2 rename gate (ADR-0001, FR-3413)', () => {
     expect(await findEditTrigger()).toBeInTheDocument();
   });
 
-  it('lets a member rename when the passed project matches the folder ownership project', async () => {
+  it('lets a project admin rename when the passed project matches the folder ownership project', async () => {
+    mockProjectAdminIds = ['folder-project-id'];
     renderName({
       project: { id: 'folder-project-id', name: 'folder-project' },
       ownerUserId: 'someone-else-uuid',
       ownershipProjectId: 'folder-project-id',
     });
     expect(await findEditTrigger()).toBeInTheDocument();
+  });
+
+  // FR-3522: a plain member of the owning project only gets READ on it, so
+  // the pencil used to hand them a guaranteed 403.
+  it('does NOT allow rename for a plain member of the folder ownership project', async () => {
+    renderName({
+      project: { id: 'folder-project-id', name: 'folder-project' },
+      ownerUserId: 'someone-else-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).not.toBeInTheDocument();
+  });
+
+  it('does NOT allow rename when the admin scope is over a different project', async () => {
+    mockProjectAdminIds = ['some-other-project-id'];
+    renderName({
+      project: { id: 'folder-project-id', name: 'folder-project' },
+      ownerUserId: 'someone-else-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).not.toBeInTheDocument();
   });
 
   it('does NOT allow rename with project null for a non-owner non-superadmin, even though the ambient decoy matches', async () => {

--- a/react/src/components/EditableVFolderNameV2.tsx
+++ b/react/src/components/EditableVFolderNameV2.tsx
@@ -53,7 +53,7 @@ interface EditableVFolderNameV2Props {
   /**
    * Explicit project prop contract (ADR-0001, FR-3413): the project context
    * the page decided on, compared against the folder's ownership project for
-   * the rename gate. With `null` (super-admin pages) the project-membership
+   * the rename gate. With `null` (super-admin pages) the project-admin
    * branch simply doesn't match — the folder owner and super admins keep
    * their rename power. Never reads the ambient current project.
    */
@@ -100,7 +100,7 @@ const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
   const [userInfo] = useCurrentUserInfo();
   // Not `useEffectiveAdminRole` — it resolves its target from the ambient
   // project, which this contract must not depend on.
-  const { isSuperAdmin } = useCurrentUserProjectRoles();
+  const { isSuperAdmin, projectAdminIds } = useCurrentUserProjectRoles();
   const baiClient = useSuspendedBackendaiClient();
   const renameMutation = useTanMutation({
     mutationFn: (input: { id: string; name: string }) => {
@@ -117,16 +117,18 @@ const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
   const [isEditing, setIsEditing] = useState(false);
 
   // Rename is allowed for the folder owner, super admins (any project —
-  // their power must not flicker with header state), or members of the
-  // page-decided project when the folder belongs to that project. With
-  // `project === null` the membership branch never matches.
+  // their power must not flicker with header state), or project admins of
+  // the page-decided project when the folder belongs to it. A plain project
+  // member only gets READ on a project-scoped folder, so offering the pencil
+  // to one only produced a 403 (FR-3522).
   const isEditingAllowed =
     editable &&
     (userInfo.uuid === vfolderNode.ownership?.userId ||
       isSuperAdmin ||
       (project !== null &&
         !!vfolderNode.ownership?.projectId &&
-        project.id === vfolderNode.ownership.projectId)) &&
+        project.id === vfolderNode.ownership.projectId &&
+        projectAdminIds.includes(project.id))) &&
     !isDeletedCategory(vfolderNode.status);
 
   const isPendingRenameMutation =

--- a/react/src/components/FolderExplorerHeaderV2.tsx
+++ b/react/src/components/FolderExplorerHeaderV2.tsx
@@ -28,7 +28,7 @@ interface FolderExplorerHeaderV2Props {
    * Explicit project prop contract (ADR-0001, FR-3412/FR-3413): pass-through
    * for the FileBrowser/SFTP session-launch buttons (`null` renders them
    * disabled with `noProjectTooltip` as the reason) and for the rename
-   * gating of `EditableVFolderNameV2` (`null` drops the project-membership
+   * gating of `EditableVFolderNameV2` (`null` drops the project-admin
    * branch — owner/super-admin keep their power).
    */
   project: ProjectContextOrNull;


### PR DESCRIPTION
Resolves #8715 (FR-3522)

## What changed

The rename pencil on the folder detail header (`EditableVFolderNameV2`, gated in FR-3413 / #8469) was offered to **any member** of the page-decided project whenever the folder belonged to that project. The manager does not let a plain project member rename a project-owned folder, so clicking it always failed with `403 role_create_forbidden`.

This narrows that third branch of the gate from *member of the page project* to *project admin of the page project*. The owner and super-admin branches are untouched.

```diff
   (project !== null &&
     !!vfolderNode.ownership?.projectId &&
-    project.id === vfolderNode.ownership.projectId)
+    project.id === vfolderNode.ownership.projectId &&
+    projectAdminIds.includes(project.id))
```

`useCurrentUserProjectRoles()` already returns `projectAdminIds` and was already called in this component (only `isSuperAdmin` was destructured), so no new query, no new hook, no i18n or Relay change.

## Who may rename, per the manager (backend.ai `main`)

- `src/ai/backend/manager/api/rest/vfolder/registry.py:162-174` — `POST /{name}/rename` is registered behind `_vfolder_resolver(VFolderPermission.OWNER_PERM, …)`. The WebUI client calls it with the vfolder **UUID** (`packages/backend.ai-client/src/resources/vfolder.ts:182-191`), and for a UUID path parameter the resolver (`registry.py:34-86`) skips the legacy lookup and delegates permission evaluation to the RBAC validator on the action the handler invokes.
- `src/ai/backend/manager/api/rest/vfolder/handler.py:673-700` → `UpdateVFolderAttributeAction`, whose `operation_type()` is `ActionOperationType.UPDATE` (`services/vfolder/actions/base.py:120-132`), registered as `group.single_entity(...)` — i.e. RBAC-validated (`services/vfolder/processors/vfolder.py:202-204`).
- `src/ai/backend/manager/models/alembic/versions/2185ae0dd371_migrate_vfolder_data_to_rbac.py:63-80` — a permission group whose role name ends with `member` gets `OperationType.member_operations()`, which is `{READ}` (`models/rbac_models/migration/enums.py:75-82`). Admin/owner roles get `owner_operations()` = every operation, including `UPDATE`.
- `src/ai/backend/manager/models/vfolder/row.py:1098-1118` — the legacy (name-based) path agrees: `ADMIN_PERMISSIONS` contains `UPDATE_ATTRIBUTE`, `MEMBER_PERMISSIONS` is the empty frozenset.
- `src/ai/backend/manager/errors/permission.py:134-145` — `NotEnoughPermission` maps to `ErrorCode(domain=ROLE, operation=CREATE, detail=FORBIDDEN)`, which is exactly the `role_create_forbidden` the reporter saw.

So the set the manager accepts is *owner, super admin, project admin* — which is now the set the pencil is shown to.

## Design decisions

- **No per-folder permission query.** `VFolder.accessControl.permission` is a `VFolderMountPermission` (`READ_ONLY` / `READ_WRITE` / `RW_DELETE`) — there is no schema field that answers "can I rename this folder", so a role-derived gate is the closest available signal. A future follow-up could ask `myRoles(filter: { permission: { entityType: VFOLDER, operation: UPDATE, scopeId: <projectId> } })` directly; that is a larger change and not needed to stop the 403.
- **The legacy V1 chain (`EditableVFolderName` / `FolderExplorerHeader` / `FolderExplorerModal`) is untouched** — it is unreachable (`FolderExplorerOpener.tsx:9` lazy-loads only `FolderExplorerModalV2`), and deleting it is out of scope for this fix.

## Tests

- `react/src/components/EditableVFolderNameV2.test.tsx` — the existing "member of the owning project" case became a **project admin** case, and two negatives were added: a plain member of the owning project, and an admin whose scope is over a *different* project. 7/7 pass:
  `pnpm exec vitest run src/components/EditableVFolderNameV2.test.tsx` → `Test Files 1 passed (1) · Tests 7 passed (7)`

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Open a **project-owned** folder's detail page as a plain member of that project: the pencil next to the folder name should be gone (before this PR it was shown and returned 403 on submit).
- As a **project admin** of that same project, and as the folder's **owner**, and as a **super admin**: the pencil is still there and rename still works.
- A user-owned folder is unaffected — that path goes through the owner branch, which did not change.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
