### PR TITLE
refactor(FR-3346): collapse revision preset selects onto one select

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.test.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.test.tsx
@@ -138,6 +138,8 @@ vi.mock('./EnvVarFormList', () => ({ default: () => null }));
 vi.mock('./VFolderTableFormItem', () => ({ default: () => null }));
 vi.mock('./DeploymentPresetDetailModal', () => ({ default: () => null }));
 
+let presetSelectMounts = 0;
+
 // The model-folder picker is the probe for the folder-picker side of the
 // contract: it surfaces the `currentProjectId` it was scoped to.
 vi.mock('backend.ai-ui', async (importOriginal) => {
@@ -157,19 +159,28 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
         'select-model-folder',
       ),
     // The preset picker is the probe for the single-select contract: it
-    // surfaces the model-card scope it was given and its disabled hint.
-    BAIAvailablePresetSelect: (props: any) =>
-      React.createElement(
+    // surfaces the model-card scope it was given, its disabled hint, and a
+    // per-instance mount id (the select owns a search string, so a source
+    // switch must remount it rather than reuse the instance).
+    BAIAvailablePresetSelect: (props: any) => {
+      const mountId = React.useRef<number | null>(null);
+      if (mountId.current === null) {
+        presetSelectMounts += 1;
+        mountId.current = presetSelectMounts;
+      }
+      return React.createElement(
         'button',
         {
           'data-testid': 'mock-preset-select',
           'data-model-card-id': props.modelCardId ?? '',
           'data-description': props.description ?? '',
+          'data-mount-id': String(mountId.current),
           disabled: props.isDisabled ?? false,
           type: 'button',
         },
         'select-preset',
-      ),
+      );
+    },
     BAIRuntimeVariantSelect: () => null,
   };
 });
@@ -342,6 +353,8 @@ describe('DeploymentAddRevisionModal preset select (FR-3346)', () => {
     expect(folderModePreset).toHaveAttribute('data-model-card-id', '');
     expect(folderModePreset).toHaveAttribute('data-description', '');
     expect(folderModePreset).toBeEnabled();
+    const folderModeMountId =
+      folderModePreset.getAttribute('data-mount-id') ?? '';
 
     await user.click(
       screen.getByRole('radio', { name: 'deployment.ModelCard' }),
@@ -355,6 +368,13 @@ describe('DeploymentAddRevisionModal preset select (FR-3346)', () => {
     expect(screen.getByTestId('mock-preset-select')).toHaveAttribute(
       'data-description',
       'deployment.SelectModelCardFirst',
+    );
+    // One element type now serves both sources, so the source switch has to
+    // remount it explicitly — otherwise a folder-mode search string would
+    // survive and filter the card's compatible presets.
+    expect(screen.getByTestId('mock-preset-select')).not.toHaveAttribute(
+      'data-mount-id',
+      folderModeMountId,
     );
   });
 });

--- a/react/src/components/DeploymentAddRevisionModal.test.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.test.tsx
@@ -10,6 +10,7 @@ import DeploymentAddRevisionModal, {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -155,7 +156,20 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
         },
         'select-model-folder',
       ),
-    BAIAvailablePresetSelect: () => null,
+    // The preset picker is the probe for the single-select contract: it
+    // surfaces the model-card scope it was given and its disabled hint.
+    BAIAvailablePresetSelect: (props: any) =>
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'mock-preset-select',
+          'data-model-card-id': props.modelCardId ?? '',
+          'data-description': props.description ?? '',
+          disabled: props.isDisabled ?? false,
+          type: 'button',
+        },
+        'select-preset',
+      ),
     BAIRuntimeVariantSelect: () => null,
   };
 });
