### PR TITLE
feat(FR-3664): sync login session expiry across browser tabs

### DIFF
--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -3,8 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useActiveErrorBoundaryControl } from '../hooks/useActiveErrorBoundary';
+import { isLoginSessionExpiredState } from '../hooks/useLoginSessionExpiration';
 import { theme } from '../theme-shim';
-import { isLoginSessionExpiredState } from './LoginSessionExtendButton';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';

--- a/react/src/components/LoginSessionExtendButton.tsx
+++ b/react/src/components/LoginSessionExtendButton.tsx
@@ -4,19 +4,31 @@
  */
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
+import {
+  isLoginSessionExpiredState,
+  learnLoginSessionExpiresAtState,
+  loginSessionExpiresAtState,
+  parseLoginSessionExpiresAt,
+  publishLoginSessionExpiresAt,
+  readLoginSessionExpiresAt,
+  useSyncLoginSessionExpiresAt,
+} from '../hooks/useLoginSessionExpiration';
 import { useBAIBreakpoint } from '../theme-shim';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
-import { useUpdatableState, BAIFlex, BAIIntervalView } from 'backend.ai-ui';
+import {
+  useUpdatableState,
+  BAIFlex,
+  BAIIntervalView,
+  INITIAL_FETCH_KEY,
+} from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
-import { atom, useAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { Clock, Repeat2Icon } from 'lucide-react';
-import React, { useTransition } from 'react';
+import React, { useEffect, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface LoginSessionExtendButtonProps {}
-
-export const isLoginSessionExpiredState = atom(false);
 
 const LoginSessionExtendButton: React.FC<
   LoginSessionExtendButtonProps
@@ -24,7 +36,7 @@ const LoginSessionExtendButton: React.FC<
   const { t } = useTranslation();
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
   const [isPending, startTransition] = useTransition();
-  const [fetchKey, updateFetchKey] = useUpdatableState('first');
+  const [fetchKey, updateFetchKey] = useUpdatableState(INITIAL_FETCH_KEY);
 
   // RESPONSIVE-POLICY R3: antd `Grid.useBreakpoint()` → the theme-shim's
   // `useBAIBreakpoint()` (MAPPING §3.9 — `useMediaQuery` is not equivalent).
@@ -33,12 +45,25 @@ const LoginSessionExtendButton: React.FC<
   const [isLoginSessionExpired, setIsLoginSessionExpired] = useAtom(
     isLoginSessionExpiredState,
   );
+  const sharedExpiresAt = useAtomValue(loginSessionExpiresAtState);
+  const learnExpiresAt = useSetAtom(learnLoginSessionExpiresAtState);
+  useSyncLoginSessionExpiresAt();
 
   const { data } = useSuspenseTanQuery<{
     expires: string;
   }>({
     queryKey: ['TimeContainerExpires', fetchKey],
-    queryFn: () => {
+    queryFn: async () => {
+      // All tabs share one webserver session and `/server/extend-login-session`
+      // is the only way to read its expiry (it always extends, and
+      // `/server/login-check` reports none), so a tab that opens while a
+      // sibling holds a live expiry reuses it rather than extending again.
+      if (fetchKey === INITIAL_FETCH_KEY) {
+        const sharedExpires = readLoginSessionExpiresAt();
+        if (sharedExpires !== null && sharedExpires > Date.now()) {
+          return { expires: new Date(sharedExpires).toISOString() };
+        }
+      }
       return baiRequestWithPromise({
         method: 'POST',
         url: `/server/extend-login-session`,
@@ -46,6 +71,18 @@ const LoginSessionExtendButton: React.FC<
     },
     staleTime: 1000,
   });
+
+  useEffect(() => {
+    if (!data?.expires) return;
+    learnExpiresAt(parseLoginSessionExpiresAt(data.expires));
+    publishLoginSessionExpiresAt(data.expires);
+  }, [data?.expires, learnExpiresAt]);
+
+  const queryExpiresAt = parseLoginSessionExpiresAt(data?.expires);
+  const expiresAt =
+    sharedExpiresAt !== null && queryExpiresAt !== null
+      ? Math.max(sharedExpiresAt, queryExpiresAt)
+      : (sharedExpiresAt ?? queryExpiresAt);
 
   if (isLoginSessionExpired) {
     const error = new Error('Login session expired');
@@ -56,12 +93,16 @@ const LoginSessionExtendButton: React.FC<
   return (
     <BAIFlex direction="row" gap="xs">
       <BAIIntervalView
+        triggerKey={String(expiresAt)}
         callback={() => {
-          const diff = dayjs(data?.expires).diff(dayjs(), 'seconds');
+          const diff =
+            expiresAt === null ? 0 : dayjs(expiresAt).diff(dayjs(), 'seconds');
           const duration = dayjs.duration(Math.max(0, diff), 'seconds');
           const days = Math.floor(duration.asDays());
-          const isExpired = duration.asMilliseconds() <= 0;
-          setIsLoginSessionExpired(isExpired);
+          // An unknown expiry never expires the tab: only the server may.
+          setIsLoginSessionExpired(
+            expiresAt !== null && duration.asMilliseconds() <= 0,
+          );
           return gridBreakpoint.lg
             ? `${days ? days + 'd ' : ''}${duration.format('HH:mm:ss')}`
             : days

--- a/react/src/hooks/useLoginSessionExpiration.test.tsx
+++ b/react/src/hooks/useLoginSessionExpiration.test.tsx
@@ -1,0 +1,150 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY,
+  isLoginSessionExpiredState,
+  learnLoginSessionExpiresAtState,
+  loginSessionExpiresAtState,
+  parseLoginSessionExpiresAt,
+  publishLoginSessionExpiresAt,
+  readLoginSessionExpiresAt,
+  useSyncLoginSessionExpiresAt,
+} from './useLoginSessionExpiration';
+import { act, renderHook } from '@testing-library/react';
+import { Provider, createStore } from 'jotai';
+
+const iso = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
+
+const fireStorage = (key: string | null, newValue: string | null) => {
+  window.dispatchEvent(new StorageEvent('storage', { key, newValue }));
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('parseLoginSessionExpiresAt', () => {
+  it('parses an ISO timestamp into epoch milliseconds', () => {
+    expect(parseLoginSessionExpiresAt('2026-01-02T03:04:05.000Z')).toBe(
+      Date.parse('2026-01-02T03:04:05.000Z'),
+    );
+  });
+
+  it('returns null for empty or unparsable values', () => {
+    expect(parseLoginSessionExpiresAt(null)).toBeNull();
+    expect(parseLoginSessionExpiresAt('')).toBeNull();
+    expect(parseLoginSessionExpiresAt('not a date')).toBeNull();
+  });
+});
+
+describe('publishLoginSessionExpiresAt', () => {
+  it('publishes an expiry other tabs can read back', () => {
+    const expires = iso(60_000);
+    publishLoginSessionExpiresAt(expires);
+    expect(localStorage.getItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY)).toBe(
+      expires,
+    );
+    expect(readLoginSessionExpiresAt()).toBe(Date.parse(expires));
+  });
+
+  it('never rolls the shared expiry back to an earlier value', () => {
+    const later = iso(600_000);
+    publishLoginSessionExpiresAt(later);
+    publishLoginSessionExpiresAt(iso(60_000));
+    expect(localStorage.getItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY)).toBe(
+      later,
+    );
+  });
+});
+
+describe('learnLoginSessionExpiresAtState', () => {
+  it('keeps the later expiry and clears the expired flag', () => {
+    const store = createStore();
+    store.set(isLoginSessionExpiredState, true);
+
+    store.set(learnLoginSessionExpiresAtState, 2_000);
+    expect(store.get(loginSessionExpiresAtState)).toBe(2_000);
+    expect(store.get(isLoginSessionExpiredState)).toBe(false);
+
+    // An earlier value from a slower tab must not shorten the session.
+    store.set(learnLoginSessionExpiresAtState, 1_000);
+    expect(store.get(loginSessionExpiresAtState)).toBe(2_000);
+  });
+
+  it('clears the shared expiry when the value is dropped', () => {
+    const store = createStore();
+    store.set(learnLoginSessionExpiresAtState, 2_000);
+    store.set(learnLoginSessionExpiresAtState, null);
+    expect(store.get(loginSessionExpiresAtState)).toBeNull();
+  });
+});
+
+describe('useSyncLoginSessionExpiresAt', () => {
+  const renderWithStore = (store: ReturnType<typeof createStore>) =>
+    renderHook(() => useSyncLoginSessionExpiresAt(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+  it('adopts the expiry a sibling tab already stored', () => {
+    const expires = iso(60_000);
+    localStorage.setItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY, expires);
+    const store = createStore();
+
+    renderWithStore(store);
+
+    expect(store.get(loginSessionExpiresAtState)).toBe(Date.parse(expires));
+  });
+
+  it("adopts a sibling tab's renewal and un-expires this tab", () => {
+    const store = createStore();
+    store.set(learnLoginSessionExpiresAtState, Date.now());
+    store.set(isLoginSessionExpiredState, true);
+    renderWithStore(store);
+
+    const renewed = iso(600_000);
+    act(() => {
+      fireStorage(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY, renewed);
+    });
+
+    expect(store.get(loginSessionExpiresAtState)).toBe(Date.parse(renewed));
+    expect(store.get(isLoginSessionExpiredState)).toBe(false);
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    const store = createStore();
+    renderWithStore(store);
+
+    act(() => {
+      fireStorage('some.other.key', iso(600_000));
+    });
+
+    expect(store.get(loginSessionExpiresAtState)).toBeNull();
+  });
+
+  it('clears the shared expiry when a sibling tab logs out', () => {
+    localStorage.setItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY, iso(60_000));
+    const store = createStore();
+    renderWithStore(store);
+
+    act(() => {
+      localStorage.removeItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY);
+      fireStorage(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY, null);
+    });
+
+    expect(store.get(loginSessionExpiresAtState)).toBeNull();
+  });
+
+  it('stops listening once unmounted', () => {
+    const store = createStore();
+    const { unmount } = renderWithStore(store);
+    unmount();
+
+    act(() => {
+      fireStorage(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY, iso(600_000));
+    });
+
+    expect(store.get(loginSessionExpiresAtState)).toBeNull();
+  });
+});

--- a/react/src/hooks/useLoginSessionExpiration.ts
+++ b/react/src/hooks/useLoginSessionExpiration.ts
@@ -1,0 +1,100 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { atom, useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+
+/**
+ * Every tab of a browser profile shares one cookie-backed webserver login
+ * session, so the expiry must be one shared value instead of a per-tab
+ * countdown. The `BackendAIWebUI.login.` prefix makes `clearLoginStorage()`
+ * in `useLogout` drop it on logout.
+ */
+export const LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY =
+  'BackendAIWebUI.login.sessionExpiresAt';
+
+/** Expiry of the shared login session in epoch milliseconds, or null when unknown. */
+export const loginSessionExpiresAtState = atom<number | null>(null);
+
+export const isLoginSessionExpiredState = atom(false);
+
+/**
+ * Record an expiry learned from this tab's own extend call or from a sibling
+ * tab. It may only move later: the client never shortens the session, so a
+ * stale value can never sign anyone out before the server does.
+ */
+export const learnLoginSessionExpiresAtState = atom(
+  null,
+  (get, set, expiresAt: number | null) => {
+    if (expiresAt === null) {
+      set(loginSessionExpiresAtState, null);
+      return;
+    }
+    const current = get(loginSessionExpiresAtState);
+    if (current !== null && expiresAt <= current) return;
+    set(loginSessionExpiresAtState, expiresAt);
+    set(isLoginSessionExpiredState, false);
+  },
+);
+
+export const parseLoginSessionExpiresAt = (
+  value?: string | null,
+): number | null => {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? null : time;
+};
+
+export const readLoginSessionExpiresAt = (): number | null => {
+  try {
+    return parseLoginSessionExpiresAt(
+      localStorage.getItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY),
+    );
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies).
+    return null;
+  }
+};
+
+/**
+ * Publish an expiry to the sibling tabs. Writing an earlier value is skipped so
+ * a slow response cannot roll the shared expiry back.
+ */
+export const publishLoginSessionExpiresAt = (expires: string): void => {
+  const incoming = parseLoginSessionExpiresAt(expires);
+  if (incoming === null) return;
+  const stored = readLoginSessionExpiresAt();
+  if (stored !== null && incoming <= stored) return;
+  try {
+    localStorage.setItem(LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY, expires);
+  } catch {
+    // Storage can be unavailable; the tab still counts down from its own value.
+  }
+};
+
+/**
+ * Mirror the stored expiry into `loginSessionExpiresAtState` and keep it in
+ * sync with the other tabs. `storage` never fires in the tab that wrote the
+ * value, so the writer updates the atom itself.
+ */
+export const useSyncLoginSessionExpiresAt = (): void => {
+  'use memo';
+  const learnExpiresAt = useSetAtom(learnLoginSessionExpiresAtState);
+
+  useEffect(() => {
+    learnExpiresAt(readLoginSessionExpiresAt());
+    const handleStorage = (event: StorageEvent) => {
+      // A null key means localStorage.clear(), which drops our key too.
+      if (
+        event.key !== null &&
+        event.key !== LOGIN_SESSION_EXPIRES_AT_STORAGE_KEY
+      ) {
+        return;
+      }
+      learnExpiresAt(parseLoginSessionExpiresAt(event.newValue));
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [learnExpiresAt]);
+};


### PR DESCRIPTION
Resolves #9044 (FR-3664)

Every tab ran its own login-session countdown, off the `expires` its own boot-time POST to `/server/extend-login-session` returned and kept only in that tab's react-query cache; the jotai atom held nothing but an expired / not-expired boolean. All tabs of a browser profile share **one** cookie-backed webserver session, so the timers drifted apart: whichever tab extended last moved the server-side expiry, while the others kept counting down from a stale value and eventually threw `AuthorizationError`, dropping the user onto the expired-session page over a session that was still alive.

This makes the expiry one shared value.

## What changed

- **New `react/src/hooks/useLoginSessionExpiration.ts`** holds the expiry *timestamp* (`loginSessionExpiresAtState`) next to the existing `isLoginSessionExpiredState`, and mirrors it through the `BackendAIWebUI.login.sessionExpiresAt` localStorage key. The `storage` event fans a renewal out to the sibling tabs; the writing tab — which never receives its own `storage` event — updates the atom directly.
- **`LoginSessionExtendButton`** counts down from the shared timestamp instead of its own query result, so every tab shows the same remaining time and renews as one. A sibling's renewal also clears the expired flag and restarts the ticker.
- **`BAIErrorBoundary`** now imports `isLoginSessionExpiredState` from the hook module rather than from the button (the atom moved; the read is unchanged).

## Design decisions

- **localStorage over `BroadcastChannel`.** A `BroadcastChannel` only reaches tabs that are already open; a stored value is also inherited by a tab opened later, which is exactly the case that made the boot-time extend call droppable. It is also the idiom already in the tree (`useCustomThemeConfig.tsx:59`), so no new dependency.
- **The shared expiry only ever moves later** — enforced both in the atom writer and in the localStorage publisher. A slow response or a stale value can never sign a user out before the server does, and an unknown expiry never expires a tab. This was the deliberate bias: an over-lenient client shows a dead session's remaining time until the next 401; an over-eager one logs everybody out.
- **Key prefix `BackendAIWebUI.login.`** so `clearLoginStorage()` in `useLogout` drops it on logout, which — through the same `storage` event — also clears it in the sibling tabs. No extra logout wiring.
- **The unconditional boot-time extend is now conditional, not gone.** A tab that opens while a sibling holds a live expiry reuses it; otherwise it still POSTs. It cannot be dropped outright, which answers the ticket's open question: the webserver's `/server/extend-login-session` is POST-only and *always* resets `session.expiration_dt = now + login_session_extension_sec` (backend.ai `src/ai/backend/web/server.py:607-618`, route registered at `:1089`), and `/server/login-check` returns only `authenticated` / `access_key` / `role` / `session_id` with no expiry (`:330-347`). There is no read-only way for the client to learn the expiry; dropping the call outright would need a new webserver endpoint.

## Tests

- New `react/src/hooks/useLoginSessionExpiration.test.tsx` (11 cases): ISO parsing, the publisher refusing to roll the shared expiry back, the atom writer keeping the later value and clearing the expired flag, and the `storage` listener adopting a sibling's stored expiry / adopting a renewal and un-expiring the tab / ignoring unrelated keys / clearing on a sibling logout / detaching on unmount.
- Re-ran the tests around the touched surface: `src/components/MainLayout/WebUIHeader.test.tsx`, `src/hooks/useLogout.test.ts`, `src/hooks/useLoginSessionExpiration.test.tsx` — 3 files, 55 tests passed.

Not exercised against a live cluster: reproducing the drift end to end needs a webserver with a short `login_session_extension_sec` (see Review notes).

## Verification

```
bash scripts/verify.sh
...
=== ALL PASS ===
```

## Review notes

- Configure a test webserver with a short `session.login_session_extension_sec` (a minute or two). Open two tabs, let both count down, press the extend button in **one** — the other tab's countdown should jump to the same new value within ~100ms instead of continuing to drain.
- Let both tabs run to zero: they should now hit the expired-session page together rather than one tab dropping out while the other still shows time.
- Open a third tab while the first two are counting down: its header should show the same remaining time, and the network panel should show **no** `POST /server/extend-login-session` for that tab. Then log out in one tab and reload another — the next boot does POST again, because logout removes the shared key.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup) — a webserver with a short `session.login_session_extension_sec`
- [x] Minimum requirements to check during review — two or more tabs on the same origin
- [x] Test case(s) to demonstrate the difference of before/after — `react/src/hooks/useLoginSessionExpiration.test.tsx`

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
