### PR TITLE
fix(FR-3724): show a loading row in the select popup while the list is in flight

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIComplexSelect.popup.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIComplexSelect.popup.test.tsx
@@ -288,3 +288,50 @@ describe('BAIComplexSelect popup — reopen', () => {
     expect(highlightedLabels()).toEqual([]);
   });
 });
+
+describe('BAIComplexSelect popup — empty state', () => {
+  it('says "no results" for an empty list that is not loading', async () => {
+    const user = userEvent.setup();
+    render(<BAIComplexSelect label="Targets" options={[]} />);
+
+    await user.click(trigger());
+    expect(listbox()).toHaveTextContent(/no results/i);
+    expect(listbox()).not.toHaveTextContent(/loading/i);
+  });
+
+  it('says "loading" instead while the list is still in flight (FR-3724)', async () => {
+    const user = userEvent.setup();
+    render(<BAIComplexSelect label="Targets" options={[]} isLoading />);
+
+    // The RBAC scope target select opens before its network-only refetch
+    // lands, and "No results" there reads as "there are none".
+    await user.click(trigger());
+    expect(listbox()).toHaveTextContent('Loading...');
+    expect(listbox()).not.toHaveTextContent(/no results/i);
+  });
+
+  it('leaves a populated list alone while loading — no flicker', async () => {
+    const user = userEvent.setup();
+    render(<BAIComplexSelect label="Targets" options={OPTIONS} isLoading />);
+
+    await user.click(trigger());
+    expect(optionRows()).toHaveLength(3);
+    expect(listbox()).not.toHaveTextContent(/loading/i);
+  });
+
+  it('still lets `emptyContent` win over both', async () => {
+    const user = userEvent.setup();
+    render(
+      <BAIComplexSelect
+        label="Targets"
+        options={[]}
+        isLoading
+        emptyContent={<span>pick a scope first</span>}
+      />,
+    );
+
+    await user.click(trigger());
+    expect(listbox()).toHaveTextContent('pick a scope first');
+    expect(listbox()).not.toHaveTextContent(/loading/i);
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIComplexSelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAIComplexSelect.tsx
@@ -152,7 +152,8 @@ export interface BAIComplexSelectProps {
   /** antd `onSearch` — fires on every keystroke; debounce upstream. */
   onSearch?: (value: string) => void;
   searchPlaceholder?: string;
-  /** antd `loading` — spinner on the trigger. */
+  /** antd `loading` — spinner on the trigger, and a loading row in an
+   * otherwise empty popup instead of "No results". */
   isLoading?: boolean;
   isDisabled?: boolean;
   isRequired?: boolean;
@@ -179,7 +180,7 @@ export interface BAIComplexSelectProps {
   header?: React.ReactNode;
   /** antd `BAISelect.footer` (rendered below the option list). */
   footer?: React.ReactNode;
-  /** antd `notFoundContent`. */
+  /** antd `notFoundContent`. Overrides the loading row too. */
   emptyContent?: React.ReactNode;
   /**
    * Reports popup open/close. `BAIUserSelect` and friends use this to flip
@@ -626,9 +627,19 @@ const BAIComplexSelect: React.FC<BAIComplexSelectProps> = ({
             {options.length === 0
               ? (emptyContent ?? (
                   <div className="bai-complex-select__empty">
-                    <Text color="secondary">
-                      {t('comp:BAIComplexSelect.NoResults')}
-                    </Text>
+                    {isLoading ? (
+                      // An empty list while a fetch is in flight is not "no
+                      // results" — the open-triggered refetch lands here first
+                      // (FR-3724).
+                      <HStack gap={1} vAlign="center" hAlign="center">
+                        <Spinner size="sm" />
+                        <Text color="secondary">{t('general.Loading')}</Text>
+                      </HStack>
+                    ) : (
+                      <Text color="secondary">
+                        {t('comp:BAIComplexSelect.NoResults')}
+                      </Text>
+                    )}
                   </div>
                 ))
               : _.map(options, (option, index) => {
@@ -697,7 +708,9 @@ const BAIComplexSelect: React.FC<BAIComplexSelectProps> = ({
               </HStack>
             ) : null)}
           <VisuallyHidden as="div" aria-live="polite">
-            {t('general.TotalItems', { total: options.length })}
+            {options.length === 0 && isLoading
+              ? t('general.Loading')
+              : t('general.TotalItems', { total: options.length })}
           </VisuallyHidden>
         </div>
       )}

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminContainerRegistrySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminContainerRegistrySelect.tsx
@@ -285,6 +285,10 @@ const BAIAdminContainerRegistrySelect: React.FC<
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminModelServiceSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminModelServiceSelect.tsx
@@ -218,6 +218,10 @@ const BAIAdminModelServiceSelect: React.FC<BAIAdminModelServiceSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminProjectSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminProjectSelect.tsx
@@ -246,6 +246,10 @@ const BAIAdminProjectSelect: React.FC<BAIAdminProjectSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminSessionSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminSessionSelect.tsx
@@ -242,6 +242,10 @@ const BAIAdminSessionSelect: React.FC<BAIAdminSessionSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIKeypairSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIKeypairSelect.tsx
@@ -227,6 +227,10 @@ const BAIKeypairSelect: React.FC<BAIKeypairSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIStorageHostSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIStorageHostSelect.tsx
@@ -236,6 +236,10 @@ const BAIStorageHostSelect: React.FC<BAIStorageHostSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIUserSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIUserSelect.tsx
@@ -26,9 +26,8 @@
     survives — `BAIComplexSelect.onOpenChange` re-exposes the open state that
     `ComplexSelector` otherwise keeps private.
   - P26-7 antd's `notFoundContent={<Skeleton.Input/>}` first-load placeholder
-    is dropped: `emptyContent` takes a ReactNode but a skeleton row inside an
-    Astryx popup adds an antd dependency back into a migrated surface. The
-    empty state is the shared "No results" text (simplicity policy).
+    stays dropped, but the empty popup is no longer unconditionally "No
+    results": `BAIComplexSelect` draws a spinner row while `isLoading` (FR-3724).
 */
 import { BAIUserSelectPaginatedQuery } from '../../__generated__/BAIUserSelectPaginatedQuery.graphql';
 import { BAIUserSelectValueQuery } from '../../__generated__/BAIUserSelectValueQuery.graphql';
@@ -291,6 +290,10 @@ const BAIUserSelect: React.FC<BAIUserSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== debouncedDeferredValue ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -342,6 +342,10 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
       multiple={multiple}
       isLoading={
         isLoading ||
+        // The open-driven `network-only` refetch is a deferred update and
+        // raises no pending flag of its own (FR-3724). Only the opening
+        // half counts; closing would flash the spinner for nothing.
+        (!!controllableOpen && !deferredOpen) ||
         controllableValue !== deferredControllableValue ||
         searchStr !== deferredSearchStr ||
         isPendingRefetch

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Alle abwählen",
     "File": "Datei",
     "Increase": "Erhöhen",
+    "Loading": "Wird geladen...",
     "NSelected": "{{count}} ausgewählt",
     "Optional": "Optional",
     "Project": "Projekt",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Αποεπιλογή όλων",
     "File": "Αρχείο",
     "Increase": "Αύξηση",
+    "Loading": "Φόρτωση...",
     "NSelected": "{{count}} Επιλεγμένη",
     "Optional": "Προαιρετικό",
     "Project": "Έργο",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Deselect all",
     "File": "File",
     "Increase": "Increase",
+    "Loading": "Loading...",
     "NSelected": "{{count}} selected",
     "Optional": "Optional",
     "Project": "Project",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Deseleccionar todo",
     "File": "Archivo",
     "Increase": "Aumentar",
+    "Loading": "Cargando...",
     "NSelected": "{{count}} seleccionado",
     "Optional": "Opcional",
     "Project": "Proyecto",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Poista kaikki valinnat",
     "File": "Tiedosto",
     "Increase": "Lisää",
+    "Loading": "Ladataan...",
     "NSelected": "{{count}} valittu",
     "Optional": "Valinnainen",
     "Project": "Projekti",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Tout désélectionner",
     "File": "Fichier",
     "Increase": "Augmenter",
+    "Loading": "Chargement...",
     "NSelected": "{{count}} sélectionné",
     "Optional": "Facultatif",
     "Project": "Projet",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Batalkan semua pilihan",
     "File": "Berkas",
     "Increase": "Tambah",
+    "Loading": "Memuat...",
     "NSelected": "{{count}} dipilih",
     "Optional": "Opsional",
     "Project": "Proyek",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Deseleziona tutto",
     "File": "File",
     "Increase": "Aumenta",
+    "Loading": "Caricamento...",
     "NSelected": "{{count}} selezionato",
     "Optional": "Opzionale",
     "Project": "Progetto",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -762,6 +762,7 @@
     "DeselectAll": "すべて選択解除",
     "File": "ファイル",
     "Increase": "増やす",
+    "Loading": "読み込み中...",
     "NSelected": "{{count}}選択",
     "Optional": "任意",
     "Project": "プロジェクト",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -762,6 +762,7 @@
     "DeselectAll": "선택 취소",
     "File": "파일",
     "Increase": "증가",
+    "Loading": "로딩 중...",
     "NSelected": "{{count}}개 선택됨",
     "Optional": "선택",
     "Project": "프로젝트",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Бүгдийг сонголтоос хасах",
     "File": "Файл",
     "Increase": "Нэмэх",
+    "Loading": "Ачаалж байна...",
     "NSelected": "{{count}} сонгогдсон",
     "Optional": "Заавал биш",
     "Project": "Төсөл",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Nyahpilih semua",
     "File": "Fail",
     "Increase": "Tambah",
+    "Loading": "Memuatkan...",
     "NSelected": "{{count}} dipilih",
     "Optional": "Pilihan",
     "Project": "Projek",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Odznacz wszystko",
     "File": "Plik",
     "Increase": "Zwiększ",
+    "Loading": "Ładowanie...",
     "NSelected": "{{count}}",
     "Optional": "Opcjonalne",
     "Project": "Projekt",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -768,6 +768,7 @@
     "DeselectAll": "Desmarcar tudo",
     "File": "Arquivo",
     "Increase": "Aumentar",
+    "Loading": "Carregando...",
     "NSelected": "{{count}} selecionado",
     "Optional": "Opcional",
     "Project": "Projeto",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Desmarcar tudo",
     "File": "Arquivo",
     "Increase": "Aumentar",
+    "Loading": "A carregar...",
     "NSelected": "{{count}} selecionado",
     "Optional": "Opcional",
     "Project": "Projeto",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Снять выделение",
     "File": "Файл",
     "Increase": "Увеличить",
+    "Loading": "Загрузка...",
     "NSelected": "{{count}} выбрал",
     "Optional": "Необязательно",
     "Project": "Проект",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -762,6 +762,7 @@
     "DeselectAll": "ยกเลิกการเลือกทั้งหมด",
     "File": "ไฟล์",
     "Increase": "เพิ่ม",
+    "Loading": "กำลังโหลด...",
     "NSelected": "{{count}} เลือก",
     "Optional": "ไม่บังคับ",
     "Project": "โครงการ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Tüm seçimi kaldır",
     "File": "Dosya",
     "Increase": "Artır",
+    "Loading": "Yükleniyor...",
     "NSelected": "{{count}} seçildi",
     "Optional": "İsteğe bağlı",
     "Project": "Proje",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -762,6 +762,7 @@
     "DeselectAll": "Bỏ chọn tất cả",
     "File": "Tệp",
     "Increase": "Tăng",
+    "Loading": "Đang tải...",
     "NSelected": "{{count}} Đã chọn",
     "Optional": "Không bắt buộc",
     "Project": "Dự án",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -762,6 +762,7 @@
     "DeselectAll": "取消全选",
     "File": "文件",
     "Increase": "增加",
+    "Loading": "加载中...",
     "NSelected": "{{count}}选择",
     "Optional": "可选",
     "Project": "项目",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -762,6 +762,7 @@
     "DeselectAll": "取消全選",
     "File": "檔案",
     "Increase": "增加",
+    "Loading": "載入中...",
     "NSelected": "{{count}}選擇",
     "Optional": "選填",
     "Project": "專案",


### PR DESCRIPTION
Resolves #9172 (FR-3724)

In **RBAC management → Create role**, picking a **Scope** makes the adjacent **Target** selector fetch its list. Opening it during that fetch showed only "No results", which reads as "there are none" rather than "not loaded yet".

Two gaps produced that:

- **`BAIComplexSelect` never consulted `isLoading` for its empty state** — it rendered the NoResults text whenever `options.length === 0`. The popup now draws a spinner row with a new `general.Loading` string in that case. A non-empty list is untouched (no flicker on a background refetch), and an explicit `emptyContent` still wins over both.
- **The open-triggered refetch raised no pending flag.** The Relay-backed selects fetch the real list only once opened, under `fetchPolicy: deferredOpen ? 'network-only' : 'store-only'`. `deferredOpen` is a `useDeferredValue`, so the refetch is a deferred update: it suspends without a fallback and nothing — neither the trigger spinner nor the popup — knew a fetch was running. Each of the eight open-driven selects `ScopeIdSelect` can mount now folds the *opening* half of that transition into the `isLoading` expression it already builds.

## Design decisions

- **The issue's open question — disabled vs. openable during loading: openable, with a loading row.** The first mount is already covered: `ScopeIdSelect` wraps every branch in a `Suspense` whose fallback is a disabled, `isLoading` field (`RoleFormModal.tsx`). Making the *reopen* path disabled as well would fight that and take the popup away mid-interaction, so the popup stays open and explains itself instead.
- **Only the opening half of the open transition counts** (`!!controllableOpen && !deferredOpen`). `deferredOpen` lags on close too, and the naive `controllableOpen !== deferredOpen` would flash the trigger spinner on every close for a transition that fetches nothing.
- **Scope of the fragment change.** The `deferredOpen` pattern appears in ~29 files; this PR touches the eight the RBAC scope router can mount (User, Project, VFolder, Session, Model deployment, Container registry, Storage host, Keypair). The Domain and Resource-group branches do not use the pattern — they fetch eagerly and are covered by the Suspense fallback. The same one-line term applies to the rest and can follow.
- **`BAIUserSelect`'s PILOT-DECISION P26-7 is rewritten, not silently contradicted** — antd's `Skeleton.Input` placeholder stays dropped; what changes is that the empty popup is no longer unconditionally "No results".

## Tests

- Four new cases in `packages/backend.ai-ui/src/components/BAIComplexSelect.popup.test.tsx`: empty + not loading says "no results"; empty + loading says "Loading..."; **populated + loading keeps its rows and shows no loading row** (the flicker guard); `emptyContent` overrides both.
- `pnpm --filter backend.ai-ui exec vitest run src/components/BAIComplexSelect src/components/fragments` → `Test Files 3 passed | 1 skipped (4)`, `Tests 32 passed | 1 skipped (33)`.
- No e2e run (needs a live cluster).

## Verification

```
bash scripts/verify.sh
...
=== ALL PASS ===
```

No CSS or design-token changes, so the Astryx token gate is untouched.

## Review notes

- **Reproduce:** RBAC management → Create role → pick Scope = `User` → open **Target** before the list lands. Before: "No results". After: a spinner + "Loading...", replaced by the users once the query resolves. Throttle the network to make the window comfortable.
- **Check the flicker guard:** open and close any `BAI*Select` (e.g. the project selector in the header) repeatedly — the trigger spinner must not blink on close, and a select whose list is already populated must never show the loading row.
- **Blast radius:** `BAIComplexSelect` backs every `BAI*Select` in the app, but the change is confined to the `options.length === 0` branch; every populated popup renders exactly as before.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
