### PR TITLE
feat(FR-454): paginate and filter the session detail kernel list

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -876,6 +876,7 @@ export class Client {
       this._features['fair-share-scheduling'] = true;
       this._features['export-csv'] = true;
       this._features['bulk-create-user'] = true;
+      this._features['session-kernels-v2'] = true;
     }
     if (this.isManagerVersionCompatibleWith('26.3.0')) {
       this._features['session-scheduling-history'] = true;

--- a/react/src/__generated__/ConnectedKernelListV2Query.graphql.ts
+++ b/react/src/__generated__/ConnectedKernelListV2Query.graphql.ts
@@ -1,0 +1,286 @@
+/**
+ * @generated SignedSource<<d2b9b625a6c2e20c09167dd8d3f16c8f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type KernelV2OrderField = "CLUSTER_HOSTNAME" | "CLUSTER_IDX" | "CLUSTER_MODE" | "CREATED_AT" | "STATUS" | "TERMINATED_AT" | "%future added value";
+export type KernelV2Status = "CANCELLED" | "CREATING" | "PENDING" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
+export type OrderDirection = "ASC" | "DESC" | "%future added value";
+export type SessionScope = {
+  sessionId: string;
+};
+export type KernelV2Filter = {
+  AND?: ReadonlyArray<KernelV2Filter> | null | undefined;
+  NOT?: ReadonlyArray<KernelV2Filter> | null | undefined;
+  OR?: ReadonlyArray<KernelV2Filter> | null | undefined;
+  id?: UUIDFilter | null | undefined;
+  sessionId?: UUIDFilter | null | undefined;
+  status?: KernelV2StatusFilter | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+};
+export type KernelV2StatusFilter = {
+  equals?: KernelV2Status | null | undefined;
+  in?: ReadonlyArray<KernelV2Status> | null | undefined;
+  notEquals?: KernelV2Status | null | undefined;
+  notIn?: ReadonlyArray<KernelV2Status> | null | undefined;
+};
+export type KernelV2OrderBy = {
+  direction?: OrderDirection;
+  field: KernelV2OrderField;
+};
+export type ConnectedKernelListV2Query$variables = {
+  filter?: KernelV2Filter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  orderBy?: ReadonlyArray<KernelV2OrderBy> | null | undefined;
+  scope: SessionScope;
+};
+export type ConnectedKernelListV2Query$data = {
+  readonly sessionKernelsV2: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly cluster: {
+          readonly clusterHostname: string;
+          readonly clusterIdx: number;
+        };
+        readonly id: string;
+        readonly lifecycle: {
+          readonly status: KernelV2Status;
+        };
+        readonly resource: {
+          readonly agentId: string | null | undefined;
+          readonly containerId: string | null | undefined;
+        };
+      };
+    }>;
+  } | null | undefined;
+};
+export type ConnectedKernelListV2Query = {
+  response: ConnectedKernelListV2Query$data;
+  variables: ConnectedKernelListV2Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "limit"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "scope"
+},
+v5 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "filter",
+        "variableName": "filter"
+      },
+      {
+        "kind": "Variable",
+        "name": "limit",
+        "variableName": "limit"
+      },
+      {
+        "kind": "Variable",
+        "name": "offset",
+        "variableName": "offset"
+      },
+      {
+        "kind": "Variable",
+        "name": "orderBy",
+        "variableName": "orderBy"
+      },
+      {
+        "kind": "Variable",
+        "name": "scope",
+        "variableName": "scope"
+      }
+    ],
+    "concreteType": "KernelV2Connection",
+    "kind": "LinkedField",
+    "name": "sessionKernelsV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "count",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "KernelV2Edge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "KernelV2",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "KernelV2ClusterInfo",
+                "kind": "LinkedField",
+                "name": "cluster",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "clusterHostname",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "clusterIdx",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "KernelV2LifecycleInfo",
+                "kind": "LinkedField",
+                "name": "lifecycle",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "status",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "KernelV2ResourceInfo",
+                "kind": "LinkedField",
+                "name": "resource",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "agentId",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "containerId",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ConnectedKernelListV2Query",
+    "selections": (v5/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v4/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ConnectedKernelListV2Query",
+    "selections": (v5/*: any*/)
+  },
+  "params": {
+    "cacheID": "e5ea7fa26d2e96ba51ea3b7ba874cc0a",
+    "id": null,
+    "metadata": {},
+    "name": "ConnectedKernelListV2Query",
+    "operationKind": "query",
+    "text": "query ConnectedKernelListV2Query(\n  $scope: SessionScope!\n  $filter: KernelV2Filter\n  $orderBy: [KernelV2OrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  sessionKernelsV2(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        cluster {\n          clusterHostname\n          clusterIdx\n        }\n        lifecycle {\n          status\n        }\n        resource {\n          agentId\n          containerId\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "eda1693d0b418b88cf250e16feb50873";
+
+export default node;

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -7,7 +7,6 @@ import {
   ConnectedKernelListFragment$key,
 } from '../../__generated__/ConnectedKernelListFragment.graphql';
 import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogModalFragment.graphql';
-// import BAIPropertyFilter from '../BAIPropertyFilter';
 import ContainerLogModal from './ContainerLogModal';
 import { Badge } from '@astryxdesign/core/Badge';
 import { IconButton } from '@astryxdesign/core/IconButton';
@@ -34,9 +33,6 @@ type Kernel = NonNullable<ConnectedKernelListFragment$data[number]>;
 interface ConnectedKernelListProps {
   kernelsFrgmt: ConnectedKernelListFragment$key;
   sessionFrgmtForLogModal: ContainerLogModalFragment$key;
-  // fetchKey?: string;
-  // get the project id of the session for <= v24.12.0.
-  // projectId?: string | null;
 }
 
 const kernelStatusTagColor = {
@@ -162,29 +158,12 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
   }, [kernelNodes]);
   return (
     <>
-      {/* TODO: implement filter when compute_session_node query supports filter */}
-      {/* <BAIPropertyFilter
-        filterProperties={[
-          {
-            key: 'agent_id',
-            propertyLabel: t('kernel.AgentId'),
-            type: 'string',
-          },
-        ]}
-        value={filterString}
-        onChange={(value) => {
-          startFilterTransition(() => {
-            setFilterString(value);
-          });
-        }}
-      /> */}
       <BAITable
         scroll={{ x: 'max-content' }}
         bordered
-        // loading={isPendingFilter}
         rowKey="id"
         columns={columns}
-        dataSource={sortedKernels} // TODO: implement pagination when compute_session_node query supports pagination
+        dataSource={sortedKernels}
       />
 
       <BAIUnmountAfterClose>

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.test.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.test.tsx
@@ -24,6 +24,16 @@ vi.mock('react-i18next', async () => {
   };
 });
 