@@ -315,5 +329,32 @@ describe('toImageFullName', () => {
   it('resolves to undefined when the preset carries no image', () => {
     expect(toImageFullName(null)).toBeUndefined();
     expect(toImageFullName(undefined)).toBeUndefined();
+  });
+});
+
+describe('DeploymentAddRevisionModal preset select (FR-3346)', () => {
+  it('serves both model sources from one select, scoped by the chosen source', async () => {
+    const user = userEvent.setup();
+    renderModal(DEPLOYMENT_METADATA);
+
+    // Folder source (default): project-wide options, no card scope, enabled.
+    const folderModePreset = await screen.findByTestId('mock-preset-select');
+    expect(folderModePreset).toHaveAttribute('data-model-card-id', '');
+    expect(folderModePreset).toHaveAttribute('data-description', '');
+    expect(folderModePreset).toBeEnabled();
+
+    await user.click(
+      screen.getByRole('radio', { name: 'deployment.ModelCard' }),
+    );
+
+    // Card source without a card yet: still ONE select, now disabled + hinted.
+    await waitFor(() => {
+      expect(screen.getAllByTestId('mock-preset-select')).toHaveLength(1);
+      expect(screen.getByTestId('mock-preset-select')).toBeDisabled();
+    });
+    expect(screen.getByTestId('mock-preset-select')).toHaveAttribute(
+      'data-description',
+      'deployment.SelectModelCardFirst',
+    );
   });
 });

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -354,35 +354,6 @@ const ModelCardDetailLoader: React.FC<{
   return <ModelCardDrawer modelCardId={modelCardId} open onClose={onClose} />;
 };
 
-// Card-mode preset selector: the same self-fetching
-// `BAIAvailablePresetSelect` used for the folder source, scoped to the
-// selected model card's resource-compatible presets via `modelCardId`. That
-// routes the list through the top-level `modelCardAvailablePresets` query (the
-// same server-filtered subset `ModelCardDeployModal` deploys against,
-// satisfying the card's minimum resource requirements), so no separate
-// card-scoped select or fragment is needed. Disabled with a hint until a card
-// is picked — the hint rides in the field's `description` slot (Astryx forbids
-// wrapping a disabled control in a Tooltip).
-const ModelCardPresetSelect: React.FC<
-  {
-    modelCardId?: string;
-  } & Omit<React.ComponentProps<typeof BAIAvailablePresetSelect>, 'modelCardId'>
-> = ({ modelCardId, ...selectProps }) => {
-  'use memo';
-  const { t } = useTranslation();
-  const isDisabled = !modelCardId;
-  return (
-    <BAIAvailablePresetSelect
-      modelCardId={modelCardId}
-      isDisabled={isDisabled}
-      description={
-        isDisabled ? t('deployment.SelectModelCardFirst') : undefined
-      }
-      {...selectProps}
-    />
-  );
-};
-
 // Suspense fallback for the self-fetching selects: the same `BAIComplexSelect`
 // they render, so the placeholder keeps their exact height and 100% width
 // (`BAISelect` sits on Astryx `Selector` — taller, and it ignores `flex: 1`).
@@ -2210,24 +2181,29 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                           />
                         }
                       >
+                        {/* `modelCardId` routes the options through the card's
+                            resource-compatible subset. The "pick a card first"
+                            hint rides in `description` because Astryx forbids
+                            wrapping a disabled control in a Tooltip. */}
                         <BAIFormItem
                           name="revisionPresetId"
                           messageVariables={{ label: t('modelStore.Preset') }}
                           noStyle
                           rules={[{ required: true }]}
                         >
-                          {source === 'card' ? (
-                            <ModelCardPresetSelect
-                              modelCardId={modelCardId}
-                              label={t('modelStore.Preset')}
-                              isLabelHidden
-                            />
-                          ) : (
-                            <BAIAvailablePresetSelect
-                              label={t('modelStore.Preset')}
-                              isLabelHidden
-                            />
-                          )}
+                          <BAIAvailablePresetSelect
+                            modelCardId={
+                              source === 'card' ? modelCardId : undefined
+                            }
+                            isDisabled={source === 'card' && !modelCardId}
+                            description={
+                              source === 'card' && !modelCardId
+                                ? t('deployment.SelectModelCardFirst')
+                                : undefined
+                            }
+                            label={t('modelStore.Preset')}
+                            isLabelHidden
+                          />
                         </BAIFormItem>
                       </Suspense>
                       <BAIFormItem dependencies={['revisionPresetId']} noStyle>

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -2184,7 +2184,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                         {/* `modelCardId` routes the options through the card's
                             resource-compatible subset. The "pick a card first"
                             hint rides in `description` because Astryx forbids
-                            wrapping a disabled control in a Tooltip. */}
+                            wrapping a disabled control in a Tooltip.
+                            `key={source}` remounts on a source switch so the
+                            select's internal search string cannot filter the
+                            other source's presets — the two swapped-in element
+                            types used to give that for free. */}
                         <BAIFormItem
                           name="revisionPresetId"
                           messageVariables={{ label: t('modelStore.Preset') }}
