### PR TITLE
feat(FR-1136): let non-superadmins export their own session history as CSV

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -892,9 +892,6 @@ export class Client {
       this._features['model-card-v2'] = true;
       this._features['my-roles'] = true;
       this._features['prometheus-auto-scaling-rule'] = true;
-      // `POST /v2/export/sessions/my/csv` (backend #10609) is auth_required and
-      // scopes rows to the caller, unlike the /export routes the WebUI calls.
-      this._features['my-sessions-export-csv'] = true;
     }
     if (this.isManagerVersionCompatibleWith('26.4.2')) {
       this._features['prometheus-query-preset'] = true;

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -892,6 +892,9 @@ export class Client {
       this._features['model-card-v2'] = true;
       this._features['my-roles'] = true;
       this._features['prometheus-auto-scaling-rule'] = true;
+      // `POST /v2/export/sessions/my/csv` (backend #10609) is auth_required and
+      // scopes rows to the caller; every other /export route is superadmin-only.
+      this._features['my-sessions-export-csv'] = true;
     }
     if (this.isManagerVersionCompatibleWith('26.4.2')) {
       this._features['prometheus-query-preset'] = true;

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -893,7 +893,7 @@ export class Client {
       this._features['my-roles'] = true;
       this._features['prometheus-auto-scaling-rule'] = true;
       // `POST /v2/export/sessions/my/csv` (backend #10609) is auth_required and
-      // scopes rows to the caller; every other /export route is superadmin-only.
+      // scopes rows to the caller, unlike the /export routes the WebUI calls.
       this._features['my-sessions-export-csv'] = true;
     }
     if (this.isManagerVersionCompatibleWith('26.4.2')) {

--- a/react/src/hooks/useCSVExport.test.ts
+++ b/react/src/hooks/useCSVExport.test.ts
@@ -1,5 +1,49 @@
-import { resolveCSVExportRoute } from './useCSVExport';
-import { describe, expect, it } from 'vitest';
+import {
+  MY_SESSION_EXPORT_FIELDS,
+  resolveCSVExportRoute,
+  useCSVExport,
+} from './useCSVExport';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('.', () => ({
+  useSuspendedBackendaiClient: () => ({
+    supports: (flag: string) => supportedFeatures.has(flag),
+  }),
+}));
+
+vi.mock('./backendai', () => ({
+  useCurrentUserRole: () => currentUserRole,
+}));
+
+// The query function runs eagerly here so a route that must never touch the
+// superadmin-only report GET is observed either issuing it or not.
+vi.mock('./reactQueryAlias', () => ({
+  useSuspenseTanQuery: ({ queryFn }: { queryFn: () => unknown }) => {
+    const data = queryFn();
+    return { data: Array.isArray(data) ? data : [] };
+  },
+}));
+
+vi.mock('backend.ai-ui', () => ({
+  useBAISignedRequestWithPromise: () => baiRequest,
+  useErrorMessageResolver: () => ({
+    getErrorMessage: (_err: unknown, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock('../helper/csv-util', () => ({
+  downloadCSV: (...args: Array<unknown>) => downloadCSVMock(...args),
+}));
+
+let supportedFeatures = new Set<string>();
+let currentUserRole: string | undefined;
+const baiRequest = vi.fn();
+const downloadCSVMock = vi.fn();
 
 const resolve = (
   overrides: Partial<Parameters<typeof resolveCSVExportRoute>[0]> = {},
@@ -42,5 +86,64 @@ describe('resolveCSVExportRoute', () => {
     expect(resolve({ userRole: 'superadmin', supportsExportCSV: false })).toBe(
       'none',
     );
+  });
+});
+
+describe('useCSVExport', () => {
+  beforeEach(() => {
+    supportedFeatures = new Set(['export-csv', 'my-sessions-export-csv']);
+    currentUserRole = 'user';
+    baiRequest.mockReset();
+    baiRequest.mockImplementation(({ method }: { method: string }) =>
+      method === 'GET'
+        ? Promise.resolve({ report: { fields: [{ key: 'id' }] } })
+        : Promise.resolve('id,name\n1,a\n'),
+    );
+    downloadCSVMock.mockReset();
+  });
+
+  it('posts a non-superadmin personal export to the my route and never issues the report GET', async () => {
+    const { result } = renderHook(() =>
+      useCSVExport('sessions', { scope: 'my' }),
+    );
+
+    expect(result.current.supportedFields).toEqual(MY_SESSION_EXPORT_FIELDS);
+    expect(baiRequest).not.toHaveBeenCalled();
+
+    const filter = { status: ['TERMINATED', 'CANCELLED'] };
+    await act(async () => {
+      await result.current.exportCSV(['id', 'name'], filter);
+    });
+
+    expect(baiRequest).toHaveBeenCalledTimes(1);
+    expect(baiRequest).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/v2/export/sessions/my/csv',
+      body: { fields: ['id', 'name'], filter },
+    });
+    expect(downloadCSVMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a superadmin on the admin report GET and the admin export POST', async () => {
+    currentUserRole = 'superadmin';
+    const { result } = renderHook(() =>
+      useCSVExport('sessions', { scope: 'my' }),
+    );
+
+    expect(baiRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/export/reports/sessions',
+    });
+
+    baiRequest.mockClear();
+    await act(async () => {
+      await result.current.exportCSV(['id']);
+    });
+
+    expect(baiRequest).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/export/sessions/csv',
+      body: { fields: ['id'] },
+    });
   });
 });

--- a/react/src/hooks/useCSVExport.test.ts
+++ b/react/src/hooks/useCSVExport.test.ts
@@ -1,0 +1,46 @@
+import { resolveCSVExportRoute } from './useCSVExport';
+import { describe, expect, it } from 'vitest';
+
+const resolve = (
+  overrides: Partial<Parameters<typeof resolveCSVExportRoute>[0]> = {},
+) =>
+  resolveCSVExportRoute({
+    nodeKey: 'sessions',
+    scope: 'admin',
+    userRole: 'user',
+    supportsExportCSV: true,
+    supportsMySessionsExport: true,
+    ...overrides,
+  });
+
+describe('resolveCSVExportRoute', () => {
+  it('keeps a superadmin on the admin route regardless of the requested scope', () => {
+    expect(resolve({ userRole: 'superadmin' })).toBe('admin');
+    expect(resolve({ userRole: 'superadmin', scope: 'my' })).toBe('admin');
+    expect(resolve({ userRole: 'superadmin', nodeKey: 'users' })).toBe('admin');
+  });
+
+  it('routes a non-superadmin asking for the personal scope to the my route', () => {
+    expect(resolve({ scope: 'my' })).toBe('my');
+    expect(resolve({ scope: 'my', userRole: 'admin' })).toBe('my');
+  });
+
+  it('gives a non-superadmin no route without the personal scope', () => {
+    expect(resolve({ userRole: 'admin' })).toBe('none');
+    expect(resolve({ userRole: undefined })).toBe('none');
+  });
+
+  it('offers the personal scope for sessions only', () => {
+    expect(resolve({ scope: 'my', nodeKey: 'users' })).toBe('none');
+    expect(resolve({ scope: 'my', nodeKey: 'audit-logs' })).toBe('none');
+  });
+
+  it('falls back to no route on managers without the matching feature', () => {
+    expect(resolve({ scope: 'my', supportsMySessionsExport: false })).toBe(
+      'none',
+    );
+    expect(resolve({ userRole: 'superadmin', supportsExportCSV: false })).toBe(
+      'none',
+    );
+  });
+});

--- a/react/src/hooks/useCSVExport.test.ts
+++ b/react/src/hooks/useCSVExport.test.ts
@@ -53,7 +53,6 @@ const resolve = (
     scope: 'admin',
     userRole: 'user',
     supportsExportCSV: true,
-    supportsMySessionsExport: true,
     ...overrides,
   });
 
@@ -79,10 +78,8 @@ describe('resolveCSVExportRoute', () => {
     expect(resolve({ scope: 'my', nodeKey: 'audit-logs' })).toBe('none');
   });
 
-  it('falls back to no route on managers without the matching feature', () => {
-    expect(resolve({ scope: 'my', supportsMySessionsExport: false })).toBe(
-      'none',
-    );
+  it('falls back to no route on managers without export-csv', () => {
+    expect(resolve({ scope: 'my', supportsExportCSV: false })).toBe('none');
     expect(resolve({ userRole: 'superadmin', supportsExportCSV: false })).toBe(
       'none',
     );
@@ -91,7 +88,7 @@ describe('resolveCSVExportRoute', () => {
 
 describe('useCSVExport', () => {
   beforeEach(() => {
-    supportedFeatures = new Set(['export-csv', 'my-sessions-export-csv']);
+    supportedFeatures = new Set(['export-csv']);
     currentUserRole = 'user';
     baiRequest.mockReset();
     baiRequest.mockImplementation(({ method }: { method: string }) =>

--- a/react/src/hooks/useCSVExport.ts
+++ b/react/src/hooks/useCSVExport.ts
@@ -67,9 +67,8 @@ export const MY_SESSION_EXPORT_FIELDS = [
 ];
 
 /**
- * Every `/export` route is `superadmin_required` except `POST
- * /v2/export/sessions/my/csv`, which is `auth_required` and scopes the rows to
- * the caller — so a non-superadmin can export their own sessions and nothing else.
+ * The `/export` routes this hook calls are `superadmin_required` except `POST
+ * /v2/export/sessions/my/csv`, which is `auth_required` and caller-scoped.
  */
 export const resolveCSVExportRoute = ({
   nodeKey,

--- a/react/src/hooks/useCSVExport.ts
+++ b/react/src/hooks/useCSVExport.ts
@@ -75,19 +75,15 @@ export const resolveCSVExportRoute = ({
   scope,
   userRole,
   supportsExportCSV,
-  supportsMySessionsExport,
 }: {
   nodeKey: SupportedNodeKeys;
   scope: CSVExportScope;
   userRole: string | undefined;
   supportsExportCSV: boolean;
-  supportsMySessionsExport: boolean;
 }): CSVExportRoute => {
   if (!supportsExportCSV) return 'none';
   if (userRole === 'superadmin') return 'admin';
-  if (scope === 'my' && nodeKey === 'sessions' && supportsMySessionsExport) {
-    return 'my';
-  }
+  if (scope === 'my' && nodeKey === 'sessions') return 'my';
   return 'none';
 };
 
@@ -122,7 +118,6 @@ export const useCSVExport = (
     scope,
     userRole,
     supportsExportCSV: baiClient.supports('export-csv'),
-    supportsMySessionsExport: baiClient.supports('my-sessions-export-csv'),
   });
 
   const { data: supportedFields } = useSuspenseTanQuery<Array<string>>({

--- a/react/src/hooks/useCSVExport.ts
+++ b/react/src/hooks/useCSVExport.ts
@@ -12,6 +12,86 @@ import { useTranslation } from 'react-i18next';
 
 type SupportedNodeKeys = 'sessions' | 'users' | 'projects' | 'audit-logs';
 
+/** Export route the caller asks for; `my` is only available for `sessions`. */
+export type CSVExportScope = 'admin' | 'my';
+
+/** Route the hook resolved to, or `none` when the user can reach neither. */
+export type CSVExportRoute = CSVExportScope | 'none';
+
+/**
+ * Field keys of the manager's `sessions` export report. `GET /export/reports/*`
+ * is superadmin-only, so the `my` route cannot discover them at runtime
+ * (backend.ai `manager/repositories/export/reports/session.py`, SESSION_FIELDS).
+ */
+export const MY_SESSION_EXPORT_FIELDS = [
+  'id',
+  'name',
+  'session_type',
+  'domain_name',
+  'access_key',
+  'status',
+  'status_info',
+  'cluster_size',
+  'resource_used',
+  'resource_requested',
+  'created_at',
+  'terminated_at',
+  'project_name',
+  'project_description',
+  'project_resource_policy',
+  'project_is_active',
+  'project_created_at',
+  'project_policy_max_vfolder_count',
+  'project_policy_max_quota_scope_size',
+  'project_policy_max_network_count',
+  'user_email',
+  'user_username',
+  'user_full_name',
+  'user_role',
+  'resource_group_name',
+  'resource_group_description',
+  'resource_group_is_active',
+  'resource_group_is_public',
+  'resource_group_scheduler',
+  'resource_group_created_at',
+  'kernel_id',
+  'kernel_role',
+  'kernel_status',
+  'kernel_image',
+  'kernel_architecture',
+  'kernel_registry',
+  'kernel_tag',
+  'kernel_agent',
+  'kernel_created_at',
+  'kernel_terminated_at',
+];
+
+/**
+ * Every `/export` route is `superadmin_required` except `POST
+ * /v2/export/sessions/my/csv`, which is `auth_required` and scopes the rows to
+ * the caller — so a non-superadmin can export their own sessions and nothing else.
+ */
+export const resolveCSVExportRoute = ({
+  nodeKey,
+  scope,
+  userRole,
+  supportsExportCSV,
+  supportsMySessionsExport,
+}: {
+  nodeKey: SupportedNodeKeys;
+  scope: CSVExportScope;
+  userRole: string | undefined;
+  supportsExportCSV: boolean;
+  supportsMySessionsExport: boolean;
+}): CSVExportRoute => {
+  if (!supportsExportCSV) return 'none';
+  if (userRole === 'superadmin') return 'admin';
+  if (scope === 'my' && nodeKey === 'sessions' && supportsMySessionsExport) {
+    return 'my';
+  }
+  return 'none';
+};
+
 type ReportResponse = {
   report: {
     report_key: string;
@@ -26,7 +106,10 @@ type ReportResponse = {
   };
 };
 
-export const useCSVExport = (nodeKey: SupportedNodeKeys) => {
+export const useCSVExport = (
+  nodeKey: SupportedNodeKeys,
+  { scope = 'admin' }: { scope?: CSVExportScope } = {},
+) => {
   'use memo';
 
   const { t } = useTranslation();
@@ -35,19 +118,19 @@ export const useCSVExport = (nodeKey: SupportedNodeKeys) => {
   const { getErrorMessage } = useErrorMessageResolver();
   const userRole = useCurrentUserRole();
 
-  const isAdmin = userRole === 'superadmin' || userRole === 'admin';
-  const isExportCSVSupported = baiClient.supports('export-csv');
+  const route = resolveCSVExportRoute({
+    nodeKey,
+    scope,
+    userRole,
+    supportsExportCSV: baiClient.supports('export-csv'),
+    supportsMySessionsExport: baiClient.supports('my-sessions-export-csv'),
+  });
 
   const { data: supportedFields } = useSuspenseTanQuery<Array<string>>({
-    queryKey: [
-      'CSVExport',
-      'supportedFields',
-      nodeKey,
-      isAdmin,
-      isExportCSVSupported,
-    ],
+    queryKey: ['CSVExport', 'supportedFields', nodeKey, route],
     queryFn: () => {
-      if (!isAdmin || !isExportCSVSupported) return [];
+      if (route === 'none') return [];
+      if (route === 'my') return MY_SESSION_EXPORT_FIELDS;
       return baiRequestWithPromise({
         method: 'GET',
         url: `/export/reports/${nodeKey}`,
@@ -63,7 +146,10 @@ export const useCSVExport = (nodeKey: SupportedNodeKeys) => {
   ) => {
     return await baiRequestWithPromise({
       method: 'POST',
-      url: `/export/${nodeKey}/csv`,
+      url:
+        route === 'my'
+          ? `/v2/export/${nodeKey}/my/csv`
+          : `/export/${nodeKey}/csv`,
       body: {
         fields: selectedExportKeys,
         ...(filter && { filter }),

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -21,7 +21,7 @@ import SessionResourceGrid from '../components/SessionResourceGrid';
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
-import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
@@ -96,7 +96,6 @@ const ComputeSessionListPage = () => {
   'use memo';
   const currentProject = useCurrentProjectValue();
 
-  const userRole = useCurrentUserRole();
   const [currentUser] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
 
@@ -115,7 +114,11 @@ const ComputeSessionListPage = () => {
     'table_column_overrides.ComputeSessionListPage',
   );
 
-  const { supportedFields, exportCSV } = useCSVExport('sessions');
+  // This page is strictly personal, so a non-superadmin exports through the
+  // auth_required `my` route instead of the superadmin-only admin one.
+  const { supportedFields, exportCSV } = useCSVExport('sessions', {
+    scope: 'my',
+  });
 
   const {
     baiPaginationOption,
@@ -654,8 +657,7 @@ const ComputeSessionListPage = () => {
                 onColumnOverridesChange: setColumnOverrides,
               }}
               exportSettings={
-                !_.isEmpty(supportedFields) &&
-                (userRole === 'superadmin' || userRole === 'admin')
+                !_.isEmpty(supportedFields)
                   ? {
                       supportedFields,
                       onExport: async (selectedExportKeys) => {


### PR DESCRIPTION
Resolves #3853 (FR-1136)

## What changed

Session history CSV export existed, but only a superadmin could actually use it.
Every `/export` route the WebUI called is `superadmin_required` on the manager
(`api/rest/export/registry.py`), so:

- a plain user saw no export control at all (`useCSVExport` returned an empty
  `supportedFields` for anyone outside `admin`/`superadmin`, and both call sites
  gated the control on the same roles);
- a **domain admin** passed the client-side gate, issued `GET
  /export/reports/sessions`, got 403 back, and the rejection escaped a
  page-level `useSuspenseTanQuery` with no catch.

This PR wires the `auth_required` personal route instead:

- `react/src/hooks/useCSVExport.ts` — the hook takes a `scope` (`'admin'` |
  `'my'`) and resolves the reachable route from the role through the exported
  pure helper `resolveCSVExportRoute`, behind the existing `export-csv`
  feature gate. `POST /v2/export/sessions/my/csv` landed in manager 26.4.0
  (backend.ai `166fd86f67`, PR #10609); it is not gated separately because the
  26.4 LTS line is the floor this WebUI targets. A
  superadmin keeps the admin route for every node key; a non-superadmin gets
  the `my` route for `sessions` and nothing otherwise, so the report request
  that used to 403 for domain admins is no longer issued.
- `react/src/pages/ComputeSessionListPage.tsx` — the personal session list opts
  into `scope: 'my'` and drops its own role gate, leaving the decision in the
  hook.

`AdminComputeSessionListPage`, `AdminUserManagement` and `ProjectPage` are
untouched: they keep the default `'admin'` scope, and their existing
`!_.isEmpty(supportedFields)` guard now hides the button for the roles whose
requests the manager refuses.

## Design decisions

- **Same request shape.** `POST /v2/export/sessions/my/csv` takes the same
  `SessionExportCSVInput` body as the admin route (`common/dto/manager/v2/export/request.py:298`)
  and scopes rows to the caller server-side (`ExportMySessionsCSVAction`), so
  the page's existing `status` / `session_type` filters — including
  `['TERMINATED','CANCELLED']` on the history tab — carry over unchanged. The
  pre-existing `user.email` filter stays too; on the `my` route it is a no-op
  for the caller's own email.
- **Field list is mirrored, not fetched.** `GET /export/reports/{key}` is
  superadmin-only in both v1 and v2, so the `my` route cannot discover its
  fields at runtime. `MY_SESSION_EXPORT_FIELDS` mirrors the manager's `sessions`
  report definition (`manager/repositories/export/reports/session.py`,
  `SESSION_FIELDS`) so a user gets the same column choices a superadmin does.
  Relaxing that endpoint to `auth_required` would let this constant go away.

## Tests

- New `react/src/hooks/useCSVExport.test.ts` — 5 cases over
  `resolveCSVExportRoute` (superadmin stays on the admin route, non-superadmin
  personal scope resolves to `my`, no route without the personal scope, `my` is
  sessions-only, no `export-csv` falls back to `none`) plus 2 hook-level cases
  that render `useCSVExport` with mocked dependencies: a non-superadmin
  personal export POSTs `/v2/export/sessions/my/csv` and never issues the
  superadmin-only report GET, and a superadmin keeps the admin GET + POST.
  `pnpm exec vitest run src/hooks/useCSVExport.test.ts` → 7 passed.
- No CSS/token changes, so the Astryx token gate was not applicable.
- Not exercised against a live cluster; the route/DTO claims above are read off
  backend.ai `main`.

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Log in as a **non-admin** user, open **Sessions**, switch to the finished
  (history) tab and use the table's CSV export — the request should go to
  `POST /v2/export/sessions/my/csv` and return only that user's terminated /
  cancelled sessions.
- Log in as a **domain admin** and open the same page: previously the page
  threw on the 403 from `GET /export/reports/sessions`; now it loads and the
  export uses the `my` route.
- Superadmin behaviour should be byte-identical to before, on both the personal
  Sessions page and the admin session list.
- Against a manager older than 26.2.0 (`export-csv`) the export control does
  not render for anyone; between 26.2.0 and 26.4.0 a non-superadmin would see
  it and get a 404 on the `my` route, which is out of the supported LTS range.

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version — 26.4.0 for the non-superadmin path (not
  gated in code; 26.4 LTS is the floor)
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — a non-superadmin account
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ

