### PR TITLE
fix(FR-3836): propagate EXT_HTTP_PROXY to the API-mode TCP gateway

### DIFF
--- a/src/wsproxy/gateway/tcpwsproxy.js
+++ b/src/wsproxy/gateway/tcpwsproxy.js
@@ -1,11 +1,14 @@
 const Server = require('../lib/backend.ai-ws-appproxy.js');
 
 module.exports = proxy = class Proxy {
-  constructor(env) {
+  // `extProxyURL` is passed separately because API mode's `env` is a
+  // ClientConfig, which has no place to carry it (SESSION mode's `cf` does).
+  constructor(env, extProxyURL) {
     this.env = env;
+    this.extProxyURL = extProxyURL;
   }
   async start_proxy(kernelId, app, ip, port, envs = {}, args = {}) {
-    this.c = new Server(this.env);
+    this.c = new Server(this.env, this.extProxyURL);
     return this.c.start(kernelId, app, ip, port, envs, args);
   }
 

--- a/src/wsproxy/lib/backend.ai-ws-appproxy.js
+++ b/src/wsproxy/lib/backend.ai-ws-appproxy.js
@@ -4,7 +4,7 @@ const WebSocket = require('ws');
 const ai = require('backend.ai-client');
 const bind = require('./bindStream');
 const htmldeco = require('./htmldeco');
-const HttpsProxyAgent = require('https-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 /*
 const i18next = require('i18next');
 const i18next_backend = require('i18next-sync-fs-backend');
@@ -24,11 +24,12 @@ i18next
   */
 
 module.exports = proxy = class Proxy extends ai.backend.Client {
-  constructor(env) {
+  constructor(env, extProxyURL) {
     super(env);
-    // TODO(FR-3836): in API mode `env` is a ClientConfig, which carries no ext_proxy_url,
-    // so the external-proxy branch in _start never fires (SESSION mode gets it via cf).
     this._env = env;
+    // API mode passes the URL explicitly (its `env` is a ClientConfig with no
+    // ext_proxy_url); SESSION mode carries it on the `cf` object it passes as `env`.
+    this._extProxyURL = extProxyURL ?? env.ext_proxy_url;
     this._running = false;
     this._resolve = undefined;
     this._connectionCount = 0;
@@ -151,11 +152,9 @@ module.exports = proxy = class Proxy extends ai.backend.Client {
       logger.info('destination: ' + url);
       const optionalHeaders = hdrs();
       let ws;
-      if (this._env.ext_proxy_url) {
-        logger.info(
-          '- try using external http proxy: ' + this._env.ext_proxy_url,
-        );
-        const agent = new HttpsProxyAgent(this._env.ext_proxy_url);
+      if (this._extProxyURL) {
+        logger.info('- try using external http proxy: ' + this._extProxyURL);
+        const agent = new HttpsProxyAgent(this._extProxyURL);
         ws = new WebSocket(url, {
           agent: agent,
           headers: optionalHeaders,

--- a/src/wsproxy/lib/console-appproxy.js
+++ b/src/wsproxy/lib/console-appproxy.js
@@ -3,7 +3,7 @@ const logger = require('./logger')(__filename);
 const WebSocket = require('ws');
 const bind = require('./bindStream');
 const htmldeco = require('./htmldeco');
-const HttpsProxyAgent = require('https-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 /*
 const i18next = require('i18next');
 const i18next_backend = require('i18next-sync-fs-backend');

--- a/src/wsproxy/manager.js
+++ b/src/wsproxy/manager.js
@@ -317,7 +317,7 @@ class Manager extends EventEmitter {
             gateway = new SGateway(this._config);
           } else {
             const Gateway = require('./gateway/tcpwsproxy');
-            gateway = new Gateway(this.aiclient._config);
+            gateway = new Gateway(this.aiclient._config, this.extHttpProxyURL);
           }
           this.proxies[p] = gateway;
 

--- a/src/wsproxy/manager.test.ts
+++ b/src/wsproxy/manager.test.ts
@@ -1,4 +1,5 @@
 import Manager from './manager.js';
+import { createRequire } from 'node:module';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
@@ -266,5 +267,96 @@ describe('wsproxy Manager security (FR-3227)', () => {
       expect(() => manager._evictStaleGateway('sess-3|jupyter')).not.toThrow();
       expect(manager.proxies.hasOwnProperty('sess-3|jupyter')).toBe(false);
     });
+  });
+});
+
+/**
+ * Regression tests for EXT_HTTP_PROXY propagation (FR-3836).
+ *
+ * SESSION mode reaches the gateway through the `cf` object, which carries
+ * `ext_proxy_url`. API mode hands the gateway `aiclient._config` — a
+ * `ClientConfig` with no such field — so the proxy URL has to travel as its
+ * own constructor argument or it is silently dropped.
+ *
+ * Both gateway modules require `backend.ai-client`, a build artifact the
+ * source-only checkout does not have (see the top-of-file comment), so each
+ * test seeds `require.cache` with a stub for the module one hop down and
+ * asserts on the arguments that arrive there.
+ */
+describe('EXT_HTTP_PROXY propagation (FR-3836)', () => {
+  const req = createRequire(import.meta.url);
+  const extProxyURL = 'http://10.20.30.40:3128';
+  const stubbed: Array<string> = [];
+
+  const stubModule = (id: string, exports: unknown) => {
+    const filename = req.resolve(id);
+    stubbed.push(filename);
+    req.cache[filename] = {
+      id: filename,
+      filename,
+      loaded: true,
+      exports,
+    } as any;
+  };
+
+  afterEach(() => {
+    while (stubbed.length) delete req.cache[stubbed.pop() as string];
+  });
+
+  it('hands the API-mode TCP gateway the manager EXT_HTTP_PROXY value', async () => {
+    const constructorArgs: Array<Array<unknown>> = [];
+    stubModule(
+      './gateway/tcpwsproxy',
+      class StubGateway {
+        constructor(...args: Array<unknown>) {
+          constructorArgs.push(args);
+        }
+        async start_proxy() {}
+        getPort() {
+          return 12345;
+        }
+        isAlive() {
+          return true;
+        }
+      },
+    );
+
+    const manager: any = new Manager('127.0.0.1', '127.0.0.1', 0);
+    const port = await manager.start();
+    // Stand in for a completed API-mode `PUT /conf`, which constructs the
+    // Backend.AI client (a build artifact) before this branch is reached.
+    const clientConfig = { endpoint: 'http://localhost:8081' };
+    manager.extHttpProxyURL = extProxyURL;
+    manager._config = { mode: 'API' };
+    manager.aiclient = { _config: clientConfig };
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/proxy/${encodeURIComponent(manager.secretToken)}/sess-api/add?app=jupyter`,
+    );
+    await new Promise<void>((resolve) =>
+      manager.listener.close(() => resolve()),
+    );
+
+    expect(res.status).toBe(200);
+    expect(constructorArgs).toEqual([[clientConfig, extProxyURL]]);
+  });
+
+  it('forwards the proxy URL from the TCP gateway to the app-proxy server', async () => {
+    const constructorArgs: Array<Array<unknown>> = [];
+    stubModule(
+      './lib/backend.ai-ws-appproxy.js',
+      class StubServer {
+        constructor(...args: Array<unknown>) {
+          constructorArgs.push(args);
+        }
+        async start() {}
+      },
+    );
+
+    const Gateway = req('./gateway/tcpwsproxy');
+    const env = { endpoint: 'http://localhost:8081' };
+    await new Gateway(env, extProxyURL).start_proxy('sess-api', 'jupyter');
+
+    expect(constructorArgs).toEqual([[env, extProxyURL]]);
   });
 });


### PR DESCRIPTION
Resolves #9364 (FR-3836)

In the Electron local proxy, API mode handed the TCP gateway `aiclient._config` — a `ClientConfig`, which has no `ext_proxy_url` field — so the external-proxy branch in `src/wsproxy/lib/backend.ai-ws-appproxy.js` never fired and `EXT_HTTP_PROXY` was silently ignored for API-mode app streams (SSH, VSCode Desktop, …). SESSION mode was unaffected: its gateway receives the `cf` object, which carries `ext_proxy_url`.

## What changed

- `src/wsproxy/manager.js` — the API-mode branch now passes `this.extHttpProxyURL` alongside `aiclient._config`.
- `src/wsproxy/gateway/tcpwsproxy.js` — stores the URL and forwards it to the app-proxy server.
- `src/wsproxy/lib/backend.ai-ws-appproxy.js` — the constructor takes the optional URL and resolves `extProxyURL ?? env.ext_proxy_url`; the `HttpsProxyAgent` branch reads that. The `TODO(FR-3836)` marker is removed.
- `src/wsproxy/lib/backend.ai-ws-appproxy.js` + `src/wsproxy/lib/console-appproxy.js` — `require('https-proxy-agent')` → `const { HttpsProxyAgent } = require(…)`.

### Design decisions

- **The URL travels as its own constructor argument, not on `ClientConfig`.** `aiclient._config` is the live client's config object, shared with every other request; adding `ext_proxy_url` to it would leak the setting into unrelated consumers. The explicit argument keeps the change additive, and the `??` fallback means SESSION mode (which arrives with `cf.ext_proxy_url`) is untouched.
- **The `https-proxy-agent` import fix is in scope, not drive-by.** The package is at v7, which exports `HttpsProxyAgent` as a **named** export. The existing default-style `require` bound the module namespace object, so `new HttpsProxyAgent(url)` throws `TypeError: … is not a constructor`. Verified locally against the installed 7.0.6:

  ```
  default-call FAILS: m is not a constructor
  named-call OK
  ```

  Without this, the branch this PR enables would crash on its first use. `console-appproxy.js` (the SESSION-mode twin, which already receives the URL today) had the identical latent break, so it is fixed in the same one-line shape.

## Tests

- Two new unit tests in `src/wsproxy/manager.test.ts` pin both hops of the wiring:
  - the API-mode `/add` route constructs the TCP gateway with `(aiclient._config, extHttpProxyURL)`;
  - `tcpwsproxy.start_proxy()` forwards `(env, extProxyURL)` to the app-proxy server.

  Both gateway modules require `backend.ai-client`, a build artifact the source-only checkout does not have (the suite's existing top-of-file comment explains this constraint), so each test seeds `require.cache` with a stub for the module one hop down and asserts on the arguments that arrive there. Both tests were confirmed to fail against the pre-fix code (the gateway received a single argument).
- `npx vitest run src/wsproxy/manager.test.ts` → **20 passed** (18 pre-existing + 2 new).

**Not covered by CI:** end-to-end verification needs an API-mode Backend.AI deployment reachable only through an external HTTP proxy, driving a TCP app stream (SSH or VSCode Desktop) with `EXT_HTTP_PROXY` set. The unit tests are the automated evidence; that check still needs a human on a proxied deployment.

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- The behavioural change is one argument at `manager.js:320`; everything downstream is pass-through. Confirm `aiclient._config` is **not** mutated — that was the alternative approach and it was deliberately rejected.
- To exercise it manually: start the Electron app with `EXT_HTTP_PROXY=http://<proxy>:3128`, log in to an **API-mode** endpoint, and open an SSH / VSCode Desktop app. The local proxy logs `- try using external http proxy: <url>` when the branch fires; before this PR that line never appeared in API mode.
- SESSION mode should be unchanged — the same log line, same behaviour — since `extProxyURL` is `undefined` there and the `?? env.ext_proxy_url` fallback takes over.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup) — needs `EXT_HTTP_PROXY` set and an API-mode endpoint behind that proxy; see Review notes.
- [x] Minimum requirements to check during review — Electron build, API-mode login, a TCP app (SSH / VSCode Desktop).
- [x] Test case(s) to demonstrate the difference of before/after — `src/wsproxy/manager.test.ts`, `EXT_HTTP_PROXY propagation (FR-3836)`.

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
