### PR TITLE
style(FR-3876): align inputs and spacing in the keypair resource policy modal

### DIFF
--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -62,7 +62,15 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
       : undefined;
 
   return (
-    <BAIFlex direction="column" align="start">
+    // The grid cell stretches to its row's tallest item; bottom-aligning the
+    // stack keeps every input on one baseline when labels wrap to two lines.
+    <BAIFlex
+      direction="column"
+      align="stretch"
+      justify="end"
+      gap="xs"
+      style={{ height: '100%' }}
+    >
       <BAIFormItem
         style={{ margin: 0 }}
         name={name}

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -290,7 +290,9 @@ const KeypairResourcePolicySettingModal: React.FC<
 
   return (
     <BAIModal
-      width={800}
+      // The widest cell holds a number input plus a unit selector; 800px left
+      // it colliding with the next column at the 3-column track width.
+      width={960}
       title={
         keypairResourcePolicy === null
           ? t('resourcePolicy.CreateKeypairResourcePolicy')
@@ -395,7 +397,7 @@ const KeypairResourcePolicySettingModal: React.FC<
               a responsive span, so the layout still settles into ~3 columns
               on the modal's fixed width without a breakpoint concept. */}
           <Card padding={4}>
-            <HStack wrap="wrap" gap={6}>
+            <HStack wrap="wrap" gap={8}>
               {_.map(_.keys(resourceSlots), (resourceSlotKey) => (
                 <div
                   key={resourceSlotKey}
@@ -463,8 +465,8 @@ const KeypairResourcePolicySettingModal: React.FC<
         </BAIFormItem>
         <BAIFormItem label={t('resourcePolicy.Sessions')}>
           <Card padding={4}>
-            <HStack wrap="wrap" gap={6}>
-              <div style={{ flex: '1 1 220px', minWidth: 220 }}>
+            <HStack wrap="wrap" gap={8}>
+              <div style={{ flex: '1 1 240px', minWidth: 240 }}>
                 <FormItemWithUnlimited
                   label={t('resourcePolicy.ClusterSize')}
                   name="max_containers_per_session"
@@ -478,7 +480,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                   />
                 </FormItemWithUnlimited>
               </div>
-              <div style={{ flex: '1 1 220px', minWidth: 220 }}>
+              <div style={{ flex: '1 1 240px', minWidth: 240 }}>
                 <FormItemWithUnlimited
                   name={'max_session_lifetime'}
                   unlimitedValue={0}
@@ -493,7 +495,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                 </FormItemWithUnlimited>
               </div>
               {baiClient.supports('max-pending-session-count') ? (
-                <div style={{ flex: '1 1 220px', minWidth: 220 }}>
+                <div style={{ flex: '1 1 240px', minWidth: 240 }}>
                   <FormItemWithUnlimited
                     name={'max_pending_session_count'}
                     unlimitedValue={null}
@@ -508,7 +510,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                   </FormItemWithUnlimited>
                 </div>
               ) : null}
-              <div style={{ flex: '1 1 220px', minWidth: 220 }}>
+              <div style={{ flex: '1 1 240px', minWidth: 240 }}>
                 <FormItemWithUnlimited
                   name={'max_concurrent_sessions'}
                   label={t('resourcePolicy.Concurrency')}
@@ -522,7 +524,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                   />
                 </FormItemWithUnlimited>
               </div>
-              <div style={{ flex: '1 1 220px', minWidth: 220 }}>
+              <div style={{ flex: '1 1 240px', minWidth: 240 }}>
                 <FormItemWithUnlimited
                   name={'idle_timeout'}
                   unlimitedValue={0}
@@ -536,7 +538,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                   />
                 </FormItemWithUnlimited>
               </div>
-              <div style={{ flex: '1 1 220px', minWidth: 220 }}>
+              <div style={{ flex: '1 1 240px', minWidth: 240 }}>
                 <FormItemWithUnlimited
                   name={'max_concurrent_sftp_sessions'}
                   unlimitedValue={0}

--- a/react/src/components/KeypairResourcePolicyV2SettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicyV2SettingModal.tsx
@@ -314,7 +314,9 @@ const KeypairResourcePolicyV2SettingModal: React.FC<
 
   return (
     <BAIModal
-      width={800}
+      // The widest cell holds a number input plus a unit selector; 800px left
+      // it colliding with the next column at the 3-column track width.
+      width={960}
       title={
         keypairResourcePolicy === null
           ? t('resourcePolicy.CreateKeypairResourcePolicy')
@@ -388,7 +390,7 @@ const KeypairResourcePolicyV2SettingModal: React.FC<
         </BAIFormItem>
         <BAIFormItem label={t('resourcePolicy.ResourcePolicy')}>
           <Card padding={4}>
-            <Grid columns={{ minWidth: 220, max: 3 }} gap={6}>
+            <Grid columns={{ minWidth: 240, max: 3 }} columnGap={8} rowGap={6}>
               {_.map(_.keys(resourceSlots), (resourceSlotKey) => (
                 <FormItemWithUnlimited
                   key={resourceSlotKey}
@@ -421,7 +423,10 @@ const KeypairResourcePolicyV2SettingModal: React.FC<
                   ]}
                 >
                   {_.includes(resourceSlotKey, 'mem') ? (
-                    <BAIDynamicUnitInputNumber defaultUnit="g" />
+                    <BAIDynamicUnitInputNumber
+                      defaultUnit="g"
+                      style={{ width: '100%' }}
+                    />
                   ) : (
                     <AstryxFormNumberInput
                       label={
@@ -444,7 +449,7 @@ const KeypairResourcePolicyV2SettingModal: React.FC<
         </BAIFormItem>
         <BAIFormItem label={t('resourcePolicy.Sessions')}>
           <Card padding={4}>
-            <Grid columns={{ minWidth: 220, max: 3 }} gap={6}>
+            <Grid columns={{ minWidth: 240, max: 3 }} columnGap={8} rowGap={6}>
               <FormItemWithUnlimited
                 label={t('resourcePolicy.ClusterSize')}
                 name="max_containers_per_session"


### PR DESCRIPTION
Resolves #9524 (FR-3876)

## Summary

The Resource Policy and Sessions panels of the keypair resource policy setting modal pair every numeric input with an "Unlimited" checkbox. Three things made them read as a cramped block:

- The checkbox sat flush against its input, with no separation between the two.
- Cells were top-aligned, so a label that wrapped to a second line pushed its input down and broke the row's shared baseline. At the 3-column track width both "Max Pending Session Count" and "Max Concurrent SFTP Sessions" wrap, so two of the six Sessions fields were offset from their neighbours.
- At 800px the Memory field — a number input plus a unit selector — ran close enough to the next column to look overlapped.

Changes:

- `FormItemWithUnlimited` now stretches to fill its grid cell and bottom-aligns its stack, so inputs sit on one baseline no matter how many lines the label takes. It also stretches its children to the cell width (they were previously shrink-wrapped by `align="start"`, which gave neighbouring inputs different widths) and puts a gap between the input and its checkbox.
- Both modals widen from 800px to 960px, with the column track raised to 240px and an explicit column gap.
- The V2 modal's memory input fills its column, matching what the V1 modal already did.

Applied to the V2 modal and to the V1 modal it falls back to on backends without V2 support, since both share `FormItemWithUnlimited` and had the same defect.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → no new findings (the 2 reported are pre-existing, in `BAIDialog.css` / `BAIDrawerPortal.css`, untouched here)
- Measured in the browser after the change: all three inputs in each row share one bottom edge, are each 268px wide, and sit 32px apart. Memory ends at 729px where the next column starts at 761px — previously the three inputs were 410 / 472 / 403px wide at differing baselines.

## Screenshots

Create Keypair Resource Policy modal, captured against a live backend.

| Before | After |
|--------|-------|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9525/20260908-110210-before.png" width="420"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9525/20260908-110221-after.png" width="420"> |

In the "before" shot the `Unlimited` checkbox is flush against its input, the three Resource Policy inputs have different widths, and `Max Pending Session Count` wraps to two lines so its input hangs below its row neighbours.

The second Sessions row is where the baseline fix is clearest — `Max Concurrent SFTP Sessions` still wraps to two lines, but its input and checkbox now line up exactly with `Concurrent Sessions` and `Idle timeout`:

<img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9525/20260908-110228-after-sessions-row2.png" width="640">
