### PR TITLE
fix(FR-2526): block file browser access while a revision is being added

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.test.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.test.tsx
@@ -7,7 +7,8 @@ import type { DeploymentAddRevisionModalTestQuery } from '../__generated__/Deplo
 import DeploymentAddRevisionModal from './DeploymentAddRevisionModal';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -142,6 +143,8 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
   const originalModule = await importOriginal<typeof import('backend.ai-ui')>();
   return {
     ...originalModule,
+    // Clicking the probe writes a value into the enclosing Form.Item, which is
+    // what lets a test drive the preset form to a submittable state.
     BAIVFolderSelect: (props: any) =>
       React.createElement(
         'button',
@@ -150,13 +153,32 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
           'data-current-project-id': props.currentProjectId ?? '',
           disabled: props.isDisabled ?? props.disabled,
           type: 'button',
+          onClick: () => props.onChange?.(MOCK_MODEL_FOLDER_ID),
         },
         'select-model-folder',
       ),
-    BAIAvailablePresetSelect: () => null,
+    BAIAvailablePresetSelect: (props: any) =>
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'mock-preset-select',
+          type: 'button',
+          onClick: () => props.onChange?.('revision-preset-id'),
+        },
+        'select-preset',
+      ),
     BAIRuntimeVariantSelect: () => null,
   };
 });