@@ -2192,6 +2196,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                           rules={[{ required: true }]}
                         >
                           <BAIAvailablePresetSelect
+                            key={source}
                             modelCardId={
                               source === 'card' ? modelCardId : undefined
                             }


### PR DESCRIPTION
Resolves #8331 (FR-3346)

## What changed

The add-revision preset field still branched between two JSX components:

```tsx
{source === 'card' ? <ModelCardPresetSelect … /> : <BAIAvailablePresetSelect … />}
```

`ModelCardPresetSelect` was a ~15-line local wrapper in
`DeploymentAddRevisionModal.tsx` that rendered the very same
`BAIAvailablePresetSelect` and only added the disabled state plus the
"select a model card first" hint. The card scoping itself already lives
inside `BAIAvailablePresetSelect` (its `modelCardId` prop, added in
FR-3314 / #8246).

This PR deletes the wrapper and renders one select, passing `modelCardId`
only in card mode and inlining `isDisabled` / `description`:

```tsx
<BAIAvailablePresetSelect
  modelCardId={source === 'card' ? modelCardId : undefined}
  isDisabled={source === 'card' && !modelCardId}
  description={source === 'card' && !modelCardId ? t('deployment.SelectModelCardFirst') : undefined}
  …
/>
```

No behaviour change, no new strings, no GraphQL change.

## Design decisions / scope note

**The "filter prop" half of the issue is not implementable today, and is not
attempted here.** The issue's plan was to extend `BAIAvailablePresetSelect`
with a model-card *filter* on the top-level `deploymentRevisionPresets`
query, gated by manager version. Neither `data/schema.graphql` nor
backend.ai `main` declares such a field — `DeploymentRevisionPresetFilter`
carries only `id` / `name` / `runtimeVariantId` / `AND` / `OR` / `NOT`.
BA-6946 shipped the capability as a **separate root field**,
`modelCardAvailablePresets(scope: {modelCardId})`, which is exactly what
`BAIAvailablePresetSelect` already routes to. So:

- The user-facing goal of the issue (one select for both model sources) is
  what this PR completes.
- No `isManagerVersionCompatibleWith` gate is added: there is no filter to
  gate, and the card-scoped query is only issued when a card is selected.
- The two `useLazyPaginatedQuery` blocks inside `BAIAvailablePresetSelect`
  stay as they are — collapsing them would require the schema change above.

## Tests

- `pnpm exec vitest run src/components/DeploymentAddRevisionModal.test.tsx`
  (from `react/`) — 4 passed. The existing `BAIAvailablePresetSelect` stub
  is promoted from `() => null` to a probe that surfaces `modelCardId`,
  `description` and `isDisabled`, and a new case asserts that exactly one
  preset select serves both sources: enabled and unscoped in folder mode,
  disabled with the hint after switching to the model-card source.

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Open a deployment → **Add revision** → preset mode. With **Model folder**
  selected the preset list is the project-wide one, exactly as before.
- Switch **Model source** to **Model card**: the preset select goes disabled
  and shows the "select a model card first" hint under the field (it is one
  control now, not a swapped-in second one).
- Pick a model card: the options become the card's resource-compatible
  subset (`modelCardAvailablePresets`), and the preset-detail button next to
  the select still resolves the chosen preset.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