+vi.mock('../../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({
+      supports: (feature: string) => feature === 'sub-filter',
+    }),
+  };
+});
+
 const KERNEL_UUID = '11111111-1111-1111-1111-111111111111';
 
 const renderList = () => {

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.test.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.test.tsx
@@ -1,0 +1,97 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../../__test__/matchMedia.mock.js';
+import '../../../__test__/resizeObserver.mock.js';
+import ConnectedKernelListV2 from './ConnectedKernelListV2';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  };
+});
+
+const KERNEL_UUID = '11111111-1111-1111-1111-111111111111';
+
+const renderList = () => {
+  const environment = createMockEnvironment();
+  const seenVariables: Array<Record<string, any>> = [];
+  environment.mock.queueOperationResolver((operation) => {
+    seenVariables.push(operation.request.variables);
+    return MockPayloadGenerator.generate(operation, {
+      KernelV2Connection: () => ({
+        count: 1,
+        edges: [
+          {
+            node: {
+              id: btoa(`KernelV2:${KERNEL_UUID}`),
+              cluster: { clusterHostname: 'main1', clusterIdx: 0 },
+              lifecycle: { status: 'RUNNING' },
+              resource: { agentId: 'i-agent-01', containerId: 'container-01' },
+            },
+          },
+        ],
+      }),
+    });
+  });
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback={null}>
+        <ConnectedKernelListV2
+          sessionId="22222222-2222-2222-2222-222222222222"
+          sessionFrgmtForLogModal={null as any}
+        />
+      </Suspense>
+    </RelayEnvironmentProvider>,
+  );
+  return seenVariables;
+};
+
+describe('ConnectedKernelListV2 (FR-454)', () => {
+  it('pages sessionKernelsV2 with limit/offset only', async () => {
+    const seenVariables = renderList();
+
+    await waitFor(() => expect(seenVariables).toHaveLength(1));
+    const variables = seenVariables[0];
+    expect(variables).toMatchObject({
+      scope: { sessionId: '22222222-2222-2222-2222-222222222222' },
+      limit: 10,
+      offset: 0,
+    });
+    // A Strawberry V2 connection rejects mixed pagination modes at runtime.
+    expect(variables.first).toBeUndefined();
+    expect(variables.after).toBeUndefined();
+    expect(variables.last).toBeUndefined();
+    expect(variables.before).toBeUndefined();
+  });
+
+  it('orders by the cluster index so the main kernel stays first', async () => {
+    const seenVariables = renderList();
+
+    await waitFor(() => expect(seenVariables).toHaveLength(1));
+    expect(seenVariables[0].orderBy).toEqual([
+      { field: 'CLUSTER_IDX', direction: 'ASC' },
+    ]);
+  });
+
+  it('renders a kernel row from the nested KernelV2 shape', async () => {
+    renderList();
+
+    expect(await screen.findByText('main1')).toBeInTheDocument();
+    expect(screen.getByText('RUNNING')).toBeInTheDocument();
+    expect(screen.getByText('i-agent-01')).toBeInTheDocument();
+  });
+});

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.tsx
@@ -1,0 +1,255 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  ConnectedKernelListV2Query,
+  KernelV2Filter,
+  KernelV2OrderBy,
+} from '../../__generated__/ConnectedKernelListV2Query.graphql';
+import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogModalFragment.graphql';
+import { convertToOrderBy } from '../../helper';
+import { useBAIPaginationOptionState } from '../../hooks/reactPaginationQueryOptions';
+import ContainerLogModal from './ContainerLogModal';
+import { Badge } from '@astryxdesign/core/Badge';
+import { IconButton } from '@astryxdesign/core/IconButton';
+import { Text } from '@astryxdesign/core/Text';
+import {
+  badgeVariantForStatus,
+  safeDecodeUuid,
+  BAIColumnsType,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  BAIId,
+  BAITable,
+  BAIText,
+  BAIUnmountAfterClose,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { ScrollTextIcon } from 'lucide-react';
+import { useDeferredValue, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+type Kernel = NonNullable<
+  NonNullable<
+    ConnectedKernelListV2Query['response']['sessionKernelsV2']
+  >['edges'][number]
+>['node'];
+
+// `KernelV2Status` is not exported as a standalone type by the compiler, so the
+// filter options are listed from the schema enum.
+const KERNEL_STATUSES = [
+  'PENDING',
+  'SCHEDULED',
+  'PREPARING',
+  'PREPARED',
+  'CREATING',
+  'RUNNING',
+  'TERMINATING',
+  'TERMINATED',
+  'CANCELLED',
+];
+
+interface ConnectedKernelListV2Props {
+  sessionId: string;
+  sessionFrgmtForLogModal: ContainerLogModalFragment$key;
+  fetchKey?: string;
+}
+
+const ConnectedKernelListV2: React.FC<ConnectedKernelListV2Props> = ({
+  sessionId,
+  sessionFrgmtForLogModal,
+  fetchKey,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [kernelIdForLogModal, setKernelIdForLogModal] = useState<string>();
+  const [filter, setFilter] = useState<KernelV2Filter>();
+  const [order, setOrder] = useState<string | null>('cluster.clusterIdx');
+  const {
+    baiPaginationOption,
+    tablePaginationOption,
+    setTablePaginationOption,
+  } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
+
+  const deferredFetchKey = useDeferredValue(fetchKey);
+  const deferredFilter = useDeferredValue(filter);
+  const deferredOrder = useDeferredValue(order);
+  const deferredLimit = useDeferredValue(baiPaginationOption.limit);
+  const deferredOffset = useDeferredValue(baiPaginationOption.offset);
+
+  const { sessionKernelsV2 } = useLazyLoadQuery<ConnectedKernelListV2Query>(
+    graphql`
+      query ConnectedKernelListV2Query(
+        $scope: SessionScope!
+        $filter: KernelV2Filter
+        $orderBy: [KernelV2OrderBy!]
+        $limit: Int
+        $offset: Int
+      ) {
+        sessionKernelsV2(
+          scope: $scope
+          filter: $filter
+          orderBy: $orderBy
+          limit: $limit
+          offset: $offset
+        ) {
+          count
+          edges {
+            node {
+              id
+              cluster {
+                clusterHostname
+                clusterIdx
+              }
+              lifecycle {
+                status
+              }
+              resource {
+                agentId
+                containerId
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      scope: { sessionId },
+      filter: deferredFilter,
+      orderBy: convertToOrderBy<KernelV2OrderBy>(deferredOrder),
+      limit: deferredLimit,
+      offset: deferredOffset,
+    },
+    {
+      fetchKey: deferredFetchKey,
+      fetchPolicy: 'store-and-network',
+    },
+  );
+
+  const columns: BAIColumnsType<Kernel> = [
+    {
+      title: t('kernel.Hostname'),
+      dataIndex: ['cluster', 'clusterHostname'],
+      sorter: true,
+      render: (hostname, record) => {
+        const kernelId = safeDecodeUuid(record.id);
+        return (
+          <>
+            <Text>{hostname}</Text>
+            <IconButton
+              variant="ghost"
+              size="sm"
+              icon={<ScrollTextIcon />}
+              label={t('session.SeeContainerLogs')}
+              tooltip={t('session.SeeContainerLogs')}
+              isDisabled={!kernelId}
+              onClick={() => {
+                kernelId && setKernelIdForLogModal(kernelId);
+              }}
+            />
+          </>
+        );
+      },
+    },
+    {
+      title: t('kernel.Status'),
+      dataIndex: ['lifecycle', 'status'],
+      sorter: true,
+      render: (status) => (
+        <Badge
+          variant={badgeVariantForStatus('kernel', status)}
+          label={status}
+        />
+      ),
+    },
+    {
+      title: t('kernel.AgentId'),
+      dataIndex: ['resource', 'agentId'],
+      render: (id) => (_.isEmpty(id) ? '-' : <BAIText copyable>{id}</BAIText>),
+    },
+    {
+      title: t('kernel.KernelId'),
+      fixed: 'left',
+      dataIndex: 'id',
+      render: (id) => {
+        const kernelId = safeDecodeUuid(id);
+        return kernelId ? <BAIId uuid={kernelId} /> : '-';
+      },
+    },
+    {
+      title: t('kernel.ContainerId'),
+      dataIndex: ['resource', 'containerId'],
+      render: (id) => (_.isEmpty(id) ? '-' : <BAIId uuid={id} />),
+    },
+  ];
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIGraphQLPropertyFilter
+        value={filter}
+        onChange={(next) => {
+          setFilter(next);
+          setTablePaginationOption({ current: 1 });
+        }}
+        filterProperties={[
+          {
+            key: 'id',
+            propertyLabel: t('kernel.KernelId'),
+            type: 'uuid',
+          },
+          {
+            key: 'status',
+            propertyLabel: t('kernel.Status'),
+            type: 'enum',
+            strictSelection: true,
+            options: _.map(KERNEL_STATUSES, (status) => ({
+              label: status,
+              value: status,
+            })),
+          },
+        ]}
+      />
+      <BAITable
+        scroll={{ x: 'max-content' }}
+        bordered
+        loading={
+          deferredFilter !== filter ||
+          deferredOrder !== order ||
+          deferredLimit !== baiPaginationOption.limit ||
+          deferredOffset !== baiPaginationOption.offset
+        }
+        rowKey="id"
+        columns={columns}
+        dataSource={_.map(sessionKernelsV2?.edges, 'node')}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          setOrder(nextOrder ?? null);
+          setTablePaginationOption({ current: 1 });
+        }}
+        pagination={{
+          pageSize: tablePaginationOption.pageSize,
+          current: tablePaginationOption.current,
+          total: sessionKernelsV2?.count ?? 0,
+          onChange: (current, pageSize) => {
+            setTablePaginationOption({ current, pageSize });
+          },
+        }}
+      />
+
+      <BAIUnmountAfterClose>
+        <ContainerLogModal
+          open={!!kernelIdForLogModal}
+          sessionFrgmt={sessionFrgmtForLogModal || null}
+          defaultKernelId={kernelIdForLogModal}
+          onCancel={() => {
+            setKernelIdForLogModal(undefined);
+          }}
+        />
+      </BAIUnmountAfterClose>
+    </BAIFlex>
+  );
+};
+
+export default ConnectedKernelListV2;

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../__generated__/ConnectedKernelListV2Query.graphql';
 import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogModalFragment.graphql';
 import { convertToOrderBy } from '../../helper';
+import { useSuspendedBackendaiClient } from '../../hooks';
 import { useBAIPaginationOptionState } from '../../hooks/reactPaginationQueryOptions';
 import ContainerLogModal from './ContainerLogModal';
 import { Badge } from '@astryxdesign/core/Badge';
@@ -51,6 +52,11 @@ const KERNEL_STATUSES = [
   'CANCELLED',
 ];
 
+// Keeps the main kernel first, matching the legacy list's client-side
+// `orderBy(['cluster_role', 'cluster_idx'])`. Offset pagination needs a
+// deterministic order, so this is restored whenever sorting is cleared.
+const DEFAULT_ORDER = 'cluster.clusterIdx';
+
 interface ConnectedKernelListV2Props {
   sessionId: string;
   sessionFrgmtForLogModal: ContainerLogModalFragment$key;
@@ -64,9 +70,13 @@ const ConnectedKernelListV2: React.FC<ConnectedKernelListV2Props> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+  // AND/OR/NOT sub-filters only exist on managers with the `sub-filter`
+  // capability; 26.2-26.6 serve `sessionKernelsV2` but reject them.
+  const supportsSubFilter = baiClient.supports('sub-filter');
   const [kernelIdForLogModal, setKernelIdForLogModal] = useState<string>();
   const [filter, setFilter] = useState<KernelV2Filter>();
-  const [order, setOrder] = useState<string | null>('cluster.clusterIdx');
+  const [order, setOrder] = useState<string | null>(DEFAULT_ORDER);
   const {
     baiPaginationOption,
     tablePaginationOption,
@@ -188,6 +198,7 @@ const ConnectedKernelListV2: React.FC<ConnectedKernelListV2Props> = ({
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
       <BAIGraphQLPropertyFilter
+        singleCondition={!supportsSubFilter}
         value={filter}
         onChange={(next) => {
           setFilter(next);
@@ -225,7 +236,7 @@ const ConnectedKernelListV2: React.FC<ConnectedKernelListV2Props> = ({
         dataSource={_.map(sessionKernelsV2?.edges, 'node')}
         order={order}
         onChangeOrder={(nextOrder) => {
-          setOrder(nextOrder ?? null);
+          setOrder(nextOrder ?? DEFAULT_ORDER);
           setTablePaginationOption({ current: 1 });
         }}
         pagination={{

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -19,6 +19,7 @@ import { ProjectContextOrNull } from '../types/projectContext';
 import BAIErrorBoundary from './BAIErrorBoundary';
 import CodeHighlighterModal from './CodeHighlighterModal';
 import ConnectedKernelList from './ComputeSessionNodeItems/ConnectedKernelList';
+import ConnectedKernelListV2 from './ComputeSessionNodeItems/ConnectedKernelListV2';
 import EditableSessionName from './ComputeSessionNodeItems/EditableSessionName';
 import SessionAccessKey from './ComputeSessionNodeItems/SessionAccessKey';
 import SessionActionButtons from './ComputeSessionNodeItems/SessionActionButtons';
@@ -671,12 +672,20 @@ const SessionDetailContent: React.FC<{
         </TabList>
         {activeTabKey === 'kernels' && (
           <Suspense fallback={<BAISkeleton />}>
-            <ConnectedKernelList
-              kernelsFrgmt={filterOutNullAndUndefined(
-                session.kernel_nodes?.edges.map((e) => e?.node),
-              )}
-              sessionFrgmtForLogModal={session}
-            />
+            {baiClient.supports('session-kernels-v2') && session.row_id ? (
+              <ConnectedKernelListV2
+                sessionId={session.row_id}
+                sessionFrgmtForLogModal={session}
+                fetchKey={fetchKey}
+              />
+            ) : (
+              <ConnectedKernelList
+                kernelsFrgmt={filterOutNullAndUndefined(
+                  session.kernel_nodes?.edges.map((e) => e?.node),
+                )}
+                sessionFrgmtForLogModal={session}
+              />
+            )}
           </Suspense>
         )}
         {activeTabKey === 'auditLog' && session.row_id && (

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -674,6 +674,10 @@ const SessionDetailContent: React.FC<{
           <Suspense fallback={<BAISkeleton />}>
             {baiClient.supports('session-kernels-v2') && session.row_id ? (
               <ConnectedKernelListV2
+                // Navigating to a dependent/dependency session swaps `row_id`
+                // without unmounting this component; remount so the filter,
+                // page and sort do not carry over.
+                key={session.row_id}
                 sessionId={session.row_id}
                 sessionFrgmtForLogModal={session}
                 fetchKey={fetchKey}


### PR DESCRIPTION
Resolves #3084 (FR-454)

The kernel table in the session detail panel rendered every kernel of a cluster session at once, ordered client-side, with its filter UI commented out — two TODOs said to wait for a query that supports filtering and pagination. Manager 26.2.0 added `sessionKernelsV2(scope: SessionScope!, filter: KernelV2Filter, orderBy: [KernelV2OrderBy!], limit, offset)`, so that query now backs the tab.

**What changed**

- **`ConnectedKernelListV2` (new)** — runs its own `useLazyLoadQuery` against `sessionKernelsV2` with:
  - **offset-mode pagination** (`limit` + `offset`). A Strawberry V2 connection rejects a mixed pagination mode at runtime, so `first` is deliberately not read off `useBAIPaginationOptionState` (`.claude/rules/graphql-pagination.md`).
  - **server-side ordering** from the table header — cluster hostname, cluster index, status — defaulting to `CLUSTER_IDX ASC` so the main kernel stays first, as the old client-side `orderBy(['cluster_role', 'cluster_idx'])` did.
  - a **`BAIGraphQLPropertyFilter`** over the properties `KernelV2Filter` actually exposes: kernel `id` and `status`. It has no `agentId` field, so the agent filter the old TODO asked for is not part of this PR.
- **`ConnectedKernelList` (legacy)** — kept unchanged as the path for managers below 26.2.0; only its two now-obsolete TODOs and the commented-out filter block are removed.
- **`SessionDetailContent`** — picks between the two behind the new `session-kernels-v2` client capability (added to the existing 26.2.0 block in `backend.ai-client`), and forwards the panel's `fetchKey` so a session refresh refetches the kernel page.

**Design decisions**

- `KernelV2` rows are addressed by their Strawberry global id, so the kernel-id column and the container-log button decode it with `safeDecodeUuid` rather than a `row_id` field (there is none).
- The container-log modal keeps its own complete `kernel_nodes` list, so its kernel picker still offers every kernel regardless of which table page is shown.
- `KernelV2` has **no `status_info` counterpart**, so the V2 status cell shows the status badge alone instead of the legacy `BAIDoubleTag`. This is the one behavioural difference between the two paths.
- No new i18n keys — the filter reuses the existing `kernel.KernelId` / `kernel.Status` column labels.

## Tests

- New: `react/src/components/ComputeSessionNodeItems/ConnectedKernelListV2.test.tsx` (3 cases) — asserts the query sends `limit`/`offset` and **no** `first`/`after`/`last`/`before`, that the default `orderBy` is `CLUSTER_IDX ASC`, and that a row renders from the nested `KernelV2` shape.
  `cd react && pnpm exec vitest run src/components/ComputeSessionNodeItems/ConnectedKernelListV2.test.tsx` → `Test Files 1 passed (1) / Tests 3 passed (3)`
- `pnpm run relay` — generated artifact committed.
- No e2e run (needs a live cluster).

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Open a **cluster session** (more than 10 kernels) → *Kernels* tab: the table now pages, and the page control reports the server `count` rather than the fetched array length.
- Type a filter token (`Status = RUNNING`, or a kernel id) and click a sortable header (Hostname / Status) — both should round-trip to the server and reset to page 1.
- Against a manager **older than 26.2.0** the tab must fall back to the original unpaginated list (unset the `session-kernels-v2` capability to simulate).

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version — 26.2.0 for the paginated path; older managers keep the legacy list
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — a cluster session with more kernels than one page
- [x] Test case(s) to demonstrate the difference of before/after — `ConnectedKernelListV2.test.tsx`

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
