### PR TITLE
style(FR-3716): fix code block background and tab strip spacing in the Downloads modal

### DIFF
--- a/react/src/components/DownloadModal.tsx
+++ b/react/src/components/DownloadModal.tsx
@@ -14,6 +14,7 @@ import { Button } from '@astryxdesign/core/Button';
 import { Divider } from '@astryxdesign/core/Divider';
 import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Selector } from '@astryxdesign/core/Selector';
+import { Stack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
@@ -241,16 +242,28 @@ const DownloadModal: React.FC<DownloadModalProps> = ({
   const showDesktopApp = baiClient?._config?.allowAppDownloadPanel;
   const showCLI = baiClient?._config?.allowCLIDownloadPanel;
 
+  // `BAITabs` renders the strip and the active panel as bare siblings, so the
+  // gap under the underline has to come from the panel itself; adding it in
+  // `BAITabs` would break the card-type call sites whose panel is continuous
+  // with the active tab.
   const tabItems = filterOutEmpty([
     showDesktopApp && {
       key: 'desktop',
       label: t('summary.DesktopApp'),
-      children: <DesktopAppDownloadTab />,
+      children: (
+        <Stack paddingBlockStart={4}>
+          <DesktopAppDownloadTab />
+        </Stack>
+      ),
     },
     showCLI && {
       key: 'cli',
       label: t('summary.CLI'),
-      children: <CLIDownloadTab />,
+      children: (
+        <Stack paddingBlockStart={4}>
+          <CLIDownloadTab />
+        </Stack>
+      ),
     },
   ]);
 

--- a/react/src/components/SourceCodeView.css
+++ b/react/src/components/SourceCodeView.css
@@ -12,6 +12,10 @@
 .source-code-view-block .shiki.github-dark {
   margin: 0 !important;
   padding: var(--spacing-3) !important;
+  /* shiki paints the code background on this `<pre>`. Without a content-driven
+     width it stops at the scroll container's edge, leaving horizontally
+     scrolled-into-view code on the bare surface behind it. */
+  min-width: max-content;
 }
 
 .source-code-view-block pre {


### PR DESCRIPTION
Resolves FR-3716 (no webui GitHub clone; Jira only)

Two visual defects in the **Downloads** modal, each fixed where it originates.

### 1. The code block background did not cover the horizontal scroll area

shiki paints the code background on the `<pre class="shiki">` it emits. That `<pre>` is a plain block box inside `SourceCodeView`'s `.source-code-view-block` `overflow: auto` scroller, so its width was the container's width — code scrolled into view horizontally sat on the bare surface behind it.

`min-width: max-content` on the `.shiki` rule lets the `<pre>` grow to its content width, so its background spans the whole scrollable area.

This lands for **every** `SourceCodeView` (chat code blocks, image install instructions, session VSCode instructions, …), which is intended — the defect was in the shared component, not in the modal.

### 2. The tab strip sat flush against the OS selector

`BAITabs` renders `<BAITabList/>` and the active panel as bare siblings inside a fragment, with no spacing element between them, so the underline sat directly on the first form row.

**Design decision:** the gap is added at `DownloadModal`'s two panels (an Astryx `Stack paddingBlockStart={4}` wrapper), *not* inside `BAITabs`. `BAITabs` feeds six call sites, including `FolderExplorerModalV2`'s card tabs, where the panel is deliberately continuous with the active tab (`BAITabList.css` knocks out the active tab's bottom edge for exactly that). Adding a gap in the wrapper would regress those. This follows the local-fix precedent set by FR-3529 (#8724).

### Out of scope (noted, not fixed)

`SourceCodeView`'s `CodeHead` hardcodes `background: 'rgba(0, 0, 0, 0.02)'`, which is effectively invisible in dark mode. Unrelated to this issue.

## Tests

No new unit test — both changes are pure CSS/layout with no testable logic. Verified by reading the rendered box model and running the existing harness.

- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 2 undeclared findings, both pre-existing in `packages/backend.ai-ui` (`BAIDialog.css`, `BAIDrawerPortal.css`), untouched by this PR. **No new findings.**
- `bash scripts/verify.sh` (Relay, Lint, Format, TypeScript, Terminology)

## Verification

```
=== ALL PASS ===
```

## Review notes

- Open **Downloads → CLI**: the pip snippet has long lines. Scroll it horizontally in **both** light and dark mode — the code background should follow the code to the end of the line instead of stopping at the box edge.
- Same modal: the underline under the `Desktop App` / `CLI` tabs should now clear the `OS` row by one spacing step (16px) on both tabs.
- Regression check on the shared component: a chat message code block and `ImageInstallModal` use the same `SourceCodeView`; confirm neither gained an unexpected scrollbar (they already had `white-space: pre` + `overflow: auto`, so only the background paint changed).

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
