### PR TITLE
fix(FR-3715): paint the primary tag sites in the menu group's accent

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAccentBadge.css
+++ b/packages/backend.ai-ui/src/components/BAIAccentBadge.css
@@ -1,0 +1,15 @@
+/*
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ `.bai-accent-badge` — a badge painted in the ACTIVE MENU GROUP's primary
+ (FR-3715), the same mechanism `BAITabCountBadge.css` documents: no
+ `Badge.variant` follows the ambient accent (this theme pins `info` to a fixed
+ blue), while `--color-accent` is already resolved per scope by
+ `AutoAdminPrimaryColorProvider`. UNLAYERED on purpose — an unlayered rule
+ beats Astryx's `@layer astryx-base` specificity boost without `!important`.
+*/
+.bai-accent-badge {
+  background-color: var(--color-accent);
+  color: var(--color-on-accent);
+}

--- a/packages/backend.ai-ui/src/components/BAIAccentBadge.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIAccentBadge.doc.ts
@@ -1,0 +1,59 @@
+import type { ComponentDoc } from '@astryxdesign/cli/authoring';
+
+export const docs = {
+  type: 'component',
+  name: 'BAIAccentBadge',
+  displayName: 'BAI Accent Badge',
+  category: 'Feedback & Status',
+  keywords: ['accent badge', 'brand badge', 'primary tag', 'admin tag', 'pill'],
+  usage: {
+    description:
+      'A read-only badge painted in the ACTIVE MENU GROUP\'s primary through `--color-accent`, which `AutoAdminPrimaryColorProvider` already resolves per scope — so the same badge is orange under the user menu and blue under admin. Astryx `Badge.variant` has no ambient-accent member (this theme pins `info` to a fixed blue), which is why the colour comes from an unlayered class in BAIAccentBadge.css rather than a variant. Use it where a badge must read as "the brand one" — the `admin` permission tag and the main-access-key tag — and plain `Badge` with a hue variant everywhere else. Every Badge prop passes through except `variant`, which this component owns.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Reserve it for the one badge in a group that carries brand emphasis, so it stays distinguishable from the neutral/hued badges beside it.',
+      },
+      {
+        guidance: false,
+        description:
+          'Expect the same colour on every page — it resolves from the surrounding menu scope, so user and admin pages differ on purpose.',
+      },
+      {
+        guidance: false,
+        description:
+          'Reach for `variant` to recolour it; the prop is omitted because the accent is owned here.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'label',
+      type: 'ReactNode',
+      description: 'Badge text content, same as Astryx Badge.',
+    },
+    {
+      name: 'icon',
+      type: 'ReactNode',
+      description: 'Optional leading icon, same as Astryx Badge.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description:
+        "Extra class on the badge, appended to the component's own bai-accent-badge class rather than replacing it.",
+    },
+  ],
+  examples: [
+    {
+      label: 'Admin permission tag',
+      code: `<HStack gap={1}>
+  <BAIAccentBadge label="admin" />
+  <Badge variant="green" label="user" />
+</HStack>`,
+    },
+  ],
+} satisfies ComponentDoc;
+
+export default docs;

