### PR TITLE
feat(FR-3468): add per-field revert-to-loaded-revision icon in DeploymentAddRevisionModal

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.test.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.test.tsx
@@ -8,6 +8,7 @@ import DeploymentAddRevisionModal from './DeploymentAddRevisionModal';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -186,7 +187,12 @@ const TestRenderer: React.FC = () => {
   );
 };
 
-const renderModal = (metadata: DeploymentMetadataMock) => {
+type MockResolvers = Parameters<typeof MockPayloadGenerator.generate>[1];
+
+const renderModal = (
+  metadata: DeploymentMetadataMock,
+  mockResolvers: MockResolvers = {},
+) => {
   const environment: RelayMockEnvironment = createMockEnvironment();
   const queryClient = new QueryClient();
   environment.mock.queueOperationResolver((operation) =>
@@ -195,6 +201,7 @@ const renderModal = (metadata: DeploymentMetadataMock) => {
       // Keep the "Load current revision" path quiet: no current revision.
       ModelDeployment: () => ({ currentRevision: null }),
       DeploymentRevisionPresetConnection: () => ({ count: 1 }),
+      ...mockResolvers,
     }),
   );
   render(
@@ -289,5 +296,68 @@ describe('DeploymentAddRevisionModal project derivation contract (ADR-0001)', ()
     expect(
       screen.queryByTestId('mock-resource-allocation-form'),
     ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Per-field revert-to-loaded-revision affordance (FR-3468). It is a
+ * dirty-field-only control: hidden while the Custom form still matches the
+ * revision it was loaded from, and it reverts only the field it sits next to.
+ */
+describe('DeploymentAddRevisionModal per-field revert (FR-3468)', () => {
+  const LOADED_MOUNT_DESTINATION = '/models/loaded';
+  const REVERT_LABEL = 'deployment.RevertToLoadedRevisionValue';
+
+  afterEach(() => {
+    mockMode = 'preset';
+  });
+
+  const loadCurrentRevision = async (
+    user: ReturnType<typeof userEvent.setup>,
+  ) => {
+    mockMode = 'custom';
+    renderModal(DEPLOYMENT_METADATA, {
+      // Let the generator build a full current revision, but pin the one
+      // field this spec reads back.
+      ModelDeployment: () => ({}),
+      ModelMountConfig: () => ({
+        mountDestination: LOADED_MOUNT_DESTINATION,
+      }),
+    });
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'deployment.LoadCurrentRevision',
+      }),
+    );
+    return screen.findByDisplayValue(LOADED_MOUNT_DESTINATION);
+  };
+
+  it('shows no revert affordance while every field still matches the loaded revision', async () => {
+    const user = userEvent.setup();
+    await loadCurrentRevision(user);
+
+    expect(
+      screen.queryByRole('button', { name: REVERT_LABEL }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reverts an edited field back to the loaded revision value', async () => {
+    const user = userEvent.setup();
+    const input = await loadCurrentRevision(user);
+
+    await user.type(input, '-edited');
+    expect(input).toHaveValue(`${LOADED_MOUNT_DESTINATION}-edited`);
+
+    await user.click(await screen.findByRole('button', { name: REVERT_LABEL }));
+
+    await waitFor(() => {
+      expect(input).toHaveValue(LOADED_MOUNT_DESTINATION);
+    });
+    // Back in sync with the revision → the affordance withdraws again.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: REVERT_LABEL }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/react/src/components/DeploymentAddRevisionModal.test.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.test.tsx
@@ -46,12 +46,16 @@ vi.mock('react-i18next', async () => {
   };
 });
 
+// The subpath field only renders on managers advertising the feature.
+let mockSupportsMountSubpath = false;
+
 vi.mock('../hooks', async (importOriginal) => {
   const originalModule = await importOriginal<typeof import('../hooks')>();
   return {
     ...originalModule,
     useSuspendedBackendaiClient: () => ({
-      supports: () => false,
+      supports: (feature: string) =>
+        feature === 'model-mount-subpath' ? mockSupportsMountSubpath : false,
       _config: { allowCustomResourceAllocation: true },
     }),
     useWebUINavigate: () => vi.fn(),
@@ -149,11 +153,24 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
         {
           'data-testid': 'mock-vfolder-select',
           'data-current-project-id': props.currentProjectId ?? '',
+          'data-value': props.value ?? '',
           disabled: props.isDisabled ?? props.disabled,
           type: 'button',
+          // Clicking stands in for picking a different folder, so the form's
+          // own onChange cleanup runs exactly as it does in the app.
+          onClick: () =>
+            props.onChange?.(
+              btoa('VirtualFolderNode:22222222-2222-2222-2222-222222222222'),
+            ),
         },
         'select-model-folder',
       ),
+    BAIVFolderPathPicker: (props: any) =>
+      React.createElement('input', {
+        'data-testid': 'mock-subpath-picker',
+        value: props.value ?? '',
+        readOnly: true,
+      }),
     BAIAvailablePresetSelect: () => null,
     BAIRuntimeVariantSelect: () => null,
   };
@@ -306,10 +323,12 @@ describe('DeploymentAddRevisionModal project derivation contract (ADR-0001)', ()
  */
 describe('DeploymentAddRevisionModal per-field revert (FR-3468)', () => {
   const LOADED_MOUNT_DESTINATION = '/models/loaded';
+  const LOADED_SUBPATH = 'loaded/subdir';
   const REVERT_LABEL = 'deployment.RevertToLoadedRevisionValue';
 
   afterEach(() => {
     mockMode = 'preset';
+    mockSupportsMountSubpath = false;
   });
 
   const loadCurrentRevision = async (
@@ -359,5 +378,54 @@ describe('DeploymentAddRevisionModal per-field revert (FR-3468)', () => {
         screen.queryByRole('button', { name: REVERT_LABEL }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  // A subpath belongs to the folder it was picked from, so the two revert
+  // together: while the folder diverges the subpath offers no revert of its
+  // own, and reverting the folder restores the loaded pair.
+  it('reverts the model folder and its subpath as a pair', async () => {
+    const user = userEvent.setup();
+    mockSupportsMountSubpath = true;
+    mockMode = 'custom';
+    renderModal(DEPLOYMENT_METADATA, {
+      ModelDeployment: () => ({}),
+      ModelMountConfig: () => ({
+        mountDestination: LOADED_MOUNT_DESTINATION,
+        subpath: LOADED_SUBPATH,
+      }),
+    });
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'deployment.LoadCurrentRevision',
+      }),
+    );
+    await screen.findByDisplayValue(LOADED_MOUNT_DESTINATION);
+
+    const folderSelect = screen.getByTestId('mock-vfolder-select');
+    const subpathPicker = screen.getByTestId('mock-subpath-picker');
+    const loadedFolderId = folderSelect.getAttribute('data-value');
+    expect(subpathPicker).toHaveValue(LOADED_SUBPATH);
+
+    // Picking another folder clears the subpath that belonged to the old one.
+    await user.click(folderSelect);
+    await waitFor(() => {
+      expect(subpathPicker).toHaveValue('');
+    });
+
+    // Only the folder offers a revert; the subpath's own would restore the
+    // loaded path into the newly picked folder.
+    const revertButtons = await screen.findAllByRole('button', {
+      name: REVERT_LABEL,
+    });
+    expect(revertButtons).toHaveLength(1);
+
+    await user.click(revertButtons[0]);
+    await waitFor(() => {
+      expect(subpathPicker).toHaveValue(LOADED_SUBPATH);
+    });
+    expect(folderSelect).toHaveAttribute('data-value', loadedFolderId);
+    expect(
+      screen.queryByRole('button', { name: REVERT_LABEL }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -108,7 +108,7 @@ import {
   useBAILogger,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { Info, RotateCw, FolderOpenIcon, PlusIcon } from 'lucide-react';
+import { Info, RotateCw, FolderOpenIcon, PlusIcon, Undo2 } from 'lucide-react';
 import React, {
   Suspense,
   startTransition,
@@ -271,6 +271,60 @@ const VariantDefaultModelDefinitionLoader: React.FC<{
   }, [data.runtimeVariant?.defaultModelDefinition]);
 
   return null;
+};
+
+// Custom-form fields that carry a per-field "revert to the loaded revision's
+// value" affordance (FR-3468). Limited to the fields this modal renders itself
+// — the shared form-item components own their own layout.
+const REVERTIBLE_FIELD_NAMES = [
+  'modelFolderId',
+  'modelMountDestination',
+  'modelSubpath',
+  'runtimeVariantId',
+  'definitionPath',
+] as const;
+
+type RevertibleFieldName = (typeof REVERTIBLE_FIELD_NAMES)[number];
+
+type RevisionBaseline = Partial<Pick<FormValues, RevertibleFieldName>>;
+
+// A cleared text input yields '' where the baseline holds `undefined`; the two
+// submit identically, so neither counts as a divergence.
+const normalizeFieldValue = (value: unknown) =>
+  value === '' || value === null ? undefined : value;
+
+// Reverts a single field back to the revision the Custom form was loaded from,
+// and renders nothing at all while that field still matches it.
+// `useWatch` rather than a `dependencies` render prop: the latter re-renders
+// only on user input, so the button would survive its own click.
+const RevertToRevisionValueButton: React.FC<{
+  name: RevertibleFieldName;
+  baseline: RevisionBaseline | null;
+  form: FormInstance<FormValues>;
+}> = ({ name, baseline, form }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const currentValue = Form.useWatch(name, form);
+  if (!baseline) return null;
+  const loadedValue = baseline[name];
+  if (
+    _.isEqual(
+      normalizeFieldValue(currentValue),
+      normalizeFieldValue(loadedValue),
+    )
+  ) {
+    return null;
+  }
+  return (
+    <IconButton
+      variant="ghost"
+      size="sm"
+      icon={<Undo2 size="1em" />}
+      label={t('deployment.RevertToLoadedRevisionValue')}
+      tooltip={t('deployment.RevertToLoadedRevisionValue')}
+      onClick={() => form.setFieldValue(name, loadedValue)}
+    />
+  );
 };
 
 const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
@@ -609,6 +663,13 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
   // After the user clicks "Load current revision" the alert vanishes — there
   // is nothing else to load and the form already reflects the prefill.
   const [hasLoadedCurrent, setHasLoadedCurrent] = useState(false);
+  // Snapshot of the values the Custom form was last loaded with from a
+  // revision — the deployment's current revision, or the source revision the
+  // modal was opened from. Drives the per-field revert buttons (FR-3468);
+  // stays null until a revision is actually loaded, so a from-scratch Custom
+  // form shows no revert affordance at all.
+  const [revisionBaseline, setRevisionBaseline] =
+    useState<RevisionBaseline | null>(null);
   // Apply the source-revision prefill exactly once on first Custom-mode
   // render so toggling Preset → Custom later does not re-stomp values the
   // user has since edited. When the modal opens in Preset mode (per the
@@ -1008,6 +1069,9 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       setSelectedCardVfolderId(null);
     }
     customForm.resetFields();
+    // The Custom edits (and therefore the revision they were loaded from) are
+    // discarded here, so the revert baseline must go with them.
+    setRevisionBaseline(null);
     setPresetTransferPrefill(null);
     setCustomTransferPrefill(
       Object.keys(carryOver).length > 0 ? carryOver : null,
@@ -1104,7 +1168,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       );
     }
 
-    customForm.setFieldsValue({
+    const nextValues = {
       cluster_mode:
         rev.clusterConfig?.mode === 'SINGLE_NODE'
           ? 'single-node'
@@ -1210,7 +1274,13 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
             port: service.port,
           }
         : {}),
-    });
+    };
+
+    customForm.setFieldsValue(nextValues);
+    // Baseline for the per-field revert affordance (FR-3468). Snapshotted from
+    // the DERIVED values, not the raw revision, so the icon only appears where
+    // the user actually diverged from what was loaded.
+    setRevisionBaseline(_.pick(nextValues, REVERTIBLE_FIELD_NAMES));
   };
 
   // One-shot consumption of preset-transfer prefill when the user transitions
@@ -2370,6 +2440,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                   );
                 }}
               </BAIFormItem>
+              <RevertToRevisionValueButton
+                name="modelFolderId"
+                baseline={revisionBaseline}
+                form={customForm}
+              />
             </BAIFlex>
           </BAIFormItem>
           {/* Model-folder mount config (FR-3205): the destination path and an
@@ -2378,33 +2453,49 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
               config-file sections. */}
           <BAIFlex gap="sm" align="start">
             <BAIFormItem
-              name="modelMountDestination"
               label={t('modelService.ModelMountDestination')}
               tooltip={t('modelService.ModelMountTooltip')}
               style={{ flex: 1 }}
             >
-              <AstryxFormTextInput
-                label={t('modelService.ModelMountDestination')}
-                hasClear
-                placeholder={modelDefinitionDefaults?.modelMountDestination}
-              />
+              <BAIFlex direction="row" gap="xs">
+                <BAIFormItem name="modelMountDestination" noStyle>
+                  <AstryxFormTextInput
+                    label={t('modelService.ModelMountDestination')}
+                    hasClear
+                    placeholder={modelDefinitionDefaults?.modelMountDestination}
+                  />
+                </BAIFormItem>
+                <RevertToRevisionValueButton
+                  name="modelMountDestination"
+                  baseline={revisionBaseline}
+                  form={customForm}
+                />
+              </BAIFlex>
             </BAIFormItem>
             {supportsMountSubpath && (
               <BAIFormItem
-                name="modelSubpath"
                 label={t('modelService.Subpath')}
                 tooltip={t('modelService.SubpathTooltip')}
                 style={{ flex: 1 }}
               >
-                <BAIVFolderPathPicker
-                  label={t('modelService.Subpath')}
-                  vfolderUuid={
-                    watchedModelFolderId
-                      ? toLocalId(watchedModelFolderId)
-                      : undefined
-                  }
-                  disabled={!watchedModelFolderId}
-                />
+                <BAIFlex direction="row" gap="xs">
+                  <BAIFormItem name="modelSubpath" noStyle>
+                    <BAIVFolderPathPicker
+                      label={t('modelService.Subpath')}
+                      vfolderUuid={
+                        watchedModelFolderId
+                          ? toLocalId(watchedModelFolderId)
+                          : undefined
+                      }
+                      disabled={!watchedModelFolderId}
+                    />
+                  </BAIFormItem>
+                  <RevertToRevisionValueButton
+                    name="modelSubpath"
+                    baseline={revisionBaseline}
+                    form={customForm}
+                  />
+                </BAIFlex>
               </BAIFormItem>
             )}
           </BAIFlex>
@@ -2414,40 +2505,53 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
             }
           >
             <BAIFormItem
-              name="runtimeVariantId"
               label={t('deployment.RuntimeVariant')}
               tooltip={t('deployment.RuntimeVariantTooltip')}
-              rules={[
-                { required: true },
-                {
-                  warningOnly: true,
-                  validator: async (_rule, value: string) => {
-                    const v = runtimeVariantMap[value];
-                    // Warn for variants that do NOT read the vfolder config
-                    // files: their default command is applied by the backend.
-                    // Fall back to the legacy `name === 'custom'` heuristic on
-                    // pre-26.8.0 managers (field stripped → undefined).
-                    const reads =
-                      v?.readsVfolderConfigFiles ?? v?.name === 'custom';
-                    if (v && !reads) {
-                      return Promise.reject(
-                        t(
-                          'modelService.RuntimeVariantDefaultCommandAppliedNote',
-                        ),
-                      );
-                    }
-                    return Promise.resolve();
-                  },
-                },
-              ]}
+              required
             >
-              <BAIRuntimeVariantSelect
-                label={t('deployment.RuntimeVariant')}
-                isLabelHidden
-                onResolvedVariantsChange={(map) =>
-                  setRuntimeVariantMap((prev) => ({ ...prev, ...map }))
-                }
-              />
+              <BAIFlex direction="row" gap="xs">
+                <BAIFormItem
+                  name="runtimeVariantId"
+                  messageVariables={{ label: t('deployment.RuntimeVariant') }}
+                  noStyle
+                  rules={[
+                    { required: true },
+                    {
+                      warningOnly: true,
+                      validator: async (_rule, value: string) => {
+                        const v = runtimeVariantMap[value];
+                        // Warn for variants that do NOT read the vfolder config
+                        // files: their default command is applied by the backend.
+                        // Fall back to the legacy `name === 'custom'` heuristic on
+                        // pre-26.8.0 managers (field stripped → undefined).
+                        const reads =
+                          v?.readsVfolderConfigFiles ?? v?.name === 'custom';
+                        if (v && !reads) {
+                          return Promise.reject(
+                            t(
+                              'modelService.RuntimeVariantDefaultCommandAppliedNote',
+                            ),
+                          );
+                        }
+                        return Promise.resolve();
+                      },
+                    },
+                  ]}
+                >
+                  <BAIRuntimeVariantSelect
+                    label={t('deployment.RuntimeVariant')}
+                    isLabelHidden
+                    onResolvedVariantsChange={(map) =>
+                      setRuntimeVariantMap((prev) => ({ ...prev, ...map }))
+                    }
+                  />
+                </BAIFormItem>
+                <RevertToRevisionValueButton
+                  name="runtimeVariantId"
+                  baseline={revisionBaseline}
+                  form={customForm}
+                />
+              </BAIFlex>
             </BAIFormItem>
           </Suspense>
 
@@ -2567,17 +2671,31 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                   does not read the vfolder config files. */}
               {readsVfolderConfigFiles && (
                 <BAIFormItem
-                  name="definitionPath"
                   label={t('deployment.ModelDefinitionPath')}
                   tooltip={t('modelService.ModelDefinitionPathTooltip')}
-                  rules={[{ whitespace: true }]}
-                  preserve={false}
                 >
-                  <AstryxFormTextInput
-                    label={t('deployment.ModelDefinitionPath')}
-                    hasClear
-                    placeholder="model-definition.yaml"
-                  />
+                  <BAIFlex direction="row" gap="xs">
+                    <BAIFormItem
+                      name="definitionPath"
+                      messageVariables={{
+                        label: t('deployment.ModelDefinitionPath'),
+                      }}
+                      noStyle
+                      rules={[{ whitespace: true }]}
+                      preserve={false}
+                    >
+                      <AstryxFormTextInput
+                        label={t('deployment.ModelDefinitionPath')}
+                        hasClear
+                        placeholder="model-definition.yaml"
+                      />
+                    </BAIFormItem>
+                    <RevertToRevisionValueButton
+                      name="definitionPath"
+                      baseline={revisionBaseline}
+                      form={customForm}
+                    />
+                  </BAIFlex>
                 </BAIFormItem>
               )}
               <BAIFormItem

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -322,7 +322,14 @@ const RevertToRevisionValueButton: React.FC<{
       icon={<Undo2 size="1em" />}
       label={t('deployment.RevertToLoadedRevisionValue')}
       tooltip={t('deployment.RevertToLoadedRevisionValue')}
-      onClick={() => form.setFieldValue(name, loadedValue)}
+      onClick={() => {
+        form.setFieldValue(name, loadedValue);
+        // A subpath belongs to the folder it was picked from, and
+        // `setFieldValue` skips the select's own onChange cleanup.
+        if (name === 'modelFolderId') {
+          form.setFieldValue('modelSubpath', baseline.modelSubpath);
+        }
+      }}
     />
   );
 };

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -305,7 +305,20 @@ const RevertToRevisionValueButton: React.FC<{
   'use memo';
   const { t } = useTranslation();
   const currentValue = Form.useWatch(name, form);
+  const currentModelFolderId = Form.useWatch('modelFolderId', form);
   if (!baseline) return null;
+  // A subpath belongs to the folder it was picked from, so while the folder
+  // itself diverges the loaded subpath would land in the wrong folder. The
+  // folder's own revert restores the pair together.
+  if (
+    name === 'modelSubpath' &&
+    !_.isEqual(
+      normalizeFieldValue(currentModelFolderId),
+      normalizeFieldValue(baseline.modelFolderId),
+    )
+  ) {
+    return null;
+  }
   const loadedValue = baseline[name];
   if (
     _.isEqual(

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Ressourcenvoreinstellung",
     "Resources": "Ressourcen",
     "Result": "Ergebnis",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Auf den Wert der geladenen Revision zurücksetzen",
     "Revision": "Revision",
     "RevisionAdded": "Die Revision wurde hinzugefügt.",
     "RevisionDetail": "Revisionsdetails",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Ressourcenvoreinstellung",
     "Resources": "Ressourcen",
     "Result": "Ergebnis",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revision",
     "RevisionAdded": "Die Revision wurde hinzugefügt.",
     "RevisionDetail": "Revisionsdetails",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Προεπιλογή πόρων",
     "Resources": "Πόροι",
     "Result": "Αποτέλεσμα",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Αναθεώρηση",
     "RevisionAdded": "Η αναθεώρηση προστέθηκε.",
     "RevisionDetail": "Λεπτομέρειες Revision",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Προεπιλογή πόρων",
     "Resources": "Πόροι",
     "Result": "Αποτέλεσμα",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Επαναφορά στην τιμή της φορτωμένης Revision",
     "Revision": "Αναθεώρηση",
     "RevisionAdded": "Η αναθεώρηση προστέθηκε.",
     "RevisionDetail": "Λεπτομέρειες Revision",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1196,6 +1196,7 @@
     "ResourcePreset": "Resource Preset",
     "Resources": "Resources",
     "Result": "Result",
+    "RevertToLoadedRevisionValue": "Revert to loaded revision value",
     "Revision": "Revision",
     "RevisionAdded": "Revision has been added.",
     "RevisionDetail": "Revision Detail",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Preset de recursos",
     "Resources": "Recursos",
     "Result": "Resultado",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisión",
     "RevisionAdded": "Se ha añadido la revisión.",
     "RevisionDetail": "Detalle de Revision",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Preset de recursos",
     "Resources": "Recursos",
     "Result": "Resultado",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Restablecer al valor de la Revision cargada",
     "Revision": "Revisión",
     "RevisionAdded": "Se ha añadido la revisión.",
     "RevisionDetail": "Detalle de Revision",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Resurssiesiasetukset",
     "Resources": "Resurssit",
     "Result": "Tulos",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Palauta ladatun Revision arvoon",
     "Revision": "Revisio",
     "RevisionAdded": "Revisio on lisätty.",
     "RevisionDetail": "Revision-tiedot",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Resurssiesiasetukset",
     "Resources": "Resurssit",
     "Result": "Tulos",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisio",
     "RevisionAdded": "Revisio on lisätty.",
     "RevisionDetail": "Revision-tiedot",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Préréglage de ressources",
     "Resources": "Ressources",
     "Result": "Résultat",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Rétablir la valeur de la Revision chargée",
     "Revision": "Révision",
     "RevisionAdded": "La révision a été ajoutée.",
     "RevisionDetail": "Détail de Revision",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Préréglage de ressources",
     "Resources": "Ressources",
     "Result": "Résultat",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Révision",
     "RevisionAdded": "La révision a été ajoutée.",
     "RevisionDetail": "Détail de Revision",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Preset Sumber Daya",
     "Resources": "Sumber Daya",
     "Result": "Hasil",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisi",
     "RevisionAdded": "Revisi telah ditambahkan.",
     "RevisionDetail": "Detail Revision",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Preset Sumber Daya",
     "Resources": "Sumber Daya",
     "Result": "Hasil",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Kembalikan ke nilai Revision yang dimuat",
     "Revision": "Revisi",
     "RevisionAdded": "Revisi telah ditambahkan.",
     "RevisionDetail": "Detail Revision",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Preset risorse",
     "Resources": "risorse",
     "Result": "Risultato",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Ripristina il valore della Revision caricata",
     "Revision": "Revisione",
     "RevisionAdded": "La revisione è stata aggiunta.",
     "RevisionDetail": "Dettaglio Revision",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Preset risorse",
     "Resources": "risorse",
     "Result": "Risultato",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisione",
     "RevisionAdded": "La revisione è stata aggiunta.",
     "RevisionDetail": "Dettaglio Revision",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "リソースプリセット",
     "Resources": "リソース",
     "Result": "結果",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "読み込んだ Revision の値に戻す",
     "Revision": "リビジョン",
     "RevisionAdded": "リビジョンが追加されました。",
     "RevisionDetail": "Revision 詳細",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "リソースプリセット",
     "Resources": "リソース",
     "Result": "結果",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "リビジョン",
     "RevisionAdded": "リビジョンが追加されました。",
     "RevisionDetail": "Revision 詳細",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "리소스 프리셋",
     "Resources": "리소스",
     "Result": "결과",
+    "RevertToLoadedRevisionValue": "불러온 리비전 값으로 되돌리기",
     "Revision": "리비전",
     "RevisionAdded": "리비전이 추가되었습니다.",
     "RevisionDetail": "리비전 상세",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Нөөцийн урьдчилсан тохиргоо",
     "Resources": "Нөөцүүд",
     "Result": "Гаралт",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Хувилбар",
     "RevisionAdded": "Хяналт нэмэгдлээ.",
     "RevisionDetail": "Revision-ы дэлгэрэнгүй",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Нөөцийн урьдчилсан тохиргоо",
     "Resources": "Нөөцүүд",
     "Result": "Гаралт",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Ачаалсан Revision-ы утга руу буцаах",
     "Revision": "Хувилбар",
     "RevisionAdded": "Хяналт нэмэгдлээ.",
     "RevisionDetail": "Revision-ы дэлгэрэнгүй",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Pratetap Sumber",
     "Resources": "Sumber",
     "Result": "Hasil",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisi",
     "RevisionAdded": "Semakan telah ditambahkan.",
     "RevisionDetail": "Butiran Revision",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Pratetap Sumber",
     "Resources": "Sumber",
     "Result": "Hasil",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Kembalikan kepada nilai Revision yang dimuatkan",
     "Revision": "Revisi",
     "RevisionAdded": "Semakan telah ditambahkan.",
     "RevisionDetail": "Butiran Revision",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Preset zasobów",
     "Resources": "Zasoby",
     "Result": "Wynik",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Rewizja",
     "RevisionAdded": "Wersja została dodana.",
     "RevisionDetail": "Szczegóły Revision",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Preset zasobów",
     "Resources": "Zasoby",
     "Result": "Wynik",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Przywróć wartość załadowanej Revision",
     "Revision": "Rewizja",
     "RevisionAdded": "Wersja została dodana.",
     "RevisionDetail": "Szczegóły Revision",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Predefinição de recursos",
     "Resources": "Recursos",
     "Result": "Resultado",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Restaurar o valor da Revision carregada",
     "Revision": "Revisão",
     "RevisionAdded": "A revisão foi adicionada.",
     "RevisionDetail": "Detalhes da Revision",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Predefinição de recursos",
     "Resources": "Recursos",
     "Result": "Resultado",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisão",
     "RevisionAdded": "A revisão foi adicionada.",
     "RevisionDetail": "Detalhes da Revision",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Predefinição de recursos",
     "Resources": "Recursos",
     "Result": "Resultado",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revisão",
     "RevisionAdded": "A revisão foi adicionada.",
     "RevisionDetail": "Detalhe da Revision",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Predefinição de recursos",
     "Resources": "Recursos",
     "Result": "Resultado",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Repor o valor da Revision carregada",
     "Revision": "Revisão",
     "RevisionAdded": "A revisão foi adicionada.",
     "RevisionDetail": "Detalhe da Revision",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Предустановка ресурсов",
     "Resources": "Ресурсы",
     "Result": "Результат",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Вернуть значение загруженной Revision",
     "Revision": "Ревизия",
     "RevisionAdded": "Ревизия была добавлена.",
     "RevisionDetail": "Детали Revision",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Предустановка ресурсов",
     "Resources": "Ресурсы",
     "Result": "Результат",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Ревизия",
     "RevisionAdded": "Ревизия была добавлена.",
     "RevisionDetail": "Детали Revision",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Kaynak Ön Ayarı",
     "Resources": "Kaynaklar",
     "Result": "Sonuç",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Revizyon",
     "RevisionAdded": "Revizyon eklendi.",
     "RevisionDetail": "Revision Detayı",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Kaynak Ön Ayarı",
     "Resources": "Kaynaklar",
     "Result": "Sonuç",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Yüklenen Revision değerine döndür",
     "Revision": "Revizyon",
     "RevisionAdded": "Revizyon eklendi.",
     "RevisionDetail": "Revision Detayı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "Cài đặt sẵn tài nguyên",
     "Resources": "Tài nguyên",
     "Result": "Kết quả",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "Khôi phục về giá trị Revision đã tải",
     "Revision": "Bản sửa đổi",
     "RevisionAdded": "Revision đã được thêm.",
     "RevisionDetail": "Chi tiết Revision",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "Cài đặt sẵn tài nguyên",
     "Resources": "Tài nguyên",
     "Result": "Kết quả",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "Bản sửa đổi",
     "RevisionAdded": "Revision đã được thêm.",
     "RevisionDetail": "Chi tiết Revision",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1209,6 +1209,7 @@
     "ResourcePreset": "资源预设",
     "Resources": "资源",
     "Result": "结果",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "修订版",
     "RevisionAdded": "Revision 已添加。",
     "RevisionDetail": "Revision 详情",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1209,7 +1209,7 @@
     "ResourcePreset": "资源预设",
     "Resources": "资源",
     "Result": "结果",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "恢复为已加载 Revision 的值",
     "Revision": "修订版",
     "RevisionAdded": "Revision 已添加。",
     "RevisionDetail": "Revision 详情",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1210,6 +1210,7 @@
     "ResourcePreset": "資源預設",
     "Resources": "資源",
     "Result": "結果",
+    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
     "Revision": "修訂版",
     "RevisionAdded": "Revision 已新增。",
     "RevisionDetail": "Revision 詳情",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1210,7 +1210,7 @@
     "ResourcePreset": "資源預設",
     "Resources": "資源",
     "Result": "結果",
-    "RevertToLoadedRevisionValue": "__NOT_TRANSLATED__",
+    "RevertToLoadedRevisionValue": "還原為已載入 Revision 的值",
     "Revision": "修訂版",
     "RevisionAdded": "Revision 已新增。",
     "RevisionDetail": "Revision 詳情",


### PR DESCRIPTION
Resolves #8587 (FR-3468)

## What changed

The Custom form of `DeploymentAddRevisionModal` could only be reset wholesale (`resetFields`), so undoing one accidental edit meant losing every other edit made alongside it.

This PR snapshots the values the Custom form was last loaded with from a revision — the deployment's current revision via **Load current revision**, or the source revision the modal was opened from — and renders a small ghost `Undo2` icon next to each field whose value has since diverged from that snapshot. Clicking it reverts **only that field**.

- The icon is **dirty-field-only**: hidden while the field still matches the loaded revision, and never rendered at all on a form that was never loaded from a revision.
- Whole-form reset is unchanged (out of scope, per the issue).
- Preset mode has no baseline: switching Custom → Preset discards the Custom edits, and the baseline is cleared with them.

## Design decisions

- **Baseline is the derived form values, not the raw GraphQL revision.** `applyRevisionToCustomForm` applies non-round-trippable transforms (resource slots → cpu/mem/accelerator, shmem units, health-check `enable` handling). Comparing against the raw revision would light the icon up on fields the user never touched, so the snapshot is taken from the object that is actually pushed into the form.
- **Field scope = the fields this modal renders itself**: model folder, mount destination, subpath, runtime variant, model definition path. The shared form-item components (`ResourceAllocationFormItems`, `ImageEnvironmentSelectFormItems`, `ModelServiceHealthCheckFormItems`, …) own their own layout and are used by other screens, so they are left untouched. The issue explicitly leaves the exact list to implementation.
- **Placement follows the modal's existing idiom** — control + `IconButton` in a `BAIFlex` row, the same shape the model-folder selector already uses — rather than injecting a button into the `<label>`.
- **Visibility subscribes via `Form.useWatch`, not a `dependencies` render prop.** The form engine notifies dependency watchers on user input but not on a programmatic `setFieldValue`, so a `dependencies`-driven button would have survived its own click (caught by the test below before it shipped).
- An empty string and `undefined` are normalized to the same thing for the comparison: clearing a text input that the revision did not set is not a divergence.

## Tests

- `react/src/components/DeploymentAddRevisionModal.test.tsx` — two new specs: no revert affordance is rendered while every field still matches the loaded revision, and editing one field then clicking its revert icon restores exactly that value and withdraws the icon.
- `pnpm --filter backend-ai-webui-react exec vitest run src/components/DeploymentAddRevisionModal.test.tsx` → **5 passed (5)**.
- `make i18n` for the new key across the locale files.

## Verification

`bash scripts/verify.sh` (Relay, Lint, Format, TypeScript, agent mappings, terminology):

```
=== ALL PASS ===
```

## Review notes

- Open a deployment with a current revision → **Add revision** → **Load current revision** (Custom mode). No revert icons should be visible immediately after loading.
- Change the **Model Mount Destination** (or Runtime Variant / Model Folder / Subpath / Model Definition Path): a small undo icon appears next to that field only. Click it — that field returns to the loaded value and the icon disappears; other edits are untouched.
- Worth a designer's eye: whether the five covered fields are the right set, and whether the icon reads well sitting to the right of each control.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
