### PR TITLE
chore(FR-3028): add ESLint rule forbidding fragment $key type at its spread site

### DIFF
--- a/.github/workflows/vitest-root.yml
+++ b/.github/workflows/vitest-root.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - scripts/**
       - src/**
+      - packages/eslint-config-bai/**
       - vitest.config.ts
       - .github/workflows/vitest-root.yml
 

--- a/packages/eslint-config-bai/bai-plugin.js
+++ b/packages/eslint-config-bai/bai-plugin.js
@@ -1,0 +1,176 @@
+/**
+ * Custom ESLint rules for Backend.AI WebUI (Relay conventions), exposed as a
+ * flat-config plugin so both `react/` and `packages/backend.ai-ui/` pick them
+ * up through `eslint-config-bai`.
+ */
+
+const KEY_SUFFIX = "$key";
+
+const isKeyTypeName = (name) =>
+  typeof name === "string" && name.endsWith(KEY_SUFFIX);
+
+const baseFragmentName = (keyTypeName) =>
+  keyTypeName.slice(0, -KEY_SUFFIX.length);
+
+/**
+ * Collect fragment definitions and named spreads from a graphql`` literal's
+ * text. Relay literals carry no `${}` interpolation, so a textual scan of the
+ * quasis is the whole document — and scanning the literal rather than the
+ * source is what keeps JS spread operators and doc strings out of the result.
+ */
+const scanGraphqlText = (text, defined, spread) => {
+  const defRe = /\bfragment\s+([A-Za-z_]\w*)\s+on\s/g;
+  let m;
+  while ((m = defRe.exec(text)) !== null) {
+    defined.add(m[1]);
+  }
+  const spreadRe = /\.\.\.\s*([A-Za-z_]\w*)/g;
+  while ((m = spreadRe.exec(text)) !== null) {
+    // `... on Type` is an inline fragment, not a named spread.
+    if (m[1] !== "on") {
+      spread.add(m[1]);
+    }
+  }
+};
+
+/**
+ * Collect `*$key` type references from structural type positions (unions,
+ * arrays, generic args, wrappers). Function-type parameters are deliberately
+ * not walked: a `$key` there is the fragment-component prop contract.
+ */
+const collectKeyTypeRefs = (typeNode, out) => {
+  if (!typeNode || typeof typeNode !== "object") {
+    return;
+  }
+  if (
+    typeNode.type === "TSTypeReference" &&
+    typeNode.typeName?.type === "Identifier" &&
+    isKeyTypeName(typeNode.typeName.name)
+  ) {
+    out.push(typeNode);
+  }
+  if (Array.isArray(typeNode.types)) {
+    typeNode.types.forEach((c) => collectKeyTypeRefs(c, out));
+  }
+  if (typeNode.elementType) {
+    collectKeyTypeRefs(typeNode.elementType, out);
+  }
+  if (typeNode.typeAnnotation) {
+    collectKeyTypeRefs(typeNode.typeAnnotation, out);
+  }
+  const typeArgs = typeNode.typeArguments || typeNode.typeParameters;
+  if (typeArgs && Array.isArray(typeArgs.params)) {
+    typeArgs.params.forEach((c) => collectKeyTypeRefs(c, out));
+  }
+};
+
+/**
+ * Disallow typing a local value (a `useState` cell or a plain variable) with a
+ * fragment's generated `$key` at a site that already spreads that fragment:
+ * the local query response is already assignable to `Foo$key`, so importing
+ * the child's `$key` only adds type coupling. A project convention, not a
+ * Relay requirement.
+ *
+ * Exempt: the fragment-owning file (it DEFINES the fragment), prop/callback
+ * parameter positions, and files that never spread the fragment.
+ */
+const noFragmentKeyAtSpreadSite = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow typing a local value with a fragment's generated $key type at a site that already spreads that fragment; derive the type from the local query node instead.",
+    },
+    schema: [],
+    messages: {
+      deriveLocally:
+        "This file spreads `...{{fragment}}` in a graphql literal, so the query/fragment response already yields a value assignable to `{{name}}`. Type this {{position}} with your own query's node type instead of the child fragment's `{{name}}` (and drop the import if nothing else uses it).",
+    },
+  },
+  create(context) {
+    const definedFragments = new Set();
+    const spreadFragments = new Set();
+    const candidates = [];
+
+    const getTypeArguments = (node) =>
+      node.typeArguments || node.typeParameters || null;
+
+    return {
+      TaggedTemplateExpression(node) {
+        if (node.tag.type !== "Identifier" || node.tag.name !== "graphql") {
+          return;
+        }
+        const text = node.quasi.quasis
+          .map((q) => (q.value && (q.value.cooked ?? q.value.raw)) || "")
+          .join("\n");
+        scanGraphqlText(text, definedFragments, spreadFragments);
+      },
+
+      // useState<...$key>() / useState<...$key | null>()
+      CallExpression(node) {
+        if (
+          node.callee.type !== "Identifier" ||
+          node.callee.name !== "useState"
+        ) {
+          return;
+        }
+        const typeArgs = getTypeArguments(node);
+        if (!typeArgs || !typeArgs.params || typeArgs.params.length === 0) {
+          return;
+        }
+        const refs = [];
+        collectKeyTypeRefs(typeArgs.params[0], refs);
+        refs.forEach((ref) =>
+          candidates.push({
+            node: ref,
+            name: ref.typeName.name,
+            position: "state",
+          }),
+        );
+      },
+
+      // const x: ...$key = ...   (plain local variable annotation)
+      VariableDeclarator(node) {
+        if (
+          node.id?.type !== "Identifier" ||
+          !node.id.typeAnnotation?.typeAnnotation
+        ) {
+          return;
+        }
+        const refs = [];
+        collectKeyTypeRefs(node.id.typeAnnotation.typeAnnotation, refs);
+        refs.forEach((ref) =>
+          candidates.push({
+            node: ref,
+            name: ref.typeName.name,
+            position: "variable",
+          }),
+        );
+      },
+
+      "Program:exit"() {
+        for (const candidate of candidates) {
+          const base = baseFragmentName(candidate.name);
+          if (definedFragments.has(base) || !spreadFragments.has(base)) {
+            continue;
+          }
+          context.report({
+            node: candidate.node,
+            messageId: "deriveLocally",
+            data: {
+              fragment: base,
+              name: candidate.name,
+              position: candidate.position,
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    "no-fragment-key-at-spread-site": noFragmentKeyAtSpreadSite,
+  },
+};

--- a/packages/eslint-config-bai/bai-plugin.js
+++ b/packages/eslint-config-bai/bai-plugin.js
@@ -13,12 +13,49 @@ const baseFragmentName = (keyTypeName) =>
   keyTypeName.slice(0, -KEY_SUFFIX.length);
 
 /**
+ * Blank out GraphQL `#` comments and string / block-string tokens so the
+ * scan below reads syntax only: a `# ...Foo` note must not register a spread,
+ * and `fragment Foo on Node` inside a description must not exempt a violation.
+ */
+const stripCommentsAndStrings = (text) => {
+  let out = "";
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === "#") {
+      while (i < text.length && text[i] !== "\n") {
+        i += 1;
+      }
+      continue;
+    }
+    if (text.startsWith('"""', i)) {
+      const end = text.indexOf('"""', i + 3);
+      i = end === -1 ? text.length : end + 3;
+      out += " ";
+      continue;
+    }
+    if (text[i] === '"') {
+      i += 1;
+      while (i < text.length && text[i] !== '"' && text[i] !== "\n") {
+        i += text[i] === "\\" ? 2 : 1;
+      }
+      i += 1;
+      out += " ";
+      continue;
+    }
+    out += text[i];
+    i += 1;
+  }
+  return out;
+};
+
+/**
  * Collect fragment definitions and named spreads from a graphql`` literal's
  * text. Relay literals carry no `${}` interpolation, so a textual scan of the
  * quasis is the whole document — and scanning the literal rather than the
  * source is what keeps JS spread operators and doc strings out of the result.
  */
-const scanGraphqlText = (text, defined, spread) => {
+const scanGraphqlText = (rawText, defined, spread) => {
+  const text = stripCommentsAndStrings(rawText);
   const defRe = /\bfragment\s+([A-Za-z_]\w*)\s+on\s/g;
   let m;
   while ((m = defRe.exec(text)) !== null) {
@@ -64,6 +101,19 @@ const collectKeyTypeRefs = (typeNode, out) => {
   }
 };
 
+/** Both call forms in use here: bare `useState` and `React.useState`. */
+const isUseStateCallee = (callee) => {
+  if (callee.type === "Identifier") {
+    return callee.name === "useState";
+  }
+  return (
+    callee.type === "MemberExpression" &&
+    !callee.computed &&
+    callee.property?.type === "Identifier" &&
+    callee.property.name === "useState"
+  );
+};
+
 /**
  * Disallow typing a local value (a `useState` cell or a plain variable) with a
  * fragment's generated `$key` at a site that already spreads that fragment:
@@ -106,12 +156,9 @@ const noFragmentKeyAtSpreadSite = {
         scanGraphqlText(text, definedFragments, spreadFragments);
       },
 
-      // useState<...$key>() / useState<...$key | null>()
+      // useState<...$key>() / React.useState<...$key | null>()
       CallExpression(node) {
-        if (
-          node.callee.type !== "Identifier" ||
-          node.callee.name !== "useState"
-        ) {
+        if (!isUseStateCallee(node.callee)) {
           return;
         }
         const typeArgs = getTypeArguments(node);

--- a/packages/eslint-config-bai/bai-plugin.js
+++ b/packages/eslint-config-bai/bai-plugin.js
@@ -28,8 +28,12 @@ const stripCommentsAndStrings = (text) => {
       continue;
     }
     if (text.startsWith('"""', i)) {
-      const end = text.indexOf('"""', i + 3);
-      i = end === -1 ? text.length : end + 3;
+      // `\"""` is the one escape a block string has; it is not the delimiter.
+      let j = i + 3;
+      while (j < text.length && !text.startsWith('"""', j)) {
+        j += text[j] === "\\" && text.startsWith('"""', j + 1) ? 4 : 1;
+      }
+      i = j >= text.length ? text.length : j + 3;
       out += " ";
       continue;
     }

--- a/packages/eslint-config-bai/bai-plugin.test.js
+++ b/packages/eslint-config-bai/bai-plugin.test.js
@@ -63,6 +63,25 @@ ruleTester.run(
       const merged = { ...Foo };
       const [x, setX] = useState<Foo$key | null>(null);
       `,
+      // A spread named only inside a `#` comment is not a spread.
+      `
+      const q = graphql\`
+        query Q {
+          # ...Foo is deliberately not selected here
+          node { id }
+        }
+      \`;
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
+      // A spread named only inside a string argument is not a spread either.
+      `
+      const q = graphql\`
+        query Q {
+          node(label: "...Foo") { id }
+        }
+      \`;
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
     ],
     invalid: [
       {
@@ -110,6 +129,32 @@ ruleTester.run(
           }
         \`;
         const [x, setX] = useState<Foo$key | null>(null);
+        `,
+        errors: [{ messageId: "deriveLocally" }],
+      },
+      // A `fragment Foo on ...` that only appears in a comment or a string
+      // does not make this the fragment-owning file.
+      {
+        code: `
+        const q = graphql\`
+          query Q {
+            # fragment Foo on Node lives in another file
+            node(label: "fragment Foo on Node") { ...Foo }
+          }
+        \`;
+        const [x, setX] = useState<Foo$key | null>(null);
+        `,
+        errors: [{ messageId: "deriveLocally" }],
+      },
+      // `React.useState` is the same declaration, spelled through the import.
+      {
+        code: `
+        const q = graphql\`
+          query Q {
+            node { ...Foo }
+          }
+        \`;
+        const [x, setX] = React.useState<Foo$key | null>(null);
         `,
         errors: [{ messageId: "deriveLocally" }],
       },

--- a/packages/eslint-config-bai/bai-plugin.test.js
+++ b/packages/eslint-config-bai/bai-plugin.test.js
@@ -1,0 +1,118 @@
+import baiPlugin from "./bai-plugin.js";
+import { RuleTester } from "eslint";
+import tseslint from "typescript-eslint";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run(
+  "no-fragment-key-at-spread-site",
+  baiPlugin.rules["no-fragment-key-at-spread-site"],
+  {
+    valid: [
+      // The fragment-owning file: it DEFINES `Foo`, so `Foo$key` is its own
+      // prop / useFragment contract.
+      `
+      const f = graphql\`
+        fragment Foo on Node {
+          ...Bar
+          id
+        }
+      \`;
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
+      // No local spread of `Foo` — the ref comes from a prop.
+      `
+      const q = graphql\`
+        query Q {
+          node { id }
+        }
+      \`;
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
+      // Parameter positions are the fragment-component prop contract.
+      `
+      const q = graphql\`
+        query Q {
+          node { ...Foo }
+        }
+      \`;
+      const cb: (ref: Foo$key) => void = () => {};
+      `,
+      // `... on Type` is an inline fragment, not a named spread.
+      `
+      const q = graphql\`
+        query Q {
+          node { ... on Session { id } }
+        }
+      \`;
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
+      // A JS spread outside a graphql literal must not register as a spread.
+      `
+      const q = graphql\`
+        query Q {
+          node { id }
+        }
+      \`;
+      const merged = { ...Foo };
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
+    ],
+    invalid: [
+      {
+        code: `
+        const q = graphql\`
+          query Q {
+            node { ...Foo }
+          }
+        \`;
+        const [x, setX] = useState<Foo$key | null>(null);
+        `,
+        errors: [{ messageId: "deriveLocally" }],
+      },
+      // Plural fragment refs are reached through the array element type.
+      {
+        code: `
+        const q = graphql\`
+          query Q {
+            nodes { ...Foo }
+          }
+        \`;
+        const [x, setX] = useState<ReadonlyArray<Foo$key>>([]);
+        `,
+        errors: [{ messageId: "deriveLocally" }],
+      },
+      // A plain local variable annotation, not just useState.
+      {
+        code: `
+        const q = graphql\`
+          query Q {
+            node { ...Foo }
+          }
+        \`;
+        const ref: Foo$key = q.node;
+        `,
+        errors: [{ messageId: "deriveLocally" }],
+      },
+      // The spread may appear in a fragment the file spreads into, and the
+      // definition of a DIFFERENT fragment must not exempt it.
+      {
+        code: `
+        const f = graphql\`
+          fragment Own on Node {
+            ...Foo
+          }
+        \`;
+        const [x, setX] = useState<Foo$key | null>(null);
+        `,
+        errors: [{ messageId: "deriveLocally" }],
+      },
+    ],
+  },
+);

--- a/packages/eslint-config-bai/bai-plugin.test.js
+++ b/packages/eslint-config-bai/bai-plugin.test.js
@@ -73,6 +73,16 @@ ruleTester.run(
       \`;
       const [x, setX] = useState<Foo$key | null>(null);
       `,
+      // A block string closes at its first UNESCAPED `"""`; the `\\"""` escape
+      // must not end it early and let the rest be scanned as syntax.
+      `
+      const q = graphql\`
+        query Q {
+          node(label: """a \\\\""" ...Foo still inside the string""") { id }
+        }
+      \`;
+      const [x, setX] = useState<Foo$key | null>(null);
+      `,
       // A spread named only inside a string argument is not a spread either.
       `
       const q = graphql\`

--- a/packages/eslint-config-bai/react.js
+++ b/packages/eslint-config-bai/react.js
@@ -1,6 +1,7 @@
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import importPlugin from "eslint-plugin-import";
+import baiPlugin from "./bai-plugin.js";
 
 export const react = [
   reactPlugin.configs.flat.recommended,
@@ -60,6 +61,16 @@ export const react = [
     rules: {
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
+    },
+  },
+
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    plugins: {
+      bai: baiPlugin,
+    },
+    rules: {
+      "bai/no-fragment-key-at-spread-site": "error",
     },
   },
 ];

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -8,7 +8,6 @@ import {
   AdminUserCredentialListQuery as AdminUserCredentialListQueryType,
   AdminUserCredentialListQuery$data,
 } from '../__generated__/AdminUserCredentialListQuery.graphql';
-import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
 import { App } from '../app-shim';
 import { theme } from '../theme-shim';
 import BAIRadioGroup from './BAIRadioGroup';
@@ -117,7 +116,7 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
   const { logger } = useBAILogger();
 
   const [keypairSettingModalFrgmt, setKeypairSettingModalFrgmt] =
-    useState<KeypairSettingModalFragment$key | null>(null);
+    useState<Keypair | null>(null);
   const [openUserKeypairSettingModal, setOpenUserKeypairSettingModal] =
     useState(false);
   const [keypairInfoModalFrgmt, setKeypairInfoModalFrgmt] = useState<any>(null);

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -7,7 +7,6 @@ import {
   BulkCreateUserFromCSVModalMutation,
   CreateUserV2Input,
 } from '../__generated__/BulkCreateUserFromCSVModalMutation.graphql';
-import type { GeneratedKeypairListModalFragment$key } from '../__generated__/GeneratedKeypairListModalFragment.graphql';
 import {
   UserRoleV2,
   UserStatusV2,
@@ -94,6 +93,12 @@ import {
   useMutation,
   useRelayEnvironment,
 } from 'react-relay';
+
+type CreatedKeypair = NonNullable<
+  NonNullable<
+    BulkCreateUserFromCSVModalMutation['response']['adminBulkCreateUsersWithKeypairV2']
+  >['created'][number]['keypair']
+>;
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -230,7 +235,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   // adminBulkCreateUsersWithKeypairV2 returns each keypair's one-time secret
   // key directly in the payload; no follow-up fetch is needed.
   const [createdKeypairs, setCreatedKeypairs] =
-    useState<GeneratedKeypairListModalFragment$key | null>(null);
+    useState<ReadonlyArray<CreatedKeypair> | null>(null);
 
   const relayEnvironment = useRelayEnvironment();
 

--- a/react/src/components/DeploymentReplicasCard.tsx
+++ b/react/src/components/DeploymentReplicasCard.tsx
@@ -7,7 +7,6 @@ import {
   ReplicaOrderBy,
 } from '../__generated__/DeploymentReplicasCardListQuery.graphql';
 import { DeploymentReplicasCard_deployment$key } from '../__generated__/DeploymentReplicasCard_deployment.graphql';
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -62,6 +61,18 @@ import {
 } from 'react-relay';
 
 type ReplicaStatusCategory = 'running' | 'terminated';
+
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          DeploymentReplicasCardListQuery['response']['deployment']
+        >['replicas']
+      >['edges'][number]
+    >['node']
+  >['revision']
+>;
 
 const TERMINATED_STATUSES = ['TERMINATED', 'FAILED_TO_START'] as const;
 
@@ -251,7 +262,7 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
     null,
   );
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const { deployment: listData } =
     useLazyLoadQuery<DeploymentReplicasCardListQuery>(
@@ -496,13 +507,7 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
         }
         return (
           <>
-            <Link
-              onClick={() =>
-                setDrawerRevisionFrgmt(
-                  revision as DeploymentRevisionDetail_revision$key,
-                )
-              }
-            >
+            <Link onClick={() => setDrawerRevisionFrgmt(revision)}>
               {revision.revisionNumber != null
                 ? `#${revision.revisionNumber}`
                 : '-'}

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -2,13 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { KeypairResourcePolicyInfoModalFragment$key } from '../__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { KeypairResourcePolicyListMutation } from '../__generated__/KeypairResourcePolicyListMutation.graphql';
 import {
   KeypairResourcePolicyListQuery,
   KeypairResourcePolicyListQuery$data,
 } from '../__generated__/KeypairResourcePolicyListQuery.graphql';
-import { KeypairResourcePolicySettingModalFragment$key } from '../__generated__/KeypairResourcePolicySettingModalFragment.graphql';
 import { App } from '../app-shim';
 import { localeCompare, numberSorterWithInfinityValue } from '../helper';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
@@ -62,9 +60,9 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [editingKeypairResourcePolicy, setEditingKeypairResourcePolicy] =
-    useState<KeypairResourcePolicySettingModalFragment$key | null>();
+    useState<KeypairResourcePolicies | null>();
   const [currentResourcePolicy, setCurrentResourcePolicy] =
-    useState<KeypairResourcePolicyInfoModalFragment$key | null>(null);
+    useState<KeypairResourcePolicies | null>(null);
   const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
     null,
   );

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -7,7 +7,6 @@ import {
   ProjectResourcePolicyListQuery,
   ProjectResourcePolicyListQuery$data,
 } from '../__generated__/ProjectResourcePolicyListQuery.graphql';
-import { ProjectResourcePolicySettingModalFragment$key } from '../__generated__/ProjectResourcePolicySettingModalFragment.graphql';
 import { App } from '../app-shim';
 import {
   bytesToGB,
@@ -55,7 +54,7 @@ const ProjectResourcePolicyList: React.FC<
     useUpdatableState('initial-fetch');
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [editingProjectResourcePolicy, setEditingProjectResourcePolicy] =
-    useState<ProjectResourcePolicySettingModalFragment$key | null>();
+    useState<ProjectResourcePolicies | null>();
   const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
     null,
   );

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -7,7 +7,6 @@ import {
   ResourcePresetListQuery,
   ResourcePresetListQuery$data,
 } from '../__generated__/ResourcePresetListQuery.graphql';
-import { ResourcePresetSettingModalFragment$key } from '../__generated__/ResourcePresetSettingModalFragment.graphql';
 import { App } from '../app-shim';
 import { localeCompare } from '../helper';
 import { reasonMessage } from '../helper/mutationError';
@@ -45,7 +44,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
   const [resourcePresetsFetchKey, updateResourcePresetsFetchKey] =
     useUpdatableState('initial-fetch');
   const [editingResourcePreset, setEditingResourcePreset] =
-    useState<ResourcePresetSettingModalFragment$key | null>(null);
+    useState<ResourcePreset | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [deletingPresetId, setDeletingPresetId] = useState<string | null>(null);
 

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -7,7 +7,6 @@ import {
   UserResourcePolicyListQuery,
   UserResourcePolicyListQuery$data,
 } from '../__generated__/UserResourcePolicyListQuery.graphql';
-import { UserResourcePolicySettingModalFragment$key } from '../__generated__/UserResourcePolicySettingModalFragment.graphql';
 import { App } from '../app-shim';
 import {
   bytesToGB,
@@ -53,7 +52,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
     useUpdatableState('initial-fetch');
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [editingUserResourcePolicy, setEditingUserResourcePolicy] =
-    useState<UserResourcePolicySettingModalFragment$key | null>();
+    useState<UserResourcePolicies | null>();
   const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
     null,
   );

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { GeneratedKeypairListModalFragment$key } from '../__generated__/GeneratedKeypairListModalFragment.graphql';
 import {
   UserSettingModalBulkCreateMutation,
   UserRoleV2,
@@ -65,6 +64,12 @@ import { CircleAlert } from 'lucide-react';
 import React, { Suspense, useDeferredValue, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation, useFragment } from 'react-relay';
+
+type CreatedKeypair = NonNullable<
+  NonNullable<
+    UserSettingModalCreateMutation['response']['adminCreateUserV2']
+  >['keypair']
+>;
 
 type UserRole = {
   [key: string]: string[];
@@ -258,7 +263,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
   const deferredOpen = useDeferredValue(baiModalProps.open);
 
   const [createdKeypairs, setCreatedKeypairs] =
-    useState<GeneratedKeypairListModalFragment$key | null>();
+    useState<ReadonlyArray<CreatedKeypair> | null>();
 
   // Users the server refused to create. Reported inside the generated-keypair
   // result modal when some users were created, or in a standalone modal over

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -9,7 +9,6 @@ import {
   DeploymentOrderBy,
   DeploymentStatus,
 } from '../__generated__/DeploymentListPageQuery.graphql';
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import { App } from '../app-shim';
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
@@ -55,6 +54,16 @@ import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        DeploymentListPageQuery['response']['myDeployments']
+      >['edges'][number]
+    >['node']
+  >['currentRevision']
+>;
+
 interface DeploymentListPageContentProps {
   /** Owned by the page so the trigger can live in the card's `extra` slot. */
   isCreating: boolean;
@@ -79,7 +88,7 @@ const DeploymentListPageContent: React.FC<DeploymentListPageContentProps> = ({
     string | null
   >(null);
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const {
     baiPaginationOption,

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import type { ProjectAdminDeploymentsPageDeleteMutation } from '../__generated__/ProjectAdminDeploymentsPageDeleteMutation.graphql';
 import type {
   DeploymentFilter,
@@ -53,6 +52,16 @@ import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        ProjectAdminDeploymentsPageQuery['response']['projectDeployments']
+      >['edges'][number]
+    >['node']
+  >['currentRevision']
+>;
+
 interface ProjectAdminDeploymentsContentProps {
   projectId: string;
 }
@@ -74,7 +83,7 @@ const ProjectAdminDeploymentsContent: React.FC<
     string | null
   >(null);
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const {
     baiPaginationOption,

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
 import {
   ArtifactRevisionFilter,
   ArtifactStatus,
@@ -79,10 +78,9 @@ const ReservoirArtifactDetailPage = () => {
     useState<BAIDeleteArtifactRevisionsModalArtifactRevisionFragmentKey>([]);
   const [selectedRevisions, setSelectedRevisions] =
     useState<BAIImportArtifactModalArtifactRevisionFragmentKey>([]);
-  const [selectedImportRevisions, setSelectedImportRevisions] =
-    useState<ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key>(
-      [],
-    );
+  const [selectedImportRevisions, setSelectedImportRevisions] = useState<
+    ReadonlyArray<RevisionNode>
+  >([]);
   const [queryParams, setQuery] = useQueryStates(
     {
       filter: parseAsJson<ArtifactRevisionFilter>(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,14 +17,19 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["{src,scripts}/**/*.{test,spec}.ts"],
+    include: [
+      "{src,scripts}/**/*.{test,spec}.ts",
+      // eslint-config-bai is plain ESM with no build step or vitest config of
+      // its own, so its rule tests run in this Node-environment suite.
+      "packages/eslint-config-bai/**/*.{test,spec}.js",
+    ],
     exclude: [
       "**/node_modules/**",
       "**/build/**",
       "**/dist/**",
-      // react/ and packages/ workspaces have their own vitest configs.
+      // react/ and the built packages have their own vitest configs.
       "react/**",
-      "packages/**",
+      "packages/!(eslint-config-bai)/**",
     ],
 
     // V8 coverage instrumentation slows down tests significantly on CI's


### PR DESCRIPTION
Resolves #7691 (FR-3028)

## Summary

Adds a custom `bai/no-fragment-key-at-spread-site` ESLint rule to `eslint-config-bai`, registered at `error` for `**/*.{ts,tsx}` in the shared `react` config, so both `react/` and `packages/backend.ai-ui/` pick it up.

The rule flags typing a **local value** (a `useState` cell or a plain variable annotation) with a Relay fragment's generated `$key` type at a site that already **spreads** that fragment in a `graphql` literal. When a component spreads `...Foo` in its own query/fragment, the response already carries `$fragmentSpreads` and is assignable to `Foo$key` — so importing the child's `$key` there only adds type coupling to the child. The type should be derived from the local query node instead.

This is a nice-to-have project convention, **not** a Relay-mandated pattern.

### Exemptions (intentionally not flagged)

- **fragment-owning files** that define `fragment Foo on ...` — they legitimately use `Foo$key` for their prop type and/or `useFragment<Foo$key>`.
- **prop / callback-parameter positions** — the standard fragment-component prop contract (function-type parameters are deliberately not walked).
- files that never spread `...Foo` (the ref is sourced from a prop elsewhere).
- `... on Type` inline fragments, and JS object/array spreads outside a `graphql` literal.

### Design decisions

- **Textual scan of the `graphql` literal, not the whole source.** Relay literals in this repo carry no `${}` interpolation, so concatenating the quasis gives the complete document — and scanning the literal rather than the file is what keeps JS spread operators and doc strings from being mistaken for fragment spreads.
- **Name-based matching**, no type-aware linting — keeps the rule cheap enough to run on every file.
- The rule's tests run in the **root** vitest project: `eslint-config-bai` is plain ESM with no build step and no vitest config of its own, so `vitest.config.ts` now includes `packages/eslint-config-bai/**/*.test.js` (and the `packages/**` exclude carves that one package out). `.github/workflows/vitest-root.yml` gained the matching path filter.

### Fixed violations (12, across 11 files)

Replaced `useState<X$key>` with the local query node type and dropped the now-unused `$key` import:

- `react/src/components/`: `AdminUserCredentialList`, `BulkCreateUserFromCSVModal`, `DeploymentReplicasCard`, `KeypairResourcePolicyList` (2), `ProjectResourcePolicyList`, `ResourcePresetList`, `UserResourcePolicyList`, `UserSettingModal`
- `react/src/pages/`: `DeploymentListPage`, `ProjectAdminDeploymentsPage`, `ReservoirArtifactDetailPage`

Plural fragment refs (`UserSettingModal`, `BulkCreateUserFromCSVModal`, `ReservoirArtifactDetailPage`) use `ReadonlyArray<Node>`. `DeploymentReplicasCard` also drops an `as DeploymentRevisionDetail_revision$key` cast that the derived type makes unnecessary. **Type annotations and imports only — no runtime behaviour changes.**

### Credit

This revives [#7692](https://github.com/lablup/backend.ai-webui/pull/7692) by @nowgnuesLee, which was closed unmerged on 2026-07-27. The rule is his; the call-site fixes are re-derived against current `main` (two of his targets have since been deleted, one was renamed `DeploymentReplicasTab` → `DeploymentReplicasCard`, and `BulkCreateUserFromCSVModal` newly matches). The RuleTester suite is new.

## Tests

- `pnpm exec vitest run packages/eslint-config-bai/bai-plugin.test.js` → 14 passed (8 valid cases covering each exemption plus the comment / string / escaped-block-string scan cases, 6 invalid covering `useState`, `React.useState`, plural refs, plain variable annotations, a file that defines a *different* fragment, and a `fragment Foo on ...` that appears only in prose).
- `pnpm exec vitest run` (root suite) → 8 files, 171 passed / 6 skipped — confirms the new file is picked up by the root project.
- `pnpm exec eslint src` in `react/` and in `packages/backend.ai-ui/` → **0** `bai/no-fragment-key-at-spread-site` violations remaining, 0 eslint errors total.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

(Relay / Lint script coverage / Lint / Format / TypeScript / TypeScript (agent-cli) / Vite warmup paths / StyleX cssInjectionTarget / Astryx theme build / Astryx integration / z-index ladder mirrors / Agent mappings / Terminology — all PASS.)

No CSS or theme tokens touched, so the Astryx token gate is not implicated.

## Review notes

- **Does the rule fire where it should, and stay quiet where it shouldn't?** `packages/eslint-config-bai/bai-plugin.test.js` is the fastest read — the `valid` array is the exemption list, one case each.
- **Is any call-site fix a behaviour change?** Every hunk is a type annotation plus a dropped import; the one exception is `DeploymentReplicasCard.tsx:507`, where a now-redundant `as ...$key` cast is removed from the `<Link onClick>` handler. `tsc` (in `verify.sh`) is the real gate here.
- **Is the vitest wiring right?** `vitest.config.ts` changes `packages/**` → `packages/!(eslint-config-bai)/**` in `exclude`; the other three package suites (`backend.ai-ui`, `backend.ai-agent-cli`, `backend.ai-client`) keep their own configs and workflows untouched.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — `bash scripts/verify.sh` ends with `=== ALL PASS ===`
- [x] Test case(s) to demonstrate the difference of before/after — `packages/eslint-config-bai/bai-plugin.test.js`

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ

