### PR TITLE
refactor(FR-2655): use the typed v2 vfolder select in the admin model card form

### DIFF
--- a/react/src/components/AdminModelCardSettingModal.test.tsx
+++ b/react/src/components/AdminModelCardSettingModal.test.tsx
@@ -1,0 +1,151 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import AdminModelCardSettingModal from './AdminModelCardSettingModal';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * The model-storage folder picker is project-scoped and emits the folder's
+ * LOCAL id, while `CreateModelCardV2Input.vfolderId` is a `UUID!` — a
+ * regression back to a global id would only surface against a live manager.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useCurrentDomainValue: () => 'default',
+  };
+});
+
+const MODEL_STORE_PROJECT = {
+  id: 'project-0000-1111-2222-333333333333',
+  name: 'model-store',
+};
+// Undashed, as a Relay global id decodes to on some manager builds.
+const PICKED_VFOLDER_LOCAL_ID = '11111111111122223333444444444444';
+const PICKED_VFOLDER_UUID = '11111111-1111-2222-3333-444444444444';
+const CREATED_VFOLDER_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const CREATED_VFOLDER_GLOBAL_ID = btoa(
+  `VirtualFolderNode:${CREATED_VFOLDER_UUID}`,
+);
+
+// The folder picker and the domain select fetch their own data; stub both and
+// surface the picker's project scope and current value for assertions.
+vi.mock('backend.ai-ui', async (importOriginal) => {
+  const React = await import('react');
+  const originalModule = await importOriginal<typeof import('backend.ai-ui')>();
+  return {
+    ...originalModule,
+    BAIDomainSelect: () => null,
+    BAIProjectVfolderSelect: (props: any) =>
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'mock-vfolder-select',
+          type: 'button',
+          'data-project-id': props.projectId,
+          'data-value': props.value ?? '',
+          onClick: () => props.onChange?.(PICKED_VFOLDER_LOCAL_ID),
+        },
+        'select-vfolder',
+      ),
+  };
+});
+
+vi.mock('./FolderCreateModalV2', async () => {
+  const React = await import('react');
+  return {
+    default: (props: any) =>
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'mock-folder-created',
+          type: 'button',
+          'data-project-id': props.project?.id ?? '',
+          onClick: () =>
+            props.onRequestClose?.({ id: CREATED_VFOLDER_GLOBAL_ID }),
+        },
+        'create-folder',
+      ),
+  };
+});
+
+const renderModal = () => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <AdminModelCardSettingModal
+        open
+        modelStoreProject={MODEL_STORE_PROJECT}
+      />
+    </RelayEnvironmentProvider>,
+  );
+  return { environment };
+};
+
+describe('AdminModelCardSettingModal model-storage folder picker', () => {
+  it('scopes the folder picker to the model-store project', async () => {
+    renderModal();
+
+    expect(await screen.findByTestId('mock-vfolder-select')).toHaveAttribute(
+      'data-project-id',
+      MODEL_STORE_PROJECT.id,
+    );
+  });
+
+  it('sends the picked folder as a dashed UUID to the create mutation', async () => {
+    const user = userEvent.setup();
+    const { environment } = renderModal();
+
+    await user.type(
+      screen.getAllByRole('textbox')[0] as HTMLElement,
+      'my-model-card',
+    );
+    await user.click(await screen.findByTestId('mock-vfolder-select'));
+    await user.click(screen.getByRole('button', { name: 'button.Create' }));
+
+    await waitFor(() => {
+      expect(
+        environment.mock.getMostRecentOperation().request.node.params.name,
+      ).toBe('AdminModelCardSettingModalCreateMutation');
+    });
+    const { input } =
+      environment.mock.getMostRecentOperation().request.variables;
+    expect(input.vfolderId).toBe(PICKED_VFOLDER_UUID);
+    expect(input.modelStoreProjectId).toBe(MODEL_STORE_PROJECT.id);
+  });
+
+  it('fills the picker with the local id of a just-created folder', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(await screen.findByTestId('mock-folder-created'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-vfolder-select')).toHaveAttribute(
+        'data-value',
+        CREATED_VFOLDER_UUID,
+      );
+    });
+  });
+});

--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -28,9 +28,9 @@ import {
   BAIFlex,
   BAIModal,
   type BAIModalProps,
-  BAIVFolderSelect,
-  BAIVFolderSelectRef,
-  toGlobalId,
+  BAIProjectVfolderSelect,
+  type BAIProjectVfolderSelectRef,
+  convertToUUID,
   toLocalId,
   useBAILogger,
 } from 'backend.ai-ui';
@@ -78,7 +78,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const formRef = useRef<FormInstance<FormInputType>>(null);
-  const vfolderSelectRef = useRef<BAIVFolderSelectRef>(null);
+  const vfolderSelectRef = useRef<BAIProjectVfolderSelectRef>(null);
   const [isOpenCreateFolderModal, setIsOpenCreateFolderModal] = useState(false);
 
   const currentDomain = useCurrentDomainValue();