--- a/packages/backend.ai-ui/src/components/BAIAccentBadge.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAccentBadge.test.tsx
@@ -1,0 +1,38 @@
+/*
+ FR-3715: the `admin` / main-access-key badges used to be a fixed green
+ (`PRIMARY_TAG_VARIANT`), which both missed the brand accent and made the
+ `admin` badge indistinguishable from the green `user` badge next to it.
+ jsdom resolves no custom properties, so the colour itself is measured on the
+ running app; what is assertable is that the accent routes through the CLASS
+ and no coloured Badge variant is pinned.
+*/
+import BAIAccentBadge from './BAIAccentBadge';
+import { render } from '@testing-library/react';
+
+const badgeOf = (container: HTMLElement) =>
+  container.querySelector('.astryx-badge');
+
+describe('BAIAccentBadge', () => {
+  it('should render its label', () => {
+    const { container } = render(<BAIAccentBadge label="admin" />);
+    expect(badgeOf(container)).toHaveTextContent('admin');
+  });
+
+  it('should carry the accent class', () => {
+    const { container } = render(<BAIAccentBadge label="admin" />);
+    expect(badgeOf(container)).toHaveClass('bai-accent-badge');
+  });
+
+  it('should keep a caller className alongside its own', () => {
+    const { container } = render(
+      <BAIAccentBadge label="admin" className="custom" />,
+    );
+    expect(badgeOf(container)).toHaveClass('bai-accent-badge');
+    expect(badgeOf(container)).toHaveClass('custom');
+  });
+
+  it('should not pin a coloured Badge variant', () => {
+    const { container } = render(<BAIAccentBadge label="admin" />);
+    expect(badgeOf(container)).toHaveAttribute('data-variant', 'neutral');
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIAccentBadge.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAccentBadge.tsx
@@ -1,0 +1,34 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ A read-only badge painted in the active menu group's primary (`--color-accent`)
+ instead of a fixed hue — the replacement for the old `PRIMARY_TAG_VARIANT`
+ (FR-3715). See `BAIAccentBadge.css` for why this cannot be a `Badge.variant`.
+*/
+import './BAIAccentBadge.css';
+import { Badge } from '@astryxdesign/core/Badge';
+import type { BadgeProps } from '@astryxdesign/core/Badge';
+import React from 'react';
+
+export interface BAIAccentBadgeProps extends Omit<BadgeProps, 'variant'> {}
+
+const BAIAccentBadge: React.FC<BAIAccentBadgeProps> = ({
+  className,
+  ...badgeProps
+}) => {
+  'use memo';
+
+  return (
+    <Badge
+      className={['bai-accent-badge', className ?? '']
+        .filter(Boolean)
+        .join(' ')}
+      {...badgeProps}
+    />
+  );
+};
+
+BAIAccentBadge.displayName = 'BAIAccentBadge';
+
+export default BAIAccentBadge;

--- a/packages/backend.ai-ui/src/components/BAIAccentBadge.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAccentBadge.tsx
@@ -14,6 +14,8 @@ import React from 'react';
 export interface BAIAccentBadgeProps extends Omit<BadgeProps, 'variant'> {}
 
 const BAIAccentBadge: React.FC<BAIAccentBadgeProps> = ({
+  label,
+  icon,
   className,
   ...badgeProps
 }) => {
@@ -24,6 +26,8 @@ const BAIAccentBadge: React.FC<BAIAccentBadgeProps> = ({
       className={['bai-accent-badge', className ?? '']
         .filter(Boolean)
         .join(' ')}
+      label={label}
+      icon={icon}
       {...badgeProps}
     />
   );

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -14,6 +14,8 @@ export { default as BAITabList } from './BAITabList';
 export type { BAITabListProps } from './BAITabList';
 export { default as BAITabCountBadge } from './BAITabCountBadge';
 export type { BAITabCountBadgeProps } from './BAITabCountBadge';
+export { default as BAIAccentBadge } from './BAIAccentBadge';
+export type { BAIAccentBadgeProps } from './BAIAccentBadge';
 export { default as BAICompactGroup } from './BAICompactGroup';
 export type { BAICompactGroupProps } from './BAICompactGroup';
 export { default as BAIMetadataList } from './BAIMetadataList';

--- a/packages/backend.ai-ui/src/helper/astryxTagVariant.test.ts
+++ b/packages/backend.ai-ui/src/helper/astryxTagVariant.test.ts
@@ -1,5 +1,4 @@
 import {
-  PRIMARY_TAG_VARIANT,
   STATUS_BADGE_VARIANT,
   badgeVariantForStatus,
   badgeVariantForTagColor,
@@ -128,10 +127,6 @@ describe('tokenColorForStatus', () => {
 });
 
 describe('module invariants', () => {
-  it('exposes a brand variant for token.colorPrimary call sites', () => {
-    expect(PRIMARY_TAG_VARIANT).toBe('green');
-  });
-
   it('every domain map value is a valid Badge variant', () => {
     const valid = new Set([
       'neutral',

--- a/packages/backend.ai-ui/src/helper/astryxTagVariant.ts
+++ b/packages/backend.ai-ui/src/helper/astryxTagVariant.ts
@@ -26,9 +26,10 @@
  * 3. `*-inverse` presets → base hue. The filled/inverse emphasis axis does not
  *    exist on Astryx Badge and is DROPPED (defaults-first; MIGRATION-SPEC §0
  *    simplicity policy — do not rebuild it).
- * 4. Theme token refs (`token.colorPrimary` at 3 sites: main-access-key tags)
- *    → `PRIMARY_TAG_VARIANT` (brand hue as a named variant). Arbitrary theme
- *    routing is NOT supported; if the brand hue changes, update that one const.
+ * 4. Theme token refs (`token.colorPrimary` at 3 sites: main-access-key and
+ *    `admin` tags) → NOT a variant: they use `BAIAccentBadge`, which paints
+ *    `--color-accent` (FR-3715). No variant follows the ambient accent, and
+ *    arbitrary theme routing is not supported by this module.
  * 5. Arbitrary hex / CSS color names / runtime metadata strings (e.g. image
  *    metadata `label.color`, AgentList `lightblue`) → normalized against the
  *    preset table; anything still unknown DROPS to `neutral`/`default`.
@@ -77,14 +78,6 @@ export type AstryxTokenColor =
   | 'purple'
   | 'pink'
   | 'gray';
-
-/**
- * Brand-accent replacement for `<Tag color={token.colorPrimary}>` sites
- * (AdminUserCredentialList, KeypairInfoModal ×2). The Backend.AI brand accent
- * is a green; Badge's closed enum cannot take the exact token, so the brand
- * hue is fixed here as a single named decision (policy class 4).
- */
-export const PRIMARY_TAG_VARIANT: AstryxBadgeVariant = 'green';
 
 /**
  * antd Tag `color` value → Astryx Badge variant.

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -29,7 +29,7 @@ import {
   BAISelectionLabel,
   useBAILogger,
   BAIText,
-  PRIMARY_TAG_VARIANT,
+  BAIAccentBadge,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
@@ -556,7 +556,7 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
             render: (isAdmin) =>
               isAdmin ? (
                 <BAIFlex gap="xs">
-                  <Badge variant={PRIMARY_TAG_VARIANT} label="admin" />
+                  <BAIAccentBadge label="admin" />
                   <Badge variant="green" label="user" />
                 </BAIFlex>
               ) : (

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -12,7 +12,7 @@ import {
   BAIMetadataList,
   BAIModal,
   type BAIModalProps,
-  PRIMARY_TAG_VARIANT,
+  BAIAccentBadge,
   badgeVariantForTagColor,
   BAIText,
 } from 'backend.ai-ui';
@@ -77,10 +77,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
               title styling is accepted as-is (defaults-first). */}
           <Text>{t('credential.KeypairDetail')}</Text>
           {user?.main_access_key === keypair?.access_key && (
-            <Badge
-              variant={PRIMARY_TAG_VARIANT}
-              label={t('credential.MainAccessKey')}
-            />
+            <BAIAccentBadge label={t('credential.MainAccessKey')} />
           )}
         </HStack>
       }
@@ -109,7 +106,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
           <MetadataListItem label={t('credential.Permission')}>
             {keypair?.is_admin ? (
               <HStack gap={1}>
-                <Badge variant={PRIMARY_TAG_VARIANT} label="admin" />
+                <BAIAccentBadge label="admin" />
                 <Badge
                   variant={badgeVariantForTagColor('green')}
                   label="user"


### PR DESCRIPTION
Resolves FR-3715 (no webui GitHub clone; Jira only)

## What changed and why

`PRIMARY_TAG_VARIANT` in `packages/backend.ai-ui/src/helper/astryxTagVariant.ts` was the literal `'green'`, fixed there when the Backend.AI brand accent was believed to be a green. It is not — `--color-accent` resolves to `#FF7A00` / `#be5e06` under the user menu group and `#028DF2` / `#0387bf` under admin. The visible symptom is worse than an off-brand hue: at `AdminUserCredentialList.tsx` and `KeypairInfoModal.tsx` the `admin` badge sits directly next to a `variant="green"` `user` badge, so today the two are indistinguishable.

Astryx `Badge.variant` is a closed enum with no ambient-accent member (this theme pins `info` to a fixed blue), so the fix cannot be "pick a different variant". This reuses the mechanism FR-3706 shipped for `BAITabCountBadge`:

- **New `BAIAccentBadge`** (BUI, per `bui-component-home.md`): an Astryx `Badge` wrapper whose props are `Omit<BadgeProps, 'variant'>` (`component-props-extension.md`), with an unlayered co-located class setting `background-color: var(--color-accent); color: var(--color-on-accent);`. Unlayered beats Astryx's `@layer astryx-base` specificity boost without `!important`, matching `BAITabCountBadge.css` / `actionAccent.css`. Ships a `.doc.ts` and a unit test; exported from the components barrel.
- **The three `token.colorPrimary` tag sites** (`AdminUserCredentialList.tsx` permission cell, `KeypairInfoModal.tsx` main-access-key title tag and permission cell) now render `BAIAccentBadge`.
- **`PRIMARY_TAG_VARIANT` is deleted**, along with its `toBe('green')` module invariant in `astryxTagVariant.test.ts`. The module's policy-class-4 note now says these sites are not a variant at all and points at the component.

### Design decisions

- A component rather than a new variant or a shared class: the accent is owned by the component, so no call site can drift back onto a fixed hue — the same reason `BAITabCountBadge` owns `variant`.
- Deleting the exported `PRIMARY_TAG_VARIANT` is a BUI package-surface change; a repo-wide grep confirms the four in-repo references, all updated here.
- **FR-3714 is still open** ("white on the brand accent is 2.61:1 — should `--color-on-accent` or the accent change app-wide?"). This change paints three more surfaces in `--color-on-accent`-on-accent and so extends that acknowledged contrast debt; it deliberately does not try to solve it, and these sites will be swept by whatever FR-3714 decides.

## Tests

- `pnpm --filter backend.ai-ui exec vitest run src/components/BAIAccentBadge.test.tsx src/helper/astryxTagVariant.test.ts` — 20 passed (2 files). The new test asserts the label renders, the accent class is applied, a caller `className` survives, and no coloured `Badge` variant is pinned (`data-variant="neutral"`) — jsdom resolves no custom properties, so the colour itself is checked in the app.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` — 2 findings, both pre-existing (`BAIDialog.css`, `BAIDrawerPortal.css`); no new findings.

## Verification

`bash scripts/verify.sh`:

```
=== ALL PASS ===
```

## Review notes

- Open **Credentials** (admin scope): the `admin` badge in the Permission column should be blue (`#028DF2`) and clearly distinct from the green `user` badge beside it; open the keypair detail modal for the same row to check the `admin` badge and the **Main Access Key** title tag.
- The colour is scope-derived, not fixed: if a badge is rendered under a user-menu page it is orange (`#FF7A00`). That is intended — same component, different `--color-accent`.
- Check both light and dark; the accent token already carries the dark value (`light-dark(#028DF2, #0387bf)`).

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
