### PR TITLE
style(FR-3713): shrink the "Unlimited" checkbox to the compact size

### DIFF
--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -84,6 +84,9 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
           it stays a plain Astryx control rather than the AstryxFormCheckbox
           adapter (which exists for controls Form.Item clones props onto). */}
       <CheckboxInput
+        // The toggle is secondary to the field it disables, so it uses the
+        // compact step instead of the default 24px indicator.
+        size="sm"
         label={t('resourcePolicy.Unlimited')}
         value={isUnlimited}
         isDisabled={disableUnlimited}


### PR DESCRIPTION
Resolves #9134 (FR-3713)

## What changed

The "Unlimited" toggle in the resource policy modals rendered with Astryx
`CheckboxInput`'s default `md` size — a 24x24px indicator sitting next to a
`--text-body-size` label — so the box read as far larger than its own text and
visually competed with the numeric field it disables.

`react/src/components/FormItemWithUnlimited.tsx` now passes `size="sm"` to that
`CheckboxInput` (20x20px indicator, 28px row). One line, one shared component.

### Design decisions

- **`size="sm"`, not a CSS override.** `sm` is the smallest step Astryx exposes
  for `CheckboxInput`, and it shrinks only the indicator — `FieldLabel`
  typography is untouched, so the label stays at body size. No new CSS, no
  hardcoded px, nothing for the token gate to look at.
- **All six modals, on purpose.** `FormItemWithUnlimited` is shared by
  `KeypairResourcePolicySettingModal`, `KeypairResourcePolicyV2SettingModal`,
  `UserResourcePolicySettingModal`, `UserResourcePolicyV2SettingModal`,
  `ProjectResourcePolicySettingModal` and `ProjectResourcePolicyV2SettingModal`.
  The reported page is the keypair one, but these modals are siblings and should
  not diverge on control size.
- **No sweep of other call sites.** The ~16 other `CheckboxInput` call sites in
  the app stay at the default `md`; changing them is a design call, not a bug fix.

## Tests

- `bash scripts/verify.sh` (Relay, Lint, Format, TypeScript, Terminology).
- No unit test added: the change is a single presentational prop with no
  branching logic, and `FormItemWithUnlimited` has no existing test file.
- Astryx token gate not run — no CSS, token or `var(--…)` was touched.

## Verification

```
=== ALL PASS ===
```

## Review notes

- Open **Resource Policy → Keypair → Create**: all nine "Unlimited" checkboxes
  (including the disabled *Cluster size* one) should now have an indicator that
  reads as secondary to the numeric input above it, not as the dominant control.
- Check the same toggle in the User and Project resource policy modals (v1 and
  v2) — they share the component and change with it.
- Check light and dark themes; nothing theme-specific changed, but the indicator
  border/fill is the thing that shrank.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
