### PR TITLE
fix(FR-3874): feed the staged value back into renderInput controls

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
@@ -4,6 +4,18 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { action } from 'storybook/actions';
 
+const sampleStorageHostOptions = [
+  { label: 'local:volume1', value: 'local:volume1' },
+  { label: 'local:volume2', value: 'local:volume2' },
+  { label: 'nfs:data', value: 'nfs:data' },
+];
+
+/** `renderInput`'s staged string -> the labeled object `BAIComplexSelect` takes. */
+const toLabeledValue = <T extends { value: string }>(
+  options: ReadonlyArray<T>,
+  value: string | null,
+): T | null => options.find((option) => option.value === value) ?? null;
+
 const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
   title: 'Filter/BAIGraphQLPropertyFilter',
   component: BAIGraphQLPropertyFilter,
@@ -24,7 +36,7 @@ const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
 New in this version:
 - **DateTime support**: When a property has type 'datetime', a DatePicker with time selection is rendered instead of a text input. Values are serialized as ISO strings and displayed in filter tags as 'YYYY-MM-DD HH:mm'.
 - **UUID support**: UUID type properties use \`equals\`, \`notEquals\`, \`in\`, \`notIn\` operators and support validation rules.
-- **Custom input via \`renderInput\`**: Replace the default AutoComplete input with any controlled control (e.g., a user/domain picker or async select). The control commits a condition via \`onAddCondition(value, label?)\` as soon as a value is selected (so a single-select picker confirms on selection); pass a human-readable \`label\` when the committed value is opaque (e.g. a UUID) so the condition tag shows the label instead. Give the control \`value={null}\` so it stays controlled and clears after each commit. Keep using a built-in \`type\` (e.g. \`uuid\`) that matches what the control emits.
+- **Custom input via \`renderInput\`**: Replace the default AutoComplete input with any controlled control (e.g., a user/domain picker or async select). The control stages a value via \`onAddCondition(value, label?)\` and the edit popover's Apply button commits it; feed the render prop's \`value\` back into the control so the staged pick stays visible (and when an existing token is reopened for editing). Pass a human-readable \`label\` when the committed value is opaque (e.g. a UUID) so the token shows the label instead. Keep using a built-in \`type\` (e.g. \`uuid\`) that matches what the control emits.
 - Operatorless fields via valueMode: 'scalar' for properties that should emit direct scalar values (e.g., { isUrgent: true }). Use implicitOperator (defaults to 'equals') to control how tags are displayed in the UI.
 
 The component generates GraphQL-compatible filter objects that can be directly used in GraphQL queries, enabling powerful and flexible data filtering across the platform.
@@ -92,14 +104,15 @@ FilterProperty = {
   // Visual operator for UI tags when valueMode='scalar' (default 'equals')
   implicitOperator?: FilterOperator;
   // Custom input renderer — replaces the default AutoComplete with a controlled
-  // control (e.g. BAIUserSelect). \`onAddCondition(value, label?)\` commits the
-  // value as a condition immediately (single-select pickers confirm on
-  // selection) and serializes it per the property's \`type\`. Pass a
-  // human-readable \`label\` when the value is opaque (e.g. a UUID) so the
-  // condition tag stays readable. Give the control \`value={null}\` so it
-  // stays controlled and clears after each commit.
+  // control (e.g. BAIUserSelect). \`onAddCondition(value, label?)\` stages the
+  // value and the edit popover's Apply button commits it, serialized per the
+  // property's \`type\`. Pass a human-readable \`label\` when the value is opaque
+  // (e.g. a UUID) so the token stays readable, and feed \`value\` back into the
+  // control so the staged pick stays visible.
   renderInput?: (props: {
     onAddCondition: (value: string | undefined, label?: string) => void;
+    value: string | null;
+    isDisabled?: boolean;
   }) => ReactNode;
 }
         `,
@@ -873,7 +886,7 @@ export const WithRenderInput: Story = {
     docs: {
       description: {
         story:
-          'When `renderInput` is provided, the default AutoComplete is replaced with a custom control. The control commits a condition via `onAddCondition(value, label?)` as soon as it emits a non-empty value; keep it controlled with `value={null}` so it clears after each commit. Useful for async selects (e.g., fetching options from an API).',
+          "When `renderInput` is provided, the default AutoComplete is replaced with a custom control. The control stages a value via `onAddCondition(value, label?)` and the edit popover's Apply button commits it; feed the render prop's `value` back into the control so the staged pick stays visible. Useful for async selects (e.g., fetching options from an API).",
       },
     },
   },
