### PR TITLE
fix(FR-2371): resolve deployment project name from projectV2

### DIFF
--- a/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b1f8b5de41b47cef366c1651696ac34>>
+ * @generated SignedSource<<730c854422157388e983a02aeda5a4f2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,6 +34,11 @@ export type DeploymentDetailPageQuery$data = {
     readonly metadata: {
       readonly name: string;
       readonly projectId: string;
+      readonly projectV2: {
+        readonly basicInfo: {
+          readonly name: string;
+        };
+      } | null | undefined;
       readonly status: DeploymentStatus;
     };
     readonly networkAccess: {
@@ -100,6 +105,18 @@ v5 = {
 v6 = {
   "alias": null,
   "args": null,
+  "concreteType": "ProjectBasicInfo",
+  "kind": "LinkedField",
+  "name": "basicInfo",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/)
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
   "concreteType": "ModelDeploymentNetworkAccess",
   "kind": "LinkedField",
   "name": "networkAccess",
@@ -122,7 +139,7 @@ v6 = {
   ],
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "ReplicaState",
@@ -140,7 +157,7 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -149,7 +166,7 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v10 = {
   "alias": "runningReplicas",
   "args": [
     {
@@ -166,23 +183,23 @@ v9 = {
   "kind": "LinkedField",
   "name": "replicas",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": "replicas(filter:{\"status\":{\"equals\":\"RUNNING\"}})"
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "AccessTokenConnection",
   "kind": "LinkedField",
   "name": "accessTokens",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": null
 },
-v11 = [
+v12 = [
   (v2/*: any*/)
 ],
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "concreteType": "UserV2BasicInfo",
@@ -200,14 +217,14 @@ v12 = {
   ],
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "vfolderId",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "concreteType": "VirtualFolderNode",
@@ -227,28 +244,28 @@ v14 = {
   ],
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mountDestination",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "definitionPath",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "subpath",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "ClusterConfig",
@@ -273,18 +290,18 @@ v18 = {
   ],
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "value",
   "storageKey": null
 },
-v20 = [
+v21 = [
   (v3/*: any*/),
-  (v19/*: any*/)
+  (v20/*: any*/)
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "ResourceConfig",
@@ -307,7 +324,7 @@ v21 = {
           "kind": "LinkedField",
           "name": "entries",
           "plural": true,
-          "selections": (v20/*: any*/),
+          "selections": (v21/*: any*/),
           "storageKey": null
         }
       ],
@@ -316,7 +333,7 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "AllocatedResourceSlot",
@@ -341,7 +358,7 @@ v22 = {
   ],
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "ExtraVFolderMountInfo",
@@ -349,8 +366,8 @@ v23 = {
   "name": "extraMounts",
   "plural": true,
   "selections": [
-    (v13/*: any*/),
-    (v15/*: any*/),
+    (v14/*: any*/),
+    (v16/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -358,11 +375,11 @@ v23 = {
       "name": "mountPerm",
       "storageKey": null
     },
-    (v14/*: any*/)
+    (v15/*: any*/)
   ],
   "storageKey": null
 },
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "EnvironmentVariables",
@@ -377,13 +394,13 @@ v24 = {
       "kind": "LinkedField",
       "name": "entries",
       "plural": true,
-      "selections": (v20/*: any*/),
+      "selections": (v21/*: any*/),
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "RuntimeVariantPresetValue",
@@ -398,7 +415,7 @@ v25 = {
       "name": "presetId",
       "storageKey": null
     },
-    (v19/*: any*/),
+    (v20/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -440,49 +457,49 @@ v25 = {
   ],
   "storageKey": null
 },
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "inferenceRuntimeConfig",
   "storageKey": null
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "modelPath",
   "storageKey": null
 },
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "command",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "shell",
   "storageKey": null
 },
-v30 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCommand",
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "port",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "PreStartAction",
@@ -507,49 +524,49 @@ v32 = {
   ],
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "path",
   "storageKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "maxRetries",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "initialDelay",
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "interval",
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "maxWaitTime",
   "storageKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "expectedStatusCode",
   "storageKey": null
 },
-v39 = {
+v40 = {
   "alias": null,
   "args": null,
   "concreteType": "ImageV2",
@@ -586,14 +603,14 @@ v39 = {
   ],
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "revisionNumber",
   "storageKey": null
 },
-v41 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -628,14 +645,26 @@ return {
               "selections": [
                 (v3/*: any*/),
                 (v4/*: any*/),
-                (v5/*: any*/)
+                (v5/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ProjectV2",
+                  "kind": "LinkedField",
+                  "name": "projectV2",
+                  "plural": false,
+                  "selections": [
+                    (v6/*: any*/)
+                  ],
+                  "storageKey": null
+                }
               ],
               "storageKey": null
             },
-            (v6/*: any*/),
             (v7/*: any*/),
-            (v9/*: any*/),
+            (v8/*: any*/),
             (v10/*: any*/),
+            (v11/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -643,7 +672,7 @@ return {
               "kind": "LinkedField",
               "name": "currentRevision",
               "plural": false,
-              "selections": (v11/*: any*/),
+              "selections": (v12/*: any*/),
               "storageKey": null
             },
             {
@@ -653,7 +682,7 @@ return {
               "kind": "LinkedField",
               "name": "deployingRevision",
               "plural": false,
-              "selections": (v11/*: any*/),
+              "selections": (v12/*: any*/),
               "storageKey": null
             },
             {
@@ -664,7 +693,7 @@ return {
               "name": "creator",
               "plural": false,
               "selections": [
-                (v12/*: any*/)
+                (v13/*: any*/)
               ],
               "storageKey": null
             },
@@ -736,32 +765,21 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "kind": "ScalarField",
-                "name": "resourceGroupName",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
                 "concreteType": "ProjectV2",
                 "kind": "LinkedField",
                 "name": "projectV2",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ProjectBasicInfo",
-                    "kind": "LinkedField",
-                    "name": "basicInfo",
-                    "plural": false,
-                    "selections": [
-                      (v3/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
+                  (v6/*: any*/),
                   (v2/*: any*/)
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "resourceGroupName",
                 "storageKey": null
               },
               {
@@ -781,10 +799,10 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/),
           (v7/*: any*/),
-          (v9/*: any*/),
+          (v8/*: any*/),
           (v10/*: any*/),
+          (v11/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -802,11 +820,11 @@ return {
                 "name": "modelMountConfig",
                 "plural": false,
                 "selections": [
-                  (v13/*: any*/),
                   (v14/*: any*/),
                   (v15/*: any*/),
                   (v16/*: any*/),
-                  (v17/*: any*/)
+                  (v17/*: any*/),
+                  (v18/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -817,10 +835,10 @@ return {
                 "name": "revisionPresetId",
                 "storageKey": null
               },
-              (v18/*: any*/),
-              (v21/*: any*/),
+              (v19/*: any*/),
               (v22/*: any*/),
               (v23/*: any*/),
+              (v24/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -856,9 +874,9 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v24/*: any*/),
                   (v25/*: any*/),
-                  (v26/*: any*/)
+                  (v26/*: any*/),
+                  (v27/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -879,7 +897,7 @@ return {
                     "plural": true,
                     "selections": [
                       (v3/*: any*/),
-                      (v27/*: any*/),
+                      (v28/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -888,11 +906,11 @@ return {
                         "name": "service",
                         "plural": false,
                         "selections": [
-                          (v28/*: any*/),
                           (v29/*: any*/),
                           (v30/*: any*/),
                           (v31/*: any*/),
                           (v32/*: any*/),
+                          (v33/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -908,16 +926,16 @@ return {
                                 "name": "enable",
                                 "storageKey": null
                               },
-                              (v33/*: any*/),
                               (v34/*: any*/),
                               (v35/*: any*/),
                               (v36/*: any*/),
                               (v37/*: any*/),
-                              (v38/*: any*/)
+                              (v38/*: any*/),
+                              (v39/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v29/*: any*/)
+                          (v30/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -927,11 +945,11 @@ return {
                 ],
                 "storageKey": null
               },
-              (v39/*: any*/),
               (v40/*: any*/),
               (v41/*: any*/),
-              (v22/*: any*/),
-              (v39/*: any*/)
+              (v42/*: any*/),
+              (v23/*: any*/),
+              (v40/*: any*/)
             ],
             "storageKey": null
           },
@@ -944,11 +962,11 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v40/*: any*/),
               (v41/*: any*/),
-              (v18/*: any*/),
+              (v42/*: any*/),
+              (v19/*: any*/),
+              (v23/*: any*/),
               (v22/*: any*/),
-              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -970,9 +988,9 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v26/*: any*/),
-                  (v24/*: any*/),
-                  (v25/*: any*/)
+                  (v27/*: any*/),
+                  (v25/*: any*/),
+                  (v26/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -984,16 +1002,16 @@ return {
                 "name": "modelMountConfig",
                 "plural": false,
                 "selections": [
-                  (v13/*: any*/),
-                  (v15/*: any*/),
+                  (v14/*: any*/),
                   (v16/*: any*/),
                   (v17/*: any*/),
-                  (v14/*: any*/)
+                  (v18/*: any*/),
+                  (v15/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v23/*: any*/),
-              (v39/*: any*/),
+              (v24/*: any*/),
+              (v40/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1011,7 +1029,7 @@ return {
                     "plural": true,
                     "selections": [
                       (v3/*: any*/),
-                      (v27/*: any*/),
+                      (v28/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1020,11 +1038,11 @@ return {
                         "name": "service",
                         "plural": false,
                         "selections": [
-                          (v28/*: any*/),
-                          (v30/*: any*/),
                           (v29/*: any*/),
                           (v31/*: any*/),
+                          (v30/*: any*/),
                           (v32/*: any*/),
+                          (v33/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1033,12 +1051,12 @@ return {
                             "name": "healthCheck",
                             "plural": false,
                             "selections": [
-                              (v33/*: any*/),
-                              (v35/*: any*/),
                               (v34/*: any*/),
                               (v36/*: any*/),
+                              (v35/*: any*/),
                               (v37/*: any*/),
-                              (v38/*: any*/)
+                              (v38/*: any*/),
+                              (v39/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1062,7 +1080,7 @@ return {
             "name": "creator",
             "plural": false,
             "selections": [
-              (v12/*: any*/),
+              (v13/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": null
@@ -1073,16 +1091,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7bc624ab346fbca25c424f1bcffa5751",
+    "cacheID": "e175df751ef01271ceaa39ee8a4dd19e",
     "id": null,
     "metadata": {},
     "name": "DeploymentDetailPageQuery",
     "operationKind": "query",
-    "text": "query DeploymentDetailPageQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    id\n    metadata {\n      name\n      status\n      projectId\n    }\n    networkAccess {\n      openToPublic\n      endpointUrl\n    }\n    replicaState {\n      desiredReplicaCount\n    }\n    runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n      count\n    }\n    accessTokens {\n      count\n    }\n    currentRevision @since(version: \"26.4.3\") {\n      id\n    }\n    deployingRevision @since(version: \"26.4.3\") {\n      id\n    }\n    creator @since(version: \"26.4.3\") {\n      basicInfo {\n        email\n      }\n      id\n    }\n    ...DeploymentAddRevisionModal_deployment\n    ...DeploymentBasicInfoCard_deployment\n    ...DeploymentRevisionCard_deployment\n    ...DeploymentReplicasCard_deployment\n    ...DeploymentAccessTokensCard_deployment\n    ...DeploymentAutoScalingCard_deployment\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment DeploymentAccessTokensCard_deployment on ModelDeployment {\n  id\n  networkAccess {\n    endpointUrl\n  }\n}\n\nfragment DeploymentAddRevisionModal_deployment on ModelDeployment {\n  id\n  metadata {\n    resourceGroupName\n    projectId\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    modelMountConfig {\n      vfolderId\n    }\n    ...DeploymentAddRevisionModal_revisionSource\n    id\n  }\n}\n\nfragment DeploymentAddRevisionModal_revisionSource on ModelRevision {\n  revisionPresetId @since(version: \"26.4.4\")\n  clusterConfig {\n    mode\n    size\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n  }\n  modelRuntimeConfig {\n    runtimeVariantId\n    runtimeVariant {\n      name\n      readsVfolderConfigFiles @since(version: \"26.8.0\")\n      id\n    }\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    vfolder {\n      id\n      name\n    }\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        shell @since(version: \"26.7.0\")\n        startCommand\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          enable @since(version: \"26.4.4\")\n          path\n          maxRetries\n          initialDelay\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n  imageV2 {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n}\n\nfragment DeploymentAutoScalingCard_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  creator @since(version: \"26.4.3\") {\n    basicInfo {\n      email\n    }\n    id\n  }\n}\n\nfragment DeploymentBasicInfoCard_deployment on ModelDeployment {\n  id\n  ...DeploymentSettingModal_deployment\n  metadata {\n    name\n    projectId\n    domainName\n    status\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    openToPublic\n    endpointUrl\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment DeploymentCurrentRevisionTab_deployment on ModelDeployment {\n  id\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  deployingRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n}\n\nfragment DeploymentReplicasCard_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentRevisionCard_deployment on ModelDeployment {\n  id\n  ...DeploymentCurrentRevisionTab_deployment\n  ...DeploymentRevisionHistoryTab_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n      preset {\n        name\n        displayName\n        targetSpec {\n          key\n        }\n        id\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentRevisionHistoryTab_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  ...DeploymentAddRevisionModal_deployment\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
+    "text": "query DeploymentDetailPageQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    id\n    metadata {\n      name\n      status\n      projectId\n      projectV2 @since(version: \"26.4.3\") {\n        basicInfo {\n          name\n        }\n        id\n      }\n    }\n    networkAccess {\n      openToPublic\n      endpointUrl\n    }\n    replicaState {\n      desiredReplicaCount\n    }\n    runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n      count\n    }\n    accessTokens {\n      count\n    }\n    currentRevision @since(version: \"26.4.3\") {\n      id\n    }\n    deployingRevision @since(version: \"26.4.3\") {\n      id\n    }\n    creator @since(version: \"26.4.3\") {\n      basicInfo {\n        email\n      }\n      id\n    }\n    ...DeploymentAddRevisionModal_deployment\n    ...DeploymentBasicInfoCard_deployment\n    ...DeploymentRevisionCard_deployment\n    ...DeploymentReplicasCard_deployment\n    ...DeploymentAccessTokensCard_deployment\n    ...DeploymentAutoScalingCard_deployment\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment DeploymentAccessTokensCard_deployment on ModelDeployment {\n  id\n  networkAccess {\n    endpointUrl\n  }\n}\n\nfragment DeploymentAddRevisionModal_deployment on ModelDeployment {\n  id\n  metadata {\n    resourceGroupName\n    projectId\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    modelMountConfig {\n      vfolderId\n    }\n    ...DeploymentAddRevisionModal_revisionSource\n    id\n  }\n}\n\nfragment DeploymentAddRevisionModal_revisionSource on ModelRevision {\n  revisionPresetId @since(version: \"26.4.4\")\n  clusterConfig {\n    mode\n    size\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n  }\n  modelRuntimeConfig {\n    runtimeVariantId\n    runtimeVariant {\n      name\n      readsVfolderConfigFiles @since(version: \"26.8.0\")\n      id\n    }\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    vfolder {\n      id\n      name\n    }\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        shell @since(version: \"26.7.0\")\n        startCommand\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          enable @since(version: \"26.4.4\")\n          path\n          maxRetries\n          initialDelay\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n  imageV2 {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n}\n\nfragment DeploymentAutoScalingCard_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  creator @since(version: \"26.4.3\") {\n    basicInfo {\n      email\n    }\n    id\n  }\n}\n\nfragment DeploymentBasicInfoCard_deployment on ModelDeployment {\n  id\n  ...DeploymentSettingModal_deployment\n  metadata {\n    name\n    projectId\n    domainName\n    status\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    openToPublic\n    endpointUrl\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment DeploymentCurrentRevisionTab_deployment on ModelDeployment {\n  id\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  deployingRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n}\n\nfragment DeploymentReplicasCard_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentRevisionCard_deployment on ModelDeployment {\n  id\n  ...DeploymentCurrentRevisionTab_deployment\n  ...DeploymentRevisionHistoryTab_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n      preset {\n        name\n        displayName\n        targetSpec {\n          key\n        }\n        id\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    subpath @since(version: \"26.4.4\")\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        command @since(version: \"26.7.0\")\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentRevisionHistoryTab_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  ...DeploymentAddRevisionModal_deployment\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9089d2f31b9601fe2fa64e840ab45300";
+(node as any).hash = "e225905c70dbae1e8c52c311d35572ba";
 
 export default node;

--- a/react/src/components/SwitchToProjectButton.test.tsx
+++ b/react/src/components/SwitchToProjectButton.test.tsx
@@ -1,0 +1,106 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * FR-2371: when the caller already knows the project name, the button must
+ * switch project without the extra `group_node` round-trip, while callers that
+ * cannot supply it (older managers) keep the query-backed fallback.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import SwitchToProjectButton from './SwitchToProjectButton';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+import { describe, expect, it, vi } from 'vitest';
+
+const { switchProject } = vi.hoisted(() => ({ switchProject: vi.fn() }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { projectName?: string | null }) =>
+      `${key}:${options?.projectName}`,
+    i18n: { language: 'en', changeLanguage: () => new Promise(() => {}) },
+    ready: true,
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+vi.mock('../hooks/useRouteScope', () => ({
+  useSwitchProject: () => switchProject,
+}));
+
+vi.mock('backend.ai-ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('backend.ai-ui')>();
+  return {
+    ...actual,
+    BAIButton: ({
+      children,
+      onClick,
+    }: {
+      children?: React.ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+const renderButton = (
+  environment: RelayMockEnvironment,
+  projectName?: string,
+) =>
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <SwitchToProjectButton
+        projectId="project-0000"
+        projectName={projectName}
+      />
+    </RelayEnvironmentProvider>,
+  );
+
+describe('SwitchToProjectButton', () => {
+  it('uses the given project name without issuing a query', () => {
+    const environment = createMockEnvironment();
+    renderButton(environment, 'alpha');
+
+    expect(
+      screen.getByText('modelService.SwitchToProject:alpha'),
+    ).toBeInTheDocument();
+    expect(environment.mock.getAllOperations()).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(switchProject).toHaveBeenCalledWith({
+      projectId: 'project-0000',
+      projectName: 'alpha',
+    });
+  });
+
+  it('falls back to the group_node lookup when no project name is given', async () => {
+    const environment = createMockEnvironment();
+    environment.mock.queueOperationResolver((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        GroupNode: () => ({
+          id: btoa('GroupNode:project-0000'),
+          name: 'beta',
+        }),
+      }),
+    );
+    renderButton(environment);
+
+    expect(
+      await screen.findByText('modelService.SwitchToProject:beta'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(switchProject).toHaveBeenCalledWith({
+      projectId: 'project-0000',
+      projectName: 'beta',
+    });
+  });
+});

--- a/react/src/components/SwitchToProjectButton.tsx
+++ b/react/src/components/SwitchToProjectButton.tsx
@@ -16,42 +16,29 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 
 interface SwitchToProjectButtonProps extends Omit<BAIButtonProps, 'onClick'> {
   projectId: string;
+  /**
+   * Project name the caller already resolved (e.g. from
+   * `ModelDeploymentMetadata.projectV2`). When omitted, the name is looked up
+   * with an extra `group_node` round-trip.
+   */
+  projectName?: string | null;
 }
 
-const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
-  projectId,
-  ...buttonProps
-}) => {
+const SwitchToProjectButtonView: React.FC<
+  Omit<SwitchToProjectButtonProps, 'projectId' | 'projectName'> & {
+    projectId?: string | null;
+    projectName?: string | null;
+  }
+> = ({ projectId, projectName, ...buttonProps }) => {
   'use memo';
   const { t } = useTranslation();
   const [isPending, startTransition] = useTransition();
   const switchProject = useSwitchProject();
 
-  const { group_node } = useLazyLoadQuery<SwitchToProjectButtonQuery>(
-    graphql`
-      query SwitchToProjectButtonQuery($projectId: String!) {
-        group_node(id: $projectId) @since(version: "24.03.0") {
-          id
-          name
-        }
-      }
-    `,
-    { projectId: toGlobalId('GroupNode', projectId) },
-  );
-
   const handleClick = () => {
-    const id = toLocalId(group_node?.id || '');
-    const name = group_node?.name;
-    if (id && name) {
+    if (projectId && projectName) {
       startTransition(() => {
-        // `useSwitchProject` applies the canonical scope rule (FR-3428): on
-        // project / project-admin scope it rewrites the `:projectName` URL
-        // segment (the URL owns the project since FR-3055); elsewhere it
-        // updates the atom directly.
-        switchProject({
-          projectId: id,
-          projectName: name,
-        });
+        switchProject({ projectId, projectName });
       });
     }
   };
@@ -64,15 +51,49 @@ const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
       onClick={handleClick}
       {...buttonProps}
     >
-      {t('modelService.SwitchToProject', { projectName: group_node?.name })}
+      {t('modelService.SwitchToProject', { projectName })}
     </BAIButton>
   );
 };
 
-const SwitchToProjectButton: React.FC<SwitchToProjectButtonProps> = (props) => {
+// Fallback for callers that cannot supply the name themselves — including
+// managers older than 26.4.3, where `projectV2` is stripped from the query.
+const SwitchToProjectButtonWithQuery: React.FC<
+  Omit<SwitchToProjectButtonProps, 'projectName'>
+> = ({ projectId, ...buttonProps }) => {
+  'use memo';
+  const { group_node } = useLazyLoadQuery<SwitchToProjectButtonQuery>(
+    graphql`
+      query SwitchToProjectButtonQuery($projectId: String!) {
+        group_node(id: $projectId) @since(version: "24.03.0") {
+          id
+          name
+        }
+      }
+    `,
+    { projectId: toGlobalId('GroupNode', projectId) },
+  );
+
+  return (
+    <SwitchToProjectButtonView
+      projectId={toLocalId(group_node?.id || '')}
+      projectName={group_node?.name}
+      {...buttonProps}
+    />
+  );
+};
+
+const SwitchToProjectButton: React.FC<SwitchToProjectButtonProps> = ({
+  projectName,
+  ...props
+}) => {
+  'use memo';
+  if (projectName) {
+    return <SwitchToProjectButtonView projectName={projectName} {...props} />;
+  }
   return (
     <Suspense fallback={<BAIButton type="link" size="small" loading />}>
-      <SwitchToProjectButtonContent {...props} />
+      <SwitchToProjectButtonWithQuery {...props} />
     </Suspense>
   );
 };

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -161,6 +161,11 @@ const DeploymentDetailPage: React.FC = () => {
               name
               status
               projectId
+              projectV2 @since(version: "26.4.3") {
+                basicInfo {
+                  name
+                }
+              }
             }
             networkAccess {
               openToPublic
@@ -246,6 +251,8 @@ const DeploymentDetailPage: React.FC = () => {
   // and suppress the "add revision" call-to-action below, which the user
   // cannot act on without switching projects anyway.
   const deploymentProjectId = deployment.metadata.projectId ?? null;
+  const deploymentProjectName =
+    deployment.metadata.projectV2?.basicInfo.name ?? null;
   const isProjectMismatch =
     pageProject !== null &&
     !!deploymentProjectId &&
@@ -338,7 +345,12 @@ const DeploymentDetailPage: React.FC = () => {
         <Banner
           status="warning"
           title={t('deployment.NotInProject')}
-          endContent={<SwitchToProjectButton projectId={deploymentProjectId} />}
+          endContent={
+            <SwitchToProjectButton
+              projectId={deploymentProjectId}
+              projectName={deploymentProjectName}
+            />
+          }
         />
       )}
       {hasNoActiveReplicas &&


### PR DESCRIPTION
Resolves #6144 (FR-2371)

`DeploymentDetailPage` renders a project-mismatch banner with a "switch to this project" shortcut. The page query only selected `metadata.projectId`, so `SwitchToProjectButton` had to resolve the human-readable name itself with a separate `group_node(id:)` query — the workaround the issue describes.

The modern deployment type already carries the project as a full object: `ModelDeploymentMetadata.projectV2: ProjectV2` (added in 26.4.3), whose `basicInfo.name` is the name the button needs. This PR selects it in the page query and hands it to the button.

**What changed**

- `DeploymentDetailPage.tsx` — the `metadata { … }` selection now also takes `projectV2 @since(version: "26.4.3") { basicInfo { name } }`, and passes `projectName` to `SwitchToProjectButton`.
- `SwitchToProjectButton.tsx` — new optional `projectName` prop. When the caller supplies it, the component renders and switches with **no query at all**; when it is absent, the existing `group_node` lookup runs as before, behind the same `Suspense`.

**Design decisions**

- The fallback is kept rather than deleted: `projectV2` is `@since 26.4.3`, so the runtime GraphQL transformer strips the field on older managers and `projectName` arrives `null`. The query-backed path therefore lives in a separate child component, so the fallback's hook is never conditional.
- The issue's original "Related Files" (`EndpointList.tsx`, `EndpointDetailPage.tsx`) no longer exist on `main`; `DeploymentDetailPage` is the successor page and the only `SwitchToProjectButton` call site. The legacy Graphene `Endpoint.project: String` field is untouched — nothing in the WebUI reads it any more.

## Tests

- New `react/src/components/SwitchToProjectButton.test.tsx`: asserts that a supplied `projectName` produces the label and the `switchProject({ projectId, projectName })` call with **zero** pending Relay operations, and that omitting it still resolves the name through `group_node`.
- `pnpm exec vitest run src/components/SwitchToProjectButton.test.tsx src/pages/DeploymentDetailPage.test.tsx` → 2 files, 4 tests passed.
- `pnpm run relay` re-run; `__generated__/DeploymentDetailPageQuery.graphql.ts` committed.

## Verification

`bash scripts/verify.sh`

```
=== ALL PASS ===
```

## Review notes

- Open a deployment that belongs to a project other than the currently selected one — the warning banner's button should read "Switch to \<project name\>" immediately, with no second network request in the Network tab (previously a `SwitchToProjectButtonQuery` fired).
- Clicking it must still switch project the same way (URL `:projectName` segment rewritten on project scope, atom updated on global admin scope).
- Against a manager older than 26.4.3, `projectV2` is stripped from the document and the button falls back to the `group_node` query — the button briefly shows its loading state, then behaves exactly as before.

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version — `projectV2` needs 26.4.3; older managers keep the `group_node` fallback
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review — a deployment whose project differs from the selected one, so the mismatch banner renders
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
