### PR TITLE
fix(FR-3865): validate the app launcher's allowed client IPs

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -12,6 +12,7 @@ import {
   useSuspendedFilteredAppTemplate,
 } from '../../hooks/useAppTemplate';
 import {
+  findInvalidClientIps,
   TCP_APPS,
   useBackendAIAppLauncher,
 } from '../../hooks/useBackendAIAppLauncher';
@@ -46,7 +47,7 @@ import {
   useErrorMessageResolver,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
@@ -89,6 +90,12 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
   const { message } = App.useApp();
   const { getErrorMessage } = useErrorMessageResolver();
 
+  // The client-IP rule only applies while the field is enabled, so toggling
+  // it must raise or clear the error instead of leaving a stale one behind.
+  useEffect(() => {
+    formRef.current?.validateFields(['clientIps']).catch(() => undefined);
+  }, [openToPublic]);
+
   const session = useFragment(
     graphql`
       fragment AppLauncherModalFragment on ComputeSessionNode {
@@ -123,9 +130,14 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
     if (!app?.name) return;
 
     try {
-      const values = await formRef.current?.validateFields().catch(() => {
+      let values;
+      try {
+        values = await formRef.current?.validateFields();
+      } catch {
+        // Invalid input (e.g. a malformed client IP) must block the launch,
+        // not silently drop the restriction the user asked for.
         return;
-      });
+      }
       const allowedClientIps = openToPublic ? values?.clientIps : undefined;
       const preferredPort = tryPreferredPort
         ? values?.preferredPort
@@ -442,6 +454,23 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                     />
                   </BAIFlex>
                 }
+                rules={[
+                  {
+                    validator: async (_rule, value) => {
+                      // Inert while the field is disabled, so a stale chip
+                      // cannot block a launch that sends no IP restriction.
+                      if (!openToPublic) return;
+                      const invalidIps = findInvalidClientIps(
+                        value as Array<string> | undefined,
+                      );
+                      if (invalidIps.length > 0) {
+                        throw new Error(
+                          `${t('credential.InvalidIP')}: ${invalidIps.join(', ')}`,
+                        );
+                      }
+                    },
+                  },
+                ]}
               >
                 <AstryxFormTagsInput
                   tokenSeparators={[',', ' ']}

--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -5,6 +5,7 @@
 import { AppLauncherModalFragment$key } from '../../__generated__/AppLauncherModalFragment.graphql';
 import { App } from '../../app-shim';
 import { Form, FormInstance } from '../../form-engine';
+import { isValidIPOrCidr } from '../../helper';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import {
   ServicePort,
@@ -12,7 +13,7 @@ import {
   useSuspendedFilteredAppTemplate,
 } from '../../hooks/useAppTemplate';
 import {
-  findInvalidClientIps,
+  normalizeAllowedClientIps,
   TCP_APPS,
   useBackendAIAppLauncher,
 } from '../../hooks/useBackendAIAppLauncher';
@@ -460,8 +461,11 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                       // Inert while the field is disabled, so a stale chip
                       // cannot block a launch that sends no IP restriction.
                       if (!openToPublic) return;
-                      const invalidIps = findInvalidClientIps(
-                        value as Array<string> | undefined,
+                      const invalidIps = _.reject(
+                        normalizeAllowedClientIps(
+                          value as Array<string> | undefined,
+                        ),
+                        isValidIPOrCidr,
                       );
                       if (invalidIps.length > 0) {
                         throw new Error(

--- a/react/src/hooks/useBackendAIAppLauncher.clientIps.test.ts
+++ b/react/src/hooks/useBackendAIAppLauncher.clientIps.test.ts
@@ -2,10 +2,7 @@
  * FR-3865: the app launcher's "Allowed client IPs" field used to accept any
  * string and forward it verbatim as the `allowed_client_ips` proxy parameter.
  */
-import {
-  findInvalidClientIps,
-  normalizeAllowedClientIps,
-} from './useBackendAIAppLauncher';
+import { normalizeAllowedClientIps } from './useBackendAIAppLauncher';
 import { describe, expect, it } from 'vitest';
 
 describe('normalizeAllowedClientIps', () => {
@@ -25,32 +22,5 @@ describe('normalizeAllowedClientIps', () => {
     expect(
       normalizeAllowedClientIps(['10.0.0.1', '', '10.0.0.2']).join(','),
     ).toBe('10.0.0.1,10.0.0.2');
-  });
-});
-
-describe('findInvalidClientIps', () => {
-  it('accepts IPv4, IPv6 and CIDR ranges', () => {
-    expect(
-      findInvalidClientIps([
-        '10.0.0.1',
-        '192.168.0.0/24',
-        '::1',
-        '2001:db8::/32',
-      ]),
-    ).toEqual([]);
-  });
-
-  it('reports entries that are neither an IP nor a CIDR range', () => {
-    expect(
-      findInvalidClientIps(['10.0.0.1', 'not-an-ip', '999.1.1.1']),
-    ).toEqual(['not-an-ip', '999.1.1.1']);
-  });
-
-  it('ignores blank entries, which are dropped before the request', () => {
-    expect(findInvalidClientIps(['', '  ', '10.0.0.1'])).toEqual([]);
-  });
-
-  it('validates trimmed entries', () => {
-    expect(findInvalidClientIps([' 10.0.0.1 '])).toEqual([]);
   });
 });

--- a/react/src/hooks/useBackendAIAppLauncher.clientIps.test.ts
+++ b/react/src/hooks/useBackendAIAppLauncher.clientIps.test.ts
@@ -1,0 +1,56 @@
+/**
+ * FR-3865: the app launcher's "Allowed client IPs" field used to accept any
+ * string and forward it verbatim as the `allowed_client_ips` proxy parameter.
+ */
+import {
+  findInvalidClientIps,
+  normalizeAllowedClientIps,
+} from './useBackendAIAppLauncher';
+import { describe, expect, it } from 'vitest';
+
+describe('normalizeAllowedClientIps', () => {
+  it('returns an empty list for nullish input', () => {
+    expect(normalizeAllowedClientIps(undefined)).toEqual([]);
+    expect(normalizeAllowedClientIps(null)).toEqual([]);
+    expect(normalizeAllowedClientIps([])).toEqual([]);
+  });
+
+  it('trims entries and drops blank ones', () => {
+    expect(
+      normalizeAllowedClientIps([' 10.0.0.1 ', '', '   ', '10.0.0.2']),
+    ).toEqual(['10.0.0.1', '10.0.0.2']);
+  });
+
+  it('never produces consecutive commas when joined', () => {
+    expect(
+      normalizeAllowedClientIps(['10.0.0.1', '', '10.0.0.2']).join(','),
+    ).toBe('10.0.0.1,10.0.0.2');
+  });
+});
+
+describe('findInvalidClientIps', () => {
+  it('accepts IPv4, IPv6 and CIDR ranges', () => {
+    expect(
+      findInvalidClientIps([
+        '10.0.0.1',
+        '192.168.0.0/24',
+        '::1',
+        '2001:db8::/32',
+      ]),
+    ).toEqual([]);
+  });
+
+  it('reports entries that are neither an IP nor a CIDR range', () => {
+    expect(
+      findInvalidClientIps(['10.0.0.1', 'not-an-ip', '999.1.1.1']),
+    ).toEqual(['not-an-ip', '999.1.1.1']);
+  });
+
+  it('ignores blank entries, which are dropped before the request', () => {
+    expect(findInvalidClientIps(['', '  ', '10.0.0.1'])).toEqual([]);
+  });
+
+  it('validates trimmed entries', () => {
+    expect(findInvalidClientIps([' 10.0.0.1 '])).toEqual([]);
+  });
+});

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -4,6 +4,7 @@
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import { useBackendAIAppLauncherFragment$key } from '../__generated__/useBackendAIAppLauncherFragment.graphql';
+import { isValidIPOrCidr } from '../helper';
 import { requestLocalProxyToken } from '../helper/localProxyToken';
 import { useSetBAINotification } from './useBAINotification';
 import { useProjectPath } from './useRouteScope';
@@ -13,6 +14,21 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export const TCP_APPS = ['sshd', 'vscode-desktop', 'xrdp', 'vnc'];
+
+/**
+ * Trims the allowed-client-IP entries and drops blank ones, so a trailing
+ * token separator cannot produce an empty item in `allowed_client_ips`.
+ */
+export const normalizeAllowedClientIps = (
+  allowedClientIps?: Array<string> | null,
+): Array<string> => _.filter(_.map(allowedClientIps ?? [], _.trim), Boolean);
+
+/** Entries that are neither a valid IP address nor a CIDR range. */
+export const findInvalidClientIps = (
+  allowedClientIps?: Array<string> | null,
+): Array<string> =>
+  _.reject(normalizeAllowedClientIps(allowedClientIps), isValidIPOrCidr);
+
 export const useBackendAIAppLauncher = (
   sessionFrgmt?: useBackendAIAppLauncherFragment$key | null,
   debugOptions?: {
@@ -388,11 +404,9 @@ export const useBackendAIAppLauncher = (
     }
     if (openToPublic) {
       searchParams.set('open_to_public', 'true');
-      if (allowedClientIps?.length > 0) {
-        searchParams.set(
-          'allowed_client_ips',
-          _.map(allowedClientIps, _.trim).join(','),
-        );
+      const normalizedClientIps = normalizeAllowedClientIps(allowedClientIps);
+      if (normalizedClientIps.length > 0) {
+        searchParams.set('allowed_client_ips', normalizedClientIps.join(','));
       }
     }
     if (_.keys(envs).length > 0) {

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -4,7 +4,6 @@
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import { useBackendAIAppLauncherFragment$key } from '../__generated__/useBackendAIAppLauncherFragment.graphql';
-import { isValidIPOrCidr } from '../helper';
 import { requestLocalProxyToken } from '../helper/localProxyToken';
 import { useSetBAINotification } from './useBAINotification';
 import { useProjectPath } from './useRouteScope';
@@ -22,12 +21,6 @@ export const TCP_APPS = ['sshd', 'vscode-desktop', 'xrdp', 'vnc'];
 export const normalizeAllowedClientIps = (
   allowedClientIps?: Array<string> | null,
 ): Array<string> => _.filter(_.map(allowedClientIps ?? [], _.trim), Boolean);
-
-/** Entries that are neither a valid IP address nor a CIDR range. */
-export const findInvalidClientIps = (
-  allowedClientIps?: Array<string> | null,
-): Array<string> =>
-  _.reject(normalizeAllowedClientIps(allowedClientIps), isValidIPOrCidr);
 
 export const useBackendAIAppLauncher = (
   sessionFrgmt?: useBackendAIAppLauncherFragment$key | null,


### PR DESCRIPTION
Resolves FR-3865 (no webui GitHub clone; Jira only)

The app launcher's "Allowed client IPs" field carried a tooltip and a label but
no `rules`, so any string the user typed was trimmed and forwarded verbatim as
the `allowed_client_ips` proxy query parameter. A typo produced an access
restriction the user believed was in place but which the proxy could not honour.

### What changed

- **`AppLauncherModal.tsx`** — the `clientIps` `Form.Item` gets a validator built
  on the existing `isValidIPOrCidr()` helper, reusing the `credential.InvalidIP`
  message the user/credential forms already show (no new i18n keys). The rule is
  **inert while "Open to public" is unchecked**, so a stale chip left in the
  disabled field cannot block a launch that sends no restriction at all; a small
  effect revalidates the field when the checkbox toggles so the error appears and
  clears with it.
- **`AppLauncherModal.tsx`** — `handleAppLaunch` no longer swallows the
  `validateFields()` rejection. Previously `.catch(() => { return; })` returned
  from the *catch callback*, leaving `values` `undefined` and letting the launch
  continue with no IP restriction and no preferred port. An invalid entry now
  aborts the launch.
- **`useBackendAIAppLauncher.tsx`** — `normalizeAllowedClientIps` is extracted
  next to the code that builds the proxy query string and shared with the
  modal's validator, so what is validated is what is sent: blank entries (easy
  to produce: `tokenSeparators` is `[',', ' ']`, so a trailing comma makes an
  empty chip) are dropped before the join and cannot yield consecutive commas.

### Design decisions

- Reused `isValidIPOrCidr()` and `credential.InvalidIP` rather than adding a
  launcher-specific validator or message, matching `UserSettingModal.tsx`'s
  `allowed_client_ip` rule.
- Aborting the launch on validation failure is slightly beyond the literal bug —
  today an out-of-range `preferredPort` also degrades silently — but silently
  dropping a restriction the user explicitly asked for is the more dangerous
  behaviour, so the fix covers both.
- **Server-side validation of `allowed_client_ips` is tracked separately as
  BA-7719.** This change does not close the CLI / direct-API path.

## Tests

- New `react/src/hooks/useBackendAIAppLauncher.clientIps.test.ts` (3 cases):
  nullish input, trimming and blank-dropping in `normalizeAllowedClientIps`,
  and the no-consecutive-commas join. IP / CIDR acceptance is `isValidIPOrCidr`'s
  contract, not this PR's.
  `pnpm exec vitest run src/hooks/useBackendAIAppLauncher.clientIps.test.ts` →
  **1 file, 3 tests passed**.

## Verification

`bash scripts/verify.sh` (Relay, Lint, Format, TypeScript, Terminology):

```
=== ALL PASS ===
```

## Review notes

- Open a running session's app launcher with `openPortToPublic` enabled, check
  **Open to public**, type `not-an-ip` and launch: the field shows
  `Invalid IP: not-an-ip` and the launch is blocked. `10.0.0.1`,
  `192.168.0.0/24`, `2001:db8::/32` all pass.
- Leave a bad chip in the field and **uncheck** "Open to public": the error
  clears and the app launches normally (the rule must stay inert when the field
  is disabled — this is the main regression risk).
- Type `10.0.0.1,` (trailing comma) to create a blank chip and launch: the proxy
  URL's `allowed_client_ips` is `10.0.0.1`, not `10.0.0.1,`.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — `config.toml` needs
      `openPortToPublic = true` for the field to render
- [x] Test case(s) to demonstrate the difference of before/after — see
      `useBackendAIAppLauncher.clientIps.test.ts` and the review notes above

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ

