### PR TITLE
fix(FR-3829): keep oversized notifications dismissable and clear of the header

### DIFF
--- a/packages/backend.ai-ui/src/components/BAINotificationStack.css
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.css
@@ -5,10 +5,18 @@
    notices carry progress bars, retry/cancel actions and a link, and they
    stack. Class names are load-bearing e2e selectors — do not rename. */
 .bai-notification-stack {
+  /* Ceiling for one notice's scrollable regions (FR-3829). */
+  --bai-notification-body-max-height: 30vh;
+
   position: fixed;
-  /* `--spacing-6` = 24px, antd's own notification inset. */
-  inset-block-end: var(--spacing-6);
-  inset-inline-end: var(--spacing-6);
+  /* `--spacing-6` = 24px, antd's own notification inset — carried as PADDING,
+     not `inset`, because `overflow` below clips to the padding box and both the
+     enter/exit slide and the notices' `elevation="high"` shadow need that room
+     inside it. `content-box` keeps `width`/`max-height` the visible figures. */
+  inset-block-end: 0;
+  inset-inline-end: 0;
+  padding: var(--spacing-6);
+  box-sizing: content-box;
   display: flex;
   flex-direction: column;
   /* Newest at the bottom, nearest the corner — the direction antd stacks
@@ -16,6 +24,15 @@
   gap: var(--spacing-3);
   width: 384px; /* antd's notification width; not on the spacing scale. */
   max-width: calc(100vw - var(--spacing-6) * 2);
+  /* FR-3829: the stack stops below the app header instead of growing over it,
+     so the header's own buttons stay reachable however many notices are open.
+     The host bridges its real header height as `--webui-header-height`
+     (`MainLayout` -> `CSSTokenVariables`). */
+  max-height: calc(
+    100dvh - var(--webui-header-height, 60px) - var(--spacing-6) * 2
+  );
+  overflow: hidden auto;
+  overscroll-behavior: contain;
   /* Top of the ladder (`../styles/zIndexLadder.ts`), so a notice clears every
      layer on it — the modal band and, since FR-3585, the scrimmed drawers. Not
      the CSS top layer: tours use the popover API and paint over notices.
@@ -62,6 +79,16 @@
 .bai-notification-stack-item[data-exiting='true'] {
   animation-name: bai-notification-exit;
   overflow: hidden;
+}
+
+/* FR-3829: an oversized error scrolls inside the notice instead of pushing the
+   `Banner` header — and the dismiss button in it — off the top of the screen.
+   Deliberately NOT on `.bai-notification-stack-item`: `bai-notification-exit`
+   animates that element's own `max-height`. */
+.bai-notification-stack-item__body {
+  max-height: var(--bai-notification-body-max-height);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 /* An entrance that only fades is still an entrance, and a user who asked for

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      "The floating notice stack anchored to the bottom-right corner — the component that replaced antd's imperative `notification` API, which Astryx has no counterpart for. Each entry renders an Astryx `Banner` at high elevation with a status icon, an optional background-task progress bar (determinate or indeterminate), action, retry and cancel buttons in the banner's end slot, and a collapsible disclosure for `children`. A per-notice `duration` closes it automatically, and that countdown banks its remaining budget while the notice is hovered or holds focus so a notice never closes out from under the reader. Newest renders nearest the corner, removals play an exit transition that respects `prefers-reduced-motion`, and the whole component is presentational: no routing, no i18n, no Relay, no jotai. Application code raises notices through `useBAINotification`, not by rendering this directly.",
+      "The floating notice stack anchored to the bottom-right corner — the component that replaced antd's imperative `notification` API, which Astryx has no counterpart for. Each entry renders an Astryx `Banner` at high elevation with a status icon, an optional background-task progress bar (determinate or indeterminate), action, retry and cancel buttons in the banner's end slot, and a collapsible disclosure for `children`. A per-notice `duration` closes it automatically, and that countdown banks its remaining budget while the notice is hovered or holds focus so a notice never closes out from under the reader. An oversized description or disclosure scrolls inside the notice rather than pushing the banner header — and its dismiss button — off screen, and the stack itself is capped so it cannot grow over an app header above it. Newest renders nearest the corner, removals play an exit transition that respects `prefers-reduced-motion`, and the whole component is presentational: no routing, no i18n, no Relay, no jotai. Application code raises notices through `useBAINotification`, not by rendering this directly.",
     bestPractices: [
       {
         guidance: true,
@@ -32,6 +32,11 @@ export const docs = {
         guidance: true,
         description:
           'Give a background-task notice both `percent` and `progressLabel` so the progress bar is announced with the name of the task it tracks.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass `maxVisible` from the host so the floating stack stays short; an app header sitting above the stack stays reachable, and the notices beyond the cap render as the visible ones close.',
       },
       {
         guidance: true,
@@ -68,7 +73,7 @@ export const docs = {
       name: 'maxVisible',
       type: 'number',
       description:
-        'Cap on simultaneously visible notices, keeping the newest. Unlimited when unset.',
+        'Cap on simultaneously visible notices, keeping the newest. Unlimited when unset; notices beyond the cap are not dropped, they render once a visible one closes.',
     },
     {
       name: 'data-testid',

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.stories.tsx
@@ -1,0 +1,88 @@
+import BAINotificationStack from './BAINotificationStack';
+import type { BAINotificationStackItem } from './BAINotificationStack';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const LONG_ERROR = `Failed to start the session: ${'the backend returned an unusually long diagnostic that used to grow the notice past the top of the viewport. '.repeat(40)}`;
+
+const meta: Meta<typeof BAINotificationStack> = {
+  title: 'Notification/BAINotificationStack',
+  component: BAINotificationStack,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+**BAINotificationStack** is the floating notice stack anchored to the bottom-right corner.
+
+## Features
+- Astryx \`Banner\` per notice, with status icon, background-task progress, action / retry / cancel buttons and a collapsible disclosure
+- Per-notice auto-close that pauses while the notice is hovered or focused
+- An oversized description or disclosure scrolls inside the notice, so the banner header and its dismiss button never leave the viewport
+- The stack itself is capped below the app header, and \`maxVisible\` keeps it short
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| notifications | \`Array<BAINotificationStackItem>\` | - | Notices, oldest first; the last renders nearest the corner |
+| onClose | \`(key: React.Key) => void\` | - | Fired by the close button and by the auto-close timer |
+| maxVisible | \`number\` | - | Cap on simultaneously visible notices, keeping the newest |
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAINotificationStack>;
+
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    notifications: [
+      { key: 'info', title: 'Session started', description: 'session-1a2b3c' },
+      {
+        key: 'task',
+        title: 'Importing image',
+        description: 'This may take a while.',
+        percent: 42,
+        progressLabel: 'Importing image',
+        cancelText: 'Cancel',
+        onCancel: () => {},
+        duration: null,
+      },
+    ],
+  },
+};
+
+/** FR-3829 — the dismiss button stays reachable however long the error is. */
+export const OversizedError: Story = {
+  args: {
+    notifications: [
+      {
+        key: 'error',
+        title: 'Failed to start the app',
+        description: LONG_ERROR,
+        status: 'error',
+        duration: null,
+        children: LONG_ERROR,
+      },
+    ],
+  },
+};
+
+/** FR-3829 — `maxVisible` keeps the stack clear of the app header. */
+export const CappedStack: Story = {
+  args: {
+    maxVisible: 3,
+    notifications: Array.from(
+      { length: 10 },
+      (_, i): BAINotificationStackItem => ({
+        key: `n${i}`,
+        title: `Notice ${i + 1}`,
+        description: 'One of ten notices raised at once.',
+        duration: null,
+      }),
+    ),
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.test.tsx
@@ -1,0 +1,70 @@
+import BAINotificationStack from './BAINotificationStack';
+import type { BAINotificationStackItem } from './BAINotificationStack';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+const items = (count: number): Array<BAINotificationStackItem> =>
+  Array.from({ length: count }, (_, i) => ({
+    key: `n${i}`,
+    title: `Notice ${i}`,
+  }));
+
+const renderedKeys = () =>
+  Array.from(
+    screen
+      .getByTestId('bai-notification-stack')
+      .querySelectorAll('[data-notification-key]'),
+  ).map((el) => el.getAttribute('data-notification-key'));
+
+describe('BAINotificationStack', () => {
+  it('should render every notice when maxVisible is unset', () => {
+    render(<BAINotificationStack notifications={items(5)} />);
+    expect(renderedKeys()).toEqual(['n0', 'n1', 'n2', 'n3', 'n4']);
+  });
+
+  it('should keep only the newest notices when maxVisible is set', () => {
+    render(<BAINotificationStack notifications={items(5)} maxVisible={3} />);
+    expect(renderedKeys()).toEqual(['n2', 'n3', 'n4']);
+  });
+
+  // FR-3829: the scroll cap sits on an inner wrapper, never on the item —
+  // `bai-notification-exit` animates the item's own `max-height`.
+  it('should wrap an oversized description in the scrollable body', () => {
+    render(
+      <BAINotificationStack
+        notifications={[
+          { key: 'e', title: 'Failed', description: 'x'.repeat(5000) },
+        ]}
+      />,
+    );
+    const description = screen.getByTestId('notification-description');
+    expect(description.closest('.bai-notification-stack-item__body')).not.toBe(
+      null,
+    );
+    expect(
+      document.querySelector('.bai-notification-stack-item'),
+    ).not.toHaveClass('bai-notification-stack-item__body');
+  });
+
+  it('should not render the scrollable body when there is nothing to scroll', () => {
+    render(<BAINotificationStack notifications={[{ key: 'a', title: 'A' }]} />);
+    expect(
+      document.querySelector('.bai-notification-stack-item__body'),
+    ).toBeNull();
+  });
+
+  it('should keep the dismiss control mounted for an oversized notice', async () => {
+    const onClose = vi.fn();
+    render(
+      <BAINotificationStack
+        notifications={[
+          { key: 'e', title: 'Failed', description: 'x'.repeat(5000) },
+        ]}
+        onClose={onClose}
+      />,
+    );
+    const { default: userEvent } = await import('@testing-library/user-event');
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onClose).toHaveBeenCalledWith('e');
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.test.tsx
@@ -53,6 +53,25 @@ describe('BAINotificationStack', () => {
     ).toBeNull();
   });
 
+  // FR-3829: exit bookkeeping runs over the visible slice, so a notice closed
+  // while hidden behind `maxVisible` never animates into the corner.
+  it('should not surface a hidden notice that is closed', () => {
+    const five = items(5);
+    const { rerender } = render(
+      <BAINotificationStack notifications={five} maxVisible={3} />,
+    );
+    expect(renderedKeys()).toEqual(['n2', 'n3', 'n4']);
+
+    // Close `n0`, which was never on screen.
+    rerender(
+      <BAINotificationStack
+        notifications={five.filter((n) => n.key !== 'n0')}
+        maxVisible={3}
+      />,
+    );
+    expect(renderedKeys()).toEqual(['n2', 'n3', 'n4']);
+  });
+
   it('should keep the dismiss control mounted for an oversized notice', async () => {
     const onClose = vi.fn();
     render(

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
@@ -338,20 +338,29 @@ const BAINotificationStack: React.FC<BAINotificationStackProps> = ({
   // animation. Without this the stack would pop rather than slide out — antd's
   // notification had a motion contract and losing it reads as a bug.
   const [exiting, setExiting] = useState<Array<BAINotificationStackItem>>([]);
-  const previousRef = useRef<Array<BAINotificationStackItem>>([]);
+  const previousVisibleRef = useRef<Array<BAINotificationStackItem>>([]);
   const stackRef = useRef<HTMLDivElement>(null);
 
+  const visible = maxVisible ? notifications.slice(-maxVisible) : notifications;
+  const newestKey = notifications.at(-1)?.key;
+
   // Once the stack hits its `max-height` cap (FR-3829) it scrolls, and the
-  // newest notice is the one at the scrolled end — keep it in view.
+  // newest notice is the one at the scrolled end — keep it in view. Keyed on
+  // the newest notice rather than the array: a background task rebuilds that
+  // every 100ms and would yank a user reading an older notice back down.
   useEffect(() => {
     const el = stackRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [notifications]);
+  }, [newestKey]);
 
   useEffect(() => {
     const currentKeys = new Set(notifications.map((n) => n.key));
-    const removed = previousRef.current.filter((n) => !currentKeys.has(n.key));
-    previousRef.current = notifications;
+    // Only a notice that was on screen gets an exit animation; one closed
+    // while hidden behind `maxVisible` would otherwise flash into the corner.
+    const removed = previousVisibleRef.current.filter(
+      (n) => !currentKeys.has(n.key),
+    );
+    previousVisibleRef.current = visible;
     if (removed.length === 0) return;
     setExiting((prev) => [...prev, ...removed]);
     const timer = window.setTimeout(() => {
@@ -359,9 +368,8 @@ const BAINotificationStack: React.FC<BAINotificationStackProps> = ({
       setExiting((prev) => prev.filter((n) => !removedKeys.has(n.key)));
     }, EXIT_ANIMATION_MS);
     return () => window.clearTimeout(timer);
-  }, [notifications]);
+  }, [notifications, visible]);
 
-  const visible = maxVisible ? notifications.slice(-maxVisible) : notifications;
   const visibleKeys = new Set(visible.map((n) => n.key));
   const stillExiting = exiting.filter((n) => !visibleKeys.has(n.key));
 

--- a/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
+++ b/packages/backend.ai-ui/src/components/BAINotificationStack.tsx
@@ -117,8 +117,9 @@ export interface BAINotificationStackProps {
   /** Fired by the close button and by the auto-close timer. */
   onClose?: (key: React.Key) => void;
   /**
-   * Cap on simultaneously visible notices; the newest win.
-   * antd had `maxCount` on the whole API. Unlimited by default, as today.
+   * Cap on simultaneously visible notices; the newest win. Unlimited when
+   * unset — the WebUI host passes one (FR-3829). The rest stay in the
+   * notification list the host owns, and render as room frees up.
    */
   maxVisible?: number;
   'data-testid'?: string;
@@ -274,15 +275,21 @@ const BAINotificationStackItemView: React.FC<{
         description={
           hasOwnContent ? undefined : item.description || hasProgress ? (
             <VStack gap={2} align="stretch">
-              {typeof item.description === 'string' ? (
-                <Text type="supporting">
-                  <span data-testid="notification-description">
-                    {item.description}
-                  </span>
-                </Text>
-              ) : (
-                item.description
-              )}
+              {/* FR-3829: the text scrolls, the header stays; a progress bar
+                  outside it stays pinned under the scrolled text. */}
+              {item.description ? (
+                <div className="bai-notification-stack-item__body">
+                  {typeof item.description === 'string' ? (
+                    <Text type="supporting">
+                      <span data-testid="notification-description">
+                        {item.description}
+                      </span>
+                    </Text>
+                  ) : (
+                    item.description
+                  )}
+                </div>
+              ) : null}
               {hasProgress ? (
                 <ProgressBar
                   value={item.percent ?? 0}
@@ -305,11 +312,15 @@ const BAINotificationStackItemView: React.FC<{
         {/* A bare string would inherit Banner's own base size (measured 16px)
             and tower over the description above it, so it gets the same
             treatment `description` does. */}
-        {typeof item.children === 'string' ? (
-          <Text type="supporting">{item.children}</Text>
-        ) : (
-          item.children
-        )}
+        {item.children ? (
+          <div className="bai-notification-stack-item__body">
+            {typeof item.children === 'string' ? (
+              <Text type="supporting">{item.children}</Text>
+            ) : (
+              item.children
+            )}
+          </div>
+        ) : null}
       </Banner>
     </div>
   );
@@ -328,6 +339,14 @@ const BAINotificationStack: React.FC<BAINotificationStackProps> = ({
   // notification had a motion contract and losing it reads as a bug.
   const [exiting, setExiting] = useState<Array<BAINotificationStackItem>>([]);
   const previousRef = useRef<Array<BAINotificationStackItem>>([]);
+  const stackRef = useRef<HTMLDivElement>(null);
+
+  // Once the stack hits its `max-height` cap (FR-3829) it scrolls, and the
+  // newest notice is the one at the scrolled end — keep it in view.
+  useEffect(() => {
+    const el = stackRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [notifications]);
 
   useEffect(() => {
     const currentKeys = new Set(notifications.map((n) => n.key));
@@ -350,6 +369,7 @@ const BAINotificationStack: React.FC<BAINotificationStackProps> = ({
 
   return (
     <div
+      ref={stackRef}
       className="bai-notification-stack"
       // e2e anchor: the stack, each notice, and each notice's status are
       // addressable without reaching into Astryx's own class names (P7).

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -128,6 +128,9 @@ export const notificationListState = atom<NotificationState[]>([]);
 
 export const CLOSING_DURATION = 4; //second
 
+/** How many notices float at once (FR-3829). The rest wait in the drawer. */
+export const MAX_VISIBLE_NOTIFICATIONS = 3;
+
 /**
  * Custom hook that returns the BAI notification state.
  * @returns A tuple containing the notifications and a function to set the BAI notification.
@@ -237,6 +240,9 @@ export const BAINotificationStackHost: React.FC = () => {
       // stack ordered it (the jotai list is newest-first).
       notifications={items.reverse()}
       onClose={closeNotification}
+      // FR-3829: keep the floating stack short. The rest stay in the
+      // notification drawer and render as the visible ones close.
+      maxVisible={MAX_VISIBLE_NOTIFICATIONS}
     />
   );
 };


### PR DESCRIPTION
Resolves #9346 (FR-3829)

A long error message (an app launch failure) grew its notification upward past the top of the viewport, taking the Astryx `Banner` header — and the dismiss button in it — off screen, so the notice could not be closed. Nothing in `BAINotificationStack.css` capped the height of a notice or of the floating stack, and the host rendered the stack with no `maxVisible`, so a tall stack could also climb over the WebUI header.

**What changed**

- **Per-notice cap.** The `description` text and the collapsible `children` disclosure are now wrapped in `.bai-notification-stack-item__body`, which is `max-height`-capped (`--bai-notification-body-max-height`, 30vh) and scrolls. The `Banner` header — with the dismiss button — stays pinned at the top of the notice however long the error is. The progress bar deliberately stays *outside* the scroll area so it stays visible under the scrolled text.
- **Stack cap.** `.bai-notification-stack` gets `max-height: calc(100dvh - var(--webui-header-height, 60px) - var(--spacing-6) * 2)` plus `overflow: hidden auto`, so it stops below the WebUI header instead of growing over it. The component keeps itself scrolled to the newest notice.
- **`maxVisible={3}`** from `BAINotificationStackHost` keeps the floating stack short. Notices beyond the cap are not dropped — they stay in the notification drawer and render as the visible ones close.

**Design decisions**

- The per-notice cap sits on an **inner wrapper**, never on `.bai-notification-stack-item`: the `bai-notification-exit` keyframes animate that element's own `max-height` (40vh → 0), so a competing declaration there would break the exit animation.
- The corner inset moved from `inset-block-end` / `inset-inline-end` to `padding` (with `box-sizing: content-box`). `overflow` clips to the padding box, and both the enter/exit slide (`translateX(--spacing-6)`) and the notices' `elevation="high"` shadow need that room inside the clip box. The visible geometry (384px wide, 24px from each edge) is unchanged.
- `--webui-header-height` is the height the host already bridges onto `:root` in `MainLayout`'s `CSSTokenVariables`; the `60px` fallback covers a page mounted without the header.
- `3` for `maxVisible` is a judgement call — a one-line change if reviewers want a different number.

## Tests

- New `packages/backend.ai-ui/src/components/BAINotificationStack.test.tsx` (5 cases): unlimited rendering without `maxVisible`, newest-3 with it, the oversized description landing inside the body wrapper (and not on the animated item element), no wrapper when there is nothing to scroll, and a 5000-character notice still dismissable through its dismiss button.
  `pnpm --filter backend.ai-ui exec vitest run src/components/BAINotificationStack.test.tsx` → 5 passed.
- New Storybook cases in `BAINotificationStack.stories.tsx`: `OversizedError` (a ~5000-character description plus the same text in the disclosure) and `CappedStack` (ten notices with `maxVisible: 3`).
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → unchanged: `undeclared: 2` (both pre-existing `--bai-dialog-z` findings), no new findings.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

## Review notes

- Storybook `Notification/BAINotificationStack` → **OversizedError**: the notice should stay a fixed height with the text scrolling inside it, and the dismiss button visible at the top the whole time.
- Storybook → **CappedStack**: only three notices render (Notice 8/9/10), stacked from the bottom-right corner.
- In the app, dismiss a notice and confirm the exit slide is not clipped, and that the drop shadow around each notice is intact — those are what the `inset` → `padding` move on the container protects.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