+
+// `toLocalId` (atob) runs over both on submit, so these must be real
+// global ids rather than opaque strings.
+const MOCK_MODEL_FOLDER_ID = btoa(
+  'VirtualFolderNode:11111111-1111-1111-1111-111111111111',
+);
+const MOCK_DEPLOYMENT_ID = btoa(
+  'ModelDeployment:22222222-2222-2222-2222-222222222222',
+);
 
 type DeploymentMetadataMock = {
   resourceGroupName: string;
@@ -193,7 +215,10 @@ const renderModal = (metadata: DeploymentMetadataMock) => {
     MockPayloadGenerator.generate(operation, {
       ModelDeploymentMetadata: () => metadata,
       // Keep the "Load current revision" path quiet: no current revision.
-      ModelDeployment: () => ({ currentRevision: null }),
+      ModelDeployment: () => ({
+        id: MOCK_DEPLOYMENT_ID,
+        currentRevision: null,
+      }),
       DeploymentRevisionPresetConnection: () => ({ count: 1 }),
     }),
   );
@@ -289,5 +314,76 @@ describe('DeploymentAddRevisionModal project derivation contract (ADR-0001)', ()
     expect(
       screen.queryByTestId('mock-resource-allocation-form'),
     ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * FR-2526: the folder-browser entry points must close while `addModelRevision`
+ * is in flight and reopen once it settles. `VFolderTable.test.tsx` covers the
+ * table prop; this covers the modal wiring that drives it, so the gate cannot
+ * regress while the table tests still pass.
+ */
+describe('DeploymentAddRevisionModal folder-access gate (FR-2526)', () => {
+  const OPEN_FOLDER = 'modelService.OpenFolder';
+  const GATE_TOOLTIP = 'deployment.FolderAccessDisabledWhileAddingRevision';
+
+  const submitPresetRevision = async () => {
+    const user = userEvent.setup();
+    const { environment } = renderModal(DEPLOYMENT_METADATA);
+
+    // Fill the two required preset fields through their form probes.
+    await user.click(await screen.findByTestId('mock-vfolder-select'));
+    await user.click(screen.getByTestId('mock-preset-select'));
+
+    const openFolderButton = screen.getByRole('button', { name: OPEN_FOLDER });
+    // A folder is selected, so the entry point is open before submit.
+    await waitFor(() => {
+      expect(openFolderButton).not.toHaveAttribute('aria-disabled', 'true');
+    });
+    expect(screen.queryByText(GATE_TOOLTIP)).toBeNull();
+
+    await user.click(
+      screen.getByRole('button', { name: 'deployment.AddRevision' }),
+    );
+
+    // `renderModal` queues a single resolver, spent on the test query, so the
+    // mutation stays pending here — which is exactly the in-flight window.
+    await waitFor(() => {
+      expect(openFolderButton).toHaveAttribute('aria-disabled', 'true');
+    });
+    // Disabled *with* the explanation, not silently dead.
+    expect(screen.getByText(GATE_TOOLTIP)).toBeInTheDocument();
+
+    return { environment, openFolderButton };
+  };
+
+  it('closes the model-folder entry point while the revision is being added, and lifts the gate on success', async () => {
+    const { environment } = await submitPresetRevision();
+
+    await act(async () => {
+      environment.mock.resolveMostRecentOperation((operation) =>
+        MockPayloadGenerator.generate(operation),
+      );
+    });
+
+    // The gate is lifted. The button itself stays disabled only because a
+    // successful add resets the preset form, leaving no folder to open.
+    await waitFor(() => {
+      expect(screen.queryByText(GATE_TOOLTIP)).toBeNull();
+    });
+  });
+
+  it('reopens the model-folder entry point when the mutation fails', async () => {
+    const { environment, openFolderButton } = await submitPresetRevision();
+
+    await act(async () => {
+      environment.mock.rejectMostRecentOperation(new Error('add failed'));
+    });
+
+    // The selection survives an error, so the entry point is fully restored.
+    await waitFor(() => {
+      expect(openFolderButton).not.toHaveAttribute('aria-disabled', 'true');
+    });
+    expect(screen.queryByText(GATE_TOOLTIP)).toBeNull();
   });
 });

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -859,6 +859,10 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       }
     `);
 
+  // FR-2526: a filebrowser session started mid-submit would change the files
+  // the new replicas are about to serve, so folder access is gated on this.
+  const isSubmitInFlight = isAddInFlight || isResolvingImage;
+
   // Build a Custom-form prefill object from a preset node read off the
   // singular `deploymentRevisionPreset(id:)` query (resolved via
   // `fetchPresetData`). The image full name is fetched async because
@@ -1927,7 +1931,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
             <Button
               variant="primary"
               label={t('deployment.AddRevision')}
-              isLoading={isAddInFlight || isResolvingImage}
+              isLoading={isSubmitInFlight}
               onClick={handleOk}
               isDisabled={
                 (effectiveMode === 'preset' && hasNoPresets) ||
@@ -1938,7 +1942,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
         </BAIFlex>
       }
       onCancel={() => onRequestClose()}
-      confirmLoading={isAddInFlight || isResolvingImage}
+      confirmLoading={isSubmitInFlight}
       destroyOnHidden
       {...restModalProps}
     >
@@ -2154,11 +2158,19 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                           // (existing key reused).
                           return (
                             <ButtonGroup label={t('deployment.ModelFolder')}>
+                              {/* FR-2526: the tooltip says why rather than
+                                  letting the button go silently dead. */}
                               <IconButton
                                 icon={<FolderOpenIcon />}
                                 label={t('modelService.OpenFolder')}
-                                tooltip={t('modelService.OpenFolder')}
-                                isDisabled={!modelFolderId}
+                                tooltip={
+                                  isSubmitInFlight
+                                    ? t(
+                                        'deployment.FolderAccessDisabledWhileAddingRevision',
+                                      )
+                                    : t('modelService.OpenFolder')
+                                }
+                                isDisabled={!modelFolderId || isSubmitInFlight}
                                 onClick={() => {
                                   if (modelFolderId) {
                                     openFolderExplorer(
@@ -2337,11 +2349,18 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                   const modelFolderId = getFieldValue('modelFolderId');
                   return (
                     <ButtonGroup label={t('deployment.ModelFolder')}>
+                      {/* FR-2526 — same gate as the Preset body above. */}
                       <IconButton
                         icon={<FolderOpenIcon />}
                         label={t('modelService.OpenFolder')}
-                        tooltip={t('modelService.OpenFolder')}
-                        isDisabled={!modelFolderId}
+                        tooltip={
+                          isSubmitInFlight
+                            ? t(
+                                'deployment.FolderAccessDisabledWhileAddingRevision',
+                              )
+                            : t('modelService.OpenFolder')
+                        }
+                        isDisabled={!modelFolderId || isSubmitInFlight}
                         onClick={() => {
                           if (modelFolderId) {
                             openFolderExplorer(toLocalId(modelFolderId));
@@ -2594,9 +2613,19 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                     <VFolderTableFormItem
                       label={t('modelService.AdditionalMounts')}
                       tooltip={t('modelService.AdditionalMountsTooltip')}
+                      // FR-2526: the folder-name cells are the other route
+                      // into the file browser, so they are gated too.
+                      extra={
+                        isSubmitInFlight
+                          ? t(
+                              'deployment.FolderAccessDisabledWhileAddingRevision',
+                            )
+                          : undefined
+                      }
                       rowKey="id"
                       tableProps={{
                         scroll: { x: 'max-content', y: 300 },
+                        isFolderLinkDisabled: isSubmitInFlight,
                       }}
                       rowFilter={(vfolder) =>
                         vfolder.usage_mode !== 'model' &&

--- a/react/src/components/VFolderTable.test.tsx
+++ b/react/src/components/VFolderTable.test.tsx
@@ -1,0 +1,142 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import VFolderTable from './VFolderTable';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { MemoryRouter } from 'react-router-dom';
+import { createMockEnvironment } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * FR-2526: the folder-name cell is a file-browser entry point, so it must stop
+ * navigating while the form that owns the table has a submit in flight.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  };
+});
+
+const MOUNTABLE_HOST = 'local:volume1';
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({
+      _config: { accessKey: 'AKIATEST', domainName: 'default' },
+    }),
+  };
+});
+
+vi.mock('../hooks/hooksUsingRelay', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/hooksUsingRelay')>();
+  return {
+    ...originalModule,
+    useKeyPairLazyLoadQuery: () => [{ resource_policy: 'default' }, vi.fn()],
+  };
+});
+
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'test-project-id',
+      name: 'test-project-name',
+    }),
+  };
+});
+
+// The folder list is REST-backed; serve it directly instead of a signed request.
+vi.mock('../hooks/reactQueryAlias', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/reactQueryAlias')>();
+  return {
+    ...originalModule,
+    useSuspenseTanQuery: () => ({
+      data: [
+        {
+          id: 'folder-id-1',
+          name: 'my-model-folder',
+          host: MOUNTABLE_HOST,
+          status: 'ready',
+          usage_mode: 'model',
+          ownership_type: 'user',
+          permission: 'rw',
+          type: 'user',
+        },
+      ],
+    }),
+  };
+});
+
+vi.mock('./FolderExplorerOpener', () => ({
+  useFolderExplorerOpener: () => ({
+    open: vi.fn(),
+    generateFolderPath: (id: string) => `/folder/${id}`,
+  }),
+}));
+
+vi.mock('./FolderCreateModalV2', () => ({ default: () => null }));
+
+const renderTable = (isFolderLinkDisabled: boolean) => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  const allowedHosts = JSON.stringify({
+    [MOUNTABLE_HOST]: ['mount-in-session'],
+  });
+  environment.mock.queueOperationResolver(() => ({
+    data: {
+      domain: { allowed_vfolder_hosts: allowedHosts },
+      group: { allowed_vfolder_hosts: allowedHosts },
+      keypair_resource_policy: { allowed_vfolder_hosts: allowedHosts },
+    },
+  }));
+
+  return render(
+    <MemoryRouter>
+      <RelayEnvironmentProvider environment={environment}>
+        <Suspense fallback={null}>
+          <VFolderTable
+            rowKey="id"
+            isFolderLinkDisabled={isFolderLinkDisabled}
+          />
+        </Suspense>
+      </RelayEnvironmentProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('VFolderTable folder-link gate (FR-2526)', () => {
+  it('links the folder name to the folder explorer by default', async () => {
+    renderTable(false);
+
+    const link = await screen.findByRole('link', { name: 'my-model-folder' });
+    expect(link).toHaveAttribute('href');
+    expect(link).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('renders the folder name as a non-navigating link while disabled', async () => {
+    renderTable(true);
+
+    const name = await screen.findByText('my-model-folder');
+    // No destination at all: the file browser cannot be reached from the cell.
+    expect(screen.queryByRole('link', { name: 'my-model-folder' })).toBeNull();
+    expect(name.closest('[aria-disabled="true"]')).not.toBeNull();
+  });
+});

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -91,6 +91,12 @@ export interface VFolderTableProps extends Omit<
     invalidKeys: VFolderKey[],
     validVFolders: VFolder[],
   ) => void;
+  /**
+   * Renders the folder-name cells as disabled links instead of navigating to
+   * the folder explorer. Set it while a form submit is in flight so the file
+   * browser cannot change the folders that submit is about to mount (FR-2526).
+   */
+  isFolderLinkDisabled?: boolean;
 }
 
 export const vFolderAliasNameRegExp = /^[a-zA-Z0-9_/.-]*$/;
@@ -108,6 +114,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   showAutoMountedFoldersSection,
   ownerEmail,
   onValidateSelectedRowKeys,
+  isFolderLinkDisabled = false,
   ...tableProps
 }) => {
   'use memo';
@@ -413,7 +420,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
             }
           >
             <BAILink
-              type="hover"
+              type={isFolderLinkDisabled ? 'disabled' : 'hover'}
               to={generateFolderPath(record.id)}
               style={{
                 overflow: 'hidden',

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Bereitstellung konnte nicht gelöscht werden.",
     "FailedToRollback": "Rollback zur ausgewählten Revision ist fehlgeschlagen.",
     "FailedToUpdateDeployment": "Bereitstellung konnte nicht aktualisiert werden.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Der Ordnerzugriff ist nicht verfügbar, während die Revision hinzugefügt wird.",
     "FromStatus": "Von Status",
     "GoToDetailPage": "Bereitstellungsdetails anzeigen",
     "HealthStatus": "Gesundheitsstatus",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Bereitstellung konnte nicht gelöscht werden.",
     "FailedToRollback": "Rollback zur ausgewählten Revision ist fehlgeschlagen.",
     "FailedToUpdateDeployment": "Bereitstellung konnte nicht aktualisiert werden.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Von Status",
     "GoToDetailPage": "Bereitstellungsdetails anzeigen",
     "HealthStatus": "Gesundheitsstatus",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Αποτυχία διαγραφής ανάπτυξης.",
     "FailedToRollback": "Αποτυχία επαναφοράς στην επιλεγμένη Revision.",
     "FailedToUpdateDeployment": "Αποτυχία ενημέρωσης ανάπτυξης.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Από κατάσταση",
     "GoToDetailPage": "Προβολή λεπτομερειών ανάπτυξης",
     "HealthStatus": "Κατάσταση υγείας",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Αποτυχία διαγραφής ανάπτυξης.",
     "FailedToRollback": "Αποτυχία επαναφοράς στην επιλεγμένη Revision.",
     "FailedToUpdateDeployment": "Αποτυχία ενημέρωσης ανάπτυξης.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Η πρόσβαση στους φακέλους δεν είναι διαθέσιμη κατά την προσθήκη της Revision.",
     "FromStatus": "Από κατάσταση",
     "GoToDetailPage": "Προβολή λεπτομερειών ανάπτυξης",
     "HealthStatus": "Κατάσταση υγείας",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1129,6 +1129,7 @@
     "FailedToDeleteDeployment": "Failed to delete deployment.",
     "FailedToRollback": "Failed to rollback to the selected revision.",
     "FailedToUpdateDeployment": "Failed to update deployment.",
+    "FolderAccessDisabledWhileAddingRevision": "Folder access is unavailable while the revision is being added.",
     "FromStatus": "From Status",
     "GoToDetailPage": "View Deployment Details",
     "HealthStatus": "Health Status",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Error al eliminar el despliegue.",
     "FailedToRollback": "Error al revertir a la Revision seleccionada.",
     "FailedToUpdateDeployment": "Error al actualizar el despliegue.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Estado de origen",
     "GoToDetailPage": "Ver detalles del despliegue",
     "HealthStatus": "Estado de salud",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Error al eliminar el despliegue.",
     "FailedToRollback": "Error al revertir a la Revision seleccionada.",
     "FailedToUpdateDeployment": "Error al actualizar el despliegue.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "El acceso a las carpetas no está disponible mientras se agrega la Revision.",
     "FromStatus": "Estado de origen",
     "GoToDetailPage": "Ver detalles del despliegue",
     "HealthStatus": "Estado de salud",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Käyttöönoton poistaminen epäonnistui.",
     "FailedToRollback": "Palautus valittuun Revision epäonnistui.",
     "FailedToUpdateDeployment": "Käyttöönoton päivittäminen epäonnistui.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Edellinen tila",
     "GoToDetailPage": "Näytä käyttöönoton tiedot",
     "HealthStatus": "Terveystila",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Käyttöönoton poistaminen epäonnistui.",
     "FailedToRollback": "Palautus valittuun Revision epäonnistui.",
     "FailedToUpdateDeployment": "Käyttöönoton päivittäminen epäonnistui.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Kansioiden käyttö ei ole mahdollista, kun Revision lisätään.",
     "FromStatus": "Edellinen tila",
     "GoToDetailPage": "Näytä käyttöönoton tiedot",
     "HealthStatus": "Terveystila",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Échec de la suppression du déploiement.",
     "FailedToRollback": "Échec du retour à la Revision sélectionnée.",
     "FailedToUpdateDeployment": "Échec de la mise à jour du déploiement.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "L'accès aux dossiers n'est pas disponible pendant l'ajout de la Revision.",
     "FromStatus": "Statut source",
     "GoToDetailPage": "Voir les détails du déploiement",
     "HealthStatus": "État de santé",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Échec de la suppression du déploiement.",
     "FailedToRollback": "Échec du retour à la Revision sélectionnée.",
     "FailedToUpdateDeployment": "Échec de la mise à jour du déploiement.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Statut source",
     "GoToDetailPage": "Voir les détails du déploiement",
     "HealthStatus": "État de santé",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Gagal menghapus penerapan.",
     "FailedToRollback": "Gagal kembali ke Revision yang dipilih.",
     "FailedToUpdateDeployment": "Gagal memperbarui penerapan.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Akses folder tidak tersedia saat Revision sedang ditambahkan.",
     "FromStatus": "Dari Status",
     "GoToDetailPage": "Lihat detail penyebaran",
     "HealthStatus": "Status Kesehatan",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Gagal menghapus penerapan.",
     "FailedToRollback": "Gagal kembali ke Revision yang dipilih.",
     "FailedToUpdateDeployment": "Gagal memperbarui penerapan.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Dari Status",
     "GoToDetailPage": "Lihat detail penyebaran",
     "HealthStatus": "Status Kesehatan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Eliminazione della distribuzione non riuscita.",
     "FailedToRollback": "Ripristino alla Revision selezionata non riuscito.",
     "FailedToUpdateDeployment": "Aggiornamento della distribuzione non riuscito.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "L'accesso alle cartelle non è disponibile mentre la Revision viene aggiunta.",
     "FromStatus": "Stato di origine",
     "GoToDetailPage": "Visualizza i dettagli della distribuzione",
     "HealthStatus": "Stato di salute",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Eliminazione della distribuzione non riuscita.",
     "FailedToRollback": "Ripristino alla Revision selezionata non riuscito.",
     "FailedToUpdateDeployment": "Aggiornamento della distribuzione non riuscito.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Stato di origine",
     "GoToDetailPage": "Visualizza i dettagli della distribuzione",
     "HealthStatus": "Stato di salute",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "デプロイの削除に失敗しました。",
     "FailedToRollback": "選択した Revision へのロールバックに失敗しました。",
     "FailedToUpdateDeployment": "デプロイの更新に失敗しました。",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "元のステータス",
     "GoToDetailPage": "デプロイの詳細を表示",
     "HealthStatus": "ヘルス状態",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "デプロイの削除に失敗しました。",
     "FailedToRollback": "選択した Revision へのロールバックに失敗しました。",
     "FailedToUpdateDeployment": "デプロイの更新に失敗しました。",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Revision の追加中はフォルダーにアクセスできません。",
     "FromStatus": "元のステータス",
     "GoToDetailPage": "デプロイの詳細を表示",
     "HealthStatus": "ヘルス状態",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "배포 삭제에 실패했습니다.",
     "FailedToRollback": "선택한 리비전으로 롤백하는 데 실패했습니다.",
     "FailedToUpdateDeployment": "배포 업데이트에 실패했습니다.",
+    "FolderAccessDisabledWhileAddingRevision": "리비전을 추가하는 동안에는 폴더에 접근할 수 없습니다.",
     "FromStatus": "이전 상태",
     "GoToDetailPage": "배포 자세히 보기",
     "HealthStatus": "헬스 상태",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Байршуулалт устгахад алдаа гарлаа.",
     "FailedToRollback": "Сонгосон Revision руу буцаахад алдаа гарлаа.",
     "FailedToUpdateDeployment": "Байршуулалт шинэчлэхэд алдаа гарлаа.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Revision нэмэгдэж байх үед фолдер руу хандах боломжгүй.",
     "FromStatus": "Өмнөх статус",
     "GoToDetailPage": "Түгээлтийн дэлгэрэнгүйг үзэх",
     "HealthStatus": "Эрүүл мэндийн төлөв",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Байршуулалт устгахад алдаа гарлаа.",
     "FailedToRollback": "Сонгосон Revision руу буцаахад алдаа гарлаа.",
     "FailedToUpdateDeployment": "Байршуулалт шинэчлэхэд алдаа гарлаа.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Өмнөх статус",
     "GoToDetailPage": "Түгээлтийн дэлгэрэнгүйг үзэх",
     "HealthStatus": "Эрүүл мэндийн төлөв",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Gagal memadam penggunaan.",
     "FailedToRollback": "Gagal kembali ke Revision yang dipilih.",
     "FailedToUpdateDeployment": "Gagal mengemas kini penggunaan.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Akses folder tidak tersedia semasa Revision sedang ditambah.",
     "FromStatus": "Dari Status",
     "GoToDetailPage": "Lihat butiran penggelaran",
     "HealthStatus": "Status Kesihatan",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Gagal memadam penggunaan.",
     "FailedToRollback": "Gagal kembali ke Revision yang dipilih.",
     "FailedToUpdateDeployment": "Gagal mengemas kini penggunaan.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Dari Status",
     "GoToDetailPage": "Lihat butiran penggelaran",
     "HealthStatus": "Status Kesihatan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Nie udało się usunąć wdrożenia.",
     "FailedToRollback": "Nie udało się cofnąć do wybranej Revision.",
     "FailedToUpdateDeployment": "Nie udało się zaktualizować wdrożenia.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Z statusu",
     "GoToDetailPage": "Wyświetl szczegóły wdrożenia",
     "HealthStatus": "Stan zdrowia",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Nie udało się usunąć wdrożenia.",
     "FailedToRollback": "Nie udało się cofnąć do wybranej Revision.",
     "FailedToUpdateDeployment": "Nie udało się zaktualizować wdrożenia.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Dostęp do folderów jest zablokowany podczas dodawania Revision.",
     "FromStatus": "Z statusu",
     "GoToDetailPage": "Wyświetl szczegóły wdrożenia",
     "HealthStatus": "Stan zdrowia",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Falha ao excluir a implantação.",
     "FailedToRollback": "Falha ao reverter para a Revision selecionada.",
     "FailedToUpdateDeployment": "Falha ao atualizar a implantação.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Do status",
     "GoToDetailPage": "Ver detalhes da implantação",
     "HealthStatus": "Status de saúde",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Falha ao excluir a implantação.",
     "FailedToRollback": "Falha ao reverter para a Revision selecionada.",
     "FailedToUpdateDeployment": "Falha ao atualizar a implantação.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "O acesso às pastas não está disponível enquanto a Revision está sendo adicionada.",
     "FromStatus": "Do status",
     "GoToDetailPage": "Ver detalhes da implantação",
     "HealthStatus": "Status de saúde",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Falha ao eliminar a implementação.",
     "FailedToRollback": "Falha ao reverter para a Revision selecionada.",
     "FailedToUpdateDeployment": "Falha ao atualizar a implementação.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Status anterior",
     "GoToDetailPage": "Ver detalhes da implantação",
     "HealthStatus": "Estado de saúde",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Falha ao eliminar a implementação.",
     "FailedToRollback": "Falha ao reverter para a Revision selecionada.",
     "FailedToUpdateDeployment": "Falha ao atualizar a implementação.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "O acesso às pastas não está disponível enquanto a Revision está a ser adicionada.",
     "FromStatus": "Status anterior",
     "GoToDetailPage": "Ver detalhes da implantação",
     "HealthStatus": "Estado de saúde",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Не удалось удалить развёртывание.",
     "FailedToRollback": "Не удалось выполнить откат до выбранной Revision.",
     "FailedToUpdateDeployment": "Не удалось обновить развёртывание.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Исходный статус",
     "GoToDetailPage": "Просмотреть детали развертывания",
     "HealthStatus": "Состояние здоровья",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Не удалось удалить развёртывание.",
     "FailedToRollback": "Не удалось выполнить откат до выбранной Revision.",
     "FailedToUpdateDeployment": "Не удалось обновить развёртывание.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Доступ к папкам невозможен во время добавления Revision.",
     "FromStatus": "Исходный статус",
     "GoToDetailPage": "Просмотреть детали развертывания",
     "HealthStatus": "Состояние здоровья",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "ไม่สามารถลบการปรับใช้ได้",
     "FailedToRollback": "ไม่สามารถย้อนกลับไปยัง Revision ที่เลือกได้",
     "FailedToUpdateDeployment": "ไม่สามารถอัปเดตการปรับใช้ได้",
+    "FolderAccessDisabledWhileAddingRevision": "ไม่สามารถเข้าถึงโฟลเดอร์ขณะกำลังเพิ่ม Revision",
     "FromStatus": "จากสถานะ",
     "GoToDetailPage": "ดูรายละเอียดการปรับใช้",
     "HealthStatus": "สถานะสุขภาพ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Dağıtım silinemedi.",
     "FailedToRollback": "Seçilen Revision'a geri alınamadı.",
     "FailedToUpdateDeployment": "Dağıtım güncellenemedi.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Revision eklenirken klasör erişimi kullanılamaz.",
     "FromStatus": "Başlangıç Durumu",
     "GoToDetailPage": "Dağıtım ayrıntılarını görüntüle",
     "HealthStatus": "Sağlık Durumu",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Dağıtım silinemedi.",
     "FailedToRollback": "Seçilen Revision'a geri alınamadı.",
     "FailedToUpdateDeployment": "Dağıtım güncellenemedi.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Başlangıç Durumu",
     "GoToDetailPage": "Dağıtım ayrıntılarını görüntüle",
     "HealthStatus": "Sağlık Durumu",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "Không thể xóa triển khai.",
     "FailedToRollback": "Không thể khôi phục về Revision đã chọn.",
     "FailedToUpdateDeployment": "Không thể cập nhật triển khai.",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "Từ trạng thái",
     "GoToDetailPage": "Xem chi tiết triển khai",
     "HealthStatus": "Trạng thái sức khỏe",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "Không thể xóa triển khai.",
     "FailedToRollback": "Không thể khôi phục về Revision đã chọn.",
     "FailedToUpdateDeployment": "Không thể cập nhật triển khai.",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "Không thể truy cập thư mục trong khi Revision đang được thêm.",
     "FromStatus": "Từ trạng thái",
     "GoToDetailPage": "Xem chi tiết triển khai",
     "HealthStatus": "Trạng thái sức khỏe",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1142,6 +1142,7 @@
     "FailedToDeleteDeployment": "删除部署失败。",
     "FailedToRollback": "回滚到所选 Revision 失败。",
     "FailedToUpdateDeployment": "更新部署失败。",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "来源状态",
     "GoToDetailPage": "查看部署详情",
     "HealthStatus": "健康状态",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1142,7 +1142,7 @@
     "FailedToDeleteDeployment": "删除部署失败。",
     "FailedToRollback": "回滚到所选 Revision 失败。",
     "FailedToUpdateDeployment": "更新部署失败。",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "添加 Revision 期间无法访问文件夹。",
     "FromStatus": "来源状态",
     "GoToDetailPage": "查看部署详情",
     "HealthStatus": "健康状态",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1143,7 +1143,7 @@
     "FailedToDeleteDeployment": "刪除部署失敗。",
     "FailedToRollback": "回滾到所選 Revision 失敗。",
     "FailedToUpdateDeployment": "更新部署失敗。",
-    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
+    "FolderAccessDisabledWhileAddingRevision": "新增 Revision 期間無法存取文件夾。",
     "FromStatus": "來源狀態",
     "GoToDetailPage": "檢視部署詳細資訊",
     "HealthStatus": "健康狀態",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1143,6 +1143,7 @@
     "FailedToDeleteDeployment": "刪除部署失敗。",
     "FailedToRollback": "回滾到所選 Revision 失敗。",
     "FailedToUpdateDeployment": "更新部署失敗。",
+    "FolderAccessDisabledWhileAddingRevision": "__NOT_TRANSLATED__",
     "FromStatus": "來源狀態",
     "GoToDetailPage": "檢視部署詳細資訊",
     "HealthStatus": "健康狀態",


### PR DESCRIPTION
Resolves #6603 (FR-2526)

The issue was filed against `ServiceLauncherPageContent`, which was deleted in #7325 (FR-2852) together with the `modify_endpoint` path it guarded. The request itself is still undelivered: the model-service update path today is `DeploymentAddRevisionModal`, and it embeds the same two file-browser entry points with no in-flight gate.

While `addModelRevision` is running, the modal body stays fully interactive — `confirmLoading` only spins the OK button (`BAIModal` passes it to the OK button's `isLoading` and renders no mask). So a user can still open the folder explorer, start a filebrowser session, and edit files in a folder the new replicas are about to mount. A revision references a model folder, it does not snapshot its contents, so those edits land in what the new replicas serve.

## What changed

- `DeploymentAddRevisionModal` gets a single `isSubmitInFlight` flag (`isAddInFlight || isResolvingImage` — the same state the submit button already shows, so the image-name resolution that precedes the mutation is covered too) and uses it for the submit button, `confirmLoading`, and the new gates.
- Both "Open Folder" icon buttons (Preset body and Custom body) are disabled while it is true, and their tooltip switches to an explanation rather than the button silently going dead.
- `VFolderTable` gains `isFolderLinkDisabled`, which renders the folder-name cells as `BAILink type="disabled"` — an aria-disabled, non-navigating link — instead of a route to the folder explorer. The additional-mounts form item carries the same explanation in its `extra` slot.
- New i18n key `deployment.FolderAccessDisabledWhileAddingRevision`, translated in all 21 locale files. `th` is not in `i18n.config.js`'s `lngs` so `make i18n` skips it; it is added by hand, the way the rest of `th.json` is kept in sync.

Access is restored automatically when the mutation settles, success or error. The create path is untouched — this modal only adds revisions to an existing deployment.

### Design decisions

- **A prop on `VFolderTable`, not a tooltip per row.** Astryx's disabled `Link` sets `pointer-events: none`, so a `Tooltip` wrapping the cell would never fire. The "why" is therefore shown once, in the form item's `extra`, while the cells themselves just stop navigating.
- **The gate is not extended to "create folder" / "refresh"** in the same button group: neither mutates the contents of a mounted folder, and the issue asks specifically about file-browser access.

## Scope — what this does *not* close

Both limits below are deliberate; flagging them so a reviewer can confirm the narrower scope is acceptable for FR-2526 rather than discover it after merge.

- **Only the two entry points are gated, not sessions already open.** A `FolderExplorerModal` already open via the global `?folder=` query param, or a filebrowser session already launched in another browser tab, keeps working when the submit starts. Revoking those means force-closing a modal the user may be mid-upload in (`FileUploadManager`), and a tab this modal has no handle on at all — a product call, not a mechanical one. The gate closes the routes this form owns.
- **The rest of the modal stays editable during the mutation.** The deleted `ServiceLauncherPageContent` gated its whole `<Form disabled=…>`; this PR does not, because `BAIModal`'s `confirmLoading` renders no mask and blanket-disabling every field mid-submit is a wider UX change than the issue asks for. Edits made in that window are discarded when the modal closes on success, so they do not reach the submitted revision.

## Tests

- New `react/src/components/VFolderTable.test.tsx` (2 cases): the folder name is a real link by default; with `isFolderLinkDisabled` there is no link role and the name sits inside an `aria-disabled` element. `pnpm exec vitest run src/components/VFolderTable.test.tsx` — 2 passed.
- `pnpm exec vitest run src/components/DeploymentAddRevisionModal.test.tsx` — 3 passed (no regression).

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

## Review notes

- Open a deployment → **Add revision**, pick a model folder, submit, and watch the "Open Folder" button during the request: it should be disabled with the explanatory tooltip, and enabled again once the modal settles.
- In Custom mode, expand the additional-mounts table while submitting: folder names should be grey and non-clickable, with the explanation under the field.
- The gate uses the same flag as the submit spinner, so anything that makes the button spin also closes the folder routes — there is no second source of truth to keep in sync.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
