### PR TITLE
fix(FR-3721): keep row action colours in the more menu

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.css
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.css
@@ -13,6 +13,8 @@
  styling hooks: `calculateVisibleActions` measures the title icon through
  `querySelector('.bai-name-action-cell-title-icon')`, and ~20 e2e specs locate
  the action group through `.bai-name-action-cell-actions`. They stay.
+ `bai-nac-menu-icon` is one too: `BAINameActionCell.test.tsx` reads the
+ more-menu icon's tint through it.
 
  The styling hooks that used to be emotion hashes are namespaced `bai-nac-*`
  instead of reusing the `bai-name-action-cell-*` family, whose only survivor
@@ -92,6 +94,16 @@
   overflow: visible;
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Wraps a more-menu row's icon so its box matches Astryx's own icon slot
+   (`Item`'s startContent is a flex row, which would otherwise stretch the
+   glyph). The colour itself stays inline on the element — the menu renders in
+   a Layer outside the container that publishes `--bai-nac-*`. */
+.bai-nac-menu-icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .bai-nac-action-button-default {

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.doc.ts
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.doc.ts
@@ -39,6 +39,11 @@ export const docs = {
           'Set `minVisibleActions` when an action must never hide, and `showInMenu: "always"` for secondary actions that should only ever live in the more menu.',
       },
       {
+        guidance: true,
+        description:
+          'Mark destructive row actions with `type: "danger"` — the red carries into the more menu, where the row renders as an Astryx destructive item.',
+      },
+      {
         guidance: false,
         description:
           'Add a parallel actions column beside this cell — the overflow measurement assumes the actions share the cell with the title.',

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.test.tsx
@@ -6,6 +6,7 @@
  reason inside the flag that disables it — the two cannot drift apart, and a
  silent disable is only reachable by writing `true` on purpose.
 */
+import { theme } from '../../theme-shim';
 import BAINameActionCell from './BAINameActionCell';
 import type { BAINameActionCellAction } from './BAINameActionCell';
 import '@testing-library/jest-dom';
@@ -108,9 +109,24 @@ describe('BAINameActionCell — the overflow row keeps its action colour (FR-372
   const menuRow = () => screen.getByText('Act').closest('[role="menuitem"]');
   // `.bai-nac-menu-icon` is this component's own wrapper, so the tint is read
   // off our markup; `data-variant` is Astryx's documented theming attribute.
-  const menuIconTint = () =>
-    screen.getByTestId('act-icon').closest<HTMLElement>('.bai-nac-menu-icon')
-      ?.style.color;
+  // Returning the element (not `?.style.color`) keeps a missing wrapper a
+  // failure instead of an `undefined` that satisfies a negated assertion.
+  const menuIcon = () =>
+    screen.getByTestId('act-icon').closest<HTMLElement>('.bai-nac-menu-icon');
+
+  // The expected tint, read the same way the component reads it and put
+  // through the same `style.color` normalisation the assertion compares.
+  const expectedMenuIconTint = () => {
+    let value = '';
+    const Probe = () => {
+      value = theme.useToken().token.colorInfo;
+      return null;
+    };
+    render(<Probe />);
+    const probe = document.createElement('span');
+    probe.style.color = value;
+    return probe.style.color;
+  };
 
   it('a danger action stays destructive once it overflows into the menu', () => {
     renderAction({
@@ -122,16 +138,23 @@ describe('BAINameActionCell — the overflow row keeps its action colour (FR-372
     expect(menuRow()).toHaveAttribute('data-variant', 'destructive');
     // Astryx tints the whole destructive row, so the icon must not be
     // re-coloured on top of it.
-    expect(menuIconTint()).toBe('');
+    expect(menuIcon()).not.toBeNull();
+    expect(menuIcon()?.style.color).toBe('');
   });
 
   it('a default action carries the info tint on its menu icon', () => {
+    const expectedTint = expectedMenuIconTint();
+    expect(expectedTint).not.toBe('');
+
     renderAction({
       showInMenu: 'always',
       icon: <span data-testid="act-icon" />,
     });
 
     expect(menuRow()).not.toHaveAttribute('data-variant', 'destructive');
-    expect(menuIconTint()).not.toBe('');
+    expect(menuIcon()).not.toBeNull();
+    // A present wrapper carrying exactly the info token — dropping either the
+    // wrapper or the colour fails here.
+    expect(menuIcon()?.style.color).toBe(expectedTint);
   });
 });

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.test.tsx
@@ -105,7 +105,12 @@ describe('BAINameActionCell — disabled carries its reason (FR-3722)', () => {
 });
 
 describe('BAINameActionCell — the overflow row keeps its action colour (FR-3721)', () => {
-  const menuIcon = () => screen.getByTestId('act-icon');
+  const menuRow = () => screen.getByText('Act').closest('[role="menuitem"]');
+  // `.bai-nac-menu-icon` is this component's own wrapper, so the tint is read
+  // off our markup; `data-variant` is Astryx's documented theming attribute.
+  const menuIconTint = () =>
+    screen.getByTestId('act-icon').closest<HTMLElement>('.bai-nac-menu-icon')
+      ?.style.color;
 
   it('a danger action stays destructive once it overflows into the menu', () => {
     renderAction({
@@ -114,12 +119,10 @@ describe('BAINameActionCell — the overflow row keeps its action colour (FR-372
       icon: <span data-testid="act-icon" />,
     });
 
-    expect(
-      screen.getByText('Act').closest('[data-variant="destructive"]'),
-    ).not.toBeNull();
+    expect(menuRow()).toHaveAttribute('data-variant', 'destructive');
     // Astryx tints the whole destructive row, so the icon must not be
     // re-coloured on top of it.
-    expect(menuIcon().parentElement?.style.color).toBe('');
+    expect(menuIconTint()).toBe('');
   });
 
   it('a default action carries the info tint on its menu icon', () => {
@@ -128,9 +131,7 @@ describe('BAINameActionCell — the overflow row keeps its action colour (FR-372
       icon: <span data-testid="act-icon" />,
     });
 
-    expect(
-      screen.getByText('Act').closest('[data-variant="destructive"]'),
-    ).toBeNull();
-    expect(menuIcon().parentElement?.style.color).not.toBe('');
+    expect(menuRow()).not.toHaveAttribute('data-variant', 'destructive');
+    expect(menuIconTint()).not.toBe('');
   });
 });

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.test.tsx
@@ -103,3 +103,34 @@ describe('BAINameActionCell — disabled carries its reason (FR-3722)', () => {
     expect(item.closest('[aria-disabled="true"],[disabled]')).not.toBeNull();
   });
 });
+
+describe('BAINameActionCell — the overflow row keeps its action colour (FR-3721)', () => {
+  const menuIcon = () => screen.getByTestId('act-icon');
+
+  it('a danger action stays destructive once it overflows into the menu', () => {
+    renderAction({
+      showInMenu: 'always',
+      type: 'danger',
+      icon: <span data-testid="act-icon" />,
+    });
+
+    expect(
+      screen.getByText('Act').closest('[data-variant="destructive"]'),
+    ).not.toBeNull();
+    // Astryx tints the whole destructive row, so the icon must not be
+    // re-coloured on top of it.
+    expect(menuIcon().parentElement?.style.color).toBe('');
+  });
+
+  it('a default action carries the info tint on its menu icon', () => {
+    renderAction({
+      showInMenu: 'always',
+      icon: <span data-testid="act-icon" />,
+    });
+
+    expect(
+      screen.getByText('Act').closest('[data-variant="destructive"]'),
+    ).toBeNull();
+    expect(menuIcon().parentElement?.style.color).not.toBe('');
+  });
+});

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -334,10 +334,9 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
 
   // More menu: overflowed auto actions + menu-only actions
   const hasMoreMenu = hasOverflow || menuOnlyActions.length > 0;
-  // An overflowed action keeps the colour its inline button has (FR-3721):
-  // `variant: 'destructive'` tints a danger row's label and icon, and the
-  // default row's icon carries `token.colorInfo` inline — the menu renders in
-  // a Layer outside the container that publishes `--bai-nac-*`.
+  // An overflowed action keeps the colour its inline button has (FR-3721).
+  // The default row's tint is inline because the menu renders in a Layer
+  // outside the container that publishes `--bai-nac-*`.
   const toMenuItem = (
     action: BAINameActionCellAction,
   ): DropdownMenuItemData => ({
@@ -348,14 +347,18 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
       ? `${action.title} — ${disabledReason(action.disabled)}`
       : action.title,
     variant: action.type === 'danger' ? 'destructive' : 'default',
-    icon:
-      action.icon && action.type !== 'danger' ? (
-        <span style={{ display: 'inline-flex', color: token.colorInfo }}>
-          {action.icon}
-        </span>
-      ) : (
-        action.icon
-      ),
+    // Both rows use the same wrapper so the icon box is identical; only the
+    // default one needs a colour, a danger row inherits `--color-error`.
+    icon: action.icon ? (
+      <span
+        className="bai-nac-menu-icon"
+        style={
+          action.type === 'danger' ? undefined : { color: token.colorInfo }
+        }
+      >
+        {action.icon}
+      </span>
+    ) : undefined,
     isDisabled: !!action.disabled,
     onClick: () => {
       if (action.onClick || action.action) {

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -9,6 +9,7 @@ import './BAINameActionCell.css';
 import { Button } from '@astryxdesign/core/Button';
 import {
   DropdownMenu,
+  type DropdownMenuItemData,
   type DropdownMenuOption,
 } from '@astryxdesign/core/DropdownMenu';
 import { Popover } from '@astryxdesign/core/Popover';
@@ -333,41 +334,28 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
 
   // More menu: overflowed auto actions + menu-only actions
   const hasMoreMenu = hasOverflow || menuOnlyActions.length > 0;
-  // PILOT-DECISION (to-astryx W2-D): `DropdownMenuItemData` has no `danger`
-  // flag AND its `label` is typed `string`, not `ReactNode` — its rows are
-  // uniform (P5). A destructive overflow row therefore relies on its icon and
-  // label alone, exactly as it already does inside the `modal.confirm` it
-  // escalates to. The visible (non-overflowed) button keeps its danger tint
-  // through `bai-nac-action-button-danger`.
-  //
-  // Re-examined for QA-FINDINGS Q-15 ("더보기 버튼을 눌렀을 때 버튼 색상이 모두
-  // default 색상으로 처리됨", measured #141414/#FFFFFF where antd set
-  // `danger: action.type === 'danger'` and drew #FF4D4F/#BE3D3F). The colour IS
-  // reachable — but only through `DropdownMenu`'s COMPOUND mode, whose
-  // `DropdownMenuItem` takes `label: ReactNode` plus `style`. That means
-  // rewriting this menu's whole render path (data `items` -> children),
-  // carrying the divider, disabled and keyboard behaviour across with it, for a
-  // change the reporter themselves marked optional. Left as-is and reported
-  // rather than taken on inside a QA row.
-  const toMenuItem = (action: BAINameActionCellAction) => ({
+  // An overflowed action keeps the colour its inline button has (FR-3721):
+  // `variant: 'destructive'` tints a danger row's label and icon, and the
+  // default row's icon carries `token.colorInfo` inline — the menu renders in
+  // a Layer outside the container that publishes `--bai-nac-*`.
+  const toMenuItem = (
+    action: BAINameActionCellAction,
+  ): DropdownMenuItemData => ({
     // FR-3423: a disabled action must still explain itself once it overflows
-    // into this menu — otherwise a narrow viewport turns "disabled with a
-    // reason" into "disabled for no visible reason".
-    //
-    // PILOT-DECISION (to-astryx): the antd original wrapped the label in a
-    // `Tooltip` (a disabled antd menu item swallows hover, so the tooltip had
-    // to sit on the label). Astryx's DATA mode types
-    // `DropdownMenuItemData.label` as `string`, and `DropdownMenuItem`'s
-    // `description` slot is reachable only through the compound render path —
-    // which `items` disables outright (`DropdownMenu.js`: `children` is
-    // ignored whenever `items` is passed). Rewriting this menu to the
-    // compound path would have to carry the divider / disabled / keyboard
-    // behaviour across with it. The reason is folded into the label text
-    // instead: still visible, still read out, no tooltip needed.
+    // into this menu. The reason is folded into the label text rather than a
+    // tooltip, which a disabled menu row swallows.
     label: disabledReason(action.disabled)
       ? `${action.title} — ${disabledReason(action.disabled)}`
       : action.title,
-    icon: action.icon,
+    variant: action.type === 'danger' ? 'destructive' : 'default',
+    icon:
+      action.icon && action.type !== 'danger' ? (
+        <span style={{ display: 'inline-flex', color: token.colorInfo }}>
+          {action.icon}
+        </span>
+      ) : (
+        action.icon
+      ),
     isDisabled: !!action.disabled,
     onClick: () => {
       if (action.onClick || action.action) {


### PR DESCRIPTION
Resolves #9161 (FR-3721)

## What changed

A `BAINameActionCell` row action lost its colour as soon as it collapsed into the ⋮ overflow menu (reported on Admin → Serving / Runtime Variant Presets): `toMenuItem` built each row as `{ label, icon, isDisabled, onClick }`, so a `type: 'danger'` action rendered in the default text colour, while the same action's inline button stayed red through `bai-nac-action-button-danger`.

- Danger rows now pass `variant: 'destructive'` to the Astryx menu item, which tints the row's label and its `currentColor` icon with `--color-error`.
- Default rows carry `token.colorInfo` on the icon inline, matching the blue of the inline button.
- Both row types wrap the icon in the same `.bai-nac-menu-icon` element, whose box geometry lives in the co-located CSS (`inline-flex`, `align-items: center`, `flex-shrink: 0`) — Astryx's `Item` renders `startContent` as a flex row, so the wrapper has to constrain itself or the glyph stretches.
- The migration-era `PILOT-DECISION` block that justified the missing colour is replaced by a three-line note; it was factually stale (see below).

## Design decisions

- **Why the data path is enough now.** The old note said the colour was reachable "only through `DropdownMenu`'s COMPOUND mode". In the pinned Astryx 0.5.2, `DropdownMenuItemData` `Pick`s `variant` from `DropdownMenuItemProps` and `renderDropdownItems` forwards every field wholesale into `DropdownMenuItem`, so no move off `items` is needed.
- **Why the default icon tint is inline, not `var(--bai-nac-info)`.** The menu renders in a Layer/portal outside the actions container that publishes the `--bai-nac-*` custom properties, so the variable would not resolve there. `token.colorInfo` is the same measured value the container publishes. `DropdownMenuItemData` exposes no `style`/`className` of its own, so the wrapper element is the only data-mode surface that can carry it.
- **Why the danger icon carries no colour.** Astryx already tints the whole destructive row through `--color-error`; the wrapper is still there so both row types have an identical icon box, it just sets no colour of its own.
- `toMenuItem` gained an explicit `DropdownMenuItemData` return type so the `variant` literal does not widen to `string`.

## Tests

- `pnpm --filter backend.ai-ui exec vitest run src/components/Table/BAINameActionCell.test.tsx` — 8 passed, including two new cases (danger row carries `data-variant="destructive"` and no extra icon tint; default row carries the info tint and no destructive variant). Both were confirmed to fail against the pre-fix component.
- The two new cases locate the row through `role="menuitem"` and assert on `data-variant` — Astryx's documented consumer-facing theming attribute — and read the tint off this component's own `.bai-nac-menu-icon` wrapper, so they break on a colour regression rather than on an Astryx markup change.
- `pnpm --filter backend.ai-ui exec vitest run src/components/Table src/app-shim` — 11 files, 72 passed.

## Verification

```
bash scripts/verify.sh
...
=== ALL PASS ===
```

`node scripts/migration-gates/astryx-token-gate.mjs --strict` reports the same 2 pre-existing findings (`BAIDialog.css`, `BAIDrawerPortal.css`) and no new ones — the added CSS rule uses no `var()`.

## Review notes

- Open any list with more row actions than fit the name column (Admin → Serving → Runtime Variant Presets, Users, Resource Presets), narrow the column until actions collapse, and open ⋮ — a delete/deactivate row is red, the rest carry the blue icon.
- Check dark mode too: the danger tint comes from Astryx's `--color-error`, the blue from the theme shim's `colorInfo`, so both follow the active theme.
- A danger row now also tints its **label**, not just the icon — slightly beyond the issue's "icon colors" wording. This is Astryx's `destructive` variant behaving as designed, and it restores what antd's `danger: true` did before the migration.
- 76 files import `BAINameActionCell`, so every overflow menu in the app picks this up at once; the change is colour-only — label text, disabled behaviour, dividers and the `popConfirm` → `modal.confirm` fallback are untouched.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
