### PR TITLE
feat(FR-3795): run the version-alignment gate in query and explain

### DIFF
--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -421,9 +421,11 @@ verdict is also part of the data, so `--json` carries it.
 
 Each command narrows the comparison to what it touched: `schema show` and
 `explain` to the entry they resolved (plus the enum value an `=VALUE` names),
-`query` to every `Type.field`, `Enum.VALUE` and variable type its document
-selects. `query` runs the gate **before** the request, so `--strict` refuses a
-document the manager cannot answer instead of sending it.
+`query` to every `Type.field`, `Enum.VALUE`, variable type and input-object
+field its document names — including the fields inside a `--var` value, since a
+filter input usually carries no marker of its own while its fields do. `query`
+runs the gate **before** the request, so `--strict` refuses a document the
+manager cannot answer instead of sending it.
 
 The manager version is read from `GET <endpoint>/func/`, which answers
 `{ version, manager }` — the same call the WebUI client makes

--- a/packages/backend.ai-agent-cli/README.md
+++ b/packages/backend.ai-agent-cli/README.md
@@ -406,9 +406,9 @@ exists, and a verdict.
 ### Version alignment
 
 The SDL is a snapshot; the manager you are talking to is not necessarily at the
-same version. `whoami`, `schema show` — and `query` / `explain` once they land —
-compare the manager against the `Added in` / `Deprecated since` markers and warn
-once, on **stderr**:
+same version. `whoami`, `schema show`, `query` and `explain` compare the manager
+against the `Added in` / `Deprecated since` markers and warn once, on
+**stderr**:
 
 ```
 warning: schema is not aligned with manager 26.8.0rc1: 97 not in the manager yet
@@ -418,6 +418,12 @@ warning: schema is not aligned with manager 26.8.0rc1: 97 not in the manager yet
 
 `--strict` refuses instead: exit **1**, code `version_mismatch`, same hint. The
 verdict is also part of the data, so `--json` carries it.
+
+Each command narrows the comparison to what it touched: `schema show` and
+`explain` to the entry they resolved (plus the enum value an `=VALUE` names),
+`query` to every `Type.field`, `Enum.VALUE` and variable type its document
+selects. `query` runs the gate **before** the request, so `--strict` refuses a
+document the manager cannot answer instead of sending it.
 
 The manager version is read from `GET <endpoint>/func/`, which answers
 `{ version, manager }` — the same call the WebUI client makes

--- a/packages/backend.ai-agent-cli/src/commands/explain.ts
+++ b/packages/backend.ai-agent-cli/src/commands/explain.ts
@@ -8,7 +8,19 @@ import type { Block, RenderOptions } from '../output.js';
 import { list, record, renderBlocks, section } from '../output.js';
 import { resolveRepoContext } from '../repo-context.js';
 import { INDEX_LANG } from '../search/docs-corpus.js';
+import { loadSchema } from '../search/schema-sdl.js';
+import type { VersionAlignment } from '../version-align.js';
+import {
+  applyVersionAlignmentGate,
+  renderAlignment,
+  STRICT_FLAG,
+} from '../version-align.js';
 import { parseLang } from './search.js';
+
+export interface ExplainWithAlignment extends ExplainData {
+  /** Present only when a stored session let the manager version be read. */
+  alignment?: VersionAlignment;
+}
 
 export const EXPLAIN_FLAGS: FlagSpec[] = [
   {
@@ -24,6 +36,7 @@ export const EXPLAIN_FLAGS: FlagSpec[] = [
       'Override the docs channel in built URLs (default: derived from the checkout).',
     type: 'string',
   },
+  STRICT_FLAG,
 ];
 
 const flagString = (context: RunContext, name: string): string | undefined => {
@@ -32,7 +45,7 @@ const flagString = (context: RunContext, name: string): string | undefined => {
 };
 
 export function renderExplain(
-  data: ExplainData,
+  data: ExplainWithAlignment,
   { verbosity }: RenderOptions,
 ): string {
   if (verbosity === 'dense') {
@@ -129,17 +142,30 @@ export function renderExplain(
       ]),
     );
   }
+  if (data.alignment) blocks.push(...renderAlignment(data.alignment));
   return renderBlocks(blocks);
 }
 
-export const explainCommand = defineCommand<ExplainData>({
+/**
+ * `Type.field` plus, for a `=VALUE` the enum really declares, `Enum.VALUE` —
+ * the ids the version gate compares against the manager.
+ */
+function alignmentIds(data: ExplainData): string[] {
+  const { enumType, enumValues } = data.schema;
+  const value = data.value?.name;
+  return enumType && value && enumValues?.includes(value)
+    ? [data.schema.id, `${enumType}.${value}`]
+    : [data.schema.id];
+}
+
+export const explainCommand = defineCommand<ExplainWithAlignment>({
   name: 'explain',
   summary:
     'Explain what a schema type, field or value means to a WebUI user, tagged by where each piece came from.',
-  usage: `${CLI_NAME} explain <Type | Type.field | Type.field=VALUE> [--lang <code>] [--json]`,
+  usage: `${CLI_NAME} explain <Type | Type.field | Type.field=VALUE> [--lang <code>] [--strict] [--json]`,
   flags: EXPLAIN_FLAGS,
   maxArgs: 1,
-  run: (context) => {
+  run: async (context) => {
     const target = context.args[0]?.trim();
     if (!target) {
       throw new CliError('usage', 'explain requires a name.', {
@@ -147,11 +173,20 @@ export const explainCommand = defineCommand<ExplainData>({
       });
     }
     const repo = resolveRepoContext(context.cwd);
-    return explain(repo, {
+    const data = explain(repo, {
       target,
       lang: parseLang(repo, flagString(context, 'lang')),
       docsVersion: flagString(context, 'docs-version'),
     });
+    // Without a stored session the gate makes no request: explain stays offline.
+    const { alignment } = await applyVersionAlignmentGate({
+      cwd: context.cwd,
+      schemaCtx: { schema: loadSchema(repo) },
+      selectedFields: alignmentIds(data),
+      strict: context.flags.strict === true,
+      notify: context.notify,
+    });
+    return alignment ? { ...data, alignment } : data;
   },
   render: renderExplain,
 });

--- a/packages/backend.ai-agent-cli/src/commands/query.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.test.ts
@@ -1,6 +1,13 @@
 import { EXIT } from '../errors.js';
+import { clearManagerVersionCache } from '../manager.js';
 import { ALLOWED_MUTATION_NAMES } from '../mutation-allowlist.js';
-import { parseVariables } from '../query/document.js';
+import {
+  executableSchema,
+  parseDocument,
+  parseVariables,
+  selectedSchemaIds,
+} from '../query/document.js';
+import { resolveRepoContext } from '../repo-context.js';
 import { runCli } from '../run.js';
 import { saveSession } from '../session.js';
 import { mkdtempSync } from 'node:fs';
@@ -26,12 +33,36 @@ const io = {
 
 const run = (argv: string[]) => runCli({ argv, cwd, io });
 
+/**
+ * The manager: GraphQL answers `body`, and the version probe the alignment
+ * gate makes 404s, so the gate stays silent unless a test opts into
+ * `stubManager`.
+ */
 const stubFetch = (body: unknown) => {
-  fetchMock = vi.fn(
-    async () => new Response(JSON.stringify(body), { status: 200 }),
+  fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) =>
+    isGql(input)
+      ? new Response(JSON.stringify(body), { status: 200 })
+      : new Response('{}', { status: 404 }),
   );
   vi.stubGlobal('fetch', fetchMock);
 };
+
+/** The same, with a manager version the gate can read. */
+const stubManager = (version: string, body: unknown) => {
+  fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) =>
+    isGql(input)
+      ? new Response(JSON.stringify(body), { status: 200 })
+      : new Response(JSON.stringify({ manager: version }), { status: 200 }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+};
+
+const isGql = (input: Parameters<typeof fetch>[0]) =>
+  String(input).endsWith('/admin/gql');
+
+/** GraphQL calls only; the gate's version probes are not the subject. */
+const gqlCalls = () =>
+  fetchMock.mock.calls.filter(([input]) => isGql(input));
 
 const jsonOut = () => JSON.parse(out.join('')) as { data: Record<string, any> };
 const jsonErr = () =>
@@ -72,10 +103,12 @@ beforeEach(() => {
     savedAt: '2026-08-29T00:00:00.000Z',
   });
   stubFetch({ data: {} });
+  clearManagerVersionCache();
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  clearManagerVersionCache();
 });
 
 describe('SDL pre-validation', () => {
@@ -213,7 +246,7 @@ describe('the mutation allow-list', () => {
     await expect(
       run(['query', CREATE_VFOLDER, '--allow-mutation', '--json']),
     ).resolves.toBe(EXIT.ok);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(gqlCalls()).toHaveLength(1);
     expect(jsonOut().data.result.createVfolderV2.vfolder.id).toBe('vf-9');
   });
 });
@@ -242,9 +275,9 @@ describe('variables', () => {
       ]),
     ).resolves.toBe(EXIT.ok);
 
-    const body = JSON.parse(
-      String(fetchMock.mock.calls[0][1].body),
-    ) as { variables: Record<string, unknown> };
+    const body = JSON.parse(String(gqlCalls()[0][1].body)) as {
+      variables: Record<string, unknown>;
+    };
     expect(body.variables).toEqual({ first: 2 });
     expect(jsonOut().data.variables).toEqual({ first: 2 });
   });
@@ -909,5 +942,100 @@ describe('text output', () => {
     expect(printed).toContain('operation:');
     expect(printed).toContain(`/session?sessionDetail=${rowUuid(0)}`);
     expect(printed).toContain('session-0');
+  });
+});
+
+describe('selectedSchemaIds', () => {
+  const schema = executableSchema(resolveRepoContext(cwd));
+  const ids = (source: string) =>
+    selectedSchemaIds(schema, parseDocument(source).document);
+
+  it('names every selected field by the type that declares it', () => {
+    expect(
+      ids(
+        'query { compute_session_nodes(first: 1) { edges { node { status } } } }',
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        'Query.compute_session_nodes',
+        'ComputeSessionNode.status',
+      ]),
+    );
+  });
+
+  it('names an enum literal by its enum, and a variable by its type', () => {
+    expect(ids('query { images(filter_by_statuses: [ALIVE]) { name } }')).toContain(
+      'ImageStatus.ALIVE',
+    );
+    expect(
+      ids(
+        'query Images($f: [ImageStatus]) { images(filter_by_statuses: $f) { name } }',
+      ),
+    ).toContain('ImageStatus');
+  });
+
+  it('falls back to the parent type for a meta field, and repeats no id', () => {
+    const found = ids(
+      'query { compute_session_nodes(first: 1) { edges { node { __typename status } } } }',
+    );
+    expect(found).toContain('ComputeSessionNode');
+    expect(found).toHaveLength(new Set(found).size);
+  });
+
+  it('leaves a built-in scalar variable out', () => {
+    expect(
+      ids('query Sessions($first: Int) { compute_session_nodes(first: $first) { count } }'),
+    ).not.toContain('Int');
+  });
+});
+
+describe('version alignment', () => {
+  // Older than every `Added in` marker in the committed SDL.
+  const OLD = '20.03.0';
+  const DOC =
+    'query { compute_session_nodes(first: 1) { edges { node { status } } } }';
+
+  /** Every document the run actually sent to the manager. */
+  const sentDocuments = () =>
+    gqlCalls().map(([, init]) => String(init?.body ?? ''));
+
+  it('warns on stderr and carries the verdict in --json', async () => {
+    stubManager(OLD, { data: { compute_session_nodes: { edges: [] } } });
+
+    await expect(run(['query', DOC, '--json'])).resolves.toBe(EXIT.ok);
+
+    expect(err.join('')).toContain(
+      `warning: schema is not aligned with manager ${OLD}`,
+    );
+    const { alignment } = jsonOut().data;
+    expect(alignment.aligned).toBe(false);
+    expect(alignment.newer.map((finding: { id: string }) => finding.id)).toContain(
+      'ComputeSessionNode.status',
+    );
+  });
+
+  it('refuses under --strict without sending the document', async () => {
+    stubManager(OLD, { data: { compute_session_nodes: { edges: [] } } });
+
+    await expect(run(['query', DOC, '--strict', '--json'])).resolves.toBe(
+      EXIT.error,
+    );
+
+    expect(
+      sentDocuments().some((body) => body.includes('compute_session_nodes')),
+    ).toBe(false);
+    const envelope = jsonErr();
+    expect(envelope.code).toBe('version_mismatch');
+    expect(envelope.hint).toBe(`bai-agent schema sync --tag ${OLD}`);
+  });
+
+  it('says nothing when the manager version cannot be read', async () => {
+    stubFetch({ data: { compute_session_nodes: { edges: [] } } });
+
+    await expect(run(['query', DOC, '--strict', '--json'])).resolves.toBe(
+      EXIT.ok,
+    );
+    expect(err.join('')).not.toContain('warning:');
+    expect(jsonOut().data.alignment).toBeUndefined();
   });
 });

--- a/packages/backend.ai-agent-cli/src/commands/query.test.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.test.ts
@@ -947,8 +947,8 @@ describe('text output', () => {
 
 describe('selectedSchemaIds', () => {
   const schema = executableSchema(resolveRepoContext(cwd));
-  const ids = (source: string) =>
-    selectedSchemaIds(schema, parseDocument(source).document);
+  const ids = (source: string, variables?: Record<string, unknown>) =>
+    selectedSchemaIds(schema, parseDocument(source).document, variables);
 
   it('names every selected field by the type that declares it', () => {
     expect(
@@ -986,6 +986,56 @@ describe('selectedSchemaIds', () => {
     expect(
       ids('query Sessions($first: Int) { compute_session_nodes(first: $first) { count } }'),
     ).not.toContain('Int');
+  });
+
+  // `RuntimeVariantFilter` dates from 26.4.2 and carries no marker of its own,
+  // but its `AND` field is `Added in 26.7.0`: naming only the type would let a
+  // 26.4.x manager look aligned.
+  it('names an input-object field written inline in an argument', () => {
+    expect(
+      ids(
+        'query { runtimeVariants(filter: { AND: [{ name: { equals: "vllm" } }] }) { count } }',
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        'RuntimeVariantFilter.AND',
+        'RuntimeVariantFilter.name',
+        'StringFilter.equals',
+      ]),
+    );
+  });
+
+  it('names an input-object field supplied through a variable value', () => {
+    const found = ids(
+      'query Variants($filter: RuntimeVariantFilter) { runtimeVariants(filter: $filter) { count } }',
+      { filter: { AND: [{ name: { equals: 'vllm' } }] } },
+    );
+    expect(found).toEqual(
+      expect.arrayContaining([
+        'RuntimeVariantFilter',
+        'RuntimeVariantFilter.AND',
+        'RuntimeVariantFilter.name',
+        'StringFilter.equals',
+      ]),
+    );
+    expect(found).toHaveLength(new Set(found).size);
+  });
+
+  it('skips a variable key the input type does not declare', () => {
+    expect(
+      ids(
+        'query Variants($filter: RuntimeVariantFilter) { runtimeVariants(filter: $filter) { count } }',
+        { filter: { nope: 1 } },
+      ),
+    ).not.toContain('RuntimeVariantFilter.nope');
+  });
+
+  it('reads no variable value when none was supplied', () => {
+    expect(
+      ids(
+        'query Variants($filter: RuntimeVariantFilter) { runtimeVariants(filter: $filter) { count } }',
+      ),
+    ).toEqual(expect.arrayContaining(['RuntimeVariantFilter']));
   });
 });
 
@@ -1027,6 +1077,29 @@ describe('version alignment', () => {
     const envelope = jsonErr();
     expect(envelope.code).toBe('version_mismatch');
     expect(envelope.hint).toBe(`bai-agent schema sync --tag ${OLD}`);
+  });
+
+  // A 26.4.2 manager has `Query.runtimeVariants` and `RuntimeVariantFilter`,
+  // but not the filter's `AND` (26.7.0). The mismatch only exists inside the
+  // variable's value.
+  it('refuses a variable value carrying a field the manager lacks', async () => {
+    stubManager('26.4.2', { data: { runtimeVariants: { count: 0 } } });
+
+    await expect(
+      run([
+        'query',
+        'query Variants($filter: RuntimeVariantFilter) { runtimeVariants(filter: $filter) { count } }',
+        '--var',
+        'filter={"AND":[{"name":{"equals":"vllm"}}]}',
+        '--strict',
+        '--json',
+      ]),
+    ).resolves.toBe(EXIT.error);
+
+    expect(sentDocuments().some((body) => body.includes('runtimeVariants'))).toBe(
+      false,
+    );
+    expect(jsonErr().code).toBe('version_mismatch');
   });
 
   it('says nothing when the manager version cannot be read', async () => {

--- a/packages/backend.ai-agent-cli/src/commands/query.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.ts
@@ -11,6 +11,12 @@ import { list, record, renderBlocks, section, text } from '../output.js';
 import { resolveRepoContext } from '../repo-context.js';
 import { loadSchema } from '../search/schema-sdl.js';
 import { loadSession, resolveEndpoint } from '../session.js';
+import type { VersionAlignment } from '../version-align.js';
+import {
+  applyVersionAlignmentGate,
+  renderAlignment,
+  STRICT_FLAG,
+} from '../version-align.js';
 import { listPath } from '../webui-path.js';
 import type { QueryLink } from '../query/links.js';
 import { annotateResult, survivingLinks } from '../query/links.js';
@@ -18,6 +24,7 @@ import {
   executableSchema,
   parseDocument,
   parseVariables,
+  selectedSchemaIds,
   validateAgainstSchema,
 } from '../query/document.js';
 import { DEFAULT_MAX_BYTES, jsonBytes, truncateToBudget } from '../query/truncate.js';
@@ -37,6 +44,8 @@ export interface QueryData {
   truncated: string[];
   links: QueryLink[];
   result: unknown;
+  /** Present only when a stored session let the manager version be read. */
+  alignment?: VersionAlignment;
 }
 
 const flagString = (
@@ -164,7 +173,7 @@ export const queryCommand = defineCommand<QueryData>({
   name: 'query',
   summary:
     'Run a raw GraphQL document against the manager, pre-validated against the checkout SDL.',
-  usage: `${CLI_NAME} query '<document>' | --file <path> | (stdin) [--var k=v]... [--allow-mutation] [--max-bytes <n>] [--endpoint <url>] [--webui <origin>] [--json]`,
+  usage: `${CLI_NAME} query '<document>' | --file <path> | (stdin) [--var k=v]... [--allow-mutation] [--max-bytes <n>] [--endpoint <url>] [--webui <origin>] [--strict] [--json]`,
   flags: [
     {
       flag: '--file <path>',
@@ -197,6 +206,7 @@ export const queryCommand = defineCommand<QueryData>({
       type: 'string',
     },
     ENDPOINT_FLAG,
+    STRICT_FLAG,
   ],
   maxArgs: 1,
   run: async (context) => {
@@ -241,6 +251,17 @@ export const queryCommand = defineCommand<QueryData>({
         hint: `${CLI_NAME} login --endpoint ${endpoint}`,
       });
     }
+
+    // Before the manager runs anything: under `--strict` a document that
+    // names fields this manager does not have is refused, not executed.
+    const { alignment } = await applyVersionAlignmentGate({
+      cwd: context.cwd,
+      schemaCtx: { schema: loadSchema(repo) },
+      selectedFields: selectedSchemaIds(executableSchema(repo), document),
+      strict: context.flags.strict === true,
+      notify: context.notify,
+      endpointFlag: endpoint,
+    });
 
     const primary = operations[0];
     if (mutations.length > 0) {
@@ -288,6 +309,7 @@ export const queryCommand = defineCommand<QueryData>({
       truncated: cut.truncated,
       links,
       result: cut.value,
+      ...(alignment ? { alignment } : {}),
     };
   },
   render: (data, { verbosity }) => {
@@ -327,6 +349,9 @@ export const queryCommand = defineCommand<QueryData>({
           ),
         ),
       );
+    }
+    if (data.alignment && verbosity !== 'dense') {
+      blocks.push(...renderAlignment(data.alignment));
     }
     blocks.push(section('Result'), text(JSON.stringify(data.result, null, 2)));
     return renderBlocks(blocks);

--- a/packages/backend.ai-agent-cli/src/commands/query.ts
+++ b/packages/backend.ai-agent-cli/src/commands/query.ts
@@ -257,7 +257,11 @@ export const queryCommand = defineCommand<QueryData>({
     const { alignment } = await applyVersionAlignmentGate({
       cwd: context.cwd,
       schemaCtx: { schema: loadSchema(repo) },
-      selectedFields: selectedSchemaIds(executableSchema(repo), document),
+      selectedFields: selectedSchemaIds(
+        executableSchema(repo),
+        document,
+        variables,
+      ),
       strict: context.flags.strict === true,
       notify: context.notify,
       endpointFlag: endpoint,

--- a/packages/backend.ai-agent-cli/src/query/document.ts
+++ b/packages/backend.ai-agent-cli/src/query/document.ts
@@ -6,8 +6,17 @@ import type {
   GraphQLSchema,
   OperationTypeNode,
   SelectionNode,
+  TypeNode,
 } from 'graphql';
-import { buildASTSchema, parse, validate } from 'graphql';
+import {
+  buildASTSchema,
+  getNamedType,
+  parse,
+  TypeInfo,
+  validate,
+  visit,
+  visitWithTypeInfo,
+} from 'graphql';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -273,6 +282,52 @@ export function validateAgainstSchema(
         : `${CLI_NAME} schema sync`,
     },
   );
+}
+
+/** `[Foo!]!` -> `Foo`, on the AST rather than a built type. */
+function namedTypeIn(node: TypeNode): string {
+  return node.kind === 'NamedType' ? node.name.value : namedTypeIn(node.type);
+}
+
+/**
+ * The schema ids a document touches, in `checkVersionAlignment`'s vocabulary:
+ * `Type.field` per selection, `Enum.VALUE` per enum literal, and `Type` for a
+ * variable's named type. Deduplicated, in document order.
+ *
+ * A field id carries its type's marker when it has none of its own, so the
+ * parent type is not emitted alongside — except for a meta field (`__typename`),
+ * which the schema does not declare and whose parent type is the only thing the
+ * selection actually names.
+ */
+export function selectedSchemaIds(
+  schema: GraphQLSchema,
+  document: DocumentNode,
+): string[] {
+  const ids = new Set<string>();
+  const typeInfo = new TypeInfo(schema);
+  visit(
+    document,
+    visitWithTypeInfo(typeInfo, {
+      Field(node) {
+        const parent = typeInfo.getParentType();
+        if (!parent) return;
+        ids.add(
+          node.name.value.startsWith('__')
+            ? parent.name
+            : `${parent.name}.${node.name.value}`,
+        );
+      },
+      EnumValue(node) {
+        const input = typeInfo.getInputType();
+        if (input) ids.add(`${getNamedType(input).name}.${node.value}`);
+      },
+      VariableDefinition(node) {
+        const name = namedTypeIn(node.type);
+        if (!BUILT_IN_SCALARS.has(name)) ids.add(name);
+      },
+    }),
+  );
+  return [...ids];
 }
 
 /** `--var k=v`, JSON-decoded when the value parses, otherwise the raw string. */

--- a/packages/backend.ai-agent-cli/src/query/document.ts
+++ b/packages/backend.ai-agent-cli/src/query/document.ts
@@ -3,6 +3,7 @@ import { CLI_NAME } from '../meta.js';
 import type { RepoContext } from '../repo-context.js';
 import type {
   DocumentNode,
+  GraphQLInputType,
   GraphQLSchema,
   OperationTypeNode,
   SelectionNode,
@@ -11,6 +12,7 @@ import type {
 import {
   buildASTSchema,
   getNamedType,
+  isInputObjectType,
   parse,
   TypeInfo,
   validate,
@@ -290,9 +292,39 @@ function namedTypeIn(node: TypeNode): string {
 }
 
 /**
+ * `InputType.field` for every key a `--var` value actually sets, walked
+ * against the variable's declared type. An input-object field carries its own
+ * `Added in` marker while its type usually does not, so a variable is only as
+ * checkable as the keys inside it. Keys the type does not declare are skipped —
+ * SDL validation owns that error, not the gate.
+ */
+function addInputValueIds(
+  type: GraphQLInputType | undefined,
+  value: unknown,
+  ids: Set<string>,
+): void {
+  if (!type || value === null || value === undefined) return;
+  const named = getNamedType(type);
+  if (Array.isArray(value)) {
+    for (const item of value) addInputValueIds(named, item, ids);
+    return;
+  }
+  if (!isInputObjectType(named) || typeof value !== 'object') return;
+  const fields = named.getFields();
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const field = fields[key];
+    if (!field) continue;
+    ids.add(`${named.name}.${key}`);
+    addInputValueIds(field.type, nested, ids);
+  }
+}
+
+/**
  * The schema ids a document touches, in `checkVersionAlignment`'s vocabulary:
- * `Type.field` per selection, `Enum.VALUE` per enum literal, and `Type` for a
- * variable's named type. Deduplicated, in document order.
+ * `Type.field` per selection, `Enum.VALUE` per enum literal, `Type` for a
+ * variable's named type, and `InputType.field` for every input-object field —
+ * written inline in an argument, or supplied through `variables`.
+ * Deduplicated, in document order.
  *
  * A field id carries its type's marker when it has none of its own, so the
  * parent type is not emitted alongside — except for a meta field (`__typename`),
@@ -302,6 +334,7 @@ function namedTypeIn(node: TypeNode): string {
 export function selectedSchemaIds(
   schema: GraphQLSchema,
   document: DocumentNode,
+  variables: Record<string, unknown> = {},
 ): string[] {
   const ids = new Set<string>();
   const typeInfo = new TypeInfo(schema);
@@ -317,13 +350,26 @@ export function selectedSchemaIds(
             : `${parent.name}.${node.name.value}`,
         );
       },
+      ObjectField(node) {
+        const parent = typeInfo.getParentInputType();
+        if (parent) ids.add(`${getNamedType(parent).name}.${node.name.value}`);
+      },
       EnumValue(node) {
         const input = typeInfo.getInputType();
         if (input) ids.add(`${getNamedType(input).name}.${node.value}`);
       },
       VariableDefinition(node) {
         const name = namedTypeIn(node.type);
-        if (!BUILT_IN_SCALARS.has(name)) ids.add(name);
+        if (BUILT_IN_SCALARS.has(name)) return;
+        ids.add(name);
+        const declared = schema.getType(name);
+        if (declared) {
+          addInputValueIds(
+            declared as GraphQLInputType,
+            variables[node.variable.name.value],
+            ids,
+          );
+        }
       },
     }),
   );

--- a/packages/backend.ai-agent-cli/src/version-align.test.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.test.ts
@@ -562,6 +562,75 @@ describe('schema show against a mocked manager', () => {
   });
 });
 
+describe('explain against a mocked manager', () => {
+  beforeEach(() => {
+    clearManagerVersionCache();
+    process.env.BAI_AGENT_CONFIG_DIR = mkdtempSync(
+      join(tmpdir(), 'bai-agent-explain-'),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearManagerVersionCache();
+  });
+
+  const loggedIn = () =>
+    saveSession({
+      endpoint: ENDPOINT,
+      webui: '',
+      sessionId: SESSION_ID,
+      savedAt: new Date().toISOString(),
+    });
+
+  it('checks the field and the enum value the target resolved to', async () => {
+    loggedIn();
+    // Older than every `Added in` marker in the committed SDL.
+    vi.stubGlobal('fetch', fakeManager('20.03.0').impl);
+
+    const { exitCode, stdout, stderr } = await invoke([
+      'explain',
+      'Role.status=ACTIVE',
+      '--json',
+    ]);
+    expect(exitCode).toBe(EXIT.ok);
+    expect(stderr).toContain('warning:');
+    const { data } = JSON.parse(stdout);
+    expect(data.alignment.aligned).toBe(false);
+    expect(
+      data.alignment.newer.map((finding: { id: string }) => finding.id),
+    ).toEqual(['Role.status', 'RoleStatus.ACTIVE']);
+  });
+
+  it('exits 1 with version_mismatch under --strict', async () => {
+    loggedIn();
+    vi.stubGlobal('fetch', fakeManager('20.03.0').impl);
+
+    const { exitCode, stderr } = await invoke([
+      'explain',
+      'ComputeSessionNode.status',
+      '--strict',
+      '--json',
+    ]);
+    expect(exitCode).toBe(EXIT.error);
+    const envelope = JSON.parse(stderr);
+    expect(envelope.code).toBe('version_mismatch');
+    expect(envelope.hint).toBe('bai-agent schema sync --tag 20.03.0');
+  });
+
+  it('stays offline when no session is stored', async () => {
+    const spy = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', spy);
+
+    const { exitCode } = await invoke([
+      'explain',
+      'ComputeSessionNode.status',
+      '--json',
+    ]);
+    expect(exitCode).toBe(EXIT.ok);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
 describe('doctor schema alignment', () => {
   beforeEach(() => {
     clearManagerVersionCache();

--- a/packages/backend.ai-agent-cli/src/version-align.ts
+++ b/packages/backend.ai-agent-cli/src/version-align.ts
@@ -355,7 +355,7 @@ function syncedSchemaTag(options: AlignmentGateOptions): string | undefined {
 }
 
 /**
- * The gate `whoami`, `schema show` — and later `query` / `explain` — run.
+ * The gate `whoami`, `schema show`, `query` and `explain` run.
  *
  * Without a stored session it does nothing and touches the network zero times.
  * With one it reads the manager version, warns once on stderr by default, and


### PR DESCRIPTION
Resolves #9287 (FR-3795)

FR-3770 (#9252) landed the version-alignment gate — `checkVersionAlignment` /
`applyVersionAlignmentGate` / `STRICT_FLAG` — and wired it into `whoami`,
`doctor` and `schema show`. `query` and `explain`, the two commands most likely
to trip over a schema the manager does not have, were left outside it. This PR
finishes the job: both take `--strict`, both warn once on stderr by default, and
both carry the verdict in their envelope (`data.alignment`) and text output.

### `query`

The gate needs the ids a command touched. `selectedSchemaIds` (new, in
`query/document.ts`) walks the parsed document with graphql-js `TypeInfo` and
emits the gate's own vocabulary:

- `Type.field` for every selection, named by the type that *declares* the field
- `Enum.VALUE` for every enum literal in an argument
- `Type` for a variable's named type (built-in scalars left out)
- the parent type alone for a meta field (`__typename`) — the schema does not
  declare it, so the parent type is the only thing the selection names

The gate runs **after** SDL validation and the mutation allow-list check but
**before** `gqlRequest`, so `--strict` refuses a document the manager cannot
answer rather than sending it. The already-resolved endpoint is handed to the
gate so the session is looked up once.

### `explain`

Checks the entry the target resolved to, plus `Enum.VALUE` when the target named
a value the enum actually declares (`explain Role.status=ACTIVE` → `Role.status`
and `RoleStatus.ACTIVE`). `run` became `async`; nothing else changed for callers.

### Design decisions

- **`explain` stays offline without a session.** It was an offline-only command.
  `applyVersionAlignmentGate` already no-ops when no session is stored and
  swallows an unreachable manager, so that contract is preserved — a test asserts
  `fetch` is never called in that case.
- **Unknown ids are skipped silently** by `selectedEntries`, so a wrong id shape
  would produce *zero* findings rather than an error. The tests therefore assert
  a **positive** finding (`ComputeSessionNode.status` in `newer`), not just
  "no crash".
- **No `CLAUDE.md` change.** The generated `BAI-AGENT` block lists command
  summaries, not flags; regenerating it produces a byte-identical block
  (verified — `src/init/block.test.ts` passes).

## Tests

- `pnpm --filter backend.ai-agent-cli exec vitest run src/commands/query.test.ts src/version-align.test.ts src/explain` → **3 files, 102 tests passed**
- New coverage:
  - `selectedSchemaIds` — field ids named by the declaring type, enum literal by
    its enum, variable by its type, meta-field fallback + dedup, built-in scalar
    excluded.
  - `query` — warns on stderr and carries the verdict in `--json`; under
    `--strict` exits 1 with `version_mismatch` **and does not send the document**;
    stays silent when the manager version cannot be read.
  - `explain` — checks field + enum value, exits 1 under `--strict`, makes zero
    requests with no stored session.
- Full package suite: 561/563 pass. The 2 failures are **pre-existing and
  environmental**, reproduced on a clean tree at this same base commit:
  `init/block.test.ts` symlink test (macOS `/var` vs `/private/var` realpath) and
  `search.regression.test.ts` "mirrors the JSON envelope of schema show"
  (30s timeout — a real stored session makes `schema show` probe an unreachable
  manager). Neither touches this diff.

## Verification

`bash scripts/verify.sh`:

```
=== ALL PASS ===
```

No CSS/token changes, so the Astryx token gate does not apply.

## Review notes

- The only genuinely new logic is `selectedSchemaIds` in
  `packages/backend.ai-agent-cli/src/query/document.ts` — check the emitted id
  shapes against `selectedEntries` in `version-align.ts` (`Type`, `Type.field`,
  `Enum.VALUE`); a mismatch fails open (no findings), which is why the tests
  assert a positive finding.
- Confirm the gate's placement in `commands/query.ts` is before `gqlRequest`:
  under `--strict` the document must never reach the manager.
- Try it live against a manager older than the committed SDL:
  `bai-agent query '{ compute_session_nodes(first:1){ edges{ node{ status } } } }' --strict`
  should exit 1 with `version_mismatch`, and the same without `--strict` should
  warn on stderr and still return rows.

**Checklist:** (if applicable)

- [x] Documentation — `packages/backend.ai-agent-cli/README.md` "Version alignment" updated
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
