### PR TITLE
fix(FR-3587): render the fallback image meta icon as a themed glyph

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIImageMetaIcon.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIImageMetaIcon.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'The framework icon for a Backend.AI container image. It reads image metadata through `useBAIImageMetaData()` and joins the host-supplied `imagePath` with the icon filename declared for that image (falling back to `default.png`), then renders a 1em square `<img>` aligned to the surrounding text. It renders nothing when the host application has not provided an `imagePath` — the package resolves no asset paths of its own — so a consumer must sit under `BAIMetaDataProvider` for an icon to appear.',
+      'The framework icon for a Backend.AI container image. It reads image metadata through `useBAIImageMetaData()` and joins the host-supplied `imagePath` with the icon filename declared for that image, then renders a 1em square `<img>` aligned to the surrounding text. An image whose metadata declares no icon renders a themed inline `</>` glyph instead of a raster fallback, so it stays legible in both light and dark themes. It renders nothing when the host application has not provided an `imagePath` — the package resolves no asset paths of its own — so a consumer must sit under `BAIMetaDataProvider` for an icon to appear.',
     bestPractices: [
       {
         guidance: true,

--- a/packages/backend.ai-ui/src/components/BAIImageMetaIcon.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIImageMetaIcon.test.tsx
@@ -1,0 +1,60 @@
+import BAIImageMetaIcon from './BAIImageMetaIcon';
+import { BAIMetaDataProvider } from './provider';
+import type { ImageMetaData } from './provider';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+const imageMetaData: ImageMetaData = {
+  imageInfo: {
+    python: { name: 'Python', description: '', group: '', tags: [] },
+    tensorflow: {
+      name: 'TensorFlow',
+      description: '',
+      group: '',
+      tags: [],
+      icon: 'tensorflow.svg',
+    },
+  },
+  tagAlias: {},
+  tagReplace: {},
+};
+
+const renderIcon = (image: string) =>
+  render(
+    <BAIMetaDataProvider imageMetaData={imageMetaData} imagePath="icons">
+      <BAIImageMetaIcon image={image} />
+    </BAIMetaDataProvider>,
+  );
+
+describe('BAIImageMetaIcon', () => {
+  it('renders the declared vendor icon as an <img>', () => {
+    const { container } = renderIcon('cr.backend.ai/x/tensorflow:2.0');
+
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      'icons/tensorflow.svg',
+    );
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  // FR-3587: the raster fallback was fixed dark ink and disappeared in dark
+  // mode, so an image with no declared icon renders a themed glyph instead.
+  it('renders a themed glyph instead of the raster fallback', () => {
+    const { container } = renderIcon('cr.backend.ai/x/python:3.9');
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    const glyph = container.querySelector('svg');
+    expect(glyph).toBeInTheDocument();
+    expect(glyph).toHaveStyle({ color: 'var(--color-text-primary)' });
+  });
+
+  it('renders nothing without an imagePath', () => {
+    const { container } = render(
+      <BAIMetaDataProvider imageMetaData={imageMetaData}>
+        <BAIImageMetaIcon image="cr.backend.ai/x/python:3.9" />
+      </BAIMetaDataProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIImageMetaIcon.tsx
+++ b/packages/backend.ai-ui/src/components/BAIImageMetaIcon.tsx
@@ -1,4 +1,5 @@
 import { useBAIImageMetaData } from './provider';
+import { CodeXml } from 'lucide-react';
 import React from 'react';
 
 export interface BAIImageMetaIconProps {
@@ -12,9 +13,9 @@ export interface BAIImageMetaIconProps {
  * v2/package counterpart of the React app's `ImageMetaIcon`. Resolves the
  * framework icon URL for an image by joining the `imagePath` provided via
  * `BAIMetaDataProvider` with the icon filename declared in the image metadata
- * (`imageInfo[].icon`, falling back to `default.png`). Renders nothing when
- * the host app has not provided an `imagePath` — the package never bundles or
- * resolves app asset paths on its own.
+ * (`imageInfo[].icon`). Images with no declared icon get a themed inline glyph
+ * instead. Renders nothing when the host app has not provided an `imagePath` —
+ * the package never bundles or resolves app asset paths on its own.
  */
 const BAIImageMetaIcon: React.FC<BAIImageMetaIconProps> = ({
   image,
@@ -22,21 +23,29 @@ const BAIImageMetaIcon: React.FC<BAIImageMetaIconProps> = ({
   alt = '',
 }) => {
   'use memo';
-  const [, { getImageIcon }] = useBAIImageMetaData();
+  const [, { getImageIcon, hasImageIcon }] = useBAIImageMetaData();
   const src = getImageIcon(image);
+  const iconStyle: React.CSSProperties = {
+    width: '1em',
+    height: '1em',
+    verticalAlign: 'middle',
+    ...style,
+  };
 
-  return src ? (
-    <img
-      src={src}
-      style={{
-        width: '1em',
-        height: '1em',
-        verticalAlign: 'middle',
-        ...style,
-      }}
-      alt={alt}
+  if (!src) return null;
+
+  // The raster fallback is fixed dark ink, so images without a vendor icon get
+  // a themed glyph instead (FR-3587).
+  return hasImageIcon(image) ? (
+    <img src={src} style={iconStyle} alt={alt} />
+  ) : (
+    <CodeXml
+      style={{ color: 'var(--color-text-primary)', ...iconStyle }}
+      role={alt ? 'img' : undefined}
+      aria-label={alt || undefined}
+      aria-hidden={alt ? undefined : true}
     />
-  ) : null;
+  );
 };
 
 export default BAIImageMetaIcon;

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIImageMetaData.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIImageMetaData.ts
@@ -58,6 +58,14 @@ const useBAIImageMetaData = () => {
         'default.png';
       return resolveIconPath(iconFileName);
     },
+    /**
+     * Whether the metadata declares a vendor icon for the image, i.e.
+     * `getImageIcon` does not resolve to the generic `default.png` fallback.
+     */
+    hasImageIcon: (imageName?: string | null) =>
+      Boolean(
+        imageName && metadata?.imageInfo[getImageMeta(imageName).key]?.icon,
+      ),
     getBaseVersion: (imageName: string) => {
       return (
         _.first(_.split(_.last(_.split(imageName, ':')), /[^a-zA-Z\d.]+/)) || ''

--- a/react/src/components/ImageMetaIcon.tsx
+++ b/react/src/components/ImageMetaIcon.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useBackendAIImageMetaData } from '../hooks';
+import { CodeXml } from 'lucide-react';
 import React from 'react';
 
 const ImageMetaIcon: React.FC<{
@@ -10,17 +11,25 @@ const ImageMetaIcon: React.FC<{
   style?: React.CSSProperties;
   alt?: string;
 }> = ({ image, style = {}, alt = '' }) => {
-  const [, { getImageIcon }] = useBackendAIImageMetaData();
-  return (
-    <img
-      src={getImageIcon(image)}
-      style={{
-        width: '1em',
-        height: '1em',
-        verticalAlign: 'middle',
-        ...style,
-      }}
-      alt={alt}
+  'use memo';
+  const [, { getImageIcon, hasImageIcon }] = useBackendAIImageMetaData();
+  const iconStyle: React.CSSProperties = {
+    width: '1em',
+    height: '1em',
+    verticalAlign: 'middle',
+    ...style,
+  };
+
+  // The raster fallback is fixed dark ink, so images without a vendor icon get a
+  // themed glyph instead (FR-3587).
+  return hasImageIcon(image) ? (
+    <img src={getImageIcon(image)} style={iconStyle} alt={alt} />
+  ) : (
+    <CodeXml
+      style={{ color: 'var(--color-text-primary)', ...iconStyle }}
+      role={alt ? 'img' : undefined}
+      aria-label={alt || undefined}
+      aria-hidden={alt ? undefined : true}
     />
   );
 };

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -541,6 +541,13 @@ export const useBackendAIImageMetaData = () => {
             : 'default.png')
         );
       },
+      /** Whether the metadata declares a vendor icon, i.e. `getImageIcon` does
+       * not resolve to the generic `default.png` fallback. */
+      hasImageIcon: (imageName?: string | null) => {
+        if (!imageName) return false;
+        const { key } = getImageMeta(imageName);
+        return metadata?.imageInfo[key]?.icon !== undefined;
+      },
       getNamespace: (imageName: string) => {
         const names = imageName.split('/');
         return names.length < 2 ? names[0] : names[1] || '';


### PR DESCRIPTION
Resolves #8880 (FR-3587)

The default `</>` image meta icon is `resources/icons/default.png` — a 32x32
grayscale PNG of dark ink on transparency. A raster asset cannot follow the
theme, so on the Session Launcher's dark surfaces the fallback glyph is barely
visible.

`ImageMetaIcon` (host) and its BUI twin `BAIImageMetaIcon` now render an inline
lucide `CodeXml` glyph — the same `</>` shape — painted with the
`--color-text-primary` token when the image metadata declares no vendor icon.
The raster fallback is no longer used on that path, which takes it out of the
theming problem entirely. Images that resolve a real vendor icon still render
that asset untouched.

Design decisions:

- The fallback branch is selected by a new `hasImageIcon()` helper on both
  `useBackendAIImageMetaData` and `useBAIImageMetaData`, rather than comparing
  the resolved URL against the `default.png` filename.
- The glyph keeps the same `1em` box and `verticalAlign: middle`, and merges the
  caller's `style` exactly like the `<img>` did, so the call sites that size it
  down (`ImageEnvironmentSelectFormItems` passes `15x15`) are unaffected.
- `--color-text-primary` (not `secondary`) was chosen so light mode looks
  essentially unchanged — the PNG was near-black ink — while dark mode inverts.
- `BAIImageMetaIcon` still renders `null` when the host provided no `imagePath`,
  so its documented "renders nothing outside `BAIMetaDataProvider`" contract is
  unchanged; only the fallback rendering moved.

## Tests

- New `packages/backend.ai-ui/src/components/BAIImageMetaIcon.test.tsx` (3 cases:
  declared vendor icon renders `<img>`, undeclared icon renders the themed glyph,
  no `imagePath` renders nothing) — `pnpm --filter backend.ai-ui exec vitest run
  src/components/BAIImageMetaIcon.test.tsx` → 3 passed.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → `undeclared: 2`,
  identical to the pre-existing baseline on `main` (no new findings).

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

## Review notes

- Open the Session Launcher in dark mode and pick an image with no vendor icon
  in `resources/image_metadata.json` (any `imageInfo` entry without an `icon`
  key): the `</>` glyph should read at the same contrast as the image name next
  to it. Toggle to light mode — it should look as before.
- Check the other surfaces that render these icons for unchanged layout: the
  environment select dropdown (`ImageEnvironmentSelectFormItems`, sized 15x15),
  the session list image tags, and `BAIImageNodeSimpleTagV2`.
- Confirm a well-known image (e.g. a TensorFlow or PyTorch entry) still shows its
  coloured vendor logo, not the glyph.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
