### PR TITLE
fix(FR-3316): carry the model card's folder into Custom mode

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.test.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.test.tsx
@@ -8,6 +8,7 @@ import DeploymentAddRevisionModal from './DeploymentAddRevisionModal';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -72,19 +73,23 @@ vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
   };
 });
 
-// Mode is user-persisted; tests pin it per scenario.
+// Mode is user-persisted; tests pin the initial value per scenario and the
+// stand-in keeps it in real state so the mode toggle actually switches forms.
 let mockMode: 'preset' | 'custom' = 'preset';
 vi.mock('../hooks/useBAISetting', async (importOriginal) => {
+  const React = await import('react');
   const originalModule =
     await importOriginal<typeof import('../hooks/useBAISetting')>();
+  function useBAISettingUserState(key: string) {
+    const state = React.useState<'preset' | 'custom'>(mockMode);
+    if (key === 'deploymentRevisionCreationMode') {
+      return state;
+    }
+    throw new Error(`Unexpected setting key in test: ${key}`);
+  }
   return {
     ...originalModule,
-    useBAISettingUserState: (key: string) => {
-      if (key === 'deploymentRevisionCreationMode') {
-        return [mockMode, vi.fn()];
-      }
-      throw new Error(`Unexpected setting key in test: ${key}`);
-    },
+    useBAISettingUserState,
   };
 });
 
@@ -135,8 +140,34 @@ vi.mock('./EnvVarFormList', () => ({ default: () => null }));
 vi.mock('./VFolderTableFormItem', () => ({ default: () => null }));
 vi.mock('./DeploymentPresetDetailModal', () => ({ default: () => null }));
 
+// The model-card picker is Relay-backed; the stand-in reports a card whose
+// backing vfolder id is what the mode transfer must carry.
+const MOCK_CARD_VFOLDER_ID = 'card-backing-vfolder-uuid';
+vi.mock('./ModelCardSelect', async () => {
+  const React = await import('react');
+  return {
+    default: (props: any) =>
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'mock-model-card-select',
+          type: 'button',
+          onClick: () => {
+            props.onChange?.('mock-card-id');
+            props.onSelectCard?.({
+              id: 'mock-card-id',
+              vfolderId: 'card-backing-vfolder-uuid',
+            });
+          },
+        },
+        'select-model-card',
+      ),
+  };
+});
+
 // The model-folder picker is the probe for the folder-picker side of the
-// contract: it surfaces the `currentProjectId` it was scoped to.
+// contract: it surfaces the `currentProjectId` it was scoped to, and the
+// value it holds (the mode-transfer assertions read that).
 vi.mock('backend.ai-ui', async (importOriginal) => {
   const React = await import('react');
   const originalModule = await importOriginal<typeof import('backend.ai-ui')>();
@@ -148,6 +179,7 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
         {
           'data-testid': 'mock-vfolder-select',
           'data-current-project-id': props.currentProjectId ?? '',
+          'data-value': props.value ?? '',
           disabled: props.isDisabled ?? props.disabled,
           type: 'button',
         },
@@ -289,5 +321,33 @@ describe('DeploymentAddRevisionModal project derivation contract (ADR-0001)', ()
     expect(
       screen.queryByTestId('mock-resource-allocation-form'),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('DeploymentAddRevisionModal model source mode transfer (FR-3316)', () => {
+  afterEach(() => {
+    mockMode = 'preset';
+  });
+
+  it("carries the model card's backing folder into Custom mode as a global id", async () => {
+    const user = userEvent.setup();
+    renderModal(DEPLOYMENT_METADATA);
+
+    await user.click(
+      await screen.findByRole('radio', { name: 'deployment.ModelCard' }),
+    );
+    await user.click(await screen.findByTestId('mock-model-card-select'));
+    await user.click(
+      screen.getByRole('radio', { name: 'deployment.CustomMode' }),
+    );
+
+    // The card stores a raw vfolder UUID; the Custom form's folder field is
+    // global-id valued, so the carry has to re-encode it.
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-vfolder-select')).toHaveAttribute(
+        'data-value',
+        btoa(`VirtualFolderNode:${MOCK_CARD_VFOLDER_ID}`),
+      );
+    });
   });
 });

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -982,7 +982,16 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
           prefill = await buildPrefillFromPreset(preset);
         }
       }
-      if (presetValues.modelFolderId) {
+      if (presetValues.presetModelSource === 'card') {
+        // Card source keeps its backing folder in `selectedCardVfolderId` as a
+        // raw UUID; the Custom form's `modelFolderId` holds a global id.
+        if (selectedCardVfolderId) {
+          prefill.modelFolderId = toGlobalId(
+            'VirtualFolderNode',
+            selectedCardVfolderId,
+          );
+        }
+      } else if (presetValues.modelFolderId) {
         prefill.modelFolderId = presetValues.modelFolderId;
       }
       setPresetTransferPrefill(


### PR DESCRIPTION
Resolves #8255 (FR-3316)

## What changed

`DeploymentAddRevisionModal`'s Preset → Custom transfer now carries the model
card's backing folder.

In Preset mode's **Model Card** source the picked card resolves to a backing
vfolder that lives in `selectedCardVfolderId` (a raw UUID), not in the form's
`modelFolderId`. `handleModeChange` only carried `presetValues.modelFolderId`,
so switching to Custom mode with a card selected silently dropped the folder and
left the Custom form's required Model Folder field empty. The carry is now
source-aware: in card mode it re-encodes `selectedCardVfolderId` with
`toGlobalId('VirtualFolderNode', …)`, because the Custom form's `modelFolderId`
is global-id valued (its submit path runs `toLocalId`), so the raw UUID cannot be
handed over as-is. The folder-source branch is untouched, and the reverse
Custom → Preset direction was already handled in #8246.

### Not included: the E2E half of the issue

Item 2 of the issue (Playwright coverage for the Model Card branch: preset
scoping to the card's `availablePresets`, source-reset on toggle back, and
submission of the card's vfolder) is **not** in this PR. Meaningful coverage
needs either a cluster carrying a model card whose backing folder is mountable,
or a new set of GraphQL mocks for `projectModelCardsV2` /
`modelCardAvailablePresets` in `e2e/serving/mocking/`; neither locators nor mock
shapes can be validated from this environment, and an unrunnable spec on a suite
that executes against real clusters is worse than none. Please keep #8255 open
for that half (or split it out) rather than letting the auto-close take it.

## Tests

- `pnpm exec vitest run src/components/DeploymentAddRevisionModal.test.tsx`
  (from `react/`) — 4 passed. The new case drives the real transition (source
  radio → card pick → mode toggle) and asserts the Custom folder selector
  receives the re-encoded global id. Verified it **fails** with the source
  change reverted, so it genuinely guards the fix.
- No E2E was run (requires a live cluster).

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

## Review notes

- Open a deployment → **Add Revision** (Preset Mode) → set Model Source to
  **Model Card** → pick a card → switch to **Advanced Mode**: the Model Folder
  selector should now be pre-filled with the card's backing folder.
- The mirror direction is unchanged: Advanced → Preset still forces
  `presetModelSource: 'folder'`, clears the card, and nulls
  `selectedCardVfolderId`.
- The unit test's `useBAISettingUserState` stand-in now holds the mode in real
  state (it used to return a `vi.fn()` setter), which is what lets the mode
  toggle actually switch forms; the three pre-existing contract tests still
  pin their mode via `mockMode` and pass unchanged.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