@@ -257,7 +257,9 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
           commitCreateModelCard({
             variables: {
               input: {
-                vfolderId: toLocalId(values.vfolderId),
+                // `BAIProjectVfolderSelect` emits the folder's local id;
+                // `vfolderId` is a `UUID!`.
+                vfolderId: convertToUUID(values.vfolderId),
                 // The model card must be created in the MODEL_STORE project —
                 // the same project that backs the VFolder selector above.
                 // TODO: model cards in the model-store project are slated to
@@ -305,7 +307,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
             !isModelStoreProjectResolved || modalProps.okButtonProps?.disabled,
         }}
       >
-        {!isModelStoreProjectResolved ? (
+        {!modelStoreProjectContext ? (
           <Banner
             status="error"
             title={t('modelStore.ProjectNotFound')}
@@ -370,13 +372,12 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
                         },
                       ]}
                     >
-                      <BAIVFolderSelect
+                      <BAIProjectVfolderSelect
                         ref={vfolderSelectRef}
                         label={t('adminModelCard.ModelStorageFolder')}
                         isLabelHidden
                         excludeDeleted
-                        filter='ownership_type == "group"'
-                        currentProjectId={modelStoreProject?.id ?? undefined}
+                        projectId={modelStoreProjectContext.id}
                       />
                     </BAIFormItem>
                   </Suspense>
@@ -562,7 +563,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
           setIsOpenCreateFolderModal(false);
           if (result) {
             formRef.current?.setFieldsValue({
-              vfolderId: toGlobalId('VirtualFolderNode', toLocalId(result.id)),
+              vfolderId: toLocalId(result.id),
             });
             vfolderSelectRef.current?.refetch();
           }


### PR DESCRIPTION
Resolves #6892 (FR-2655)

The model-storage folder picker in the admin Model Card form was still the untyped `BAIVFolderSelect`, narrowed with the hand-written string filter `ownership_type == "group"` on the Graphene `vfolder_nodes` connection — the FR-2651 workaround. BUI already ships the typed replacement, `BAIProjectVfolderSelect`, backed by `projectVfolders(projectId:, filter: VFolderFilter)`; it had no consumer yet. This PR swaps the call site over.

`projectVfolders(projectId:)` resolves to the same row set the old `scope_id: project:<id>` + `ownership_type == "group"` pair produced (`ProjectVFolderOperationScope.to_condition()` is `VFolderRow.group == project_id`), so the admin sees exactly the same folders — the filter is now the schema's own input type instead of a string the compiler cannot check.

**Design decisions**

- **`projectVfolders`, not `adminVfoldersV2`.** The issue proposed `adminVfoldersV2`, but `VFolderFilter` exposes no ownership-type or project field (`name` / `host` / `status` / `usageMode` / `cloneable` / `createdAt` only), so the system-wide connection cannot be narrowed to the model-store project's folders. `projectVfolders` is the only typed field that expresses the existing behaviour. The page is superadmin-only either way (`AdminDeploymentPage` is routed `access: 'superadmin'`), so neither field's authorization gate is the deciding factor.
- **No `usageMode: MODEL` filter.** Adding one would be a behaviour change relative to today's picker, which does not filter usage mode — a model-store folder created as `GENERAL` would silently disappear from the list. Left alone deliberately.
- **Id shape.** `BAIProjectVfolderSelect` emits the folder's *local* id where the old select emitted the Relay *global* id, so the two conversions around it move with it: the create mutation now sends `convertToUUID(values.vfolderId)` for its `vfolderId: UUID!`, and a just-created folder is written into the form as `toLocalId(result.id)` rather than being re-encoded back to a global id.
- The `!isModelStoreProjectResolved` render guard became `!modelStoreProjectContext` so TypeScript narrows the now-required `projectId` prop; the boolean is still what disables the OK button.

## Tests

- New `react/src/components/AdminModelCardSettingModal.test.tsx` (3 cases): the picker is scoped to the model-store project, the create mutation receives the dashed UUID, and a just-created folder lands in the form as its local id. Both id assertions fail against the previous code (`toLocalId` on a raw UUID throws).
- `pnpm exec vitest run src/components/AdminModelCardSettingModal.test.tsx` from `react/` — 3 passed.
- Not run: e2e (needs a live cluster).

## Verification

`bash scripts/verify.sh` →

```
=== ALL PASS ===
```

## Review notes

- Open **Deployments → Model Cards** as a superadmin and hit **Create**: the folder dropdown should list the same project folders as before, and searching should still filter by name.
- Create a folder from the `+` button next to the picker — it should be selected automatically when the dialog closes, and saving should succeed (this is the id-shape path).
- Edit mode is untouched: it renders a `FolderLink`, not the picker.

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version — `projectVfolders` / `vfolderV2` are "Added in 26.4.2"
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — a superadmin account and a MODEL_STORE project with at least one project folder
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