@@ -890,19 +903,16 @@ export const WithRenderInput: Story = {
         propertyLabel: 'Storage Host',
         type: 'string',
         defaultOperator: 'equals',
-        renderInput: ({ onAddCondition }) => (
+        renderInput: ({ onAddCondition, value, isDisabled }) => (
           <BAIComplexSelect
             label="Storage Host"
             isLabelHidden
             placeholder="Select storage host"
             width={180}
             hasSearch={false}
-            options={[
-              { label: 'local:volume1', value: 'local:volume1' },
-              { label: 'local:volume2', value: 'local:volume2' },
-              { label: 'nfs:data', value: 'nfs:data' },
-            ]}
-            value={null}
+            options={sampleStorageHostOptions}
+            isDisabled={isDisabled}
+            value={toLabeledValue(sampleStorageHostOptions, value)}
             onChange={(next) => {
               const labeled = next as BAILabeledValue | null;
               onAddCondition(labeled?.value);
@@ -969,7 +979,7 @@ export const WithCustomType: Story = {
     docs: {
       description: {
         story:
-          "A property whose input is a controlled antd Select supplied via `renderInput`. Selecting an option calls `onAddCondition(value, label)` — the filter commits the value as a condition serialized per `type: 'uuid'` → `{ owner: { id: { equals: <id> } } }`, while the condition tag shows the label (email) instead of the opaque UUID.",
+          "A property whose input is a controlled `BAIComplexSelect` supplied via `renderInput`. Selecting an option calls `onAddCondition(value, label)`, which stages the value; the edit popover's Apply button commits it, serialized per `type: 'uuid'` → `{ owner: { id: { equals: <id> } } }`, while the token shows the label (email) instead of the opaque UUID. The render prop's `value` is fed back into the select so the staged pick stays visible.",
       },
     },
   },
@@ -980,14 +990,15 @@ export const WithCustomType: Story = {
         propertyLabel: 'Owner',
         type: 'uuid',
         fixedOperator: 'equals',
-        renderInput: ({ onAddCondition }) => (
+        renderInput: ({ onAddCondition, value, isDisabled }) => (
           <BAIComplexSelect
             label="Owner"
             isLabelHidden
             placeholder="Select owner"
             width={220}
             options={sampleOwnerOptions}
-            value={null}
+            isDisabled={isDisabled}
+            value={toLabeledValue(sampleOwnerOptions, value)}
             onChange={(next) => {
               const labeled = next as BAILabeledValue | null;
               onAddCondition(labeled?.value, labeled?.label);

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
@@ -10,12 +10,6 @@ const sampleStorageHostOptions = [
   { label: 'nfs:data', value: 'nfs:data' },
 ];
 
-/** `renderInput`'s staged string -> the labeled object `BAIComplexSelect` takes. */
-const toLabeledValue = <T extends { value: string }>(
-  options: ReadonlyArray<T>,
-  value: string | null,
-): T | null => options.find((option) => option.value === value) ?? null;
-
 const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
   title: 'Filter/BAIGraphQLPropertyFilter',
   component: BAIGraphQLPropertyFilter,
@@ -912,7 +906,11 @@ export const WithRenderInput: Story = {
             hasSearch={false}
             options={sampleStorageHostOptions}
             isDisabled={isDisabled}
-            value={toLabeledValue(sampleStorageHostOptions, value)}
+            value={
+              sampleStorageHostOptions.find(
+                (option) => option.value === value,
+              ) ?? null
+            }
             onChange={(next) => {
               const labeled = next as BAILabeledValue | null;
               onAddCondition(labeled?.value);
@@ -998,7 +996,10 @@ export const WithCustomType: Story = {
             width={220}
             options={sampleOwnerOptions}
             isDisabled={isDisabled}
-            value={toLabeledValue(sampleOwnerOptions, value)}
+            value={
+              sampleOwnerOptions.find((option) => option.value === value) ??
+              null
+            }
             onChange={(next) => {
               const labeled = next as BAILabeledValue | null;
               onAddCondition(labeled?.value, labeled?.label);

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
@@ -902,7 +902,6 @@ export const WithRenderInput: Story = {
             label="Storage Host"
             isLabelHidden
             placeholder="Select storage host"
-            width={180}
             hasSearch={false}
             options={sampleStorageHostOptions}
             isDisabled={isDisabled}
@@ -993,7 +992,6 @@ export const WithCustomType: Story = {
             label="Owner"
             isLabelHidden
             placeholder="Select owner"
-            width={220}
             options={sampleOwnerOptions}
             isDisabled={isDisabled}
             value={

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -190,10 +190,7 @@ type BaseFilterProperty = {
   implicitOperator?: FilterOperator;
   /**
    * Replaces the built-in value editor with a controlled control (e.g.
-   * `BAIUserSelect`). Call `onAddCondition(value, label?)` to stage the value;
-   * the popover's Apply button commits it. Pass the human-readable `label`
-   * when the committed value is opaque (e.g. a UUID) so the token shows the
-   * label while the raw value still serializes into the filter unchanged.
+   * `BAIUserSelect`); see `FilterRenderInput` for the stage/Apply contract.
    */
   renderInput?: FilterRenderInput;
 };

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.test.tsx
@@ -1,0 +1,48 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+*/
+import {
+  useRenderInputEditors,
+  type FilterRenderInput,
+} from './BAIPowerSearchAdapters';
+import { render, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const editorFor = (renderInput: FilterRenderInput) => {
+  const recordLabel = vi.fn();
+  const { result } = renderHook(() =>
+    useRenderInputEditors({
+      recordLabel,
+      resolveLabel: (_property, value) => value,
+    }),
+  );
+  const operatorValue = result.current.operatorValueFor('owner', renderInput);
+  if (!operatorValue) throw new Error('expected a custom operator value');
+  return { Editor: operatorValue.Editor, recordLabel };
+};
+
+describe('useRenderInputEditors', () => {
+  it('passes the staged value and disabled state to renderInput', () => {
+    const renderInput = vi.fn<FilterRenderInput>(() => null);
+    const { Editor } = editorFor(renderInput);
+
+    render(<Editor onChange={vi.fn()} placeholder="" value="u-1" isDisabled />);
+
+    expect(renderInput).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'u-1', isDisabled: true }),
+    );
+  });
+
+  it('records the label and stages the value through onAddCondition', () => {
+    const renderInput = vi.fn<FilterRenderInput>(() => null);
+    const { Editor, recordLabel } = editorFor(renderInput);
+    const onChange = vi.fn();
+
+    render(<Editor onChange={onChange} placeholder="" value={null} />);
+    renderInput.mock.calls[0][0].onAddCondition('u-2', 'bob');
+
+    expect(recordLabel).toHaveBeenCalledWith('owner', 'u-2', 'bob');
+    expect(onChange).toHaveBeenCalledWith('u-2');
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -50,7 +50,12 @@ export type FilterPropertyOption = {
 
 /** The `renderInput` escape hatch shared by both filters (FR-3011 / FR-3258). */
 export type FilterRenderInput = (props: {
+  /** Stages a value; the edit popover's Apply button commits it. */
   onAddCondition: (value: string | undefined, label?: string) => void;
+  /** The staged (or committed) value — feed it back so the pick stays visible. */
+  value: string | null;
+  /** The popover's disabled state. */
+  isDisabled?: boolean;
 }) => ReactNode;
 
 /** Only string-ish labels survive into a token; anything else falls back. */
@@ -123,11 +128,7 @@ type EditorProps = {
 
 /**
  * Builds (and caches) one `custom` operator value per `renderInput` property.
- *
- * PILOT-DECISION: the antd filter committed a condition the instant the
- * control emitted a value. PowerSearch owns the commit (its popover has an
- * Apply button), so the control now stages the value and the user confirms.
- * One extra click; the alternative was reimplementing the popover.
+ * The control stages a value; the popover's Apply button commits it.
  */
 export function useRenderInputEditors({
   recordLabel,
@@ -150,24 +151,29 @@ export function useRenderInputEditors({
     const cached = editorCacheRef.current.get(propertyKey);
     if (cached) return cached;
 
-    const Editor: ComponentType<EditorProps> = ({ onChange }) => {
+    const Editor: ComponentType<EditorProps> = ({
+      onChange,
+      value,
+      isDisabled,
+    }) => {
       const render = latestRenderInputRef.current[propertyKey];
       return (
-        // The consumer's control is very often an antd Select whose dropdown
-        // lives in a body portal. Stop pointer events from bubbling out of the
-        // editor so the popover's dismiss-on-outside-click does not fire while
-        // the user is picking an option.
+        // The consumer's control usually opens its dropdown in a body portal;
+        // stop pointer events here so the popover's dismiss-on-outside-click
+        // does not fire while the user is picking an option.
         <div
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
         >
           {render?.({
-            onAddCondition: (value, label) => {
+            value,
+            isDisabled,
+            onAddCondition: (committed, label) => {
               // Truthy guard: an empty label would blank the token.
-              if (value != null && label) {
-                recordLabel(propertyKey, value, label);
+              if (committed != null && label) {
+                recordLabel(propertyKey, committed, label);
               }
-              onChange(value ?? null);
+              onChange(committed ?? null);
             },
           })}
         </div>

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -164,9 +164,9 @@ export function useRenderInputEditors({
         <div
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
-          // The popover row sizes its value slot from this box's content, so
-          // cap it: a long picked label must not squeeze the field selector.
-          style={{ maxWidth: '8rem' }}
+          // The popover row sizes its value slot from this box's content, so a
+          // long label must not set the slot: claim a fixed share, then fill it.
+          style={{ width: '8rem', minWidth: '100%', maxWidth: '100%' }}
         >
           {render?.({
             value,

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -166,7 +166,7 @@ export function useRenderInputEditors({
           onMouseDown={(event) => event.stopPropagation()}
           // The popover row sizes its value slot from this box's content, so a
           // long label must not set the slot: claim a fixed share, then fill it.
-          style={{ width: '12rem', minWidth: '100%', maxWidth: '100%' }}
+          style={{ width: '8rem', minWidth: '100%', maxWidth: '100%' }}
         >
           {render?.({
             value,

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -164,9 +164,9 @@ export function useRenderInputEditors({
         <div
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
-          // The popover row sizes its value slot from this box's content, so a
-          // long label must not set the slot: claim a fixed share, then fill it.
-          style={{ width: '8rem', minWidth: '100%', maxWidth: '100%' }}
+          // The popover row sizes its value slot from this box's content, so
+          // cap it: a long picked label must not squeeze the field selector.
+          style={{ maxWidth: '8rem' }}
         >
           {render?.({
             value,

--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -164,6 +164,9 @@ export function useRenderInputEditors({
         <div
           onPointerDown={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
+          // The popover row sizes its value slot from this box's content, so a
+          // long label must not set the slot: claim a fixed share, then fill it.
+          style={{ width: '12rem', minWidth: '100%', maxWidth: '100%' }}
         >
           {render?.({
             value,

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -311,7 +311,6 @@ export const WithRenderInput: Story = {
             label="Owner"
             isLabelHidden
             placeholder="Select owner"
-            width={220}
             options={sampleOwnerOptions}
             isDisabled={isDisabled}
             value={

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -283,13 +283,19 @@ const sampleOwnerOptions = [
   { label: 'carol@example.com', value: 'owner-uuid-0003' },
 ];
 
+/** `renderInput`'s staged string -> the labeled object `BAIComplexSelect` takes. */
+const toLabeledValue = <T extends { value: string }>(
+  options: ReadonlyArray<T>,
+  value: string | null,
+): T | null => options.find((option) => option.value === value) ?? null;
+
 export const WithRenderInput: Story = {
   name: 'Custom Input via renderInput',
   parameters: {
     docs: {
       description: {
         story:
-          'When `renderInput` is provided, the default AutoComplete is replaced with a custom control. The control commits a condition via `onAddCondition(value, label?)` as soon as it emits a non-empty value; keep it controlled with `value={null}` so it clears after each commit. Pass the option label as the second argument so the condition tag shows a human-readable label (e.g. an email) instead of the opaque committed value (e.g. a UUID). Same contract as the one `BAIGraphQLPropertyFilter` adopts in FR-3011 (#8082), so controls become interchangeable once both land.',
+          "When `renderInput` is provided, the built-in value editor is replaced with a custom control. The control stages a value via `onAddCondition(value, label?)` and the edit popover's Apply button commits it; feed the render prop's `value` back into the control so the staged pick stays visible (and when an existing token is reopened for editing). Pass the option label as the second argument so the token shows a human-readable label (e.g. an email) instead of the opaque committed value (e.g. a UUID). Same contract as `BAIGraphQLPropertyFilter`, so controls are interchangeable.",
       },
     },
   },
@@ -306,14 +312,15 @@ export const WithRenderInput: Story = {
         propertyLabel: 'Owner',
         type: 'string',
         defaultOperator: '==',
-        renderInput: ({ onAddCondition }) => (
+        renderInput: ({ onAddCondition, value, isDisabled }) => (
           <BAIComplexSelect
             label="Owner"
             isLabelHidden
             placeholder="Select owner"
             width={220}
             options={sampleOwnerOptions}
-            value={null}
+            isDisabled={isDisabled}
+            value={toLabeledValue(sampleOwnerOptions, value)}
             onChange={(next) => {
               const labeled = next as BAILabeledValue | null;
               onAddCondition(labeled?.value, labeled?.label);

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -283,12 +283,6 @@ const sampleOwnerOptions = [
   { label: 'carol@example.com', value: 'owner-uuid-0003' },
 ];
 
-/** `renderInput`'s staged string -> the labeled object `BAIComplexSelect` takes. */
-const toLabeledValue = <T extends { value: string }>(
-  options: ReadonlyArray<T>,
-  value: string | null,
-): T | null => options.find((option) => option.value === value) ?? null;
-
 export const WithRenderInput: Story = {
   name: 'Custom Input via renderInput',
   parameters: {
@@ -320,7 +314,10 @@ export const WithRenderInput: Story = {
             width={220}
             options={sampleOwnerOptions}
             isDisabled={isDisabled}
-            value={toLabeledValue(sampleOwnerOptions, value)}
+            value={
+              sampleOwnerOptions.find((option) => option.value === value) ??
+              null
+            }
             onChange={(next) => {
               const labeled = next as BAILabeledValue | null;
               onAddCondition(labeled?.value, labeled?.label);

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -94,10 +94,7 @@ export type FilterProperty = {
   };
   /**
    * Replaces the built-in value editor with a controlled control (e.g.
-   * `BAIUserSelect`). Call `onAddCondition(value, label?)` to stage the value;
-   * the popover's Apply button commits it. Pass the human-readable `label`
-   * when the committed value is opaque (e.g. a UUID) so the token shows the
-   * label while the raw value still serializes unchanged.
+   * `BAIUserSelect`); see `FilterRenderInput` for the stage/Apply contract.
    */
   renderInput?: FilterRenderInput;
 };

--- a/react/src/components/AdminModelCard.tsx
+++ b/react/src/components/AdminModelCard.tsx
@@ -346,12 +346,13 @@ const AdminModelCard: React.FC<AdminModelCardProps> = ({
                 type: 'string',
                 operators: ['equals', 'notEquals'],
                 defaultOperator: 'equals',
-                renderInput: ({ onAddCondition }) => (
+                renderInput: ({ onAddCondition, value, isDisabled }) => (
                   <BAIStorageHostSelect
                     // The filter row already prints the property label.
                     label={t('import.StorageHost')}
                     isLabelHidden
-                    value={null}
+                    value={value}
+                    isDisabled={isDisabled}
                     onChange={(value) =>
                       // Single-select mode (no `multiple` prop) always emits a
                       // single value.

--- a/react/src/components/UserFolderPermissionPanelV2.tsx
+++ b/react/src/components/UserFolderPermissionPanelV2.tsx
@@ -174,7 +174,6 @@ const UserFolderPermissionPanelV2: React.FC<
                           _.castArray(option ?? [])[0]?.label,
                         )
                       }
-                      width={200}
                     />
                   ),
                 },

--- a/react/src/components/UserFolderPermissionPanelV2.tsx
+++ b/react/src/components/UserFolderPermissionPanelV2.tsx
@@ -155,13 +155,14 @@ const UserFolderPermissionPanelV2: React.FC<
                   propertyLabel: t('storageHost.permission.User'),
                   type: 'uuid',
                   fixedOperator: 'equals',
-                  renderInput: ({ onAddCondition }) => (
+                  renderInput: ({ onAddCondition, value, isDisabled }) => (
                     <BAIUserSelect
                       // The filter row already prints the property label.
                       label={t('storageHost.permission.User')}
                       isLabelHidden
                       valuePropName="id"
-                      value={null}
+                      value={value}
+                      isDisabled={isDisabled}
                       onChange={(value, option) =>
                         // Single-select mode (no `multiple` prop) always emits
                         // a single value, so the P3C-1 `option` argument is the

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -363,12 +363,13 @@ const AdminComputeSessionListPage = () => {
                   propertyLabel: t('data.Project'),
                   type: 'string',
                   defaultOperator: '==',
-                  renderInput: ({ onAddCondition }) => (
+                  renderInput: ({ onAddCondition, value, isDisabled }) => (
                     <BAIAdminProjectSelect
                       // The filter row already prints the property label.
                       label={t('data.Project')}
                       isLabelHidden
-                      value={null}
+                      value={value}
+                      isDisabled={isDisabled}
                       width={200}
                       onChange={(value, option) => {
                         // P3C-1: the second argument survives on this wrapper so

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -370,7 +370,6 @@ const AdminComputeSessionListPage = () => {
                       isLabelHidden
                       value={value}
                       isDisabled={isDisabled}
-                      width={200}
                       onChange={(value, option) => {
                         // P3C-1: the second argument survives on this wrapper so
                         // the condition tag stays human-readable (project name)

--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -409,12 +409,13 @@ const ModelStoreListPageV2: React.FC = () => {
                 type: 'string',
                 operators: ['equals', 'notEquals'],
                 defaultOperator: 'equals',
-                renderInput: ({ onAddCondition }) => (
+                renderInput: ({ onAddCondition, value, isDisabled }) => (
                   <BAIStorageHostSelect
                     // The filter row already prints the property label.
                     label={t('import.StorageHost')}
                     isLabelHidden
-                    value={null}
+                    value={value}
+                    isDisabled={isDisabled}
                     onChange={(value) =>
                       // Single-select mode (no `multiple` prop) always emits a
                       // single value.

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -273,10 +273,11 @@ const RBACManagementPage: React.FC = () => {
                   propertyLabel: t('rbac.AssignedUser'),
                   type: 'uuid',
                   fixedOperator: 'equals',
-                  renderInput: ({ onAddCondition }) => (
+                  renderInput: ({ onAddCondition, value, isDisabled }) => (
                     <BAIUserSelect
                       valuePropName="id"
-                      value={null}
+                      value={value}
+                      isDisabled={isDisabled}
                       label={t('rbac.AssignedUser')}
                       isLabelHidden
                       onChange={(value, option) =>

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -291,7 +291,6 @@ const RBACManagementPage: React.FC = () => {
                             : option?.label,
                         )
                       }
-                      width={200}
                     />
                   ),
                 },


### PR DESCRIPTION
Resolves #9501 (FR-3874)

https://fr-3874-pr9502-feed-staged-value.seungwon.10-82-0-159.sslip.io

## Symptom

A filter property that renders its own picker through `renderInput` (project select on the admin session list, user select on RBAC and the user folder permission panel, storage host select on the model store and the admin model card) loses its selection visually:

- Pick an option in the edit popover: Apply enables, but the select snaps back to its placeholder, so the pick is invisible until Apply.
- Click an existing token to edit it: the select opens empty instead of pre-populated.

## Cause

Since the Astryx `PowerSearch` rebuild the picked value is staged in PowerSearch state and committed by the popover's Apply button. `useRenderInputEditors` (`BAIPowerSearchAdapters.tsx`) receives that staged `value` and `isDisabled` from PowerSearch but forwarded only `onChange`, and every call site pinned `value={null}` — the antd-era convention, where a pick committed immediately and the control had to clear itself.

## Change

- `FilterRenderInput` now receives `value: string | null` and `isDisabled?: boolean`; the cached editor passes them through. Serialization is untouched.
- The five `renderInput` call sites feed `value` / `isDisabled` back into their select.
- The stage/Apply contract prose lives once on `FilterRenderInput`; both filters' `renderInput` docs point at it.
- Stories updated to the current contract (`toLabeledValue` helper maps the staged string to `BAIComplexSelect`'s labeled value).
- New `BAIPowerSearchAdapters.test.tsx` covers the pass-through and the label recording.

This is the `value` forwarding part of FR-3691 (#9089), split out so the visible defect can ship on its own. The `entitySource` redesign in #9089 is on hold (it drops the selects' scroll pagination).

## Verification

```
=== ALL PASS ===   (bash scripts/verify.sh)

 Test Files  3 passed (3)
      Tests  107 passed (107)   (BAIPowerSearchAdapters, BAIPropertyFilter, BAIGraphQLPropertyFilter)
```

Live check against a local webserver (RBAC → 할당된 사용자): the picked email stays in the select with Apply enabled, the token reads the email while the URL carries the UUID, and re-opening the token shows the select pre-populated.
