### PR TITLE
feat(FR-3879): per-PR docs site preview with change highlighting

### DIFF
--- a/.github/scripts/pr-preview/build-docs-preview.sh
+++ b/.github/scripts/pr-preview/build-docs-preview.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Build the docs site twice — the PR's tree and its merge base — with the PR's
+# own toolkit, then stamp the head build with what changed between them.
+#
+# Usage:
+#   build-docs-preview.sh --base-ref origin/main --languages en,ko --out <dir> \
+#     [--label "PR preview"] [--skip-diff]
+#
+# Produces <out>/head (the stamped `dist/web` tree to publish) and <out>/base.
+# `packages/backend.ai-webui-docs/src` is swapped out for the base build and
+# restored on every exit path, including a failure or a cancelled run.
+set -euo pipefail
+
+BASE_REF=""
+LANGUAGES=""
+OUT=""
+LABEL="PR preview"
+SKIP_DIFF=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base-ref) BASE_REF="${2:?--base-ref needs a value}"; shift 2 ;;
+    --languages) LANGUAGES="${2:?--languages needs a value}"; shift 2 ;;
+    --out) OUT="${2:?--out needs a value}"; shift 2 ;;
+    --label) LABEL="${2:?--label needs a value}"; shift 2 ;;
+    --skip-diff) SKIP_DIFF=1; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$BASE_REF" ] || { echo "usage: --base-ref <ref> --languages <en,ko> --out <dir>" >&2; exit 2; }
+[ -n "$LANGUAGES" ] || { echo "usage: --base-ref <ref> --languages <en,ko> --out <dir>" >&2; exit 2; }
+[ -n "$OUT" ] || { echo "usage: --base-ref <ref> --languages <en,ko> --out <dir>" >&2; exit 2; }
+
+LANG_LIST="$(echo "$LANGUAGES" | tr ',' ' ')"
+for lang in $LANG_LIST; do
+  case "$lang" in
+    [a-z][a-z] | [a-z][a-z]-[a-z0-9]*) ;;
+    *) echo "Not a language code: ${lang}" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+DOCS="packages/backend.ai-webui-docs"
+SRC="${DOCS}/src"
+WEB="${DOCS}/dist/web"
+
+mkdir -p "$OUT"
+OUT="$(cd "$OUT" && pwd)"
+
+# The base build replaces `src/` wholesale, so uncommitted work there would be
+# destroyed. CI checkouts are always clean; a local run has to be too.
+if [ -n "$(git status --porcelain -- "$SRC")" ]; then
+  echo "::error::${SRC} has uncommitted changes — refusing to swap it out." >&2
+  exit 1
+fi
+
+SRC_SWAPPED=0
+restore_src() {
+  [ "$SRC_SWAPPED" -eq 1 ] || return 0
+  SRC_SWAPPED=0
+  rm -rf "$SRC"
+  git -C "$REPO_ROOT" checkout HEAD -- "$SRC"
+  echo "Restored ${SRC} to HEAD."
+}
+trap restore_src EXIT
+
+BASE_SHA="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+echo "Head: $(git rev-parse --short HEAD) · Base: $(git rev-parse --short "$BASE_SHA") · Languages: ${LANGUAGES}"
+
+docs_toolkit() { pnpm --filter backend.ai-webui-docs exec docs-toolkit "$@"; }
+
+src_langs() {
+  find "$SRC" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | tr '\n' ' '
+}
+
+# Which of the requested languages exist in the tree as it stands right now — a
+# language the PR adds is absent from the base tree.
+present_langs() {
+  local found=() lang
+  for lang in $LANG_LIST; do
+    if [ -d "${SRC}/${lang}" ]; then
+      found+=("$lang")
+    else
+      echo "Language '${lang}' does not exist in this tree — skipping." >&2
+    fi
+  done
+  printf '%s ' ${found[@]+"${found[@]}"}
+}
+
+# `dist/web` accumulates across invocations, so per-language builds land side by
+# side; `--lang all` is one pass when every language is wanted anyway. Called as
+# a plain command so `set -e` still aborts on a build failure.
+run_build() {
+  local lang
+  # `--no-strict` matches amplify.yml's production path: a preview must never be
+  # redder than the deploy it previews.
+  if [ "$1" = "$(src_langs)" ]; then
+    docs_toolkit build:web --lang all --no-strict
+  else
+    for lang in $1; do
+      docs_toolkit build:web --lang "$lang" --no-strict
+    done
+  fi
+}
+
+echo "::group::Build the toolkit"
+# `dist/cli.js` does not exist on a fresh install, so pnpm skipped the
+# `docs-toolkit` bin link; `pnpm rebuild` is what re-creates it (as amplify.yml).
+pnpm --filter backend.ai-docs-toolkit run build
+pnpm rebuild
+echo "::endgroup::"
+
+rm -rf "${OUT}/head" "${OUT}/base"
+
+echo "::group::Build the docs site from the PR head"
+HEAD_LANGS="$(present_langs)"
+[ -n "${HEAD_LANGS// /}" ] || { echo "::error::None of '${LANGUAGES}' exists under ${SRC}." >&2; exit 1; }
+rm -rf "$WEB"
+run_build "$HEAD_LANGS"
+mv "$WEB" "${OUT}/head"
+echo "::endgroup::"
+
+echo "::group::Build the docs site from the merge base"
+rm -rf "$SRC"
+SRC_SWAPPED=1
+git checkout "$BASE_SHA" -- "$SRC"
+BASE_LANGS="$(present_langs)"
+rm -rf "$WEB"
+if [ -n "${BASE_LANGS// /}" ]; then
+  run_build "$BASE_LANGS"
+  mv "$WEB" "${OUT}/base"
+else
+  echo "::warning::No requested language exists at the merge base — every page counts as new."
+  mkdir -p "${OUT}/base"
+fi
+restore_src
+echo "::endgroup::"
+
+if [ "$SKIP_DIFF" -eq 1 ]; then
+  echo "Skipping diff:web (--skip-diff)."
+  exit 0
+fi
+
+echo "::group::Mark the head build with what changed"
+docs_toolkit diff:web \
+  --base "${OUT}/base" \
+  --head "${OUT}/head" \
+  --lang "$LANGUAGES" \
+  --label "$LABEL"
+echo "::endgroup::"

--- a/.github/scripts/pr-preview/build-docs-preview.sh
+++ b/.github/scripts/pr-preview/build-docs-preview.sh
@@ -66,7 +66,39 @@ restore_src() {
 }
 trap restore_src EXIT
 
-BASE_SHA="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+# Deepen until a merge base exists. Falling back to the base TIP would silently
+# change the comparison: every base commit since the fork point would be
+# attributed to this PR, so no merge base is a hard failure instead.
+resolve_base_sha() {
+  local sha branch attempt
+  sha="$(git merge-base "$BASE_REF" HEAD 2>/dev/null)" && { printf '%s' "$sha"; return 0; }
+
+  branch="${BASE_REF#origin/}"
+  # A bare SHA has no branch to fetch, so there is nothing to deepen.
+  [ "$branch" != "$BASE_REF" ] || return 1
+
+  for attempt in 1 2 3 4 5; do
+    [ "$(git rev-parse --is-shallow-repository)" = "true" ] || break
+    echo "No merge base with ${BASE_REF} yet — deepening (${attempt}/5)." >&2
+    git fetch --deepen=200 origin "+refs/heads/${branch}:refs/remotes/origin/${branch}" >&2 || break
+    # The PR's own history can be the truncated side, so deepen it as well.
+    git fetch --deepen=200 origin >&2 || true
+    sha="$(git merge-base "$BASE_REF" HEAD 2>/dev/null)" && { printf '%s' "$sha"; return 0; }
+  done
+
+  if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    echo "Still no merge base — unshallowing." >&2
+    git fetch --unshallow origin "+refs/heads/${branch}:refs/remotes/origin/${branch}" >&2 || true
+    git fetch --unshallow origin >&2 || true
+    sha="$(git merge-base "$BASE_REF" HEAD 2>/dev/null)" && { printf '%s' "$sha"; return 0; }
+  fi
+  return 1
+}
+
+BASE_SHA="$(resolve_base_sha)" || {
+  echo "::error::No merge base between ${BASE_REF} and HEAD — refusing to compare against the base tip." >&2
+  exit 1
+}
 echo "Head: $(git rev-parse --short HEAD) · Base: $(git rev-parse --short "$BASE_SHA") · Languages: ${LANGUAGES}"
 
 docs_toolkit() { pnpm --filter backend.ai-webui-docs exec docs-toolkit "$@"; }

--- a/.github/scripts/pr-preview/compact-gh-pages-history.sh
+++ b/.github/scripts/pr-preview/compact-gh-pages-history.sh
@@ -2,10 +2,11 @@
 # Squash gh-pages down to a single orphan commit.
 #
 # Every preview deploy and every cleanup adds a commit whose tree carries ~18 MB
-# of Storybook output per live PR. The history of those trees is worthless — only
-# the current tree is ever served — but it is what makes the branch grow without
-# bound in a repository that is already ~800 MB. Rewriting to one orphan commit
-# lets git drop every unreferenced blob on the next gc.
+# of Storybook output and ~52 MB of built manual per language, per live PR. The
+# history of those trees is worthless — only the current tree is ever served —
+# but it is what makes the branch grow without bound in a repository that is
+# already ~800 MB. Rewriting to one orphan commit lets git drop every
+# unreferenced blob on the next gc.
 #
 # Force-pushing a branch is normally off-limits here. gh-pages is the exception:
 # it holds no reviewed history, nobody branches from it, and the tree is
@@ -16,8 +17,9 @@ set -euo pipefail
 BRANCH="${BRANCH:-gh-pages}"
 WORK="${WORK:-${RUNNER_TEMP:-/tmp}/gh-pages-compact}"
 # Below this, the rewrite costs more (a full force-push of the tree) than the
-# history it reclaims.
-MIN_COMMITS="${MIN_COMMITS:-10}"
+# history it reclaims. Lowered from 10 once docs previews joined: each commit
+# now carries far more tree, so the crossover comes sooner.
+MIN_COMMITS="${MIN_COMMITS:-5}"
 # REPO_URL is overridable so the logic can be exercised against a local bare
 # repository; CI leaves it unset and gets the token URL.
 if [ -z "${REPO_URL:-}" ]; then

--- a/.github/scripts/pr-preview/docs-changed-languages.mjs
+++ b/.github/scripts/pr-preview/docs-changed-languages.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Decide whether a PR needs a docs preview, and which languages to build.
+//
+// The workflow's event-level `paths:` filter is a union across every job it
+// hosts, so each job has to re-ask the question against the PR's own diff.
+//
+// Usage:
+//   node docs-changed-languages.mjs --base origin/main --head HEAD [--output docs-meta.json]
+//   git diff --name-only origin/main...HEAD | node docs-changed-languages.mjs --stdin
+//
+// Prints `{ docs, languages, reason }` as JSON on stdout.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const DOCS_PKG = "packages/backend.ai-webui-docs/";
+const DOCS_SRC = `${DOCS_PKG}src/`;
+const TOOLKIT_PKG = "packages/backend.ai-docs-toolkit/";
+
+// Same shape the comment generator accepts, so an unexpected directory under
+// `src/` can never reach a URL: two letters plus an optional region suffix.
+const LANG_RE = /^[a-z]{2}(-[a-z0-9]+)?$/;
+
+// Files that change how EVERY page is built rather than what one language says.
+// A PR touching one of these gets an `en` preview so the layout is reviewable.
+const isBuildInput = (file) =>
+  file.startsWith(TOOLKIT_PKG) ||
+  file === `${DOCS_SRC}book.config.yaml` ||
+  file === `${DOCS_PKG}docs-toolkit.config.yaml` ||
+  file.startsWith(`${DOCS_PKG}scripts/`) ||
+  file.startsWith(`${DOCS_PKG}assets/`) ||
+  file === ".github/workflows/pr-preview.yml" ||
+  file.startsWith(".github/scripts/pr-preview/");
+
+const contentLanguage = (file) => {
+  if (!file.startsWith(DOCS_SRC)) return null;
+  const rest = file.slice(DOCS_SRC.length);
+  const slash = rest.indexOf("/");
+  if (slash === -1) return null;
+  const lang = rest.slice(0, slash);
+  return LANG_RE.test(lang) ? lang : null;
+};
+
+export function classify(files) {
+  const languages = new Set();
+  let buildInput = false;
+
+  for (const file of files) {
+    if (!file) continue;
+    const lang = contentLanguage(file);
+    if (lang) languages.add(lang);
+    if (isBuildInput(file)) buildInput = true;
+  }
+
+  const content = languages.size > 0;
+  if (buildInput) languages.add("en");
+
+  const reason = buildInput
+    ? content
+      ? "mixed"
+      : "toolkit"
+    : content
+      ? "content"
+      : "none";
+
+  return {
+    docs: languages.size > 0,
+    languages: [...languages].sort(),
+    reason,
+  };
+}
+
+const getArg = (name) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+};
+
+function changedFiles(base, head) {
+  const git = (args) =>
+    execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 })
+      .split("\n")
+      .filter(Boolean);
+  // Three dots first: it reports what the branch changed, ignoring commits that
+  // landed on base meanwhile. It needs a merge base, which a shallow clone may
+  // not have — the two-dot fallback compares the two trees instead.
+  try {
+    return git(["diff", "--name-only", `${base}...${head}`]);
+  } catch {
+    return git(["diff", "--name-only", base, head]);
+  }
+}
+
+function main() {
+  const files = process.argv.includes("--stdin")
+    ? readFileSync(0, "utf8").split("\n")
+    : changedFiles(getArg("base") ?? "origin/main", getArg("head") ?? "HEAD");
+
+  const result = classify(files);
+  const json = JSON.stringify(result);
+  const output = getArg("output");
+  if (output) writeFileSync(output, `${json}\n`);
+  console.log(json);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/.github/scripts/pr-preview/docs-changed-languages.test.mjs
+++ b/.github/scripts/pr-preview/docs-changed-languages.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { classify } from "./docs-changed-languages.mjs";
+
+const DOCS = "packages/backend.ai-webui-docs";
+
+test("a PR outside the manual and the toolkit needs no preview", () => {
+  assert.deepEqual(classify(["react/src/pages/SessionListPage.tsx"]), {
+    docs: false,
+    languages: [],
+    reason: "none",
+  });
+});
+
+test("content changes select their own languages", () => {
+  const result = classify([
+    `${DOCS}/src/ko/session/session_list.md`,
+    `${DOCS}/src/en/session/session_list.md`,
+    `${DOCS}/src/en/images/session_list.png`,
+  ]);
+  assert.deepEqual(result, {
+    docs: true,
+    languages: ["en", "ko"],
+    reason: "content",
+  });
+});
+
+test("a toolkit change builds en even with no content change", () => {
+  const result = classify([
+    "packages/backend.ai-docs-toolkit/src/styles-web.ts",
+  ]);
+  assert.deepEqual(result, {
+    docs: true,
+    languages: ["en"],
+    reason: "toolkit",
+  });
+});
+
+test("build inputs inside the docs package also mean en", () => {
+  for (const file of [
+    `${DOCS}/src/book.config.yaml`,
+    `${DOCS}/docs-toolkit.config.yaml`,
+    `${DOCS}/scripts/check-nav-titles.mjs`,
+    `${DOCS}/assets/logo.svg`,
+    ".github/workflows/pr-preview.yml",
+    ".github/scripts/pr-preview/build-docs-preview.sh",
+  ]) {
+    assert.deepEqual(
+      classify([file]),
+      { docs: true, languages: ["en"], reason: "toolkit" },
+      file,
+    );
+  }
+});
+
+test("content plus a build input is mixed, and en is added", () => {
+  const result = classify([
+    `${DOCS}/src/ko/session/session_list.md`,
+    `${DOCS}/src/book.config.yaml`,
+  ]);
+  assert.deepEqual(result, {
+    docs: true,
+    languages: ["en", "ko"],
+    reason: "mixed",
+  });
+});
+
+test("non-source files in the docs package do not trigger a build", () => {
+  const result = classify([
+    `${DOCS}/README.md`,
+    `${DOCS}/terminology.json`,
+    `${DOCS}/src/en`,
+  ]);
+  assert.deepEqual(result, { docs: false, languages: [], reason: "none" });
+});
+
+test("a directory under src/ that is not a language code is ignored", () => {
+  const result = classify([`${DOCS}/src/drafts/whatever.md`]);
+  assert.deepEqual(result, { docs: false, languages: [], reason: "none" });
+});
+
+test("a regional language code is accepted", () => {
+  const result = classify([`${DOCS}/src/pt-br/session/session_list.md`]);
+  assert.deepEqual(result, {
+    docs: true,
+    languages: ["pt-br"],
+    reason: "content",
+  });
+});

--- a/.github/scripts/pr-preview/generate-pr-comment.mjs
+++ b/.github/scripts/pr-preview/generate-pr-comment.mjs
@@ -3,8 +3,13 @@
 // Writes markdown to stdout; the calling workflow posts or updates it.
 //
 // Usage:
-//   node generate-pr-comment.mjs --analysis analysis.json --meta pr-meta.json \
-//     [--bundle-head bundle-head.json] [--bundle-base bundle-base.json]
+//   node generate-pr-comment.mjs --meta pr-meta.json \
+//     [--analysis analysis.json] [--bundle-head …] [--bundle-base …] \
+//     [--docs docs-manifest.json] [--docs-meta docs-meta.json]
+//
+// Every section is optional but `--meta`: a PR that only changed the manual
+// renders the docs section alone, and one that only changed the component
+// package renders the Storybook sections alone.
 
 import { existsSync, readFileSync } from "node:fs";
 
@@ -20,9 +25,17 @@ const analysis = readJson(getArg("analysis"));
 const meta = readJson(getArg("meta"));
 const bundleHead = readJson(getArg("bundle-head"));
 const bundleBase = readJson(getArg("bundle-base"));
+const docs = readJson(getArg("docs"));
+const docsMeta = readJson(getArg("docs-meta"));
 
-if (!analysis || !meta) {
-  console.error("Missing analysis.json or pr-meta.json");
+if (!meta) {
+  console.error("Missing pr-meta.json");
+  process.exit(1);
+}
+if (!analysis && !docs) {
+  console.error(
+    "Neither analysis.json nor docs-manifest.json — nothing to report",
+  );
   process.exit(1);
 }
 
@@ -37,171 +50,297 @@ const out = [];
 out.push("## PR Analysis Report");
 out.push("");
 
-// ── Storybook preview ────────────────────────────────────────────────────────
-out.push("### 📚 Storybook Preview");
-out.push("");
-if (meta.storybookUrl) {
-  out.push(`**${link("View Storybook for this PR", meta.storybookUrl)}**`);
+if (analysis) {
+  // ── Storybook preview ────────────────────────────────────────────────────────
+  out.push("### 📚 Storybook Preview");
   out.push("");
-  out.push(
-    "_GitHub Pages may take up to a minute to hydrate after the deploy._",
-  );
-} else {
-  out.push("_No preview was deployed for this run._");
-}
-out.push("");
-
-// ── Changed components ───────────────────────────────────────────────────────
-out.push("### 🧩 Changed Components");
-out.push("");
-// The table is the actionable part, so it holds only the components a reviewer
-// can actually open. Everything else goes below it, out of the way — a wall of
-// "no story, nothing to open" rows is what makes a report like this get ignored.
-const previewable = analysis.components.filter(
-  (c) => c.deepLink && meta.storybookUrl,
-);
-const unpreviewable = analysis.components.filter(
-  (c) => !c.deepLink || !meta.storybookUrl,
-);
-const MAX_ROWS = 30;
-
-// `components/BAIVFolderDeleteButton.tsx` and
-// `components/fragments/BAIVFolderDeleteButton.tsx` both exist. Disambiguate by
-// subdirectory, but only when a PR actually touches both — otherwise the bare
-// name reads better.
-const nameCounts = new Map();
-for (const c of analysis.components) {
-  nameCounts.set(c.name, (nameCounts.get(c.name) ?? 0) + 1);
-}
-const label = (c) => {
-  if (nameCounts.get(c.name) === 1) return c.name;
-  const rel = c.file.replace("packages/backend.ai-ui/src/components/", "");
-  return rel.replace(/\.tsx$/, "");
-};
-
-if (analysis.components.length === 0) {
-  out.push(
-    "_No component files changed in `packages/backend.ai-ui/src/components/`._",
-  );
-} else if (previewable.length === 0) {
-  out.push(
-    `_${analysis.components.length} component(s) changed, none of which has a ` +
-      "`*.stories.tsx` — nothing to open in the preview._",
-  );
-} else {
-  out.push("| Component | Changed | Stories | Open |");
-  out.push("|---|---|---|---|");
-  for (const c of previewable.slice(0, MAX_ROWS)) {
-    const changed = [
-      c.isNew ? "new" : c.sourceChanged && "source",
-      c.storiesChanged && "stories",
-    ]
-      .filter(Boolean)
-      .join(" + ");
-    out.push(
-      `| \`${label(c)}\` | ${changed} | ${c.storyCount} | ` +
-        `${link("Storybook ↗", `${meta.storybookUrl}${c.deepLink}`)} |`,
-    );
-  }
-  if (previewable.length > MAX_ROWS) {
-    out.push(`| _…and ${previewable.length - MAX_ROWS} more_ | | | |`);
-  }
-}
-out.push("");
-
-if (analysis.summary.newWithoutStories > 0) {
-  const names = analysis.components
-    .filter((c) => c.isNew && !c.hasStories)
-    .map((c) => `\`${label(c)}\``)
-    .join(", ");
-  out.push(
-    `> ⚠️ New component(s) without a \`*.stories.tsx\`: ${names}. They cannot appear ` +
-      "in the preview, and a story is the cheapest way to make a new component " +
-      "reviewable.",
-  );
-  out.push("");
-}
-
-if (unpreviewable.length > 0) {
-  out.push(
-    `<details><summary>${unpreviewable.length} changed component(s) with no story ` +
-      "to open</summary>",
-  );
-  out.push("");
-  for (const c of unpreviewable) out.push(`- \`${c.name}\` — \`${c.file}\``);
-  out.push("");
-  out.push("</details>");
-  out.push("");
-}
-
-if (analysis.otherPackageFiles.length > 0) {
-  const shown = analysis.otherPackageFiles.slice(0, 10);
-  out.push(
-    `<details><summary>${analysis.otherPackageFiles.length} other changed file(s) in ` +
-      "<code>packages/backend.ai-ui/</code></summary>",
-  );
-  out.push("");
-  for (const f of shown) out.push(`- \`${f}\``);
-  if (analysis.otherPackageFiles.length > shown.length) {
-    out.push(`- …and ${analysis.otherPackageFiles.length - shown.length} more`);
-  }
-  out.push("");
-  out.push("</details>");
-  out.push("");
-}
-
-// ── Bundle size ──────────────────────────────────────────────────────────────
-out.push("### 📦 Bundle Size");
-out.push("");
-if (!bundleHead) {
-  out.push("_Bundle was not measured for this run._");
-} else {
-  const baseByFile = new Map(
-    (bundleBase?.entries ?? []).map((e) => [e.file, e]),
-  );
-  const rows = bundleHead.entries.filter((e) => e.bytes >= 20 * 1024);
-  out.push(`| File | Size | Gzip |${bundleBase ? " Δ Gzip vs base |" : ""}`);
-  out.push(`|---|---|---|${bundleBase ? "---|" : ""}`);
-  for (const e of rows) {
-    const prev = baseByFile.get(e.file);
-    const delta = bundleBase
-      ? prev
-        ? ` ${prev.hash === e.hash ? "—" : signed(e.gzipBytes - prev.gzipBytes)} |`
-        : " 🆕 new |"
-      : "";
-    out.push(`| \`${e.file}\` | ${kb(e.bytes)} | ${kb(e.gzipBytes)} |${delta}`);
-  }
-  if (bundleBase) {
-    const totalHead = bundleHead.entries.reduce((n, e) => n + e.gzipBytes, 0);
-    const totalBase = bundleBase.entries.reduce((n, e) => n + e.gzipBytes, 0);
+  if (meta.storybookUrl) {
+    out.push(`**${link("View Storybook for this PR", meta.storybookUrl)}**`);
     out.push("");
     out.push(
-      `**Total gzip:** ${kb(totalHead)} (${signed(totalHead - totalBase)} vs \`${analysis.base}\`)`,
+      "_GitHub Pages may take up to a minute to hydrate after the deploy._",
     );
   } else {
-    out.push("");
+    out.push("_No preview was deployed for this run._");
+  }
+  out.push("");
+
+  // ── Changed components ───────────────────────────────────────────────────────
+  out.push("### 🧩 Changed Components");
+  out.push("");
+  // The table is the actionable part, so it holds only the components a reviewer
+  // can actually open. Everything else goes below it, out of the way — a wall of
+  // "no story, nothing to open" rows is what makes a report like this get ignored.
+  const previewable = analysis.components.filter(
+    (c) => c.deepLink && meta.storybookUrl,
+  );
+  const unpreviewable = analysis.components.filter(
+    (c) => !c.deepLink || !meta.storybookUrl,
+  );
+  const MAX_ROWS = 30;
+
+  // `components/BAIVFolderDeleteButton.tsx` and
+  // `components/fragments/BAIVFolderDeleteButton.tsx` both exist. Disambiguate by
+  // subdirectory, but only when a PR actually touches both — otherwise the bare
+  // name reads better.
+  const nameCounts = new Map();
+  for (const c of analysis.components) {
+    nameCounts.set(c.name, (nameCounts.get(c.name) ?? 0) + 1);
+  }
+  const label = (c) => {
+    if (nameCounts.get(c.name) === 1) return c.name;
+    const rel = c.file.replace("packages/backend.ai-ui/src/components/", "");
+    return rel.replace(/\.tsx$/, "");
+  };
+
+  if (analysis.components.length === 0) {
     out.push(
-      "_No base measurement — the merge-base build was skipped " +
-        "(dependency changes, or the base build failed)._",
+      "_No component files changed in `packages/backend.ai-ui/src/components/`._",
     );
+  } else if (previewable.length === 0) {
+    out.push(
+      `_${analysis.components.length} component(s) changed, none of which has a ` +
+        "`*.stories.tsx` — nothing to open in the preview._",
+    );
+  } else {
+    out.push("| Component | Changed | Stories | Open |");
+    out.push("|---|---|---|---|");
+    for (const c of previewable.slice(0, MAX_ROWS)) {
+      const changed = [
+        c.isNew ? "new" : c.sourceChanged && "source",
+        c.storiesChanged && "stories",
+      ]
+        .filter(Boolean)
+        .join(" + ");
+      out.push(
+        `| \`${label(c)}\` | ${changed} | ${c.storyCount} | ` +
+          `${link("Storybook ↗", `${meta.storybookUrl}${c.deepLink}`)} |`,
+      );
+    }
+    if (previewable.length > MAX_ROWS) {
+      out.push(`| _…and ${previewable.length - MAX_ROWS} more_ | | | |`);
+    }
+  }
+  out.push("");
+
+  if (analysis.summary.newWithoutStories > 0) {
+    const names = analysis.components
+      .filter((c) => c.isNew && !c.hasStories)
+      .map((c) => `\`${label(c)}\``)
+      .join(", ");
+    out.push(
+      `> ⚠️ New component(s) without a \`*.stories.tsx\`: ${names}. They cannot appear ` +
+        "in the preview, and a story is the cheapest way to make a new component " +
+        "reviewable.",
+    );
+    out.push("");
+  }
+
+  if (unpreviewable.length > 0) {
+    out.push(
+      `<details><summary>${unpreviewable.length} changed component(s) with no story ` +
+        "to open</summary>",
+    );
+    out.push("");
+    for (const c of unpreviewable) out.push(`- \`${c.name}\` — \`${c.file}\``);
+    out.push("");
+    out.push("</details>");
+    out.push("");
+  }
+
+  if (analysis.otherPackageFiles.length > 0) {
+    const shown = analysis.otherPackageFiles.slice(0, 10);
+    out.push(
+      `<details><summary>${analysis.otherPackageFiles.length} other changed file(s) in ` +
+        "<code>packages/backend.ai-ui/</code></summary>",
+    );
+    out.push("");
+    for (const f of shown) out.push(`- \`${f}\``);
+    if (analysis.otherPackageFiles.length > shown.length) {
+      out.push(
+        `- …and ${analysis.otherPackageFiles.length - shown.length} more`,
+      );
+    }
+    out.push("");
+    out.push("</details>");
+    out.push("");
+  }
+
+  // ── Bundle size ──────────────────────────────────────────────────────────────
+  out.push("### 📦 Bundle Size");
+  out.push("");
+  if (!bundleHead) {
+    out.push("_Bundle was not measured for this run._");
+  } else {
+    const baseByFile = new Map(
+      (bundleBase?.entries ?? []).map((e) => [e.file, e]),
+    );
+    const rows = bundleHead.entries.filter((e) => e.bytes >= 20 * 1024);
+    out.push(`| File | Size | Gzip |${bundleBase ? " Δ Gzip vs base |" : ""}`);
+    out.push(`|---|---|---|${bundleBase ? "---|" : ""}`);
+    for (const e of rows) {
+      const prev = baseByFile.get(e.file);
+      const delta = bundleBase
+        ? prev
+          ? ` ${prev.hash === e.hash ? "—" : signed(e.gzipBytes - prev.gzipBytes)} |`
+          : " 🆕 new |"
+        : "";
+      out.push(
+        `| \`${e.file}\` | ${kb(e.bytes)} | ${kb(e.gzipBytes)} |${delta}`,
+      );
+    }
+    if (bundleBase) {
+      const totalHead = bundleHead.entries.reduce((n, e) => n + e.gzipBytes, 0);
+      const totalBase = bundleBase.entries.reduce((n, e) => n + e.gzipBytes, 0);
+      out.push("");
+      out.push(
+        `**Total gzip:** ${kb(totalHead)} (${signed(totalHead - totalBase)} vs \`${analysis.base}\`)`,
+      );
+    } else {
+      out.push("");
+      out.push(
+        "_No base measurement — the merge-base build was skipped " +
+          "(dependency changes, or the base build failed)._",
+      );
+    }
+  }
+  out.push("");
+
+  if (analysis.diffMode === "two-dot") {
+    out.push(
+      "> ℹ️ The changed-file list came from a two-dot diff (no merge base was " +
+        "reachable in the shallow clone), so it may over- or under-report.",
+    );
+    out.push("");
   }
 }
-out.push("");
 
-if (analysis.diffMode === "two-dot") {
-  out.push(
-    "> ℹ️ The changed-file list came from a two-dot diff (no merge base was " +
-      "reachable in the shallow clone), so it may over- or under-report.",
+// ── Docs preview ─────────────────────────────────────────────────────────────
+// Everything under `docs` was written by a build of the PR's own tree, so each
+// field is range-checked or escaped before it reaches a URL or the Markdown.
+const LANG_RE = /^[a-z]{2}(-[a-z0-9]+)?$/;
+const SLUG_RE = /^[A-Za-z0-9_-]+$/;
+const MAX_PAGES = 30;
+const LANG_LABELS = {
+  en: "English",
+  ko: "한국어",
+  ja: "日本語",
+  th: "ภาษาไทย",
+};
+
+const count = (value) =>
+  Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+
+const changeSummary = (counts) => {
+  const parts = [];
+  if (count(counts.added)) parts.push(`+${count(counts.added)}`);
+  if (count(counts.modified)) parts.push(`~${count(counts.modified)}`);
+  if (count(counts.removed)) parts.push(`−${count(counts.removed)}`);
+  const images = count(counts.images);
+  const changes = parts.join(" ");
+  if (!images) return changes;
+  return changes ? `${changes}, ${images} image(s)` : `${images} image(s)`;
+};
+
+const escapeText = (value) =>
+  String(value ?? "")
+    .replace(/\s+/g, " ")
+    .replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c])
+    .replace(/([\\`*_[\]|~])/g, "\\$1")
+    .trim()
+    .slice(0, 120);
+
+function renderLanguage(lang, entry) {
+  const pages = Array.isArray(entry?.pages) ? entry.pages : [];
+  if (pages.length === 0) return [];
+
+  const lines = [];
+  const totals = changeSummary(entry.totals ?? {});
+  const label = LANG_LABELS[lang] ?? lang;
+  lines.push(
+    `**${escapeText(label)}** (\`${lang}\`) — ${pages.length} changed page(s)` +
+      (totals ? ` · ${totals}` : ""),
   );
+  lines.push("");
+  lines.push("| Page | Changes |");
+  lines.push("|---|---|");
+
+  for (const page of pages.slice(0, MAX_PAGES)) {
+    const slug =
+      typeof page.slug === "string" && SLUG_RE.test(page.slug)
+        ? page.slug
+        : null;
+    const title = escapeText(page.title || slug || "(untitled)");
+    const status = ["new", "deleted"].includes(page.status)
+      ? page.status
+      : "modified";
+    const tag =
+      status === "new" ? " `NEW`" : status === "deleted" ? " `DELETED`" : "";
+    // A deleted page has nothing to open in the head build.
+    const cell =
+      status !== "deleted" && slug && meta.docsUrl
+        ? `[${title}](${meta.docsUrl}${lang}/${slug}.html#bai-change-1)`
+        : title;
+    lines.push(
+      `| ${cell}${tag} | ${changeSummary(page.counts ?? {}) || "—"} |`,
+    );
+  }
+  if (pages.length > MAX_PAGES) {
+    lines.push(`| _…and ${pages.length - MAX_PAGES} more_ | |`);
+  }
+  lines.push("");
+  return lines;
+}
+
+// `next/` itself has no index page, so every docs link lands on a language.
+let docsEntryUrl = null;
+if (docs) {
+  const languages = (docs.languages ?? []).filter(
+    (lang) => typeof lang === "string" && LANG_RE.test(lang),
+  );
+
+  out.push("### 📖 Docs Preview");
   out.push("");
+  if (meta.docsUrl && languages.length > 0) {
+    docsEntryUrl = `${meta.docsUrl}${languages[0]}/`;
+    out.push(`**${link("View the docs preview for this PR", docsEntryUrl)}**`);
+    out.push("");
+    out.push(
+      "_GitHub Pages may take up to a minute to hydrate after the deploy._",
+    );
+    out.push("");
+  }
+
+  // A toolkit or layout change re-renders every page, so the per-page list
+  // would be the whole manual — say what was built and stop there.
+  const pageLines =
+    docsMeta?.reason === "toolkit"
+      ? []
+      : languages.flatMap((lang) => renderLanguage(lang, docs.langs?.[lang]));
+
+  if (pageLines.length > 0) {
+    out.push(...pageLines);
+  } else {
+    const names = (docsMeta?.languages ?? languages)
+      .filter((lang) => typeof lang === "string" && LANG_RE.test(lang))
+      .map((lang) => `\`${lang}\``)
+      .join(", ");
+    out.push(
+      `Preview built for ${names || "the manual"} — no content change to mark ` +
+        "(toolkit/layout change).",
+    );
+    out.push("");
+  }
 }
 
 out.push("---");
 out.push("");
 out.push(
   `<sub>Generated by the PR Preview workflow · ${
-    meta.storybookUrl ? `${link("Storybook", meta.storybookUrl)} · ` : ""
-  }${link("CI run", meta.runUrl)}</sub>`,
+    analysis && meta.storybookUrl
+      ? `${link("Storybook", meta.storybookUrl)} · `
+      : ""
+  }${docsEntryUrl ? `${link("Docs", docsEntryUrl)} · ` : ""}${link("CI run", meta.runUrl)}</sub>`,
 );
 
 console.log(out.join("\n"));

--- a/.github/scripts/pr-preview/generate-pr-comment.test.mjs
+++ b/.github/scripts/pr-preview/generate-pr-comment.test.mjs
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(
+  new URL("./generate-pr-comment.mjs", import.meta.url),
+);
+
+const META = {
+  prNumber: "9541",
+  shortHash: "a1b2c3d",
+  storybookUrl: "https://lablup.github.io/backend.ai-webui/pr/9541/storybook/",
+  docsUrl: "https://lablup.github.io/backend.ai-webui/pr/9541/docs/next/",
+  runUrl: "https://github.com/lablup/backend.ai-webui/actions/runs/1",
+};
+
+const ANALYSIS = {
+  base: "origin/main",
+  diffMode: "three-dot",
+  components: [
+    {
+      name: "BAIDeploymentTable",
+      file: "packages/backend.ai-ui/src/components/BAIDeploymentTable.tsx",
+      isNew: false,
+      sourceChanged: true,
+      storiesChanged: true,
+      hasStories: true,
+      storyCount: 4,
+      deepLink: "?path=/story/components-baideploymenttable--default",
+    },
+  ],
+  otherPackageFiles: ["packages/backend.ai-ui/src/index.ts"],
+  summary: { newWithoutStories: 0 },
+};
+
+const DOCS_MANIFEST = {
+  version: 1,
+  channel: "next",
+  label: "PR preview",
+  generatedAt: "2026-09-08T00:00:00.000Z",
+  languages: ["en", "ko"],
+  langs: {
+    en: {
+      totals: {
+        pages: 24,
+        changes: 17,
+        added: 12,
+        modified: 4,
+        removed: 1,
+        images: 2,
+        newPages: 1,
+        deletedPages: 1,
+      },
+      pages: [
+        {
+          slug: "deployment",
+          title: "Deployment",
+          status: "modified",
+          url: "next/en/deployment.html",
+          sourcePath: "src/en/deployment/deployment.md",
+          counts: { total: 6, added: 4, modified: 2, removed: 0, images: 1 },
+          fingerprints: [],
+        },
+        {
+          slug: "runtime_parameters",
+          title: "Runtime Parameters",
+          status: "new",
+          url: "next/en/runtime_parameters.html",
+          sourcePath: "src/en/runtime_parameters/runtime_parameters.md",
+          counts: { total: 11, added: 8, modified: 2, removed: 0, images: 1 },
+          fingerprints: [],
+        },
+        {
+          slug: "legacy_wsproxy",
+          title: "Legacy WSProxy",
+          status: "deleted",
+          url: "next/en/legacy_wsproxy.html",
+          sourcePath: "src/en/legacy_wsproxy/legacy_wsproxy.md",
+          counts: { total: 0, added: 0, modified: 0, removed: 1, images: 0 },
+          fingerprints: [],
+        },
+      ],
+    },
+    ko: {
+      totals: {
+        pages: 24,
+        changes: 5,
+        added: 3,
+        modified: 2,
+        removed: 0,
+        images: 0,
+        newPages: 0,
+        deletedPages: 0,
+      },
+      pages: [
+        {
+          slug: "deployment",
+          title: "배포",
+          status: "modified",
+          url: "next/ko/deployment.html",
+          sourcePath: "src/ko/deployment/deployment.md",
+          counts: { total: 5, added: 3, modified: 2, removed: 0, images: 0 },
+          fingerprints: [],
+        },
+      ],
+    },
+  },
+};
+
+const TOOLKIT_MANIFEST = {
+  version: 1,
+  channel: "next",
+  label: "PR preview",
+  generatedAt: "2026-09-08T00:00:00.000Z",
+  languages: ["en"],
+  langs: {
+    en: {
+      totals: {
+        pages: 24,
+        changes: 0,
+        added: 0,
+        modified: 0,
+        removed: 0,
+        images: 0,
+        newPages: 0,
+        deletedPages: 0,
+      },
+      pages: [],
+    },
+  },
+};
+
+const render = (files) => {
+  const dir = mkdtempSync(join(tmpdir(), "pr-comment-"));
+  const args = [SCRIPT];
+  for (const [flag, name, value] of files) {
+    const path = join(dir, name);
+    writeFileSync(path, JSON.stringify(value));
+    args.push(`--${flag}`, path);
+  }
+  return execFileSync("node", args, { encoding: "utf8" });
+};
+
+test("a docs-only PR renders the docs section and no Storybook data", () => {
+  const body = render([
+    ["meta", "pr-meta.json", META],
+    ["docs", "docs-manifest.json", DOCS_MANIFEST],
+    [
+      "docs-meta",
+      "docs-meta.json",
+      { languages: ["en", "ko"], reason: "content" },
+    ],
+  ]);
+
+  assert.match(body, /^## PR Analysis Report/);
+  assert.match(body, /### 📖 Docs Preview/);
+  assert.doesNotMatch(body, /Storybook/);
+  assert.match(
+    body,
+    /\*\*English\*\* \(`en`\) — 3 changed page\(s\) · \+12 ~4 −1, 2 image\(s\)/,
+  );
+  assert.match(
+    body,
+    /\[Deployment\]\(https:\/\/lablup\.github\.io\/backend\.ai-webui\/pr\/9541\/docs\/next\/en\/deployment\.html#bai-change-1\)/,
+  );
+  assert.match(body, /\[Runtime Parameters\]\([^)]+\) `NEW`/);
+  // A deleted page has nothing to open, so its title stays unlinked.
+  assert.match(body, /\| Legacy WSProxy `DELETED` \|/);
+  assert.doesNotMatch(body, /\[Legacy WSProxy\]/);
+  assert.match(body, /\*\*한국어\*\* \(`ko`\)/);
+});
+
+test("a storybook-only PR renders unchanged, with no docs section", () => {
+  const body = render([
+    ["meta", "pr-meta.json", META],
+    ["analysis", "analysis.json", ANALYSIS],
+  ]);
+
+  assert.match(body, /### 📚 Storybook Preview/);
+  assert.match(body, /### 🧩 Changed Components/);
+  assert.match(body, /### 📦 Bundle Size/);
+  assert.match(body, /`BAIDeploymentTable`/);
+  assert.doesNotMatch(body, /Docs Preview/);
+});
+
+test("a toolkit-only PR says what was built instead of listing pages", () => {
+  const body = render([
+    ["meta", "pr-meta.json", META],
+    ["docs", "docs-manifest.json", TOOLKIT_MANIFEST],
+    ["docs-meta", "docs-meta.json", { languages: ["en"], reason: "toolkit" }],
+  ]);
+
+  assert.match(body, /### 📖 Docs Preview/);
+  assert.match(
+    body,
+    /Preview built for `en` — no content change to mark \(toolkit\/layout change\)\./,
+  );
+  assert.doesNotMatch(body, /\| Page \| Changes \|/);
+});
+
+test("manifest fields that could reach a URL are validated, and titles escaped", () => {
+  const hostile = {
+    ...TOOLKIT_MANIFEST,
+    languages: ["en", "../../etc"],
+    langs: {
+      en: {
+        totals: { added: 1 },
+        pages: [
+          {
+            slug: "../../../evil",
+            title: "Title [with](markdown) <img src=x> | pipe",
+            status: "modified",
+            counts: { added: 1 },
+          },
+        ],
+      },
+    },
+  };
+  const body = render([
+    ["meta", "pr-meta.json", META],
+    ["docs", "docs-manifest.json", hostile],
+    ["docs-meta", "docs-meta.json", { languages: ["en"], reason: "content" }],
+  ]);
+
+  assert.doesNotMatch(body, /\.\.\//);
+  assert.doesNotMatch(body, /<img/);
+  assert.match(
+    body,
+    /Title \\\[with\\\]\(markdown\) &lt;img src=x&gt; \\\| pipe/,
+  );
+});
+
+test("neither analysis nor docs is an error", () => {
+  assert.throws(() => render([["meta", "pr-meta.json", META]]));
+});

--- a/.github/scripts/pr-preview/write-index.mjs
+++ b/.github/scripts/pr-preview/write-index.mjs
@@ -5,7 +5,7 @@
 //
 // Usage: node write-index.mjs --root <gh-pages checkout>
 
-import { existsSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const getArg = (name) => {
@@ -20,19 +20,52 @@ if (!root) {
 }
 
 const prRoot = join(root, "pr");
-const previews = existsSync(prRoot)
+const isDir = (path) => existsSync(path) && statSync(path).isDirectory();
+
+// `next/` has no index of its own, so the docs link points at a language
+// directory — whichever ones this PR built, English first when it is there.
+const docsEntry = (n) => {
+  const docsDir = join(prRoot, String(n), "docs");
+  if (!isDir(docsDir)) return null;
+  const langs = isDir(join(docsDir, "next"))
+    ? readdirSync(join(docsDir, "next"))
+        .filter((name) => /^[a-z]{2}(-[a-z0-9]+)?$/.test(name))
+        .filter((name) => isDir(join(docsDir, "next", name)))
+        .sort((a, b) => (a === "en" ? -1 : b === "en" ? 1 : a.localeCompare(b)))
+    : [];
+  return langs.length > 0
+    ? `./pr/${n}/docs/next/${langs[0]}/`
+    : `./pr/${n}/docs/`;
+};
+
+const previews = isDir(prRoot)
   ? readdirSync(prRoot)
       .filter((name) => /^\d+$/.test(name))
       .map(Number)
       .sort((a, b) => b - a)
+      .map((n) => ({
+        n,
+        storybook: isDir(join(prRoot, String(n), "storybook"))
+          ? `./pr/${n}/storybook/`
+          : null,
+        docs: docsEntry(n),
+      }))
+      .filter((entry) => entry.storybook || entry.docs)
   : [];
 
 const items = previews
-  .map(
-    (n) =>
-      `      <li><a href="./pr/${n}/storybook/">PR #${n}</a> ` +
-      `<a class="src" href="https://github.com/lablup/backend.ai-webui/pull/${n}">source ↗</a></li>`,
-  )
+  .map(({ n, storybook, docs }) => {
+    const links = [
+      storybook && `<a href="${storybook}">Storybook</a>`,
+      docs && `<a href="${docs}">Docs</a>`,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    return (
+      `      <li>PR #${n} — ${links} ` +
+      `<a class="src" href="https://github.com/lablup/backend.ai-webui/pull/${n}">source ↗</a></li>`
+    );
+  })
   .join("\n");
 
 const html = `<!doctype html>
@@ -56,10 +89,11 @@ const html = `<!doctype html>
     </style>
   </head>
   <body>
-    <h1>Backend.AI WebUI — Storybook previews</h1>
+    <h1>Backend.AI WebUI — PR previews</h1>
     <p>
-      One build of <code>packages/backend.ai-ui</code> per open pull request.
-      Previews are removed when their PR is merged or closed.
+      One build of <code>packages/backend.ai-ui</code> and of the user manual
+      per open pull request, whichever the PR changed. Previews are removed when
+      their PR is merged or closed.
     </p>
 ${previews.length > 0 ? `    <ul>\n${items}\n    </ul>` : "    <p>No live previews right now.</p>"}
   </body>

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -3,12 +3,13 @@
 # Two independent chores, both cheap and both necessary because GitHub Pages has
 # a hard 1 GB published-site ceiling and this repository is already large:
 #
-#   cleanup  — delete `pr/<n>/` for every PR that is no longer open. At ~18 MB
-#              per preview and ~29% of PRs qualifying for one, the ~98 open PRs
-#              project to ~520 MB; without this the merged ones never leave.
+#   cleanup  — delete `pr/<n>/` for every PR that is no longer open, previews of
+#              every kind included. A Storybook preview is ~18 MB; a docs preview
+#              is ~52 MB per built language, so a handful of concurrent docs PRs
+#              is already a large share of the ceiling and this is the only thing
+#              keeping the merged ones from staying forever.
 #   compact  — squash gh-pages history to a single orphan commit once a week, so
-#              the branch's *history* of those 18 MB trees stops growing the
-#              repository.
+#              the branch's *history* of those trees stops growing the repository.
 #
 # The cleanup reconciles against the live open-PR list on every run, so it needs
 # no `closed` event to be correct — firing on any preview build (plus the daily

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -1,5 +1,9 @@
-# Publish what "PR Preview" built: deploy the Storybook preview to gh-pages and
-# post/update the PR Analysis Report comment.
+# Publish what "PR Preview" built: deploy the Storybook and docs previews to
+# gh-pages and post/update the PR Analysis Report comment.
+#
+# Either preview can be absent — a PR touching only the manual produces no
+# Storybook artifact and vice versa — so every download is best-effort and the
+# deploy publishes whichever of the two showed up.
 #
 # This is the PRIVILEGED half, and it runs on `workflow_run` rather than
 # `pull_request` on purpose. A `pull_request` workflow triggered from a fork gets
@@ -21,10 +25,11 @@
 # from `workflow_run.head_sha`, which GitHub sets, and derive the preview URL
 # from that. The only artifact fields used are measurements the report renders.
 #
-# Residual risk, inherent to any Pages-hosted preview: the Storybook bundle is
-# PR-controlled content, so a fork PR can publish arbitrary static files under
-# ITS OWN `/pr/<n>/` path on the org's github.io origin. Previews are for
-# reviewers, not a trusted origin — do not host anything privileged there.
+# Residual risk, inherent to any Pages-hosted preview: the Storybook bundle and
+# the docs site are PR-controlled content, so a fork PR can publish arbitrary
+# static files under ITS OWN `/pr/<n>/` path on the org's github.io origin.
+# Previews are for reviewers, not a trusted origin — do not host anything
+# privileged there.
 #
 # NOTE: `workflow_run` workflows only fire from the version on the default
 # branch, so this does nothing until it is merged to `main`.
@@ -108,22 +113,49 @@ jobs:
         # best-effort. The check below turns it into a clean skip.
         continue-on-error: true
 
-      - name: Verify the artifact is usable
+      - name: Download docs artifact
+        if: steps.parse.outputs.deploy == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-preview-docs-${{ steps.parse.outputs.short_hash }}
+          path: docs-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Verify the artifacts are usable
         id: verify
         if: steps.parse.outputs.deploy == 'true'
         run: |
-          if [ -d storybook-dist ] && [ -n "$(ls -A storybook-dist 2>/dev/null)" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
+          set -euo pipefail
+          # A PR gets whichever previews its own diff called for, so one of the
+          # two being absent is the normal case, not a failure.
+          KINDS=()
+          for kind in storybook docs; do
+            if [ -d "${kind}-dist" ] && [ -n "$(ls -A "${kind}-dist" 2>/dev/null)" ]; then
+              echo "${kind}=true" >> "$GITHUB_OUTPUT"
+              KINDS+=("$kind")
+            else
+              echo "${kind}=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+
+          if [ ${#KINDS[@]} -eq 0 ]; then
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Storybook artifact missing or empty — skipping the deploy for this run."
+            echo "::warning::Neither preview artifact is present — skipping the deploy for this run."
+            exit 0
           fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          echo "kinds=$(printf '%s, ' "${KINDS[@]}" | sed 's/, $//')" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to gh-pages
         if: steps.parse.outputs.deploy == 'true' && steps.verify.outputs.ready == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          HAS_STORYBOOK: ${{ steps.verify.outputs.storybook }}
+          HAS_DOCS: ${{ steps.verify.outputs.docs }}
+          KINDS: ${{ steps.verify.outputs.kinds }}
         run: |
           # A manual push with retry-on-conflict rather than a Pages action, so a
           # concurrent cleanup or another PR's deploy just retries instead of
@@ -155,15 +187,24 @@ jobs:
               touch "$PAGES_DIR/.nojekyll"
             fi
 
+            # The PR's whole diff decides which previews it gets, so the set is
+            # stable across pushes and replacing the directory drops nothing
+            # that this run should have kept.
             rm -rf "${PAGES_DIR}/pr/${PR_NUMBER}"
-            mkdir -p "${PAGES_DIR}/pr/${PR_NUMBER}/storybook"
-            cp -r storybook-dist/. "${PAGES_DIR}/pr/${PR_NUMBER}/storybook/"
+            if [ "$HAS_STORYBOOK" = "true" ]; then
+              mkdir -p "${PAGES_DIR}/pr/${PR_NUMBER}/storybook"
+              cp -r storybook-dist/. "${PAGES_DIR}/pr/${PR_NUMBER}/storybook/"
+            fi
+            if [ "$HAS_DOCS" = "true" ]; then
+              mkdir -p "${PAGES_DIR}/pr/${PR_NUMBER}/docs"
+              cp -r docs-dist/. "${PAGES_DIR}/pr/${PR_NUMBER}/docs/"
+            fi
             touch "${PAGES_DIR}/.nojekyll"
             node .github/scripts/pr-preview/write-index.mjs --root "$PAGES_DIR"
 
             cd "$PAGES_DIR"
             git add -A
-            git commit -m "Deploy PR #${PR_NUMBER} Storybook preview" \
+            git commit -m "Deploy PR #${PR_NUMBER} preview (${KINDS})" \
               || { echo "Nothing to commit."; echo "::endgroup::"; exit 0; }
 
             if git push origin gh-pages; then
@@ -204,6 +245,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Download docs analysis artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-preview-docs-analysis
+          path: pr-docs-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
       - name: Post or update the PR Analysis Report
         uses: actions/github-script@v9
         with:
@@ -211,8 +261,12 @@ jobs:
             const fs = require('node:fs');
             const { execFileSync } = require('node:child_process');
 
-            if (!fs.existsSync('pr-analysis/analysis.json')) {
-              core.info('No analysis artifact — nothing to report.');
+            // Either half is enough to be worth a report: a docs-only PR
+            // produces no analysis.json, a Storybook-only PR no manifest.
+            const hasAnalysis = fs.existsSync('pr-analysis/analysis.json');
+            const hasDocs = fs.existsSync('pr-docs-analysis/docs-manifest.json');
+            if (!hasAnalysis && !hasDocs) {
+              core.info('No analysis artifacts — nothing to report.');
               return;
             }
 
@@ -243,19 +297,28 @@ jobs:
               prNumber: String(prNumber),
               shortHash: headSha.slice(0, 7),
               storybookUrl: `https://${owner}.github.io/${repo}/pr/${prNumber}/storybook/`,
+              docsUrl: `https://${owner}.github.io/${repo}/pr/${prNumber}/docs/next/`,
               runUrl: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.payload.workflow_run.id}`,
             }));
 
             const args = [
               '.github/scripts/pr-preview/generate-pr-comment.mjs',
-              '--analysis', 'pr-analysis/analysis.json',
               '--meta', 'pr-meta.json',
             ];
+            if (hasAnalysis) {
+              args.push('--analysis', 'pr-analysis/analysis.json');
+            }
             if (fs.existsSync('pr-analysis/bundle-head.json')) {
               args.push('--bundle-head', 'pr-analysis/bundle-head.json');
             }
             if (fs.existsSync('pr-analysis/bundle-base.json')) {
               args.push('--bundle-base', 'pr-analysis/bundle-base.json');
+            }
+            if (hasDocs) {
+              args.push('--docs', 'pr-docs-analysis/docs-manifest.json');
+            }
+            if (fs.existsSync('pr-docs-analysis/docs-meta.json')) {
+              args.push('--docs-meta', 'pr-docs-analysis/docs-meta.json');
             }
 
             const body = execFileSync('node', args, { encoding: 'utf8' });

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -5,6 +5,13 @@
 # Storybook artifact and vice versa — so every download is best-effort and the
 # deploy publishes whichever of the two showed up.
 #
+# Both jobs require `workflow_run.conclusion == 'success'`. `workflow_run` fires
+# for failed and cancelled runs too, and on those the missing artifact is a
+# failure rather than a job the PR's diff never asked for. Deploying anyway would
+# let the surviving half's `rm -rf pr/<n>` delete the other half's still-valid
+# preview, and would rewrite the report from half the data. Skipping leaves the
+# previous preview and comment in place, which is what a failed build should do.
+#
 # This is the PRIVILEGED half, and it runs on `workflow_run` rather than
 # `pull_request` on purpose. A `pull_request` workflow triggered from a fork gets
 # a read-only token: it cannot push to gh-pages and cannot comment, which is the
@@ -52,7 +59,9 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -222,7 +231,9 @@ jobs:
           exit 1
 
   comment:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,12 +1,14 @@
-# Build the per-PR Storybook preview and the data behind the PR Analysis Report.
+# Build the per-PR previews — Storybook, and the docs site with its changes
+# marked — plus the data behind the PR Analysis Report.
 #
 # This is the UNPRIVILEGED half. It runs on `pull_request`, so on a fork PR it
 # gets a read-only token and can neither push to gh-pages nor comment — which is
 # exactly why it does neither. It only produces artifacts; `pr-preview-publish.yml`
 # picks them up from the trusted `workflow_run` context and does the writing.
 #
-# Gated on `packages/backend.ai-ui/**` at event level: measured over the last 120
-# PRs, 35 (29%) touch it, so the other ~71% never start a runner.
+# The event-level `paths` filter is the UNION of what the two build jobs care
+# about, so each of them re-asks the question against the PR's own diff in the
+# `changes` job below and skips when the answer is no.
 
 name: PR Preview
 
@@ -14,6 +16,8 @@ on:
   pull_request:
     paths:
       - packages/backend.ai-ui/**
+      - packages/backend.ai-webui-docs/**
+      - packages/backend.ai-docs-toolkit/**
       - .github/workflows/pr-preview.yml
       - .github/scripts/pr-preview/**
 
@@ -28,7 +32,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      storybook: ${{ steps.detect.outputs.storybook }}
+      docs: ${{ steps.detect.outputs.docs }}
+      docs_langs: ${{ steps.detect.outputs.docs_langs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 50
+
+      - name: Fetch base branch
+        run: git fetch --depth=50 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Decide which previews this PR needs
+        id: detect
+        env:
+          BASE: origin/${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # A merge base is what makes the three-dot diff report only what this
+          # branch changed; deepen once before falling back to a two-dot diff.
+          if ! git merge-base "$BASE" HEAD >/dev/null 2>&1; then
+            git fetch --deepen=200 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" || true
+          fi
+
+          if git diff --name-only "${BASE}...HEAD" 2>/dev/null \
+            | grep -qE '^(packages/backend\.ai-ui/|\.github/workflows/pr-preview\.yml$|\.github/scripts/pr-preview/)'; then
+            echo "storybook=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "storybook=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          DOCS_JSON="$(node .github/scripts/pr-preview/docs-changed-languages.mjs --base "$BASE" --head HEAD)"
+          echo "Docs: ${DOCS_JSON}"
+          echo "docs=$(jq -r '.docs' <<<"$DOCS_JSON")" >> "$GITHUB_OUTPUT"
+          echo "docs_langs=$(jq -r '.languages | join(",")' <<<"$DOCS_JSON")" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: changes
+    if: needs.changes.outputs.storybook == 'true'
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --max-old-space-size=6144
@@ -122,5 +166,65 @@ jobs:
             analysis.json
             bundle-head.json
             bundle-base.json
+          if-no-files-found: error
+          retention-days: 7
+
+  docs:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=6144
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The base build checks out the merge-base tree of `src/`, so the merge
+          # base has to be inside this window (the build script falls back to the
+          # base tip when it is not).
+          fetch-depth: 50
+
+      - name: Fetch base branch
+        run: git fetch --depth=50 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Compute the artifact suffix
+        id: urls
+        run: echo "short_hash=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Build both docs trees and mark the changes
+        run: |
+          bash .github/scripts/pr-preview/build-docs-preview.sh \
+            --base-ref "origin/${{ github.base_ref }}" \
+            --languages "${{ needs.changes.outputs.docs_langs }}" \
+            --out "${RUNNER_TEMP}/docs-preview" \
+            --label "PR preview"
+
+      # `docs-meta.json` is re-derived rather than passed through the job outputs
+      # so the artifact carries the same JSON the detection script produced.
+      - name: Collect the docs analysis
+        run: |
+          set -euo pipefail
+          mkdir -p docs-analysis
+          cp "${RUNNER_TEMP}/docs-preview/head/next/changes-manifest.json" \
+            docs-analysis/docs-manifest.json
+          node .github/scripts/pr-preview/docs-changed-languages.mjs \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --output docs-analysis/docs-meta.json
+
+      - name: Upload docs preview artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-preview-docs-${{ steps.urls.outputs.short_hash }}
+          path: ${{ runner.temp }}/docs-preview/head/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload docs analysis artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-preview-docs-analysis
+          path: docs-analysis/
           if-no-files-found: error
           retention-days: 7

--- a/packages/backend.ai-docs-toolkit/README.md
+++ b/packages/backend.ai-docs-toolkit/README.md
@@ -59,6 +59,9 @@ docs-toolkit build:web --lang en --optimize-images
 # Serve the static website (live-reload)
 docs-toolkit serve:web --lang en
 
+# Mark a head build against a base build (PR preview)
+docs-toolkit diff:web --base dist/base --head dist/web --lang en,ko
+
 # Generate Claude AI agent files
 docs-toolkit agents
 docs-toolkit agents --force   # overwrite existing
@@ -120,6 +123,7 @@ agents:
 | `docs-toolkit preview:html` | HTML preview server with live-reload (no PDF) |
 | `docs-toolkit build:web` | Generate a static multi-page website |
 | `docs-toolkit serve:web` | Static website dev server with live-reload |
+| `docs-toolkit diff:web` | Diff two website builds and mark the changed blocks |
 | `docs-toolkit init` | Scaffold a new documentation project |
 | `docs-toolkit agents` | Generate Claude AI agent files from templates |
 | `docs-toolkit help` | Show the CLI help message |
@@ -144,6 +148,10 @@ docs-toolkit build:web --lang <all|en|ko|...> \
 # Static website dev server
 docs-toolkit serve:web --lang <lang> --port <port>
 
+# PR preview marks
+docs-toolkit diff:web --base <dir> --head <dir> \
+  --lang <all|en,ko> --label <text> --src <dir> --json
+
 # Agent generation
 docs-toolkit agents --force   # overwrite existing files
 ```
@@ -155,6 +163,7 @@ Notes:
 - `build:web --strict` (default) fails the build on broken links; `--no-strict` downgrades them to warnings.
 - `build:web --optimize-images` generates `.webp` variants for PNGs over 50 KB and wraps them in `<picture>`; `--optimize-images-avif` adds `.avif` variants. Both require the optional `sharp` peer dependency.
 - Default ports: `preview` → `3456`, `preview:html` → `3457`, `serve:web` → `3458`.
+- `diff:web` compares two `dist/web` roots at markdown-block level and writes into the head build: a `<slug>.changes.json` sidecar per page, a `changes-manifest.json` per channel, `base-images/` copies of the replaced images, and the `pr-preview` overlay that marks the changed blocks in the browser. `--json` prints the manifest to stdout (the summary then goes to stderr).
 
 ## Agent Template System
 

--- a/packages/backend.ai-docs-toolkit/src/cli.ts
+++ b/packages/backend.ai-docs-toolkit/src/cli.ts
@@ -23,6 +23,7 @@ const COMMANDS = [
   "preview:html",
   "build:web",
   "serve:web",
+  "diff:web",
   "init",
   "agents",
   "help",
@@ -42,6 +43,7 @@ Commands:
   preview:html   HTML preview server (live-reload, no PDF)
   build:web      Generate static multi-page website
   serve:web      Website dev server (live-reload)
+  diff:web       Mark a head website build against a base build (PR preview)
   init           Initialize a new documentation project
   agents         Generate Claude AI agent files from templates
   help           Show this help message
@@ -77,6 +79,15 @@ Options:
     --lang <en|ko|...>        Language (default: en)
     --port <number>            Port number (default: 3458)
 
+  diff:web:
+    --base <dir>              Base build root (dist/web layout, required)
+    --head <dir>              Head build root — written into (required)
+    --lang <all|en,ko>        Languages to diff (default: all)
+    --label <text>            PR label carried into the manifest
+    --src <dir>               Markdown source of the head build for file:line
+                              references (default: the configured srcDir)
+    --json                    Print the manifest to stdout
+
   agents:
     --force                    Overwrite existing agent files
 
@@ -91,6 +102,7 @@ Examples:
   docs-toolkit build:web --lang en
   docs-toolkit serve:web --lang en
   docs-toolkit serve:web --lang ko --port 3459
+  docs-toolkit diff:web --base dist/base --head dist/web --lang en,ko
   docs-toolkit init
   docs-toolkit agents
   docs-toolkit agents --force
@@ -447,6 +459,39 @@ async function main(): Promise<void> {
       const { startWebsitePreviewServer } =
         await import("./preview-server-website.js");
       await startWebsitePreviewServer(config);
+      break;
+    }
+
+    case "diff:web": {
+      const { generateWebDiff } = await import("./web-diff.js");
+      const base = getFlagValue(argv, "--base");
+      const head = getFlagValue(argv, "--head");
+      const json = hasFlag(argv, "--json");
+      for (const [flag, value] of [
+        ["--base", base],
+        ["--head", head],
+      ] as const) {
+        if (!value) {
+          console.error(
+            `Error: diff:web requires ${flag} <dir> (a dist/web build root).`,
+          );
+          process.exit(1);
+        }
+        const dir = path.resolve(config.projectRoot, value);
+        if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+          console.error(`Error: ${flag} is not a directory: ${dir}`);
+          process.exit(1);
+        }
+      }
+      const manifest = await generateWebDiff(config, {
+        base: base as string,
+        head: head as string,
+        lang: getFlagValue(argv, "--lang") ?? "all",
+        label: getFlagValue(argv, "--label"),
+        src: getFlagValue(argv, "--src"),
+        quiet: json,
+      });
+      if (json) console.log(JSON.stringify(manifest, null, 2));
       break;
     }
 

--- a/packages/backend.ai-docs-toolkit/src/web-diff.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/web-diff.test.ts
@@ -399,6 +399,28 @@ test("extractBlocks — the block key carries markup, so a bold-only edit differ
   assert.notEqual(a[0].key, b[0].key);
 });
 
+test("extractBlocks — the block key covers the element tag and the container", () => {
+  const keyOf = (html: string) => extractBlocks(page(html), "/nowhere")![0].key;
+  assert.notEqual(keyOf("<h2>Same wording</h2>"), keyOf("<h3>Same wording</h3>"));
+  assert.notEqual(
+    keyOf("<ul><li>Same item</li></ul>"),
+    keyOf("<ol><li>Same item</li></ol>"),
+  );
+});
+
+test("extractBlocks — the image key covers the authored title and size hint", () => {
+  const shot = (extra: string) =>
+    extractBlocks(
+      page(`<p><figure class="doc-figure"><img src="./a.png" alt="" class="doc-image"${extra} /><figcaption>Figure 1.1</figcaption></figure></p>`),
+      "/nowhere",
+    )![0];
+  const plain = shot("");
+  assert.notEqual(plain.key, shot(' title="Hover me"').key);
+  assert.notEqual(plain.key, shot(' style="width:50%"').key);
+  assert.equal(shot(' title="Hover me"').title, "Hover me");
+  assert.equal(shot(' style="width:50%"').style, "width:50%");
+});
+
 test("extractBlocks — a link-target-only edit also changes the block key", () => {
   const a = extractBlocks(page('<p>See <a href="./one.html">the guide</a>.</p>'), "/nowhere")!;
   const b = extractBlocks(page('<p>See <a href="./two.html">the guide</a>.</p>'), "/nowhere")!;
@@ -416,6 +438,46 @@ test("diffBlocks — a formatting-only edit pairs as modified at similarity 1", 
 });
 
 // ── source references ───────────────────────────────────────────
+
+test("extractBlocks — nested list items and images become their own blocks", () => {
+  const blocks = extractBlocks(
+    page(
+      [
+        "<ul><li>Outer item leads in:",
+        "<ul><li>Nested one</li><li>Nested two</li></ul>",
+        figure("./images/nested.png", ""),
+        "</li></ul>",
+      ].join("\n"),
+    ),
+    "/nowhere",
+  )!;
+  assert.deepEqual(
+    blocks.map((b) => [b.kind, b.container ?? null]),
+    [
+      ["list-item", "ul"],
+      ["list-item", "ul"],
+      ["list-item", "ul"],
+      ["image", null],
+    ],
+  );
+  // The parent keeps only its own words — nested content is not attributed to it.
+  assert.equal(blocks[0].text, "Outer item leads in:");
+  assert.ok(!blocks[0].inner.includes("Nested one"));
+  assert.ok(!blocks[0].inner.includes("nested.png"));
+  assert.equal(blocks[3].src, "./images/nested.png");
+});
+
+test("diffBlocks — an edit to a nested item marks only that item", () => {
+  const build = (second: string) =>
+    extractBlocks(
+      page(`<ul><li>Outer item:<ul><li>Nested one</li><li>${second}</li></ul></li></ul>`),
+      "/nowhere",
+    )!;
+  const changes = diffBlocks(build("Nested two"), build("Nested three"));
+  assert.equal(changes.length, 1);
+  assert.equal(changes[0].type, "modified");
+  assert.equal(changes[0].head?.text, "Nested three");
+});
 
 test("sourcePathOf — reads the repo-relative path off the Edit this page link", () => {
   assert.equal(
@@ -455,6 +517,29 @@ test("fingerprintOf — is stable for the same change and differs when the text 
   assert.match(a, /^[0-9a-f]{12}$/);
   const [h2] = textBlocks(["Newer text here."]);
   assert.notEqual(a, fingerprintOf({ type: "modified", base: b1, head: h2 }));
+});
+
+test("fingerprintOf — a second formatting-only edit re-fingerprints", () => {
+  const blockOf = (html: string) => extractBlocks(page(html), "/nowhere")![0];
+  const base = blockOf("<p>Read the <strong>guide</strong>.</p>");
+  const first = blockOf("<p>Read the <em>guide</em>.</p>");
+  const second = blockOf("<p>Read the <b>guide</b>.</p>");
+  // The three share their text, so a text-only fingerprint would collide and
+  // the overlay would restore "viewed" for an edit nobody has looked at.
+  assert.equal(base.text, first.text);
+  assert.notEqual(
+    fingerprintOf({ type: "modified", base, head: first }),
+    fingerprintOf({ type: "modified", base, head: second }),
+  );
+});
+
+test("fingerprintOf — a caption-only image edit re-fingerprints", () => {
+  const shot = (alt: string) =>
+    extractBlocks(page(figure("./images/a.png", alt)), "/nowhere")![0];
+  assert.notEqual(
+    fingerprintOf({ type: "modified", base: shot("old"), head: shot("new") }),
+    fingerprintOf({ type: "modified", base: shot("old"), head: shot("newer") }),
+  );
 });
 
 // ── end to end ──────────────────────────────────────────────────
@@ -622,7 +707,8 @@ test("generateWebDiff — an image is compared by bytes, and the old file is cop
   try {
     const base = path.join(root, "base");
     const head = path.join(root, "head");
-    const body = [figure("./images/a.png", "one"), figure("./images/a.png", "two")].join("\n");
+    // Identical figures, so the two swaps are the same change twice over.
+    const body = [figure("./images/a.png", ""), figure("./images/a.png", "")].join("\n");
     writePage(base, "en", "admin_menu", page(body, { slug: "admin_menu" }));
     writePage(head, "en", "admin_menu", page(body, { slug: "admin_menu" }));
     writeImage(base, "en", "a.png", "OLD-BYTES");
@@ -649,6 +735,7 @@ test("generateWebDiff — an image is compared by bytes, and the old file is cop
     // Same swap twice on one page: the repeat fingerprint is suffixed.
     const [f1, f2] = sidecar.changes.map((c) => c.fingerprint);
     assert.equal(f2, `${f1}-2`);
+    assert.match(f1, /^[0-9a-f]{12}$/);
     assert.deepEqual(manifest.langs.en.pages[0].fingerprints, [f1, f2]);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/packages/backend.ai-docs-toolkit/src/web-diff.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/web-diff.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  captionTextOf,
   diffBlocks,
   diffInlineHtml,
   extractBlocks,
@@ -13,6 +14,7 @@ import {
   injectHead,
   lineOf,
   markdownProbeLines,
+  parseHtml,
   similarity,
   sourcePathOf,
   stripInjected,
@@ -20,6 +22,7 @@ import {
   words,
   type Block,
   type ChangesManifest,
+  type ElementNode,
   type PageSidecar,
 } from "./web-diff.js";
 import type { ResolvedDocConfig } from "./config.js";
@@ -55,8 +58,8 @@ ${body}
 
 const heading = (text: string, id: string): string =>
   `<h2 id="${id}">${text}<a class="hash-link" href="#${id}">#</a></h2>`;
-const figure = (src: string, alt = "shot"): string =>
-  `<p><figure class="doc-figure"><img src="${src}" alt="${alt}" class="doc-image" /><figcaption>Figure 1. ${alt}</figcaption></figure></p>`;
+const figure = (src: string, alt = "shot", figNum = "Figure 1.1"): string =>
+  `<p><figure class="doc-figure"><img src="${src}" alt="${alt}" class="doc-image" /><figcaption>${figNum}${alt ? ` &mdash; ${alt}` : ""}</figcaption></figure></p>`;
 
 function tmpdir(name: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), `web-diff-${name}-`));
@@ -169,6 +172,67 @@ test("extractBlocks — a missing image file hashes as `missing` rather than thr
   assert.equal(blocks[0].hash, "missing");
 });
 
+test("extractBlocks — the image key covers alt text and caption, not the figure number", () => {
+  const same = (alt: string, figNum: string) =>
+    extractBlocks(page(figure("./images/a.png", alt, figNum)), "/nowhere")![0];
+  // Renumbering happens whenever an earlier image is inserted; it is not a change.
+  assert.equal(same("folder list", "Figure 1.1").key, same("folder list", "Figure 9.4").key);
+  assert.notEqual(same("folder list", "Figure 1.1").key, same("folder tree", "Figure 1.1").key);
+  assert.equal(same("folder list", "Figure 1.1").alt, "folder list");
+  assert.equal(same("folder list", "Figure 1.1").caption, "folder list");
+});
+
+test("captionTextOf — keeps a hand-written caption but drops a bare figure number", () => {
+  const capOf = (html: string) => {
+    const tree = parseHtml(html);
+    return captionTextOf(tree.children[0] as ElementNode);
+  };
+  assert.equal(capOf("<figure><figcaption>Figure 15.1</figcaption></figure>"), "");
+  assert.equal(capOf("<figure><figcaption>A hand-written caption</figcaption></figure>"), "A hand-written caption");
+  assert.equal(capOf("<figure><figcaption>รูปที่ 2.3 &mdash; หน้าจอ</figcaption></figure>"), "หน้าจอ");
+});
+
+test("similarity — a renamed image still pairs, an identical src scores higher", () => {
+  const blocks = (src: string) =>
+    extractBlocks(page(figure(src, "")), "/nowhere")![0];
+  assert.equal(similarity(blocks("./images/old.png"), blocks("./images/new.png")), 0.5);
+  assert.equal(similarity(blocks("./images/a.png"), blocks("./images/a.png")), 1);
+});
+
+test("diffBlocks — a renamed image is one modified change, not removed + added", () => {
+  const base = extractBlocks(page(figure("./images/old.png", "")), "/nowhere")!;
+  const head = extractBlocks(page(figure("./images/new.png", "")), "/nowhere")!;
+  const changes = diffBlocks(base, head);
+  assert.equal(changes.length, 1);
+  assert.equal(changes[0].type, "modified");
+  assert.equal(changes[0].base?.src, "./images/old.png");
+  assert.equal(changes[0].head?.src, "./images/new.png");
+});
+
+test("diffBlocks — two renamed images in one run pair positionally", () => {
+  const src = (a: string, b: string) =>
+    extractBlocks(page([figure(a, ""), figure(b, "")].join("\n")), "/nowhere")!;
+  const changes = diffBlocks(src("./a1.png", "./b1.png"), src("./a2.png", "./b2.png"));
+  assert.deepEqual(
+    changes.map((c) => [c.base?.src, c.head?.src]),
+    [
+      ["./a1.png", "./a2.png"],
+      ["./b1.png", "./b2.png"],
+    ],
+  );
+});
+
+test("extractBlocks — records the container a removed li / tr has to go back into", () => {
+  const blocks = extractBlocks(
+    page("<ol><li>Step one</li></ol><ul><li>Bullet</li></ul><table><tbody><tr><td>Cell</td></tr></tbody></table>"),
+    "/nowhere",
+  )!;
+  assert.deepEqual(
+    blocks.map((b) => b.container ?? null),
+    ["ol", "ul", "table"],
+  );
+});
+
 // ── pairing ─────────────────────────────────────────────────────
 
 const textBlocks = (texts: string[]): Block[] =>
@@ -247,6 +311,39 @@ test("diffInlineHtml — marks only the changed words and leaves tags atomic", (
   assert.equal(out.match(/<\/strong>/g)?.length, 1);
   assert.ok(out.startsWith("Click <strong>"));
   assert.ok(out.endsWith("</strong> to start."));
+});
+
+test("diffInlineHtml — emits only the head side's markup, so the output is balanced", () => {
+  const out = diffInlineHtml("<strong>Same</strong>", "<em>Same</em>");
+  assert.equal(out, "<em>Same</em>");
+  assert.ok(!out.includes("<strong>"));
+});
+
+test("diffInlineHtml — a link-target edit leaves exactly one anchor", () => {
+  const out = diffInlineHtml(
+    'See <a href="./one.html">the guide</a>.',
+    'See <a href="./two.html">the guide</a>.',
+  );
+  assert.equal(out.match(/<a /g)?.length, 1);
+  assert.equal(out.match(/<\/a>/g)?.length, 1);
+  assert.ok(out.includes('href="./two.html"'));
+  assert.ok(!out.includes('href="./one.html"'));
+});
+
+test("diffInlineHtml — a mixed markup + wording edit still marks the words", () => {
+  const out = diffInlineHtml(
+    "Click <strong>Create</strong> to start.",
+    "Click <em>New folder</em> to start.",
+  );
+  assert.match(out, /<del class="bai-del">Create<\/del>/);
+  // The <em> boundary splits the inserted run, but every new word is marked.
+  assert.match(out, /<ins class="bai-ins">New<\/ins>/);
+  assert.match(out, /<ins class="bai-ins">folder<\/ins>/);
+  assert.equal(out.match(/<em>/g)?.length, 1);
+  assert.equal(out.match(/<\/em>/g)?.length, 1);
+  assert.ok(!out.includes("<strong>"));
+  // A bare space is spacing, never a marked insertion.
+  assert.ok(!/<ins class="bai-ins">\s+<\/ins>/.test(out));
 });
 
 test("words — segments by locale, not by whitespace alone", () => {

--- a/packages/backend.ai-docs-toolkit/src/web-diff.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/web-diff.test.ts
@@ -1,0 +1,698 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  diffBlocks,
+  diffInlineHtml,
+  extractBlocks,
+  fingerprintOf,
+  generateWebDiff,
+  injectHead,
+  lineOf,
+  markdownProbeLines,
+  similarity,
+  sourcePathOf,
+  stripInjected,
+  segmentText,
+  words,
+  type Block,
+  type ChangesManifest,
+  type PageSidecar,
+} from "./web-diff.js";
+import type { ResolvedDocConfig } from "./config.js";
+
+// ── fixtures ────────────────────────────────────────────────────
+
+const EDIT_BASE =
+  "https://github.com/lablup/backend.ai-webui/edit/main/packages/backend.ai-webui-docs/src";
+
+function page(body: string, opts: { lang?: string; slug?: string; title?: string } = {}): string {
+  const lang = opts.lang ?? "en";
+  const slug = opts.slug ?? "vfolder";
+  const title = opts.title ?? "Folders";
+  return `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+  <meta charset="utf-8" />
+  <title>${title}</title>
+  <link rel="stylesheet" href="../../assets/styles.abcd1234.css" />
+</head>
+<body>
+  <aside><ul class="doc-sidebar-nav"><li><a href="./${slug}.html">1. ${title}</a></li></ul></aside>
+  <nav><ol><li class="breadcrumb__item breadcrumb__item--current" aria-current="page">${title}</li></ol></nav>
+  <main>
+<section class="chapter" id="chapter-${slug}">
+${body}
+</section>
+<div class="page-metadata"><a class="edit-link" href="${EDIT_BASE}/${lang}/${slug}/${slug}.md">Edit this page</a></div>
+  </main>
+</body>
+</html>`;
+}
+
+const heading = (text: string, id: string): string =>
+  `<h2 id="${id}">${text}<a class="hash-link" href="#${id}">#</a></h2>`;
+const figure = (src: string, alt = "shot"): string =>
+  `<p><figure class="doc-figure"><img src="${src}" alt="${alt}" class="doc-image" /><figcaption>Figure 1. ${alt}</figcaption></figure></p>`;
+
+function tmpdir(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `web-diff-${name}-`));
+}
+
+function makeConfig(root: string, srcDir = "src"): ResolvedDocConfig {
+  return {
+    projectRoot: root,
+    srcDir: path.join(root, srcDir),
+    distDir: path.join(root, "dist"),
+    languageLabels: { en: "English", ko: "한국어" },
+    versions: [
+      { label: "next", source: { kind: "workspace" } },
+      {
+        label: "26.8",
+        source: { kind: "archive-branch", ref: "docs-archive/26.8" },
+        latest: true,
+      },
+    ],
+  } as unknown as ResolvedDocConfig;
+}
+
+/** Write `<root>/next/<lang>/<slug>.html`, creating parents. */
+function writePage(
+  root: string,
+  lang: string,
+  slug: string,
+  html: string,
+): void {
+  const dir = path.join(root, "next", lang);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${slug}.html`), html);
+}
+
+function writeImage(root: string, lang: string, name: string, bytes: string): void {
+  const dir = path.join(root, "next", lang, "images");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), Buffer.from(bytes, "utf-8"));
+}
+
+const readSidecar = (root: string, lang: string, slug: string): PageSidecar =>
+  JSON.parse(
+    fs.readFileSync(
+      path.join(root, "next", lang, `${slug}.changes.json`),
+      "utf-8",
+    ),
+  ) as PageSidecar;
+
+// ── block extraction ────────────────────────────────────────────
+
+test("extractBlocks — returns null for a page without a chapter body", () => {
+  const html = "<html><head></head><body><p>redirecting…</p></body></html>";
+  assert.equal(extractBlocks(html, "/nowhere"), null);
+});
+
+test("extractBlocks — recognizes each block kind, and drops the heading's hash link", () => {
+  const html = page(
+    [
+      heading("Create a folder", "create-a-folder"),
+      "<p>Open the Data page.</p>",
+      "<ul><li>First item</li><li>Second item</li></ul>",
+      '<table><tbody><tr><td>Name</td><td>Size</td></tr></tbody></table>',
+      '<div class="admonition"><div class="admonition-heading"><span class="admonition-icon">i</span>Note</div><div class="admonition-content"><p>Inside the note.</p></div></div>',
+      '<div class="code-block-wrapper"><pre><code>echo hi</code></pre></div>',
+    ].join("\n"),
+  );
+  const blocks = extractBlocks(html, "/nowhere")!;
+  assert.deepEqual(
+    blocks.map((b) => b.kind),
+    [
+      "heading",
+      "paragraph",
+      "list-item",
+      "list-item",
+      "table-row",
+      "admonition-title",
+      "paragraph",
+      "code",
+    ],
+  );
+  assert.equal(blocks[0].text, "Create a folder");
+  assert.equal(blocks[0].hid, "create-a-folder");
+  assert.equal(blocks[4].text, "Name | Size");
+  assert.deepEqual(blocks[4].cells, ["Name", "Size"]);
+  assert.equal(blocks[5].text, "Note");
+});
+
+test("extractBlocks — anchors an image on the <figure>, not the wrapping <p>", () => {
+  const dir = tmpdir("figure");
+  try {
+    fs.mkdirSync(path.join(dir, "images"));
+    fs.writeFileSync(path.join(dir, "images", "a.png"), Buffer.from("AAA"));
+    const html = page(figure("./images/a.png"));
+    const blocks = extractBlocks(html, dir)!;
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].kind, "image");
+    assert.equal(blocks[0].tag, "figure");
+    assert.equal(blocks[0].src, "./images/a.png");
+    assert.match(blocks[0].hash!, /^[0-9a-f]{12}$/);
+    // The stamped attribute lands on the <figure> open tag.
+    const stamped = injectHead(html, blocks, "vfolder", "../../assets/");
+    assert.match(stamped, /<figure data-bai-block="0" class="doc-figure"/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("extractBlocks — a missing image file hashes as `missing` rather than throwing", () => {
+  const blocks = extractBlocks(page(figure("./images/gone.png")), "/nowhere")!;
+  assert.equal(blocks[0].hash, "missing");
+});
+
+// ── pairing ─────────────────────────────────────────────────────
+
+const textBlocks = (texts: string[]): Block[] =>
+  texts.map((t, idx) => ({
+    idx,
+    kind: "paragraph" as const,
+    tag: "p",
+    anchor: { start: 0, tagEnd: 0, openEnd: 0, closeStart: 0, end: 0 },
+    text: t,
+    inner: t,
+    key: `paragraph:${t}`,
+    hid: null,
+  }));
+
+test("diffBlocks — a similar replacement pairs into one `modified` change", () => {
+  const base = textBlocks(["Open the Data page and click Create."]);
+  const head = textBlocks(["Open the Data page and click New folder."]);
+  const changes = diffBlocks(base, head);
+  assert.equal(changes.length, 1);
+  assert.equal(changes[0].type, "modified");
+  assert.ok((changes[0].sim ?? 0) >= 0.4);
+});
+
+test("diffBlocks — a dissimilar replacement stays a removed + added pair", () => {
+  const base = textBlocks(["Alpha beta gamma delta epsilon."]);
+  const head = textBlocks(["Completely unrelated sentence here now."]);
+  assert.ok(similarity(base[0], head[0]) < 0.4);
+  const changes = diffBlocks(base, head);
+  assert.deepEqual(
+    changes.map((c) => c.type),
+    ["removed", "added"],
+  );
+  assert.equal(changes[0].insertAfter, -1);
+});
+
+test("diffBlocks — a pure insertion is `added` and carries the preceding block in insertAfter for later removals", () => {
+  const base = textBlocks(["One.", "Three."]);
+  const head = textBlocks(["One.", "Two.", "Three."]);
+  const changes = diffBlocks(base, head);
+  assert.equal(changes.length, 1);
+  assert.equal(changes[0].type, "added");
+  assert.equal(changes[0].head?.text, "Two.");
+});
+
+test("diffBlocks — a removal records the head block it should be drawn after", () => {
+  const base = textBlocks(["One.", "Two.", "Three."]);
+  const head = textBlocks(["One.", "Three."]);
+  const changes = diffBlocks(base, head);
+  assert.equal(changes.length, 1);
+  assert.equal(changes[0].type, "removed");
+  assert.equal(changes[0].insertAfter, 0);
+});
+
+test("diffBlocks — identical blocks produce no changes", () => {
+  const base = textBlocks(["Same.", "Also same."]);
+  assert.deepEqual(diffBlocks(base, textBlocks(["Same.", "Also same."])), []);
+});
+
+test("similarity — blocks of different kinds never pair", () => {
+  const [p] = textBlocks(["Open the Data page."]);
+  const li: Block = { ...p, kind: "list-item", key: "list-item:Open the Data page." };
+  assert.equal(similarity(p, li), 0);
+});
+
+// ── word diff ───────────────────────────────────────────────────
+
+test("diffInlineHtml — marks only the changed words and leaves tags atomic", () => {
+  const out = diffInlineHtml(
+    "Click <strong>Create</strong> to start.",
+    "Click <strong>New folder</strong> to start.",
+  );
+  assert.match(out, /<del class="bai-del">Create<\/del>/);
+  assert.match(out, /<ins class="bai-ins">New folder<\/ins>/);
+  // The <strong> tags survive as whole tokens on both sides of the change.
+  assert.equal(out.match(/<strong>/g)?.length, 1);
+  assert.equal(out.match(/<\/strong>/g)?.length, 1);
+  assert.ok(out.startsWith("Click <strong>"));
+  assert.ok(out.endsWith("</strong> to start."));
+});
+
+test("words — segments by locale, not by whitespace alone", () => {
+  assert.deepEqual(words("create a folder", "en"), ["create", "a", "folder"]);
+  assert.deepEqual(words("폴더 생성", "ko"), ["폴더", "생성"]);
+  // Thai has no word spacing; the segmenter still finds the word boundary.
+  assert.deepEqual(words("สวัสดีครับ", "th"), ["สวัสดี", "ครับ"]);
+});
+
+test("segmentText — keeps whitespace and punctuation as their own tokens", () => {
+  const toks = segmentText("Open the page.", "en");
+  assert.deepEqual(
+    toks.map((t) => `${t.t}:${t.v}`),
+    ["w:Open", "ws: ", "w:the", "ws: ", "w:page", "w:."],
+  );
+});
+
+test("segmentText — falls back to the per-character regex without Intl.Segmenter", () => {
+  const original = Intl.Segmenter;
+  // @ts-expect-error — exercising the no-Segmenter environment
+  delete Intl.Segmenter;
+  try {
+    // An otherwise-unused locale tag, so no cached segmenter short-circuits it.
+    assert.deepEqual(words("폴더 생성", "ko-x-nosegmenter"), [
+      "폴",
+      "더",
+      "생",
+      "성",
+    ]);
+  } finally {
+    Intl.Segmenter = original;
+  }
+});
+
+test("diffInlineHtml — a CJK edit marks the changed word", () => {
+  const out = diffInlineHtml("폴더를 만듭니다", "폴더를 지웁니다", "ko");
+  assert.match(out, /<del class="bai-del">만듭니다<\/del>/);
+  assert.match(out, /<ins class="bai-ins">지웁니다<\/ins>/);
+  assert.ok(out.startsWith("폴더를"));
+});
+
+test("extractBlocks — whitespace reflow alone is not a change", () => {
+  const a = extractBlocks(page("<p>Open the Data\n   page.</p>"), "/nowhere")!;
+  const b = extractBlocks(page("<p>Open the Data page.</p>"), "/nowhere")!;
+  assert.equal(a[0].key, b[0].key);
+  assert.deepEqual(diffBlocks(a, b), []);
+});
+
+test("extractBlocks — the block key carries markup, so a bold-only edit differs", () => {
+  const a = extractBlocks(page("<p>Click <strong>Create</strong> now.</p>"), "/nowhere")!;
+  const b = extractBlocks(page("<p>Click <em>Create</em> now.</p>"), "/nowhere")!;
+  assert.equal(a[0].text, b[0].text);
+  assert.notEqual(a[0].key, b[0].key);
+});
+
+test("extractBlocks — a link-target-only edit also changes the block key", () => {
+  const a = extractBlocks(page('<p>See <a href="./one.html">the guide</a>.</p>'), "/nowhere")!;
+  const b = extractBlocks(page('<p>See <a href="./two.html">the guide</a>.</p>'), "/nowhere")!;
+  assert.equal(a[0].text, b[0].text);
+  assert.notEqual(a[0].key, b[0].key);
+});
+
+test("diffBlocks — a formatting-only edit pairs as modified at similarity 1", () => {
+  const base = extractBlocks(page("<p>Click <strong>Create</strong> now.</p>"), "/nowhere")!;
+  const head = extractBlocks(page("<p>Click <em>Create</em> now.</p>"), "/nowhere")!;
+  const changes = diffBlocks(base, head);
+  assert.equal(changes.length, 1);
+  assert.equal(changes[0].type, "modified");
+  assert.equal(changes[0].sim, 1);
+});
+
+// ── source references ───────────────────────────────────────────
+
+test("sourcePathOf — reads the repo-relative path off the Edit this page link", () => {
+  assert.equal(
+    sourcePathOf(page("<p>x</p>"), "en", "vfolder"),
+    "packages/backend.ai-webui-docs/src/en/vfolder/vfolder.md",
+  );
+});
+
+test("sourcePathOf — falls back to the conventional path when there is no edit link", () => {
+  assert.equal(
+    sourcePathOf("<html><body></body></html>", "ko", "deployment"),
+    "src/ko/deployment/deployment.md",
+  );
+});
+
+test("lineOf — finds the markdown line a block came from, ignoring markup", () => {
+  const md = ["# Folders", "", "Open the **Data** page and click Create.", ""].join("\n");
+  const lines = markdownProbeLines(md);
+  assert.equal(lineOf(lines, "Open the Data page and click Create.", "paragraph"), 3);
+  assert.equal(lineOf(lines, "Nothing like this on the page", "paragraph"), null);
+  assert.equal(lineOf(null, "anything at all", "paragraph"), null);
+});
+
+test("lineOf — matches an image by its file name", () => {
+  const lines = markdownProbeLines("![shot](images/folder_create.png)\n");
+  assert.equal(lineOf(lines, "./images/folder_create.png", "image"), 1);
+});
+
+// ── fingerprints ────────────────────────────────────────────────
+
+test("fingerprintOf — is stable for the same change and differs when the text does", () => {
+  const [b1] = textBlocks(["Old text here."]);
+  const [h1] = textBlocks(["New text here."]);
+  const a = fingerprintOf({ type: "modified", base: b1, head: h1 });
+  const b = fingerprintOf({ type: "modified", base: b1, head: h1 });
+  assert.equal(a, b);
+  assert.match(a, /^[0-9a-f]{12}$/);
+  const [h2] = textBlocks(["Newer text here."]);
+  assert.notEqual(a, fingerprintOf({ type: "modified", base: b1, head: h2 }));
+});
+
+// ── end to end ──────────────────────────────────────────────────
+
+test("generateWebDiff — modified page: sidecar, manifest, stamping and idempotence", async () => {
+  const root = tmpdir("e2e");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    writePage(
+      base,
+      "en",
+      "vfolder",
+      page(
+        [
+          heading("Folders", "folders"),
+          "<p>Open the Data page and click Create.</p>",
+          "<p>This paragraph is deleted by the PR.</p>",
+        ].join("\n"),
+      ),
+    );
+    writePage(
+      head,
+      "en",
+      "vfolder",
+      page(
+        [
+          heading("Folders", "folders"),
+          "<p>Open the Data page and click New folder.</p>",
+          "<p>A brand new paragraph.</p>",
+        ].join("\n"),
+      ),
+    );
+    fs.mkdirSync(path.join(root, "src", "en", "vfolder"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "src", "en", "vfolder", "vfolder.md"),
+      ["# Folders", "", "Open the Data page and click New folder.", "", "A brand new paragraph.", ""].join("\n"),
+    );
+
+    const config = makeConfig(root);
+    const manifest = await generateWebDiff(config, {
+      base,
+      head,
+      lang: "en",
+      label: "docs PR #1",
+      quiet: true,
+    });
+
+    assert.equal(manifest.version, 1);
+    assert.equal(manifest.channel, "next");
+    assert.equal(manifest.label, "docs PR #1");
+    assert.deepEqual(manifest.languages, ["en"]);
+    const en = manifest.langs.en;
+    assert.equal(en.totals.pages, 1);
+    assert.equal(en.pages[0].url, "next/en/vfolder.html");
+    assert.equal(
+      en.pages[0].sourcePath,
+      "packages/backend.ai-webui-docs/src/en/vfolder/vfolder.md",
+    );
+
+    const sidecar = readSidecar(head, "en", "vfolder");
+    assert.equal(sidecar.status, "modified");
+    assert.deepEqual(
+      sidecar.changes.map((c) => c.type),
+      ["modified", "removed", "added"],
+    );
+    assert.equal(sidecar.counts.total, 3);
+    assert.deepEqual(en.pages[0].counts, sidecar.counts);
+    assert.deepEqual(
+      en.pages[0].fingerprints,
+      sidecar.changes.map((c) => c.fingerprint),
+    );
+
+    const modified = sidecar.changes[0];
+    assert.match(modified.diffHtml!, /<del class="bai-del">Create<\/del>/);
+    assert.deepEqual(modified.section, { text: "Folders", id: "folders", level: 2 });
+    assert.equal(modified.line, 3);
+    // The removed block is drawn after the head block that precedes it.
+    assert.equal(sidecar.changes[1].anchor, null);
+    assert.equal(sidecar.changes[1].insertAfter, 1);
+
+    const stamped = fs.readFileSync(
+      path.join(head, "next", "en", "vfolder.html"),
+      "utf-8",
+    );
+    assert.equal(stamped.match(/data-bai-block="/g)?.length, 3);
+    assert.equal(stamped.match(/pr-preview\.js/g)?.length, 1);
+    assert.match(stamped, /href="\.\.\/\.\.\/assets\/pr-preview\.css"/);
+    assert.match(stamped, /data-page="vfolder"/);
+    assert.ok(fs.existsSync(path.join(head, "assets", "pr-preview.js")));
+    assert.ok(fs.existsSync(path.join(head, "assets", "pr-preview.css")));
+
+    // Re-running against the already-stamped build changes nothing.
+    const again = await generateWebDiff(config, {
+      base,
+      head,
+      lang: "en",
+      label: "docs PR #1",
+      quiet: true,
+    });
+    const stamped2 = fs.readFileSync(
+      path.join(head, "next", "en", "vfolder.html"),
+      "utf-8",
+    );
+    assert.equal(stamped2, stamped);
+    assert.deepEqual(again.langs.en.totals, en.totals);
+    assert.deepEqual(
+      readSidecar(head, "en", "vfolder").changes.map((c) => c.fingerprint),
+      sidecar.changes.map((c) => c.fingerprint),
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generateWebDiff — flags a formatting-only change and leaves text edits unflagged", async () => {
+  const root = tmpdir("formatting");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    writePage(
+      base,
+      "en",
+      "login",
+      page(
+        [
+          "<p>Click <strong>Sign in</strong> to continue.</p>",
+          '<p>Read the <a href="./one.html">guide</a>.</p>',
+          "<p>The old wording of this sentence.</p>",
+        ].join("\n"),
+        { slug: "login" },
+      ),
+    );
+    writePage(
+      head,
+      "en",
+      "login",
+      page(
+        [
+          "<p>Click <em>Sign in</em> to continue.</p>",
+          '<p>Read the <a href="./two.html">guide</a>.</p>',
+          "<p>The new wording of this sentence.</p>",
+        ].join("\n"),
+        { slug: "login" },
+      ),
+    );
+
+    await generateWebDiff(makeConfig(root), { base, head, lang: "en", quiet: true });
+    const sidecar = readSidecar(head, "en", "login");
+    assert.equal(sidecar.counts.modified, 3);
+    const [bold, link, text] = sidecar.changes;
+    assert.equal(bold.formattingOnly, true);
+    assert.equal(bold.similarity, 1);
+    assert.equal(link.formattingOnly, true);
+    assert.match(link.newHtml!, /two\.html/);
+    assert.equal(text.formattingOnly, undefined);
+    assert.match(text.diffHtml!, /<ins class="bai-ins">new<\/ins>/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generateWebDiff — an image is compared by bytes, and the old file is copied next to the page", async () => {
+  const root = tmpdir("image");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    const body = [figure("./images/a.png", "one"), figure("./images/a.png", "two")].join("\n");
+    writePage(base, "en", "admin_menu", page(body, { slug: "admin_menu" }));
+    writePage(head, "en", "admin_menu", page(body, { slug: "admin_menu" }));
+    writeImage(base, "en", "a.png", "OLD-BYTES");
+    writeImage(head, "en", "a.png", "NEW-BYTES");
+
+    const manifest = await generateWebDiff(makeConfig(root), {
+      base,
+      head,
+      lang: "en",
+      quiet: true,
+    });
+    const sidecar = readSidecar(head, "en", "admin_menu");
+    assert.equal(sidecar.counts.images, 2);
+    assert.deepEqual(
+      sidecar.changes.map((c) => c.type),
+      ["modified", "modified"],
+    );
+    assert.equal(sidecar.changes[0].oldImage, "./base-images/a.png");
+    assert.equal(sidecar.changes[0].newImage, "./images/a.png");
+    assert.equal(
+      fs.readFileSync(path.join(head, "next", "en", "base-images", "a.png"), "utf-8"),
+      "OLD-BYTES",
+    );
+    // Same swap twice on one page: the repeat fingerprint is suffixed.
+    const [f1, f2] = sidecar.changes.map((c) => c.fingerprint);
+    assert.equal(f2, `${f1}-2`);
+    assert.deepEqual(manifest.langs.en.pages[0].fingerprints, [f1, f2]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generateWebDiff — an untouched page is `unchanged`, gets an empty sidecar and stays out of the manifest", async () => {
+  const root = tmpdir("unchanged");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    const html = page("<p>Nothing moved here.</p>", { slug: "login", title: "Login" });
+    writePage(base, "en", "login", html);
+    writePage(head, "en", "login", html);
+
+    const manifest = await generateWebDiff(makeConfig(root), {
+      base,
+      head,
+      lang: "en",
+      quiet: true,
+    });
+    assert.deepEqual(manifest.langs.en.pages, []);
+    assert.equal(manifest.langs.en.totals.changes, 0);
+    const sidecar = readSidecar(head, "en", "login");
+    assert.equal(sidecar.status, "unchanged");
+    assert.deepEqual(sidecar.changes, []);
+    assert.equal(sidecar.counts.total, 0);
+    // Even an unchanged page carries the overlay, so the navigator works there.
+    const out = fs.readFileSync(path.join(head, "next", "en", "login.html"), "utf-8");
+    assert.match(out, /pr-preview\.js/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generateWebDiff — detects new and deleted pages across two languages", async () => {
+  const root = tmpdir("pages");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    for (const lang of ["en", "ko"]) {
+      writePage(base, lang, "gone", page("<p>Old page.</p>", { lang, slug: "gone" }));
+      writePage(base, lang, "kept", page("<p>Kept page.</p>", { lang, slug: "kept" }));
+      writePage(head, lang, "kept", page("<p>Kept page.</p>", { lang, slug: "kept" }));
+      writePage(head, lang, "fresh", page("<p>Fresh page.</p>", { lang, slug: "fresh" }));
+    }
+
+    const manifest = await generateWebDiff(makeConfig(root), {
+      base,
+      head,
+      lang: "all",
+      quiet: true,
+    });
+    assert.deepEqual(manifest.languages, ["en", "ko"]);
+    for (const lang of ["en", "ko"]) {
+      const summary = manifest.langs[lang];
+      assert.deepEqual(
+        summary.pages.map((p) => [p.slug, p.status]),
+        [
+          ["fresh", "new"],
+          ["gone", "deleted"],
+        ],
+      );
+      assert.equal(summary.totals.pages, 2);
+      assert.equal(summary.totals.newPages, 1);
+      assert.equal(summary.totals.deletedPages, 1);
+      assert.equal(summary.totals.changes, 0);
+      const deleted = summary.pages.find((p) => p.status === "deleted")!;
+      assert.equal(deleted.url, null);
+      assert.equal(deleted.baseUrl, `next/${lang}/gone.html`);
+      assert.equal(readSidecar(head, lang, "fresh").status, "new");
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generateWebDiff — falls back to the head root when there is no channel directory", async () => {
+  const root = tmpdir("flat");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    for (const [root_, text] of [
+      [base, "Before."],
+      [head, "After the edit."],
+    ] as const) {
+      const dir = path.join(root_, "en");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "quickstart.html"), page(`<p>${text}</p>`, { slug: "quickstart" }));
+    }
+    const manifest = await generateWebDiff(makeConfig(root), {
+      base,
+      head,
+      lang: "en",
+      quiet: true,
+    });
+    assert.equal(manifest.channel, "");
+    assert.equal(manifest.langs.en.pages[0].url, "en/quickstart.html");
+    assert.ok(fs.existsSync(path.join(head, "changes-manifest.json")));
+    const out = fs.readFileSync(path.join(head, "en", "quickstart.html"), "utf-8");
+    assert.match(out, /href="\.\.\/assets\/pr-preview\.css"/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("stripInjected — removes the previous run's attributes and asset tags", () => {
+  const html = [
+    "<head>",
+    '  <link rel="stylesheet" href="../../assets/pr-preview.css" />',
+    '  <script defer src="../../assets/pr-preview.js" data-page="x"></script>',
+    "</head>",
+    '<p data-bai-block="0">Hi</p>',
+  ].join("\n");
+  const out = stripInjected(html);
+  assert.ok(!out.includes("pr-preview"));
+  assert.ok(!out.includes("data-bai-block"));
+  assert.match(out, /<p>Hi<\/p>/);
+});
+
+test("manifest — is valid JSON on disk with the documented top-level shape", async () => {
+  const root = tmpdir("shape");
+  try {
+    const base = path.join(root, "base");
+    const head = path.join(root, "head");
+    writePage(base, "en", "x", page("<p>One.</p>", { slug: "x" }));
+    writePage(head, "en", "x", page("<p>One and two.</p>", { slug: "x" }));
+    await generateWebDiff(makeConfig(root), { base, head, lang: "en", quiet: true });
+    const onDisk = JSON.parse(
+      fs.readFileSync(path.join(head, "next", "changes-manifest.json"), "utf-8"),
+    ) as ChangesManifest;
+    assert.deepEqual(Object.keys(onDisk).sort(), [
+      "channel",
+      "generatedAt",
+      "label",
+      "langs",
+      "languages",
+      "version",
+    ]);
+    assert.match(onDisk.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/backend.ai-docs-toolkit/src/web-diff.ts
+++ b/packages/backend.ai-docs-toolkit/src/web-diff.ts
@@ -1,0 +1,1137 @@
+/**
+ * Markdown-block level diff between two `dist/web` builds (FR-3879).
+ *
+ * Compares a base build with a head (PR) build, stamps every block of the
+ * head pages with `data-bai-block="<n>"`, writes a `<slug>.changes.json`
+ * sidecar per page plus a `changes-manifest.json` per channel, and injects
+ * the `pr-preview` overlay tags so the published preview can mark the
+ * changed blocks in place.
+ */
+
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import type { ResolvedDocConfig } from "./config.js";
+import { loadVersions } from "./versions.js";
+
+/** Pairing threshold: below this a delete/insert pair stays two changes. */
+const SIM_THRESHOLD = 0.4;
+/** LCS bail-out — above this the diff degrades to whole-block replace. */
+const MAX_DP_CELLS = 6_000_000;
+
+export type BlockKind =
+  | "paragraph"
+  | "heading"
+  | "list-item"
+  | "table-row"
+  | "image"
+  | "code"
+  | "admonition-title"
+  | "summary"
+  | "other";
+
+export type ChangeType = "added" | "modified" | "removed";
+export type PageStatus = "unchanged" | "modified" | "new" | "deleted";
+
+export interface BlockAnchor {
+  start: number;
+  tagEnd: number;
+  openEnd: number;
+  closeStart: number;
+  end: number;
+}
+
+export interface Block {
+  idx: number;
+  kind: BlockKind;
+  tag: string;
+  anchor: BlockAnchor;
+  text: string;
+  inner: string;
+  key: string;
+  hid: string | null;
+  level?: number;
+  cells?: string[];
+  src?: string;
+  hash?: string;
+  width?: string;
+  height?: string;
+}
+
+export interface SectionRef {
+  text: string;
+  id: string | null;
+  level?: number;
+}
+
+export interface SerializedChange {
+  id: number;
+  type: ChangeType;
+  blockKind: BlockKind;
+  tag: string;
+  anchor: number | null;
+  insertAfter: number | null;
+  fingerprint: string;
+  section: SectionRef | null;
+  line: number | null;
+  oldText: string;
+  newText: string;
+  oldHtml?: string;
+  newHtml?: string;
+  diffHtml?: string;
+  similarity?: number;
+  /** The rendered text is unchanged — only markup or a link target moved. */
+  formattingOnly?: boolean;
+  words?: number;
+  oldImage?: string | null;
+  newImage?: string | null;
+  width?: string;
+  height?: string;
+  oldCells?: string[] | null;
+  newCells?: string[] | null;
+}
+
+export interface ChangeCounts {
+  added: number;
+  modified: number;
+  removed: number;
+  images: number;
+  total: number;
+}
+
+export interface PageSidecar {
+  slug: string;
+  lang: string;
+  title: string;
+  status: PageStatus;
+  sourcePath: string;
+  counts: ChangeCounts;
+  changes: SerializedChange[];
+}
+
+export interface ManifestPage {
+  slug: string;
+  title: string;
+  status: Exclude<PageStatus, "unchanged">;
+  url: string | null;
+  sourcePath: string;
+  counts: ChangeCounts;
+  fingerprints: string[];
+  baseUrl?: string;
+}
+
+export interface LangTotals {
+  pages: number;
+  changes: number;
+  added: number;
+  modified: number;
+  removed: number;
+  images: number;
+  newPages: number;
+  deletedPages: number;
+}
+
+export interface ChangesManifest {
+  version: 1;
+  channel: string;
+  label: string;
+  generatedAt: string;
+  languages: string[];
+  langs: Record<string, { totals: LangTotals; pages: ManifestPage[] }>;
+}
+
+export interface WebDiffOptions {
+  /** `dist/web` root of the base (target-branch) build. */
+  base: string;
+  /** `dist/web` root of the head (PR) build — written into. */
+  head: string;
+  /** `all` (default) or a comma list such as `en,ko`. */
+  lang?: string;
+  /** Free-text PR label carried into the manifest. */
+  label?: string;
+  /** Markdown source root of the head build, for `file:line` references. */
+  src?: string;
+  /** Suppress the summary lines (the CLI's `--json` mode). */
+  quiet?: boolean;
+}
+
+// ──────────────────────────────────────────── HTML tree
+
+const VOID = new Set([
+  "img",
+  "br",
+  "hr",
+  "input",
+  "meta",
+  "link",
+  "source",
+  "wbr",
+  "col",
+  "area",
+  "base",
+  "embed",
+  "param",
+  "track",
+]);
+
+interface TextNode {
+  type: "text";
+  text: string;
+  start: number;
+  end: number;
+}
+
+export interface ElementNode {
+  type: "el";
+  tag: string;
+  attrs: string;
+  start: number;
+  tagEnd: number;
+  openEnd: number;
+  closeStart: number;
+  end: number;
+  children: HtmlNode[];
+}
+
+type HtmlNode = TextNode | ElementNode;
+
+/** Offset-preserving HTML parser: every node keeps its slice of the source. */
+export function parseHtml(html: string): ElementNode {
+  const re =
+    /<!--[\s\S]*?-->|<\/([a-zA-Z][\w-]*)\s*>|<([a-zA-Z][\w-]*)([^>]*?)(\/?)>|[^<]+|</g;
+  const root: ElementNode = {
+    type: "el",
+    tag: "#root",
+    attrs: "",
+    start: 0,
+    tagEnd: 0,
+    openEnd: 0,
+    closeStart: html.length,
+    end: html.length,
+    children: [],
+  };
+  const stack: ElementNode[] = [root];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) {
+    const s = m.index;
+    const e = s + m[0].length;
+    if (m[0].startsWith("<!--")) continue;
+    if (m[1]) {
+      const tag = m[1].toLowerCase();
+      for (let i = stack.length - 1; i > 0; i--) {
+        if (stack[i].tag === tag) {
+          for (let k = stack.length - 1; k > i; k--) {
+            stack[k].closeStart = s;
+            stack[k].end = s;
+          }
+          stack[i].closeStart = s;
+          stack[i].end = e;
+          stack.length = i;
+          break;
+        }
+      }
+      continue;
+    }
+    if (m[2]) {
+      const tag = m[2].toLowerCase();
+      const node: ElementNode = {
+        type: "el",
+        tag,
+        attrs: m[3] || "",
+        start: s,
+        tagEnd: s + 1 + m[2].length,
+        openEnd: e,
+        closeStart: e,
+        end: e,
+        children: [],
+      };
+      stack[stack.length - 1].children.push(node);
+      if (!(m[4] === "/" || VOID.has(tag))) stack.push(node);
+      continue;
+    }
+    stack[stack.length - 1].children.push({
+      type: "text",
+      text: m[0],
+      start: s,
+      end: e,
+    });
+  }
+  return root;
+}
+
+const classOf = (n: ElementNode): string =>
+  (n.attrs.match(/\bclass="([^"]*)"/) || [])[1] || "";
+const hasClass = (n: ElementNode, c: string): boolean =>
+  classOf(n).split(/\s+/).includes(c);
+const attrOf = (n: ElementNode, a: string): string | undefined =>
+  (n.attrs.match(new RegExp(`\\b${a}="([^"]*)"`)) || [])[1];
+
+function decode(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&");
+}
+
+function textOf(node: HtmlNode): string {
+  if (node.type === "text") return decode(node.text);
+  if (node.tag === "a" && hasClass(node, "hash-link")) return "";
+  if (hasClass(node, "admonition-icon") || node.tag === "svg") return "";
+  if (node.tag === "figcaption") return "";
+  return node.children.map(textOf).join("");
+}
+
+const norm = (s: string): string => s.replace(/\s+/g, " ").trim();
+
+function innerHtml(html: string, node: ElementNode): string {
+  return html
+    .slice(node.openEnd, node.closeStart)
+    .replace(/<a class="hash-link"[^>]*>#<\/a>/g, "")
+    .trim();
+}
+
+function findAll(
+  node: ElementNode,
+  pred: (n: ElementNode) => boolean,
+  out: ElementNode[] = [],
+): ElementNode[] {
+  for (const ch of node.children) {
+    if (ch.type !== "el") continue;
+    if (pred(ch)) out.push(ch);
+    else findAll(ch, pred, out);
+  }
+  return out;
+}
+
+// ──────────────────────────────────────────── blocks
+
+/**
+ * Flatten the page's `<section class="chapter">` into comparable blocks.
+ * Returns null for pages without a chapter body (redirect stubs).
+ */
+export function extractBlocks(html: string, pageDir: string): Block[] | null {
+  const secStart = html.indexOf('<section class="chapter"');
+  if (secStart < 0) return null;
+  const mainEnd = html.indexOf("</main>", secStart);
+  const secEnd = html.lastIndexOf(
+    "</section>",
+    mainEnd < 0 ? html.length : mainEnd,
+  );
+  const secHtml = html.slice(secStart, secEnd);
+  const tree = parseHtml(secHtml);
+  const section = tree.children.find(
+    (c): c is ElementNode => c.type === "el" && c.tag === "section",
+  );
+  if (!section) return null;
+
+  const blocks: Block[] = [];
+  const shift = (n: ElementNode): BlockAnchor => ({
+    start: n.start + secStart,
+    tagEnd: n.tagEnd + secStart,
+    openEnd: n.openEnd + secStart,
+    closeStart: n.closeStart + secStart,
+    end: n.end + secStart,
+  });
+
+  const push = (
+    kind: BlockKind,
+    anchor: ElementNode,
+    text: string,
+    inner: string,
+    extra: Partial<Block> = {},
+  ): void => {
+    const t = norm(text);
+    if (!t) return;
+    blocks.push({
+      idx: blocks.length,
+      kind,
+      tag: anchor.tag,
+      anchor: shift(anchor),
+      text: t,
+      inner,
+      // Keyed on markup, so a bold-only or link-target-only edit is a change.
+      key: `${kind}:${norm(inner)}`,
+      hid: attrOf(anchor, "id") ?? null,
+      ...extra,
+    });
+  };
+
+  const pushImage = (imgNode: ElementNode): void => {
+    const img =
+      imgNode.tag === "img"
+        ? imgNode
+        : findAll(imgNode, (n) => n.tag === "img")[0];
+    if (!img) return;
+    const src = attrOf(img, "src") || "";
+    const file = path.resolve(pageDir, src);
+    const hash = fs.existsSync(file)
+      ? crypto.createHash("md5").update(fs.readFileSync(file)).digest("hex").slice(0, 12)
+      : "missing";
+    // The anchor is the <figure>, never the wrapping <p> — browsers split
+    // `<p><figure>` into two paragraphs and the mark would land off-target.
+    const anchor = imgNode.tag === "figure" ? imgNode : img;
+    blocks.push({
+      idx: blocks.length,
+      kind: "image",
+      tag: anchor.tag,
+      anchor: shift(anchor),
+      text: src,
+      inner: "",
+      key: `image:${src}:${hash}`,
+      hid: attrOf(anchor, "id") ?? null,
+      src,
+      hash,
+      width: attrOf(img, "width"),
+      height: attrOf(img, "height"),
+    });
+  };
+
+  const walk = (node: { children: HtmlNode[] }): void => {
+    for (const ch of node.children) {
+      if (ch.type !== "el") continue;
+      const t = ch.tag;
+      if (/^h[1-6]$/.test(t)) {
+        push("heading", ch, textOf(ch), innerHtml(secHtml, ch), {
+          level: Number(t[1]),
+        });
+      } else if (t === "p") {
+        const figs = findAll(ch, (n) => n.tag === "figure" || n.tag === "img");
+        const txt = norm(textOf(ch));
+        if (figs.length && !txt) figs.forEach(pushImage);
+        else if (txt) push("paragraph", ch, txt, innerHtml(secHtml, ch));
+      } else if (t === "ul" || t === "ol") {
+        for (const li of ch.children) {
+          if (li.type === "el" && li.tag === "li") {
+            push("list-item", li, textOf(li), innerHtml(secHtml, li));
+          }
+        }
+      } else if (t === "table") {
+        for (const tr of findAll(ch, (n) => n.tag === "tr")) {
+          const cells = tr.children
+            .filter((c): c is ElementNode => c.type === "el")
+            .map((c) => norm(textOf(c)));
+          push("table-row", tr, cells.join(" | "), innerHtml(secHtml, tr), {
+            cells,
+          });
+        }
+      } else if (t === "figure" || t === "img") {
+        pushImage(ch);
+      } else if (t === "div" && hasClass(ch, "admonition")) {
+        for (const sub of ch.children) {
+          if (sub.type !== "el") continue;
+          if (hasClass(sub, "admonition-heading")) {
+            push("admonition-title", sub, textOf(sub), innerHtml(secHtml, sub));
+          } else if (hasClass(sub, "admonition-content")) {
+            walk(sub);
+          }
+        }
+      } else if (t === "div" && hasClass(ch, "code-block-wrapper")) {
+        const pre = findAll(ch, (n) => n.tag === "pre")[0] ?? ch;
+        push("code", ch, textOf(pre), innerHtml(secHtml, pre));
+      } else if (t === "pre") {
+        push("code", ch, textOf(ch), innerHtml(secHtml, ch));
+      } else if (t === "details") {
+        for (const sub of ch.children) {
+          if (sub.type !== "el") continue;
+          if (sub.tag === "summary") {
+            push("summary", sub, textOf(sub), innerHtml(secHtml, sub));
+          } else walk({ children: [sub] });
+        }
+      } else if (
+        t === "blockquote" ||
+        t === "div" ||
+        t === "section" ||
+        t === "nav"
+      ) {
+        walk(ch);
+      } else if (
+        t === "hr" ||
+        t === "br" ||
+        t === "a" ||
+        t === "script" ||
+        t === "style"
+      ) {
+        continue;
+      } else {
+        push("other", ch, textOf(ch), innerHtml(secHtml, ch));
+      }
+    }
+  };
+  walk(section);
+  return blocks;
+}
+
+// ──────────────────────────────────────────── diffing
+
+interface LcsOp {
+  type: "eq" | "del" | "ins";
+  i?: number;
+  j?: number;
+}
+
+function lcsOps<T>(a: T[], b: T[], eq: (x: T, y: T) => boolean): LcsOp[] {
+  const n = a.length;
+  const m = b.length;
+  const W = m + 1;
+  const dp = new Uint32Array((n + 1) * W);
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i * W + j] = eq(a[i], b[j])
+        ? dp[(i + 1) * W + j + 1] + 1
+        : Math.max(dp[(i + 1) * W + j], dp[i * W + j + 1]);
+    }
+  }
+  const ops: LcsOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (eq(a[i], b[j])) {
+      ops.push({ type: "eq", i, j });
+      i++;
+      j++;
+    } else if (dp[(i + 1) * W + j] >= dp[i * W + j + 1]) {
+      ops.push({ type: "del", i });
+      i++;
+    } else {
+      ops.push({ type: "ins", j });
+      j++;
+    }
+  }
+  while (i < n) ops.push({ type: "del", i: i++ });
+  while (j < m) ops.push({ type: "ins", j: j++ });
+  return ops;
+}
+
+function lcsLen<T>(a: T[], b: T[], eq: (x: T, y: T) => boolean): number {
+  const n = a.length;
+  const m = b.length;
+  if (n * m > MAX_DP_CELLS) return 0;
+  let prev = new Uint32Array(m + 1);
+  let cur = new Uint32Array(m + 1);
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      cur[j] = eq(a[i - 1], b[j - 1])
+        ? prev[j - 1] + 1
+        : Math.max(prev[j], cur[j - 1]);
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[m];
+}
+
+/** Fallback when `Intl.Segmenter` is missing: CJK / Thai split per character. */
+const WORD_RE =
+  /\s+|[\p{sc=Han}\p{sc=Hiragana}\p{sc=Katakana}\p{sc=Hangul}\p{sc=Thai}]|[\p{L}\p{N}_]+|[^\s\p{L}\p{N}]/gu;
+
+interface Token {
+  t: "tag" | "ws" | "w";
+  v: string;
+}
+
+const segmenters = new Map<string, Intl.Segmenter | null>();
+
+function segmenterFor(lang: string): Intl.Segmenter | null {
+  if (!segmenters.has(lang)) {
+    let seg: Intl.Segmenter | null = null;
+    try {
+      if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+        seg = new Intl.Segmenter(lang, { granularity: "word" });
+      }
+    } catch {
+      seg = null;
+    }
+    segmenters.set(lang, seg);
+  }
+  return segmenters.get(lang) ?? null;
+}
+
+/** Locale-aware word segmentation; punctuation and whitespace stay separate. */
+export function segmentText(s: string, lang = "en"): Token[] {
+  const seg = segmenterFor(lang);
+  if (!seg) {
+    return (s.match(WORD_RE) || []).map((v) => ({
+      t: /^\s+$/.test(v) ? "ws" : "w",
+      v,
+    }));
+  }
+  const out: Token[] = [];
+  for (const { segment } of seg.segment(s)) {
+    out.push({ t: /^\s+$/.test(segment) ? "ws" : "w", v: segment });
+  }
+  return out;
+}
+
+export function words(s: string, lang = "en"): string[] {
+  return segmentText(s, lang)
+    .filter((t) => t.t === "w")
+    .map((t) => t.v);
+}
+
+function tokenizeHtml(inner: string, lang: string): Token[] {
+  const toks: Token[] = [];
+  for (const part of inner.match(/<[^>]+>|[^<]+/g) || []) {
+    if (part.startsWith("<")) toks.push({ t: "tag", v: part });
+    else toks.push(...segmentText(part, lang));
+  }
+  return toks;
+}
+
+const tokEq = (x: Token, y: Token): boolean =>
+  x.t === y.t && (x.t === "ws" || x.v === y.v);
+
+/** Word-level inline diff. Tags stay atomic so the markup survives. */
+export function diffInlineHtml(
+  oldInner: string,
+  newInner: string,
+  lang = "en",
+): string {
+  const a = tokenizeHtml(oldInner, lang);
+  const b = tokenizeHtml(newInner, lang);
+  if (a.length * b.length > MAX_DP_CELLS) {
+    return `<del class="bai-del">${oldInner}</del><ins class="bai-ins">${newInner}</ins>`;
+  }
+  const ops = lcsOps(a, b, tokEq);
+  let out = "";
+  let delBuf = "";
+  let insBuf = "";
+  const flush = (): void => {
+    if (delBuf) out += `<del class="bai-del">${delBuf}</del>`;
+    if (insBuf) out += `<ins class="bai-ins">${insBuf}</ins>`;
+    delBuf = "";
+    insBuf = "";
+  };
+  for (const op of ops) {
+    if (op.type === "eq") {
+      flush();
+      out += b[op.j as number].v;
+      continue;
+    }
+    const tok = op.type === "del" ? a[op.i as number] : b[op.j as number];
+    if (tok.t === "tag") {
+      flush();
+      out += tok.v;
+      continue;
+    }
+    if (op.type === "del") delBuf += tok.v;
+    else insBuf += tok.v;
+  }
+  flush();
+  return out;
+}
+
+/** Pairing score on plain text — markup differences never lower it. */
+export function similarity(d: Block, h: Block, lang = "en"): number {
+  if (d.kind !== h.kind) return 0;
+  if (d.kind === "image") return d.src === h.src ? 1 : 0;
+  const a = words(d.text, lang);
+  const b = words(h.text, lang);
+  if (!a.length || !b.length) return 0;
+  return (2 * lcsLen(a, b, (x, y) => x === y)) / (a.length + b.length);
+}
+
+export interface RawChange {
+  type: ChangeType;
+  base?: Block;
+  head?: Block;
+  sim?: number;
+  insertAfter?: number;
+}
+
+/**
+ * Block-level LCS, then within each del/ins run pair the most similar
+ * survivors into `modified` and leave the rest as added / removed.
+ */
+export function diffBlocks(
+  baseBlocks: Block[],
+  headBlocks: Block[],
+  lang = "en",
+): RawChange[] {
+  const ops = lcsOps(baseBlocks, headBlocks, (x, y) => x.key === y.key);
+  const changes: RawChange[] = [];
+  let lastHead = -1;
+  let run: { dels: Block[]; inss: Block[] } | null = null;
+
+  const flushRun = (): void => {
+    if (!run) return;
+    const { dels, inss } = run;
+    let j = 0;
+    for (const d of dels) {
+      let best = -1;
+      let bestSim = 0;
+      for (let k = j; k < inss.length; k++) {
+        const s = similarity(d, inss[k], lang);
+        if (s > bestSim) {
+          bestSim = s;
+          best = k;
+        }
+      }
+      if (best >= 0 && bestSim >= SIM_THRESHOLD) {
+        for (let k = j; k < best; k++) {
+          changes.push({ type: "added", head: inss[k] });
+          lastHead = inss[k].idx;
+        }
+        changes.push({ type: "modified", base: d, head: inss[best], sim: bestSim });
+        lastHead = inss[best].idx;
+        j = best + 1;
+      } else {
+        changes.push({ type: "removed", base: d, insertAfter: lastHead });
+      }
+    }
+    for (; j < inss.length; j++) {
+      changes.push({ type: "added", head: inss[j] });
+      lastHead = inss[j].idx;
+    }
+    run = null;
+  };
+
+  for (const op of ops) {
+    if (op.type === "eq") {
+      flushRun();
+      lastHead = headBlocks[op.j as number].idx;
+      continue;
+    }
+    run ??= { dels: [], inss: [] };
+    if (op.type === "del") run.dels.push(baseBlocks[op.i as number]);
+    else run.inss.push(headBlocks[op.j as number]);
+  }
+  flushRun();
+  return changes;
+}
+
+// ──────────────────────────────────────────── page metadata
+
+/** Repo-relative markdown path, read off the page's "Edit this page" link. */
+export function sourcePathOf(html: string, lang: string, slug: string): string {
+  const m = html.match(/href="[^"]*\/edit\/[^"/]+\/([^"]+\.md)"/);
+  return m ? m[1] : `src/${lang}/${slug}/${slug}.md`;
+}
+
+export function pageTitle(html: string, slug: string): string {
+  const m =
+    html.match(/breadcrumb__item--current"[^>]*>([^<]*)</) ||
+    html.match(/<h1[^>]*>([^<]*)</);
+  return m ? decode(m[1]).trim() : slug;
+}
+
+const stripMd = (s: string): string =>
+  s
+    .replace(/!\[[^\]]*\]\(([^)]*)\)/g, "$1")
+    .replace(/[*_`~]|\[([^\]]*)\]\([^)]*\)|<[^>]+>|^\s*(?:[-*+]|\d+\.|#+|>|\|)\s*/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const alnum = (s: string): string =>
+  s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
+
+/** Pre-normalized markdown lines; index + 1 is the reported line number. */
+export function markdownProbeLines(source: string): string[] {
+  return source.split("\n").map((l) => alnum(stripMd(l)));
+}
+
+/** Best-effort: first source line containing the block's opening words. */
+export function lineOf(
+  mdLines: string[] | null,
+  text: string,
+  kind: BlockKind,
+): number | null {
+  if (!mdLines || !text) return null;
+  const probe = alnum(kind === "image" ? path.basename(text) : text).slice(0, 24);
+  if (probe.length < 6) return null;
+  const i = mdLines.findIndex((l) => l.includes(probe));
+  return i >= 0 ? i + 1 : null;
+}
+
+function sectionOf(
+  change: RawChange,
+  headBlocks: Block[],
+  baseBlocks: Block[],
+): SectionRef | null {
+  const blocks = change.head ? headBlocks : baseBlocks;
+  const upto = (change.head ?? change.base)!.idx;
+  for (let i = upto - 1; i >= 0; i--) {
+    if (blocks[i].kind === "heading") {
+      return { text: blocks[i].text, id: blocks[i].hid, level: blocks[i].level };
+    }
+  }
+  return null;
+}
+
+export function fingerprintOf(change: RawChange): string {
+  const blk = (change.head ?? change.base)!;
+  return crypto
+    .createHash("sha1")
+    .update(
+      [
+        change.type,
+        blk.kind,
+        change.base?.text ?? "",
+        change.head?.text ?? "",
+        change.base?.hash ?? "",
+        change.head?.hash ?? "",
+      ].join(""),
+    )
+    .digest("hex")
+    .slice(0, 12);
+}
+
+// ──────────────────────────────────────────── stamping
+
+const PREVIEW_ASSET_LINE = /^.*assets\/pr-preview\.(?:css|js).*\n/gm;
+
+/** Undo a previous run so re-running the diff is idempotent. */
+export function stripInjected(html: string): string {
+  return html.replace(/ data-bai-block="\d+"/g, "").replace(PREVIEW_ASSET_LINE, "");
+}
+
+export function injectHead(
+  html: string,
+  blocks: Block[],
+  slug: string,
+  assetPrefix: string,
+): string {
+  // Stamp from the end so the earlier offsets stay valid.
+  const sorted = [...blocks].sort((a, b) => b.anchor.tagEnd - a.anchor.tagEnd);
+  let out = html;
+  for (const b of sorted) {
+    out =
+      out.slice(0, b.anchor.tagEnd) +
+      ` data-bai-block="${b.idx}"` +
+      out.slice(b.anchor.tagEnd);
+  }
+  const tags =
+    `  <link rel="stylesheet" href="${assetPrefix}pr-preview.css" />\n` +
+    `  <script defer src="${assetPrefix}pr-preview.js" data-page="${slug}"></script>\n`;
+  return out.replace("</head>", `${tags}</head>`);
+}
+
+function countChanges(changes: SerializedChange[]): ChangeCounts {
+  const c: ChangeCounts = {
+    added: 0,
+    modified: 0,
+    removed: 0,
+    images: 0,
+    total: changes.length,
+  };
+  for (const ch of changes) {
+    c[ch.type]++;
+    if (ch.blockKind === "image") c.images++;
+  }
+  return c;
+}
+
+function listPages(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".html"))
+    .map((f) => f.replace(/\.html$/, ""));
+}
+
+/**
+ * The channel directory the pages live under — the workspace version's
+ * label. Null when the head build has no channel directory (flat layout).
+ */
+export function resolveChannel(
+  config: ResolvedDocConfig,
+  headRoot: string,
+): string | null {
+  let candidates: string[] = [];
+  try {
+    const loaded = loadVersions(config);
+    const workspace = loaded.entries.find((v) => v.source.kind === "workspace");
+    candidates = [workspace?.outDir, loaded.latest?.outDir].filter(
+      (v): v is string => typeof v === "string",
+    );
+  } catch {
+    candidates = [];
+  }
+  for (const c of candidates) {
+    if (fs.existsSync(path.join(headRoot, c))) return c;
+  }
+  return null;
+}
+
+function resolveOverlayAsset(name: string): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "templates", "assets", name);
+}
+
+/** Copy a base-build image next to the head page so the popover can show it. */
+function copyBaseImage(
+  baseDir: string,
+  headLangDir: string,
+  src: string,
+): string | null {
+  const from = path.resolve(baseDir, src);
+  if (!fs.existsSync(from)) return null;
+  const outDir = path.join(headLangDir, "base-images");
+  fs.mkdirSync(outDir, { recursive: true });
+  const bytes = fs.readFileSync(from);
+  let name = path.basename(src);
+  const to = path.join(outDir, name);
+  if (fs.existsSync(to) && !fs.readFileSync(to).equals(bytes)) {
+    const ext = path.extname(name);
+    const hash = crypto.createHash("md5").update(bytes).digest("hex").slice(0, 8);
+    name = `${name.slice(0, name.length - ext.length)}.${hash}${ext}`;
+  }
+  fs.writeFileSync(path.join(outDir, name), bytes);
+  return `./base-images/${name}`;
+}
+
+interface SerializeContext {
+  headBlocks: Block[];
+  baseBlocks: Block[];
+  mdLines: string[] | null;
+  baseDir: string;
+  headLangDir: string;
+  lang: string;
+}
+
+function serializeChange(
+  change: RawChange,
+  id: number,
+  ctx: SerializeContext,
+): SerializedChange {
+  const blk = (change.head ?? change.base)!;
+  const out: SerializedChange = {
+    id,
+    type: change.type,
+    blockKind: blk.kind,
+    tag: blk.tag,
+    anchor: change.head ? change.head.idx : null,
+    insertAfter: change.insertAfter ?? null,
+    fingerprint: fingerprintOf(change),
+    section: sectionOf(change, ctx.headBlocks, ctx.baseBlocks),
+    line: lineOf(ctx.mdLines, (change.head ?? change.base)!.text, blk.kind),
+    oldText: change.base ? change.base.text : "",
+    newText: change.head ? change.head.text : "",
+  };
+
+  if (blk.kind === "image") {
+    out.newImage = change.head?.src ?? null;
+    out.oldImage = change.base?.src
+      ? copyBaseImage(ctx.baseDir, ctx.headLangDir, change.base.src)
+      : null;
+    out.width = blk.width;
+    out.height = blk.height;
+    return out;
+  }
+
+  out.oldHtml = change.base ? change.base.inner : "";
+  out.newHtml = change.head ? change.head.inner : "";
+  out.words = words(out.newText || out.oldText, ctx.lang).length;
+  if (change.type === "modified") {
+    out.diffHtml = diffInlineHtml(
+      change.base!.inner,
+      change.head!.inner,
+      ctx.lang,
+    );
+    out.similarity = Number((change.sim ?? 0).toFixed(2));
+    // Only tag tokens differed — no word was added or deleted.
+    if (!/class="bai-(?:del|ins)"/.test(out.diffHtml)) out.formattingOnly = true;
+  }
+  if (blk.kind === "table-row") {
+    out.oldCells = change.base?.cells ?? null;
+    out.newCells = change.head?.cells ?? null;
+  }
+  return out;
+}
+
+// ──────────────────────────────────────────── entry point
+
+export async function generateWebDiff(
+  config: ResolvedDocConfig,
+  opts: WebDiffOptions,
+): Promise<ChangesManifest> {
+  const baseRoot = path.resolve(config.projectRoot, opts.base);
+  const headRoot = path.resolve(config.projectRoot, opts.head);
+  const srcRoot = path.resolve(config.projectRoot, opts.src ?? config.srcDir);
+  const log = (msg: string): void => {
+    if (opts.quiet) console.error(msg);
+    else console.log(msg);
+  };
+
+  const channel = resolveChannel(config, headRoot);
+  const baseChannelDir = channel ? path.join(baseRoot, channel) : baseRoot;
+  const headChannelDir = channel ? path.join(headRoot, channel) : headRoot;
+  const assetPrefix = channel ? "../../assets/" : "../assets/";
+  const urlPrefix = channel ? `${channel}/` : "";
+
+  const known = Object.keys(config.languageLabels);
+  const langArg = opts.lang ?? "all";
+  const languages =
+    langArg === "all"
+      ? known.filter((l) =>
+          fs.existsSync(path.join(headChannelDir, l)),
+        )
+      : langArg
+          .split(",")
+          .map((l) => l.trim())
+          .filter(Boolean);
+
+  const manifest: ChangesManifest = {
+    version: 1,
+    channel: channel ?? "",
+    label: opts.label ?? "",
+    generatedAt: new Date().toISOString(),
+    languages,
+    langs: {},
+  };
+
+  for (const lang of languages) {
+    const baseDir = path.join(baseChannelDir, lang);
+    const headDir = path.join(headChannelDir, lang);
+    const basePages = new Set(listPages(baseDir));
+    const headPages = new Set(listPages(headDir));
+    const pages: ManifestPage[] = [];
+    const totals: LangTotals = {
+      pages: 0,
+      changes: 0,
+      added: 0,
+      modified: 0,
+      removed: 0,
+      images: 0,
+      newPages: 0,
+      deletedPages: 0,
+    };
+
+    for (const slug of [...headPages].sort()) {
+      const headFile = path.join(headDir, `${slug}.html`);
+      const headHtml = stripInjected(fs.readFileSync(headFile, "utf-8"));
+      const headBlocks = extractBlocks(headHtml, headDir);
+      if (!headBlocks) continue;
+
+      const title = pageTitle(headHtml, slug);
+      const sourcePath = sourcePathOf(headHtml, lang, slug);
+      const relMd = sourcePath.replace(/^.*?(?:^|\/)src\//, "");
+      const mdFile = path.join(srcRoot, relMd);
+      const mdLines = fs.existsSync(mdFile)
+        ? markdownProbeLines(fs.readFileSync(mdFile, "utf-8"))
+        : null;
+
+      let changes: SerializedChange[] = [];
+      let status: PageStatus = "unchanged";
+      if (!basePages.has(slug)) {
+        status = "new";
+      } else {
+        const baseHtml = fs.readFileSync(
+          path.join(baseDir, `${slug}.html`),
+          "utf-8",
+        );
+        const baseBlocks = extractBlocks(baseHtml, baseDir) ?? [];
+        const ctx: SerializeContext = {
+          headBlocks,
+          baseBlocks,
+          mdLines,
+          baseDir,
+          headLangDir: headDir,
+          lang,
+        };
+        changes = diffBlocks(baseBlocks, headBlocks, lang).map((c, i) =>
+          serializeChange(c, i + 1, ctx),
+        );
+        // The same image swapped in several places shares a fingerprint.
+        const seen = new Map<string, number>();
+        for (const ch of changes) {
+          const n = (seen.get(ch.fingerprint) ?? 0) + 1;
+          seen.set(ch.fingerprint, n);
+          if (n > 1) ch.fingerprint += `-${n}`;
+        }
+        if (changes.length) status = "modified";
+      }
+
+      const counts = countChanges(changes);
+      const sidecar: PageSidecar = {
+        slug,
+        lang,
+        title,
+        status,
+        sourcePath,
+        counts,
+        changes,
+      };
+      fs.writeFileSync(
+        path.join(headDir, `${slug}.changes.json`),
+        JSON.stringify(sidecar),
+      );
+      fs.writeFileSync(
+        headFile,
+        injectHead(headHtml, headBlocks, slug, assetPrefix),
+      );
+
+      if (status === "unchanged") continue;
+      pages.push({
+        slug,
+        title,
+        status,
+        url: `${urlPrefix}${lang}/${slug}.html`,
+        sourcePath,
+        counts,
+        fingerprints: changes.map((c) => c.fingerprint),
+      });
+      totals.pages++;
+      totals.changes += counts.total;
+      totals.added += counts.added;
+      totals.modified += counts.modified;
+      totals.removed += counts.removed;
+      totals.images += counts.images;
+      if (status === "new") totals.newPages++;
+    }
+
+    for (const slug of [...basePages].filter((s) => !headPages.has(s)).sort()) {
+      const baseHtml = fs.readFileSync(
+        path.join(baseDir, `${slug}.html`),
+        "utf-8",
+      );
+      if (!extractBlocks(baseHtml, baseDir)) continue;
+      pages.push({
+        slug,
+        title: pageTitle(baseHtml, slug),
+        status: "deleted",
+        url: null,
+        sourcePath: sourcePathOf(baseHtml, lang, slug),
+        counts: countChanges([]),
+        fingerprints: [],
+        baseUrl: `${urlPrefix}${lang}/${slug}.html`,
+      });
+      totals.pages++;
+      totals.deletedPages++;
+    }
+
+    pages.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+    manifest.langs[lang] = { totals, pages };
+    log(
+      `[${lang}] ${totals.pages} pages · ${totals.changes} changes ` +
+        `(+${totals.added} ~${totals.modified} -${totals.removed}, ${totals.images} images, ` +
+        `new ${totals.newPages}, deleted ${totals.deletedPages})`,
+    );
+    for (const p of pages) {
+      log(`    ${p.status.padEnd(9)} ${p.slug.padEnd(20)} ${p.counts.total}`);
+    }
+  }
+
+  fs.mkdirSync(headChannelDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(headChannelDir, "changes-manifest.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+  const outAssets = path.join(headRoot, "assets");
+  fs.mkdirSync(outAssets, { recursive: true });
+  for (const name of ["pr-preview.js", "pr-preview.css"]) {
+    const from = resolveOverlayAsset(name);
+    if (!fs.existsSync(from)) {
+      throw new Error(
+        `Bundled ${name} not found at ${from}. ` +
+          `Reinstall backend.ai-docs-toolkit or include templates/assets/${name}.`,
+      );
+    }
+    fs.copyFileSync(from, path.join(outAssets, name));
+  }
+  log(`manifest: ${path.join(headChannelDir, "changes-manifest.json")}`);
+  return manifest;
+}

--- a/packages/backend.ai-docs-toolkit/src/web-diff.ts
+++ b/packages/backend.ai-docs-toolkit/src/web-diff.ts
@@ -56,8 +56,12 @@ export interface Block {
   cells?: string[];
   src?: string;
   hash?: string;
+  alt?: string;
+  caption?: string;
   width?: string;
   height?: string;
+  /** Parent element a removed `li` / `tr` has to be re-inserted into. */
+  container?: "ul" | "ol" | "table" | null;
 }
 
 export interface SectionRef {
@@ -87,10 +91,15 @@ export interface SerializedChange {
   words?: number;
   oldImage?: string | null;
   newImage?: string | null;
+  oldAlt?: string;
+  newAlt?: string;
+  oldCaption?: string;
+  newCaption?: string;
   width?: string;
   height?: string;
   oldCells?: string[] | null;
   newCells?: string[] | null;
+  container?: "ul" | "ol" | "table" | null;
 }
 
 export interface ChangeCounts {
@@ -311,6 +320,19 @@ function findAll(
 // ──────────────────────────────────────────── blocks
 
 /**
+ * Authored part of a `<figcaption>`. The generated `Figure N.M` prefix
+ * renumbers whenever an image is inserted, so it must stay out of the key.
+ */
+export function captionTextOf(figure: ElementNode): string {
+  const cap = findAll(figure, (n) => n.tag === "figcaption")[0];
+  if (!cap) return "";
+  const raw = norm(cap.children.map(textOf).join(""));
+  const dashed = raw.match(/(?:&mdash;|—)\s*(.*)$/);
+  if (dashed) return dashed[1].trim();
+  return /\d+\.\d+$/.test(raw) ? "" : raw;
+}
+
+/**
  * Flatten the page's `<section class="chapter">` into comparable blocks.
  * Returns null for pages without a chapter body (redirect stubs).
  */
@@ -375,6 +397,8 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
     // The anchor is the <figure>, never the wrapping <p> — browsers split
     // `<p><figure>` into two paragraphs and the mark would land off-target.
     const anchor = imgNode.tag === "figure" ? imgNode : img;
+    const alt = attrOf(img, "alt") ?? "";
+    const caption = anchor.tag === "figure" ? captionTextOf(anchor) : "";
     blocks.push({
       idx: blocks.length,
       kind: "image",
@@ -382,10 +406,13 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
       anchor: shift(anchor),
       text: src,
       inner: "",
-      key: `image:${src}:${hash}`,
+      // Re-worded alt text or caption is a change even when the bytes match.
+      key: `image:${src}:${hash}:${alt}:${caption}`,
       hid: attrOf(anchor, "id") ?? null,
       src,
       hash,
+      alt,
+      caption,
       width: attrOf(img, "width"),
       height: attrOf(img, "height"),
     });
@@ -407,7 +434,9 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
       } else if (t === "ul" || t === "ol") {
         for (const li of ch.children) {
           if (li.type === "el" && li.tag === "li") {
-            push("list-item", li, textOf(li), innerHtml(secHtml, li));
+            push("list-item", li, textOf(li), innerHtml(secHtml, li), {
+              container: t,
+            });
           }
         }
       } else if (t === "table") {
@@ -417,6 +446,7 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
             .map((c) => norm(textOf(c)));
           push("table-row", tr, cells.join(" | "), innerHtml(secHtml, tr), {
             cells,
+            container: "table",
           });
         }
       } else if (t === "figure" || t === "img") {
@@ -600,8 +630,9 @@ export function diffInlineHtml(
   let delBuf = "";
   let insBuf = "";
   const flush = (): void => {
-    if (delBuf) out += `<del class="bai-del">${delBuf}</del>`;
-    if (insBuf) out += `<ins class="bai-ins">${insBuf}</ins>`;
+    // A whitespace-only run is spacing, not an edit: drop it, or keep it bare.
+    if (delBuf && !/^\s+$/.test(delBuf)) out += `<del class="bai-del">${delBuf}</del>`;
+    if (insBuf) out += /^\s+$/.test(insBuf) ? insBuf : `<ins class="bai-ins">${insBuf}</ins>`;
     delBuf = "";
     insBuf = "";
   };
@@ -613,6 +644,8 @@ export function diffInlineHtml(
     }
     const tok = op.type === "del" ? a[op.i as number] : b[op.j as number];
     if (tok.t === "tag") {
+      // Only the head side's markup is emitted, so the output stays balanced.
+      if (op.type === "del") continue;
       flush();
       out += tok.v;
       continue;
@@ -627,7 +660,8 @@ export function diffInlineHtml(
 /** Pairing score on plain text — markup differences never lower it. */
 export function similarity(d: Block, h: Block, lang = "en"): number {
   if (d.kind !== h.kind) return 0;
-  if (d.kind === "image") return d.src === h.src ? 1 : 0;
+  // A renamed screenshot still pairs, positionally, within its del/ins run.
+  if (d.kind === "image") return d.src === h.src ? 1 : 0.5;
   const a = words(d.text, lang);
   const b = words(h.text, lang);
   if (!a.length || !b.length) return 0;
@@ -912,11 +946,17 @@ function serializeChange(
     newText: change.head ? change.head.text : "",
   };
 
+  if (blk.container) out.container = blk.container;
+
   if (blk.kind === "image") {
     out.newImage = change.head?.src ?? null;
     out.oldImage = change.base?.src
       ? copyBaseImage(ctx.baseDir, ctx.headLangDir, change.base.src)
       : null;
+    out.oldAlt = change.base?.alt ?? "";
+    out.newAlt = change.head?.alt ?? "";
+    out.oldCaption = change.base?.caption ?? "";
+    out.newCaption = change.head?.caption ?? "";
     out.width = blk.width;
     out.height = blk.height;
     return out;

--- a/packages/backend.ai-docs-toolkit/src/web-diff.ts
+++ b/packages/backend.ai-docs-toolkit/src/web-diff.ts
@@ -58,6 +58,8 @@ export interface Block {
   hash?: string;
   alt?: string;
   caption?: string;
+  title?: string;
+  style?: string;
   width?: string;
   height?: string;
   /** Parent element a removed `li` / `tr` has to be re-inserted into. */
@@ -95,6 +97,10 @@ export interface SerializedChange {
   newAlt?: string;
   oldCaption?: string;
   newCaption?: string;
+  oldTitle?: string;
+  newTitle?: string;
+  oldStyle?: string;
+  newStyle?: string;
   width?: string;
   height?: string;
   oldCells?: string[] | null;
@@ -287,21 +293,31 @@ function decode(s: string): string {
     .replace(/&amp;/g, "&");
 }
 
-function textOf(node: HtmlNode): string {
+function textOf(node: HtmlNode, omit?: Set<ElementNode>): string {
   if (node.type === "text") return decode(node.text);
+  if (omit?.has(node)) return "";
   if (node.tag === "a" && hasClass(node, "hash-link")) return "";
   if (hasClass(node, "admonition-icon") || node.tag === "svg") return "";
   if (node.tag === "figcaption") return "";
-  return node.children.map(textOf).join("");
+  return node.children.map((c) => textOf(c, omit)).join("");
 }
 
 const norm = (s: string): string => s.replace(/\s+/g, " ").trim();
 
-function innerHtml(html: string, node: ElementNode): string {
-  return html
-    .slice(node.openEnd, node.closeStart)
-    .replace(/<a class="hash-link"[^>]*>#<\/a>/g, "")
-    .trim();
+function innerHtml(
+  html: string,
+  node: ElementNode,
+  omit: ElementNode[] = [],
+): string {
+  let out = "";
+  let cursor = node.openEnd;
+  for (const o of omit) {
+    if (o.start < cursor) continue;
+    out += html.slice(cursor, o.start);
+    cursor = o.end;
+  }
+  out += html.slice(cursor, node.closeStart);
+  return out.replace(/<a class="hash-link"[^>]*>#<\/a>/g, "").trim();
 }
 
 function findAll(
@@ -326,7 +342,7 @@ function findAll(
 export function captionTextOf(figure: ElementNode): string {
   const cap = findAll(figure, (n) => n.tag === "figcaption")[0];
   if (!cap) return "";
-  const raw = norm(cap.children.map(textOf).join(""));
+  const raw = norm(cap.children.map((c) => textOf(c)).join(""));
   const dashed = raw.match(/(?:&mdash;|—)\s*(.*)$/);
   if (dashed) return dashed[1].trim();
   return /\d+\.\d+$/.test(raw) ? "" : raw;
@@ -369,6 +385,7 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
   ): void => {
     const t = norm(text);
     if (!t) return;
+    const container = extra.container ?? null;
     blocks.push({
       idx: blocks.length,
       kind,
@@ -376,14 +393,15 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
       anchor: shift(anchor),
       text: t,
       inner,
-      // Keyed on markup, so a bold-only or link-target-only edit is a change.
-      key: `${kind}:${norm(inner)}`,
+      // Element, container and markup are all part of identity: h2→h3 and
+      // ul→ol are changes even when the text is untouched.
+      key: `${kind}:${anchor.tag}:${container ?? ""}:${norm(inner)}`,
       hid: attrOf(anchor, "id") ?? null,
       ...extra,
     });
   };
 
-  const pushImage = (imgNode: ElementNode): void => {
+  const pushImage = (imgNode: ElementNode, container?: Block["container"]): void => {
     const img =
       imgNode.tag === "img"
         ? imgNode
@@ -399,6 +417,9 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
     const anchor = imgNode.tag === "figure" ? imgNode : img;
     const alt = attrOf(img, "alt") ?? "";
     const caption = anchor.tag === "figure" ? captionTextOf(anchor) : "";
+    const title = attrOf(img, "title") ?? "";
+    // The `=50%` markdown size hint renders as an inline width.
+    const style = attrOf(img, "style") ?? "";
     blocks.push({
       idx: blocks.length,
       kind: "image",
@@ -406,21 +427,55 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
       anchor: shift(anchor),
       text: src,
       inner: "",
-      // Re-worded alt text or caption is a change even when the bytes match.
-      key: `image:${src}:${hash}:${alt}:${caption}`,
+      // Re-worded alt / caption / title, or a resize, is a change even when
+      // the bytes match.
+      key: `image:${anchor.tag}:${container ?? ""}:${src}:${hash}:${alt}:${caption}:${title}:${style}`,
       hid: attrOf(anchor, "id") ?? null,
       src,
       hash,
       alt,
       caption,
+      title,
+      style,
       width: attrOf(img, "width"),
       height: attrOf(img, "height"),
+      ...(container ? { container } : {}),
     });
+  };
+
+  // Block-level content nested inside a list item, so it becomes its own block
+  // instead of disappearing into the parent item's markup.
+  const isNested = (n: ElementNode): boolean =>
+    n.tag === "ul" ||
+    n.tag === "ol" ||
+    n.tag === "figure" ||
+    n.tag === "img" ||
+    n.tag === "table" ||
+    n.tag === "pre" ||
+    (n.tag === "div" &&
+      (hasClass(n, "code-block-wrapper") || hasClass(n, "admonition")));
+
+  const pushListItem = (li: ElementNode, container: "ul" | "ol"): void => {
+    const nested = findAll(li, isNested);
+    const omit = new Set(nested);
+    push(
+      "list-item",
+      li,
+      textOf(li, omit),
+      innerHtml(secHtml, li, nested),
+      { container },
+    );
+    for (const n of nested) visit(n);
   };
 
   const walk = (node: { children: HtmlNode[] }): void => {
     for (const ch of node.children) {
-      if (ch.type !== "el") continue;
+      if (ch.type === "el") visit(ch);
+    }
+  };
+
+  const visit = (ch: ElementNode): void => {
+    {
       const t = ch.tag;
       if (/^h[1-6]$/.test(t)) {
         push("heading", ch, textOf(ch), innerHtml(secHtml, ch), {
@@ -429,15 +484,11 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
       } else if (t === "p") {
         const figs = findAll(ch, (n) => n.tag === "figure" || n.tag === "img");
         const txt = norm(textOf(ch));
-        if (figs.length && !txt) figs.forEach(pushImage);
+        if (figs.length && !txt) figs.forEach((f) => pushImage(f));
         else if (txt) push("paragraph", ch, txt, innerHtml(secHtml, ch));
       } else if (t === "ul" || t === "ol") {
         for (const li of ch.children) {
-          if (li.type === "el" && li.tag === "li") {
-            push("list-item", li, textOf(li), innerHtml(secHtml, li), {
-              container: t,
-            });
-          }
+          if (li.type === "el" && li.tag === "li") pushListItem(li, t);
         }
       } else if (t === "table") {
         for (const tr of findAll(ch, (n) => n.tag === "tr")) {
@@ -486,7 +537,7 @@ export function extractBlocks(html: string, pageDir: string): Block[] | null {
         t === "script" ||
         t === "style"
       ) {
-        continue;
+        return;
       } else {
         push("other", ch, textOf(ch), innerHtml(secHtml, ch));
       }
@@ -795,19 +846,20 @@ function sectionOf(
   return null;
 }
 
+/**
+ * Content identity of a change. The block keys already carry markup, image
+ * bytes and image metadata, so a second formatting-only edit re-fingerprints
+ * and the overlay drops it back to unviewed.
+ */
 export function fingerprintOf(change: RawChange): string {
   const blk = (change.head ?? change.base)!;
   return crypto
     .createHash("sha1")
     .update(
-      [
-        change.type,
-        blk.kind,
-        change.base?.text ?? "",
-        change.head?.text ?? "",
-        change.base?.hash ?? "",
-        change.head?.hash ?? "",
-      ].join(""),
+      // A separator that cannot occur inside a key.
+      [change.type, blk.kind, change.base?.key ?? "", change.head?.key ?? ""].join(
+        "\u0000",
+      ),
     )
     .digest("hex")
     .slice(0, 12);
@@ -957,6 +1009,10 @@ function serializeChange(
     out.newAlt = change.head?.alt ?? "";
     out.oldCaption = change.base?.caption ?? "";
     out.newCaption = change.head?.caption ?? "";
+    out.oldTitle = change.base?.title ?? "";
+    out.newTitle = change.head?.title ?? "";
+    out.oldStyle = change.base?.style ?? "";
+    out.newStyle = change.head?.style ?? "";
     out.width = blk.width;
     out.height = blk.height;
     return out;

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
@@ -116,6 +116,12 @@
 .bai-marks-off [data-bai-change].bai-viewed::after { content: none; }
 .bai-marks-off .bai-removed-placeholder { display: none !important; }
 
+/* Marks are reachable by Tab, so the focus ring must beat `marks off`. */
+.bai-pr-preview [data-bai-change]:focus-visible {
+  outline: 3px solid var(--bai-focus) !important;
+  outline-offset: 4px !important;
+}
+
 /* ---------- focus flash (navigator jump) ---------- */
 .bai-flash {
   outline: 3px solid var(--bai-focus);
@@ -241,6 +247,13 @@
   border-left: 3px solid var(--bai-add);
   padding-left: 8px;
 }
+.bai-popover__caption {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--bai-pop-border);
+  font-size: 12px;
+}
+.bai-popover__mode button[disabled] { opacity: 0.45; cursor: default; }
 .bai-popover__img {
   cursor: zoom-in;
   border: 1px solid var(--bai-pop-border);

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
@@ -1,0 +1,465 @@
+/* PR preview overlay (FR-3879): change marks, hover diff, navigator. */
+:root {
+  --bai-add: #16a34a;
+  --bai-add-bg: rgba(34, 197, 94, 0.18);
+  --bai-mod: #ca8a04;
+  --bai-mod-bg: rgba(250, 204, 21, 0.32);
+  --bai-del: #dc2626;
+  --bai-del-bg: rgba(239, 68, 68, 0.14);
+  --bai-del-fg: #dc2626;
+  --bai-ins-bg: rgba(34, 197, 94, 0.22);
+  --bai-ins-fg: #16a34a;
+  --bai-pop-bg: #fff;
+  --bai-pop-fg: #111827;
+  --bai-pop-border: #d1d5db;
+  --bai-focus: #2563eb;
+  --bai-accent: #ff7a00;
+  --bai-viewed-line: rgba(107, 114, 128, 0.55);
+  --bai-viewed-badge: #6b7280;
+  --bai-row-hover: rgba(37, 99, 235, 0.08);
+}
+[data-theme="dark"] {
+  --bai-mod-bg: rgba(250, 204, 21, 0.22);
+  --bai-add-bg: rgba(34, 197, 94, 0.22);
+  --bai-del-fg: #fca5a5;
+  --bai-ins-fg: #86efac;
+  --bai-pop-bg: #1f2937;
+  --bai-pop-fg: #f3f4f6;
+  --bai-pop-border: #4b5563;
+  --bai-row-hover: rgba(96, 165, 250, 0.16);
+}
+
+/* ---------- word-level diff ---------- */
+.bai-del {
+  background: var(--bai-del-bg);
+  color: var(--bai-del-fg);
+  text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
+  border-radius: 2px;
+}
+.bai-ins {
+  background: var(--bai-ins-bg);
+  color: var(--bai-ins-fg);
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  border-radius: 2px;
+}
+
+/* ---------- marks ---------- */
+[data-bai-change] { position: relative; }
+.bai-pr-preview [data-bai-change][data-bai-type="modified"],
+.bai-pr-preview [data-bai-change][data-bai-type="added"] {
+  background: var(--bai-mod-bg);
+  box-shadow: 0 0 0 4px var(--bai-mod-bg);
+  outline: 1.5px dashed var(--bai-accent);
+  outline-offset: 5px;
+  border-radius: 3px;
+  cursor: help;
+}
+.bai-pr-preview [data-bai-change][data-bai-type="added"] {
+  background: var(--bai-add-bg);
+  box-shadow: 0 0 0 4px var(--bai-add-bg);
+}
+.bai-pr-preview figure[data-bai-change] { display: inline-block; padding: 4px; }
+.bai-pr-preview .bai-removed-placeholder {
+  border: 1.5px dashed var(--bai-del);
+  background: var(--bai-del-bg);
+  color: var(--bai-del-fg);
+  border-radius: 4px;
+  padding: 4px 10px;
+  margin: 6px 0;
+  font-size: 0.85em;
+  cursor: help;
+}
+.bai-pr-preview .bai-removed-placeholder::before {
+  content: "− removed: ";
+  font-weight: 600;
+}
+.bai-pr-preview .bai-removed-placeholder .bai-removed-text {
+  opacity: 0.8;
+  text-decoration: line-through;
+}
+
+/* viewed: the mark recedes to a faint dashed frame with a check badge */
+.bai-pr-preview [data-bai-change].bai-viewed[data-bai-type="modified"],
+.bai-pr-preview [data-bai-change].bai-viewed[data-bai-type="added"] {
+  background: transparent;
+  box-shadow: none;
+  outline: 1.5px dashed var(--bai-viewed-line);
+}
+.bai-pr-preview .bai-removed-placeholder.bai-viewed {
+  border-color: var(--bai-viewed-line);
+  background: transparent;
+  color: var(--bai-viewed-line);
+}
+.bai-pr-preview [data-bai-change].bai-viewed::after {
+  content: "✓ viewed";
+  position: absolute;
+  top: -12px;
+  right: -6px;
+  font: 600 10px/1 system-ui, sans-serif;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--bai-viewed-badge);
+  padding: 2px 6px;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+/* ---------- marks hidden ---------- */
+.bai-marks-off [data-bai-change] {
+  background: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+  cursor: auto;
+}
+.bai-marks-off [data-bai-change].bai-viewed::after { content: none; }
+.bai-marks-off .bai-removed-placeholder { display: none !important; }
+
+/* ---------- focus flash (navigator jump) ---------- */
+.bai-flash {
+  outline: 3px solid var(--bai-focus);
+  outline-offset: 4px;
+  transition: outline-color 1.2s ease;
+}
+.bai-flash.bai-flash--fade { outline-color: transparent; }
+
+/* ---------- hover popover ---------- */
+.bai-popover {
+  position: fixed;
+  z-index: 9000;
+  max-width: min(720px, 92vw);
+  background: var(--bai-pop-bg);
+  color: var(--bai-pop-fg);
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.bai-popover[hidden] { display: none; }
+.bai-popover__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--bai-pop-border);
+  font-size: 12px;
+}
+.bai-popover__type {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.bai-popover__type--added { color: var(--bai-add); }
+.bai-popover__type--modified { color: var(--bai-mod); }
+.bai-popover__type--removed { color: var(--bai-del); }
+.bai-popover__kind { opacity: 0.7; }
+.bai-popover__spacer { flex: 1; }
+.bai-popover__mode {
+  display: inline-flex;
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.bai-popover__mode button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 2px 8px;
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+.bai-popover__mode button[aria-pressed="true"] {
+  background: var(--bai-focus);
+  color: #fff;
+}
+.bai-popover__btn {
+  border: 1px solid var(--bai-pop-border);
+  background: transparent;
+  color: inherit;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.bai-popover__btn:hover { border-color: var(--bai-focus); color: var(--bai-focus); }
+.bai-popover__btn.bai-copied,
+.bai-nav__actions button.bai-copied {
+  background: var(--bai-add);
+  border-color: var(--bai-add);
+  color: #fff;
+}
+.bai-popover__viewed {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+.bai-popover__viewed input { margin: 0; accent-color: var(--bai-add); }
+.bai-popover__where {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin-right: 10px;
+  opacity: 0.9;
+}
+.bai-popover__hint kbd {
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-size: 10px;
+}
+.bai-popover__body { padding: 10px 12px; max-height: 60vh; overflow: auto; }
+.bai-popover__body p { margin: 0; }
+.bai-popover__body img { max-width: 100%; height: auto; }
+.bai-popover__body table { border-collapse: collapse; }
+.bai-popover__body td,
+.bai-popover__body th {
+  border: 1px solid var(--bai-pop-border);
+  padding: 2px 6px;
+}
+.bai-popover__sbs { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.bai-popover__sbs--single { grid-template-columns: 1fr; }
+.bai-popover__sbs > div { min-width: 0; }
+.bai-popover__sbs .bai-col-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  opacity: 0.6;
+  margin-bottom: 4px;
+}
+.bai-popover__sbs .bai-col--old {
+  border-left: 3px solid var(--bai-del);
+  padding-left: 8px;
+}
+.bai-popover__sbs .bai-col--new {
+  border-left: 3px solid var(--bai-add);
+  padding-left: 8px;
+}
+.bai-popover__img {
+  cursor: zoom-in;
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 4px;
+}
+.bai-popover__hint { padding: 4px 12px 8px; font-size: 11px; opacity: 0.6; }
+
+/* ---------- shortcut toast ---------- */
+.bai-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 64px;
+  transform: translateX(-50%);
+  z-index: 9200;
+  background: var(--bai-pop-fg);
+  color: var(--bai-pop-bg);
+  font: 12px/1 system-ui, sans-serif;
+  padding: 6px 12px;
+  border-radius: 999px;
+  pointer-events: none;
+}
+.bai-toast[hidden] { display: none; }
+
+/* ---------- lightbox ---------- */
+.bai-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 9500;
+  background: rgba(0, 0, 0, 0.82);
+  display: grid;
+  place-items: center;
+  cursor: zoom-out;
+}
+.bai-lightbox__pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  max-width: 96vw;
+}
+.bai-lightbox__pair img {
+  max-width: 47vw;
+  max-height: 88vh;
+  object-fit: contain;
+  background: #fff;
+}
+.bai-lightbox__pair div {
+  color: #fff;
+  text-align: center;
+  font: 600 12px system-ui, sans-serif;
+  text-transform: uppercase;
+}
+.bai-lightbox__pair div:first-child img { outline: 3px solid var(--bai-del); }
+.bai-lightbox__pair div:last-child img { outline: 3px solid var(--bai-add); }
+
+/* ---------- change navigator ---------- */
+.bai-nav {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 8800;
+  font: 13px/1.4 system-ui, -apple-system, sans-serif;
+  color: var(--bai-pop-fg);
+}
+.bai-nav__badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bai-pop-bg);
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 999px;
+  padding: 6px 8px 6px 14px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+}
+.bai-nav__badge strong { font-weight: 700; }
+.bai-nav__badge button {
+  border: 1px solid var(--bai-pop-border);
+  background: transparent;
+  color: inherit;
+  border-radius: 999px;
+  width: 26px;
+  height: 26px;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+.bai-nav__badge button:hover {
+  background: var(--bai-focus);
+  color: #fff;
+  border-color: var(--bai-focus);
+}
+.bai-nav__pos {
+  min-width: 5.5em;
+  text-align: center;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.bai-nav__pos--done { color: var(--bai-add); font-weight: 600; opacity: 1; }
+.bai-nav__panel {
+  position: absolute;
+  right: 0;
+  bottom: 44px;
+  width: 320px;
+  max-height: 60vh;
+  overflow: auto;
+  background: var(--bai-pop-bg);
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22);
+  padding: 8px 0;
+}
+.bai-nav__panel[hidden] { display: none; }
+.bai-nav__section {
+  padding: 6px 14px 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.6;
+}
+.bai-nav__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 14px;
+  text-decoration: none;
+  color: inherit;
+}
+a.bai-nav__row:hover { background: var(--bai-row-hover); }
+.bai-nav__row--current { font-weight: 700; }
+.bai-nav__row--deleted { text-decoration: line-through; opacity: 0.7; }
+.bai-nav__row .bai-nav__title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.bai-nav__count {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--bai-mod-bg);
+  color: var(--bai-pop-fg);
+  font-variant-numeric: tabular-nums;
+}
+.bai-nav__count--done { background: var(--bai-add); color: #fff; }
+.bai-nav__actions {
+  display: flex;
+  gap: 6px;
+  padding: 8px 14px 4px;
+  flex-wrap: wrap;
+}
+.bai-nav__actions button {
+  border: 1px solid var(--bai-pop-border);
+  background: transparent;
+  color: inherit;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+.bai-nav__actions button:hover { border-color: var(--bai-focus); color: var(--bai-focus); }
+.bai-nav__stale {
+  margin: 6px 14px 0;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--bai-mod-bg);
+  font-size: 11.5px;
+}
+.bai-nav__tag {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 3px;
+  color: #fff;
+}
+.bai-nav__tag--new { background: var(--bai-add); }
+.bai-nav__tag--deleted { background: var(--bai-del); }
+.bai-nav__lang { display: flex; gap: 6px; padding: 4px 14px 8px; flex-wrap: wrap; }
+.bai-nav__lang a {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--bai-pop-border);
+  text-decoration: none;
+  color: inherit;
+}
+.bai-nav__lang a.bai-nav__lang--current {
+  background: var(--bai-focus);
+  color: #fff;
+  border-color: var(--bai-focus);
+}
+
+/* ---------- sidebar page badges ---------- */
+.bai-nav-badge {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--bai-mod-bg);
+  color: inherit;
+  vertical-align: middle;
+  font-variant-numeric: tabular-nums;
+}
+.bai-nav-badge--new { background: var(--bai-add); color: #fff; }
+.bai-nav-badge--deleted { background: var(--bai-del); color: #fff; }
+
+/* ---------- new / deleted page banner ---------- */
+.bai-page-banner {
+  margin: 0 0 16px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--bai-add);
+  background: var(--bai-add-bg);
+  font-size: 13px;
+}
+.bai-page-banner--deleted {
+  border-color: var(--bai-del);
+  background: var(--bai-del-bg);
+}
+.bai-page-banner .bai-nav__tag { margin-right: 6px; }

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
@@ -1,0 +1,657 @@
+/**
+ * PR preview overlay (FR-3879).
+ *
+ * Marks the blocks a PR changed on the published docs page, shows a
+ * word-level diff on hover, and offers a per-language change navigator.
+ * Reads `<slug>.changes.json` next to the page and `../changes-manifest.json`;
+ * a 404 on either leaves the page untouched.
+ */
+(() => {
+  'use strict';
+
+  const script =
+    document.currentScript || document.querySelector('script[data-page]');
+  const slug =
+    (script && script.dataset.page) ||
+    location.pathname.split('/').pop().replace(/\.html$/, '');
+  const segs = location.pathname.split('/');
+  const lang = segs[segs.length - 2];
+
+  const KIND_LABEL = {
+    paragraph: 'paragraph',
+    heading: 'heading',
+    'list-item': 'list item',
+    'table-row': 'table row',
+    image: 'image',
+    code: 'code block',
+    'admonition-title': 'admonition',
+    summary: 'summary',
+    other: 'block',
+  };
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const el = (tag, cls, html) => {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html != null) e.innerHTML = html;
+    return e;
+  };
+  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;');
+
+  // Inline / side-by-side choice, remembered across pages.
+  let modeOverride = null;
+  try {
+    modeOverride = localStorage.getItem('bai-pr-preview:mode') || null;
+  } catch {
+    /* private mode */
+  }
+  const setMode = (m) => {
+    modeOverride = m;
+    try {
+      localStorage.setItem('bai-pr-preview:mode', m);
+    } catch {
+      /* private mode */
+    }
+  };
+
+  Promise.all([
+    fetch(`./${slug}.changes.json`).then((r) =>
+      r.ok ? r.json() : { status: 'unchanged', changes: [], counts: { total: 0 } },
+    ),
+    fetch('../changes-manifest.json').then((r) => (r.ok ? r.json() : null)),
+  ])
+    .then(([page, manifest]) => {
+      if (manifest) init(page, manifest);
+    })
+    .catch(() => {
+      /* no preview data — the page renders normally */
+    });
+
+  function init(page, manifest) {
+    const section = $('section.chapter');
+    let marks = [];
+    let current = -1;
+    let marksOn = true;
+
+    // ---------------------------------------------------------- viewed state
+    // Scoped to the deployment root (`/pr/<n>/docs/` on gh-pages, else the
+    // channel directory) so it survives new pushes to the same PR.
+    const scope = (() => {
+      const p = location.pathname;
+      const i = p.indexOf('/docs/');
+      if (i >= 0) return p.slice(0, i + 6);
+      const parts = p.split('/');
+      parts.pop();
+      parts.pop();
+      return `${parts.join('/')}/`;
+    })();
+    const storeKey = (l, s) => `bai-pr-viewed:${scope}:${l}/${s}`;
+    const readViewed = (l, s) => {
+      try {
+        return new Set(JSON.parse(localStorage.getItem(storeKey(l, s)) || '[]'));
+      } catch {
+        return new Set();
+      }
+    };
+    const writeViewed = (l, s, set) => {
+      try {
+        localStorage.setItem(storeKey(l, s), JSON.stringify([...set]));
+      } catch {
+        /* private mode */
+      }
+    };
+    const viewed = readViewed(lang, slug);
+    const live = new Set((page.changes || []).map((c) => c.fingerprint));
+    const staleViewed = [...viewed].filter((f) => !live.has(f)).length;
+    if (staleViewed) {
+      for (const f of [...viewed]) if (!live.has(f)) viewed.delete(f);
+      writeViewed(lang, slug, viewed);
+    }
+    const isViewed = (change) => viewed.has(change.fingerprint);
+    function setViewed(change, on) {
+      if (on) viewed.add(change.fingerprint);
+      else viewed.delete(change.fingerprint);
+      writeViewed(lang, slug, viewed);
+      const m = marks.find((x) => x.change === change);
+      if (m) m.el.classList.toggle('bai-viewed', on);
+      updatePos();
+      if (!panel.hidden) renderPanel();
+    }
+    const viewedCountOf = (p) => {
+      if (!p.fingerprints) return 0;
+      const s = readViewed(lang, p.slug);
+      return p.fingerprints.filter((f) => s.has(f)).length;
+    };
+
+    // ---------------------------------------------------------- copyable reference
+    const pageUrl = () => {
+      const u = new URL(location.href);
+      return u.origin + u.pathname + u.search;
+    };
+    const refText = (change) => {
+      const lines = [
+        `[docs-preview] ${lang}/${slug} · change ${change.id}/${page.changes.length} · ${change.type} ${KIND_LABEL[change.blockKind] || change.blockKind}`,
+      ];
+      lines.push(
+        `- file: ${page.sourcePath || `${lang}/${slug}/${slug}.md`}${change.line ? `:${change.line}` : ''}`,
+      );
+      if (change.section)
+        lines.push(
+          `- section: "${change.section.text}"${change.section.id ? ` (#${change.section.id})` : ''}`,
+        );
+      lines.push(`- page: ${pageUrl()}#bai-change-${change.id}`);
+      if (change.blockKind === 'image') {
+        lines.push(
+          `- image: ${change.newText || change.oldText} (${change.type === 'modified' ? 'replaced' : change.type})`,
+        );
+      } else {
+        if (change.oldText) lines.push(`- old: ${change.oldText}`);
+        if (change.newText) lines.push(`- new: ${change.newText}`);
+      }
+      return lines.join('\n');
+    };
+    const pageSummaryText = () =>
+      [
+        `[docs-preview] ${lang}/${slug} — ${page.title} · ${page.changes.length} changes`,
+        `- file: ${page.sourcePath}`,
+        `- page: ${pageUrl()}`,
+        ...page.changes.map((c) => {
+          const body = c.newText || c.oldText;
+          return `${isViewed(c) ? '[x]' : '[ ]'} #${c.id} ${c.type} ${KIND_LABEL[c.blockKind] || c.blockKind}${c.line ? ` (line ${c.line})` : ''}${c.section ? ` — ${c.section.text}` : ''}: ${body.slice(0, 100)}${body.length > 100 ? '…' : ''}`;
+        }),
+      ].join('\n');
+    async function copy(text, btn) {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        const ta = el('textarea');
+        ta.value = text;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        ta.remove();
+      }
+      if (btn) {
+        const old = btn.textContent;
+        btn.textContent = 'Copied';
+        btn.classList.add('bai-copied');
+        setTimeout(() => {
+          btn.textContent = old;
+          btn.classList.remove('bai-copied');
+        }, 1200);
+      }
+    }
+
+    // ---------------------------------------------------------- marks
+    const blockEl = (idx) =>
+      idx == null || idx < 0 ? null : $(`[data-bai-block="${idx}"]`);
+    const wrapInline = (change, inner) => {
+      switch (change.blockKind) {
+        case 'table-row':
+          return `<table><tbody><tr>${inner}</tr></tbody></table>`;
+        case 'list-item':
+          return `<ul><li>${inner}</li></ul>`;
+        case 'code':
+          return `<pre>${inner}</pre>`;
+        case 'heading':
+          return `<${change.tag}>${inner}</${change.tag}>`;
+        default:
+          return `<p>${inner}</p>`;
+      }
+    };
+    const imagePair = (change) => {
+      const col = (label, src) =>
+        `<div><div class="bai-col-label">${label}</div>${src ? `<img class="bai-popover__img" src="${src}" data-bai-zoom="${change.id}" alt="${label}" />` : '<em>—</em>'}</div>`;
+      return `<div class="bai-popover__sbs">${col('Old', change.oldImage)}${col('New', change.newImage)}</div>`;
+    };
+
+    function placeholderFor(change) {
+      const short =
+        change.oldText.length > 140
+          ? `${change.oldText.slice(0, 140)}…`
+          : change.oldText;
+      let node;
+      if (change.blockKind === 'table-row') {
+        node = el(
+          'tr',
+          'bai-removed-placeholder',
+          `<td colspan="20"><span class="bai-removed-text">${esc(short)}</span></td>`,
+        );
+      } else if (change.blockKind === 'image') {
+        node = el(
+          'figure',
+          'bai-removed-placeholder',
+          `<span class="bai-removed-text">${esc(change.oldText)}</span>`,
+        );
+      } else {
+        const tag =
+          change.blockKind === 'list-item'
+            ? 'li'
+            : change.blockKind === 'heading'
+              ? change.tag
+              : 'div';
+        node = el(
+          tag,
+          'bai-removed-placeholder',
+          `<span class="bai-removed-text">${esc(short)}</span>`,
+        );
+      }
+      node.dataset.baiChange = change.id;
+      node.dataset.baiType = 'removed';
+      return node;
+    }
+
+    function apply() {
+      document.body.classList.add('bai-pr-preview');
+      document.body.classList.toggle('bai-marks-off', !marksOn);
+      marks = [];
+      if (page.status !== 'modified' || !section) return;
+      for (const change of page.changes) {
+        let node;
+        if (change.type === 'removed') {
+          node = placeholderFor(change);
+          const after = blockEl(change.insertAfter);
+          if (after) {
+            // An <li>/<tr> placeholder must stay inside its list / table.
+            if (change.blockKind === 'table-row' && after.tagName !== 'TR') {
+              const table = after.querySelector('table') || after;
+              table.after(node);
+            } else after.after(node);
+          } else section.prepend(node);
+        } else {
+          node = blockEl(change.anchor);
+          if (!node) continue;
+          node.dataset.baiChange = change.id;
+          node.dataset.baiType = change.type;
+        }
+        node.classList.toggle('bai-viewed', isViewed(change));
+        marks.push({ change, el: node });
+      }
+      marks.sort((a, b) =>
+        a.el.compareDocumentPosition(b.el) & Node.DOCUMENT_POSITION_FOLLOWING
+          ? -1
+          : 1,
+      );
+      updatePos();
+    }
+
+    // ---------------------------------------------------------- popover
+    const pop = el('div', 'bai-popover');
+    pop.hidden = true;
+    document.body.appendChild(pop);
+    let pinned = null;
+    let hovered = null;
+    let hoverTimer = 0;
+    let hideTimer = 0;
+    const changeOf = (node) =>
+      node && page.changes.find((c) => String(c.id) === node.dataset.baiChange);
+    // What a shortcut acts on: pinned popover, else hovered block, else the
+    // change last jumped to.
+    const activeChange = () =>
+      changeOf(pinned) ||
+      changeOf(hovered) ||
+      (current >= 0 && marks[current] ? marks[current].change : null);
+
+    let toastTimer = 0;
+    const toast = el('div', 'bai-toast');
+    toast.hidden = true;
+    document.body.appendChild(toast);
+    const showToast = (text) => {
+      toast.textContent = text;
+      toast.hidden = false;
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => {
+        toast.hidden = true;
+      }, 1200);
+    };
+
+    function autoMode(change) {
+      if (modeOverride) return modeOverride;
+      const w = change.words || 0;
+      if (
+        change.blockKind === 'table-row' ||
+        change.blockKind === 'list-item' ||
+        change.blockKind === 'code'
+      )
+        return w > 40 ? 'sbs' : 'inline';
+      return w > 120 ? 'sbs' : 'inline';
+    }
+
+    function render(change) {
+      const type = change.type;
+      const kind = KIND_LABEL[change.blockKind] || change.blockKind;
+      let modeHtml = '';
+      let body = '';
+      if (change.blockKind === 'image') {
+        body = imagePair(change);
+      } else if (type === 'modified') {
+        const mode = autoMode(change);
+        modeHtml = `<span class="bai-popover__mode"><button data-mode="inline" aria-pressed="${mode === 'inline'}">Inline</button><button data-mode="sbs" aria-pressed="${mode === 'sbs'}">Side by side</button></span>`;
+        body =
+          mode === 'inline'
+            ? wrapInline(change, change.diffHtml)
+            : `<div class="bai-popover__sbs"><div class="bai-col--old"><div class="bai-col-label">Old</div>${wrapInline(change, change.oldHtml)}</div><div class="bai-col--new"><div class="bai-col-label">New</div>${wrapInline(change, change.newHtml)}</div></div>`;
+      } else if (type === 'added') {
+        body = `<div class="bai-popover__sbs bai-popover__sbs--single"><div class="bai-col--new"><div class="bai-col-label">New</div>${wrapInline(change, change.newHtml)}</div></div>`;
+      } else {
+        body = `<div class="bai-popover__sbs bai-popover__sbs--single"><div class="bai-col--old"><div class="bai-col-label">Old</div>${wrapInline(change, change.oldHtml)}</div></div>`;
+      }
+      const note = change.formattingOnly
+        ? ' · formatting / link change'
+        : change.similarity != null
+          ? ` · ${Math.round(change.similarity * 100)}% similar`
+          : '';
+      const file = page.sourcePath ? page.sourcePath.split('/').pop() : '';
+      const where = `${file}${change.line ? `:${change.line}` : ''}${change.section ? ` · ${esc(change.section.text)}` : ''}`;
+      pop.innerHTML =
+        `<div class="bai-popover__head">` +
+        `<span class="bai-popover__type bai-popover__type--${type}">${type}</span>` +
+        `<span class="bai-popover__kind">${kind}${note}</span>` +
+        `<span class="bai-popover__spacer"></span>${modeHtml}` +
+        `<button class="bai-popover__btn" data-copy title="Copy a reference to this change (file:line, section, link, old/new)">Copy ref</button>` +
+        `<label class="bai-popover__viewed" title="Mark as viewed (v)"><input type="checkbox" data-viewed ${isViewed(change) ? 'checked' : ''}/> Viewed</label>` +
+        `</div><div class="bai-popover__body">${body}</div>` +
+        `<div class="bai-popover__hint"><span class="bai-popover__where">#${change.id} · ${where}</span>${change.blockKind === 'image' ? 'Click an image to enlarge · ' : ''}Click the block to pin · <kbd>c</kbd> copy ref · <kbd>v</kbd> viewed · Esc to close</div>`;
+      pop.querySelectorAll('[data-mode]').forEach((b) =>
+        b.addEventListener('click', () => {
+          setMode(b.dataset.mode);
+          render(change);
+        }),
+      );
+      pop
+        .querySelectorAll('[data-bai-zoom]')
+        .forEach((img) => img.addEventListener('click', () => lightbox(change)));
+      $('[data-copy]', pop).addEventListener('click', (e) =>
+        copy(refText(change), e.currentTarget),
+      );
+      $('[data-viewed]', pop).addEventListener('change', (e) =>
+        setViewed(change, e.target.checked),
+      );
+    }
+
+    function position(target) {
+      const r = target.getBoundingClientRect();
+      pop.style.left = '0px';
+      pop.style.top = '0px';
+      const pw = pop.offsetWidth;
+      const ph = pop.offsetHeight;
+      const left = Math.min(Math.max(8, r.left), window.innerWidth - pw - 8);
+      let top = r.bottom + 8;
+      if (top + ph > window.innerHeight - 8) top = Math.max(8, r.top - ph - 8);
+      pop.style.left = `${left}px`;
+      pop.style.top = `${top}px`;
+    }
+    function show(target) {
+      const change = changeOf(target);
+      if (!change) return;
+      current = marks.findIndex((m) => m.change === change);
+      updatePos();
+      render(change);
+      pop.hidden = false;
+      position(target);
+    }
+    function hide() {
+      hovered = null;
+      if (pinned) return;
+      pop.hidden = true;
+    }
+
+    document.addEventListener('mouseover', (e) => {
+      if (!marksOn || !(e.target instanceof Element)) return;
+      const t = e.target.closest('[data-bai-change]');
+      if (t) {
+        hovered = t;
+        clearTimeout(hideTimer);
+        clearTimeout(hoverTimer);
+        if (!pinned) hoverTimer = setTimeout(() => show(t), 120);
+        return;
+      }
+      if (e.target.closest('.bai-popover')) clearTimeout(hideTimer);
+    });
+    document.addEventListener('mouseout', (e) => {
+      if (!(e.target instanceof Element)) return;
+      if (e.target.closest('[data-bai-change]') || e.target.closest('.bai-popover')) {
+        clearTimeout(hoverTimer);
+        clearTimeout(hideTimer);
+        hideTimer = setTimeout(hide, 220);
+      }
+    });
+    document.addEventListener('click', (e) => {
+      if (!(e.target instanceof Element)) return;
+      if (e.target.closest('.bai-popover') || e.target.closest('.bai-nav')) return;
+      const t = e.target.closest('[data-bai-change]');
+      if (marksOn && t && !e.target.closest('a')) {
+        if (pinned === t) {
+          pinned = null;
+          pop.hidden = true;
+        } else {
+          pinned = t;
+          show(t);
+        }
+        return;
+      }
+      if (pinned) {
+        pinned = null;
+        pop.hidden = true;
+      }
+    });
+
+    function lightbox(change) {
+      const box = el(
+        'div',
+        'bai-lightbox',
+        `<div class="bai-lightbox__pair"><div>Old<br><img src="${change.oldImage || ''}" alt="Old" /></div><div>New<br><img src="${change.newImage || ''}" alt="New" /></div></div>`,
+      );
+      box.addEventListener('click', () => box.remove());
+      document.body.appendChild(box);
+    }
+
+    // ---------------------------------------------------------- navigator
+    const summary = (manifest.langs && manifest.langs[lang]) || {
+      totals: { pages: 0, changes: 0 },
+      pages: [],
+    };
+    const nav = el('div', 'bai-nav');
+    nav.innerHTML =
+      `<div class="bai-nav__panel" hidden></div>` +
+      `<div class="bai-nav__badge"><strong>${summary.totals.pages} pages · ${summary.totals.changes} changes</strong>` +
+      `<span class="bai-nav__pos"></span>` +
+      `<button data-nav="prev" title="Previous change ([)">‹</button>` +
+      `<button data-nav="next" title="Next change (])">›</button>` +
+      `<button data-nav="panel" title="Changed pages">☰</button></div>`;
+    document.body.appendChild(nav);
+    const panel = $('.bai-nav__panel', nav);
+    const posEl = $('.bai-nav__pos', nav);
+    const pageIdx = summary.pages.findIndex((p) => p.slug === slug);
+
+    function renderPanel() {
+      const rows = summary.pages
+        .map((p, i) => {
+          const tag =
+            p.status === 'new'
+              ? '<span class="bai-nav__tag bai-nav__tag--new">NEW</span>'
+              : p.status === 'deleted'
+                ? '<span class="bai-nav__tag bai-nav__tag--deleted">DELETED</span>'
+                : '';
+          const v = viewedCountOf(p);
+          const count =
+            p.status === 'modified'
+              ? `<span class="bai-nav__count${v === p.counts.total ? ' bai-nav__count--done' : ''}" title="viewed / total">${v}/${p.counts.total}</span>`
+              : '';
+          const inner = `${tag}<span class="bai-nav__title">${esc(p.title)}</span>${count}`;
+          // A deleted page has no copy in this build, so it is not a link.
+          if (p.status === 'deleted')
+            return `<div class="bai-nav__row bai-nav__row--deleted">${inner}</div>`;
+          return `<a class="bai-nav__row${i === pageIdx ? ' bai-nav__row--current' : ''}" href="./${p.slug}.html#bai-change-1">${inner}</a>`;
+        })
+        .join('');
+      const langs = Object.entries(manifest.langs)
+        .map(([l, s]) => {
+          const target = s.pages.some((p) => p.slug === slug)
+            ? slug
+            : s.pages.find((p) => p.status !== 'deleted')?.slug || slug;
+          return `<a class="${l === lang ? 'bai-nav__lang--current' : ''}" href="../${l}/${target}.html">${l} · ${s.totals.changes}</a>`;
+        })
+        .join('');
+      const actions =
+        `<div class="bai-nav__actions">` +
+        (marks.length
+          ? `<button data-act="copy-page">Copy page summary</button><button data-act="all-viewed">Mark all viewed</button><button data-act="reset-viewed">Reset</button>`
+          : '') +
+        `<button data-act="marks">${marksOn ? 'Hide marks' : 'Show marks'}</button></div>`;
+      const stale = staleViewed
+        ? `<div class="bai-nav__stale">${staleViewed} change${staleViewed > 1 ? 's' : ''} you had viewed ${staleViewed > 1 ? 'have' : 'has'} changed since — shown as unviewed again</div>`
+        : '';
+      panel.innerHTML =
+        `<div class="bai-nav__section">Changed pages${manifest.label ? ` — ${esc(manifest.label)}` : ''}</div>` +
+        `${rows || '<div class="bai-nav__row"><em>No page changed</em></div>'}${stale}${actions}` +
+        `<div class="bai-nav__section">Languages</div><div class="bai-nav__lang">${langs}</div>`;
+      panel.querySelectorAll('[data-act]').forEach((b) =>
+        b.addEventListener('click', (e) => {
+          const act = b.dataset.act;
+          if (act === 'copy-page') return copy(pageSummaryText(), e.currentTarget);
+          if (act === 'marks') {
+            marksOn = !marksOn;
+            document.body.classList.toggle('bai-marks-off', !marksOn);
+            if (!marksOn) {
+              pinned = null;
+              pop.hidden = true;
+            }
+            return renderPanel();
+          }
+          for (const m of marks) {
+            if (act === 'all-viewed') viewed.add(m.change.fingerprint);
+            else viewed.delete(m.change.fingerprint);
+            m.el.classList.toggle('bai-viewed', act === 'all-viewed');
+          }
+          writeViewed(lang, slug, viewed);
+          updatePos();
+          renderPanel();
+        }),
+      );
+    }
+
+    function updatePos() {
+      const v = marks.filter((m) => isViewed(m.change)).length;
+      posEl.textContent = marks.length
+        ? `${current < 0 ? '–' : current + 1} / ${marks.length}${v ? ` · ${v} viewed` : ''}`
+        : page.status === 'new'
+          ? 'new page'
+          : 'no marks';
+      posEl.classList.toggle(
+        'bai-nav__pos--done',
+        marks.length > 0 && v === marks.length,
+      );
+    }
+    function jumpTo(i, flash = true) {
+      if (!marks.length) return;
+      current = (i + marks.length) % marks.length;
+      const target = marks[current].el;
+      target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      if (flash) {
+        document
+          .querySelectorAll('.bai-flash')
+          .forEach((n) => n.classList.remove('bai-flash', 'bai-flash--fade'));
+        target.classList.add('bai-flash');
+        setTimeout(() => target.classList.add('bai-flash--fade'), 900);
+        setTimeout(
+          () => target.classList.remove('bai-flash', 'bai-flash--fade'),
+          2200,
+        );
+      }
+      updatePos();
+    }
+    function step(dir) {
+      const next = current + dir;
+      if (marks.length && next >= 0 && next < marks.length) return jumpTo(next);
+      // At either end, hop to the neighbouring changed page.
+      const pages = summary.pages.filter((p) => p.status !== 'deleted');
+      const here = pages.findIndex((p) => p.slug === slug);
+      const target = pages[(here + dir + pages.length) % pages.length];
+      if (!target || target.slug === slug)
+        return marks.length ? jumpTo(next) : undefined;
+      location.href = `./${target.slug}.html#bai-change-${dir > 0 ? '1' : 'last'}`;
+    }
+    nav.addEventListener('click', (e) => {
+      const b = e.target.closest('button[data-nav]');
+      if (!b) return;
+      if (b.dataset.nav === 'prev') step(-1);
+      else if (b.dataset.nav === 'next') step(1);
+      else {
+        renderPanel();
+        panel.hidden = !panel.hidden;
+      }
+    });
+
+    for (const p of summary.pages) {
+      const a = document.querySelector(
+        `.doc-sidebar-nav a[href="./${p.slug}.html"]`,
+      );
+      if (!a) continue;
+      a.appendChild(
+        el(
+          'span',
+          `bai-nav-badge bai-nav-badge--${p.status}`,
+          p.status === 'new'
+            ? 'NEW'
+            : p.status === 'deleted'
+              ? 'DEL'
+              : String(p.counts.total),
+        ),
+      );
+    }
+    if (section && (page.status === 'new' || page.status === 'deleted')) {
+      const banner = el(
+        'div',
+        `bai-page-banner bai-page-banner--${page.status}`,
+        page.status === 'new'
+          ? `<span class="bai-nav__tag bai-nav__tag--new">NEW</span>This page is added by this PR — everything on it is new, so no block marks are shown.`
+          : `<span class="bai-nav__tag bai-nav__tag--deleted">DELETED</span>This page is removed by this PR. It is listed in the change navigator only.`,
+      );
+      section.before(banner);
+    }
+
+    // ---------------------------------------------------------- shortcuts
+    document.addEventListener('keydown', (e) => {
+      if (
+        e.target instanceof Element &&
+        e.target.closest('input, textarea, select, [contenteditable]')
+      )
+        return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      // Physical key codes, so the shortcuts survive an active IME.
+      const code = e.code || '';
+      if (code === 'BracketLeft') step(-1);
+      else if (code === 'BracketRight') step(1);
+      else if (code === 'KeyV') {
+        const c = activeChange();
+        if (!c) return;
+        e.preventDefault();
+        setViewed(c, !isViewed(c));
+        if (!pop.hidden) render(c);
+        showToast(isViewed(c) ? `#${c.id} viewed` : `#${c.id} unviewed`);
+      } else if (code === 'KeyC') {
+        const c = activeChange();
+        if (!c) return;
+        e.preventDefault();
+        copy(refText(c), pop.hidden ? null : $('[data-copy]', pop));
+        showToast(`Copied ref #${c.id}`);
+      } else if (code === 'Escape') {
+        pinned = null;
+        pop.hidden = true;
+        panel.hidden = true;
+        document.querySelectorAll('.bai-lightbox').forEach((n) => n.remove());
+      }
+    });
+
+    apply();
+    const m = location.hash.match(/^#bai-change-(\d+|last)$/);
+    if (m && marks.length) {
+      const i =
+        m[1] === 'last'
+          ? marks.length - 1
+          : Math.max(0, Math.min(marks.length - 1, Number(m[1]) - 1));
+      setTimeout(() => jumpTo(i), 50);
+    }
+  }
+})();

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
@@ -199,17 +199,26 @@
           return `<p>${inner}</p>`;
       }
     };
-    // Alt text / caption can change without the bytes changing, so name it.
+    // Caption, alt text, title and size can all change without the bytes.
     const captionLine = (change) => {
-      const pick =
-        (change.oldCaption || '') !== (change.newCaption || '')
-          ? ['caption', change.oldCaption, change.newCaption]
-          : (change.oldAlt || '') !== (change.newAlt || '')
-            ? ['alt text', change.oldAlt, change.newAlt]
-            : null;
-      if (!pick) return '';
-      const [label, o, n] = pick;
-      return `<div class="bai-popover__caption">${label}: <del class="bai-del">${esc(o || '(none)')}</del> → <ins class="bai-ins">${esc(n || '(none)')}</ins></div>`;
+      const facets = [];
+      const differs = (a, b) => (a || '') !== (b || '');
+      if (differs(change.oldCaption, change.newCaption))
+        facets.push(['caption', change.oldCaption, change.newCaption]);
+      else if (differs(change.oldAlt, change.newAlt))
+        facets.push(['alt text', change.oldAlt, change.newAlt]);
+      if (differs(change.oldTitle, change.newTitle))
+        facets.push(['title', change.oldTitle, change.newTitle]);
+      if (differs(change.oldStyle, change.newStyle))
+        facets.push(['size', change.oldStyle, change.newStyle]);
+      if (!facets.length) return '';
+      const rows = facets
+        .map(
+          ([label, o, n]) =>
+            `<div>${label}: <del class="bai-del">${esc(o || '(none)')}</del> → <ins class="bai-ins">${esc(n || '(none)')}</ins></div>`,
+        )
+        .join('');
+      return `<div class="bai-popover__caption">${rows}</div>`;
     };
     const imagePair = (change) => {
       const col = (label, src) =>
@@ -271,32 +280,51 @@
     }
 
     // A removed <li>/<tr> has to land inside a real list / table, so it either
-    // joins the neighbouring one or brings its own.
-    function placeRemoved(node, change) {
-      const after = blockEl(change.insertAfter);
+    // joins the neighbouring one or brings its own. Returns the outermost node
+    // placed, which is what the next placeholder for this anchor follows.
+    function placeRemoved(node, change, after, adopt) {
       const list = listOf(change);
       const needsHolder = list || change.container === 'table';
       if (!after) {
-        section.prepend(needsHolder ? wrapPlaceholder(node, change) : node);
-        return;
+        const outer = needsHolder ? wrapPlaceholder(node, change) : node;
+        section.prepend(outer);
+        return outer;
       }
       if (!needsHolder) {
         // A plain block cannot sit inside a list or table — go after the whole one.
         const host = after.closest('li, tr') ? after.closest('ul, ol, table') : null;
-        return void (host || after).after(node);
+        (host || after).after(node);
+        return node;
       }
       const tag = after.tagName;
       if ((list && tag === 'LI') || (change.container === 'table' && tag === 'TR')) {
-        return void after.after(node);
+        after.after(node);
+        return after.closest('ul, ol, table') || node;
       }
-      const next = after.nextElementSibling;
-      if (list && next && (next.tagName === 'UL' || next.tagName === 'OL')) {
-        return void next.prepend(node);
+      const next = adopt ? after.nextElementSibling : null;
+      if (list && next && next.tagName === list.toUpperCase()) {
+        next.prepend(node);
+        return next;
       }
       if (change.container === 'table' && next && next.tagName === 'TABLE') {
-        return void (next.tBodies[0] || next).prepend(node);
+        (next.tBodies[0] || next).prepend(node);
+        return next;
       }
-      after.after(wrapPlaceholder(node, change));
+      const holder = wrapPlaceholder(node, change);
+      after.after(holder);
+      return holder;
+    }
+
+    // Can the new placeholder simply follow the previous one, or would that put
+    // it inside a container that cannot hold it?
+    function chainable(prevNode, change) {
+      const parent = prevNode.parentElement;
+      if (!parent) return false;
+      const list = listOf(change);
+      if (list) return parent.tagName === list.toUpperCase();
+      if (change.container === 'table')
+        return ['TBODY', 'THEAD', 'TFOOT', 'TABLE'].includes(parent.tagName);
+      return !prevNode.closest('ul, ol, table');
     }
 
     function apply() {
@@ -313,9 +341,15 @@
           node = placeholderFor(change);
           const key = change.insertAfter == null ? -1 : change.insertAfter;
           const prev = lastAt.get(key);
-          if (prev) prev.after(node);
-          else placeRemoved(node, change);
-          lastAt.set(key, node);
+          let outer;
+          if (prev && chainable(prev.inner, change)) {
+            prev.inner.after(node);
+            outer = prev.outer;
+          } else {
+            const after = prev ? prev.outer : blockEl(change.insertAfter);
+            outer = placeRemoved(node, change, after, !prev);
+          }
+          lastAt.set(key, { inner: node, outer });
         } else {
           node = blockEl(change.anchor);
           if (!node) continue;
@@ -331,14 +365,23 @@
           : 1,
       );
       for (const { change, el: node } of marks) {
-        node.tabIndex = 0;
         node.setAttribute('role', 'button');
         node.setAttribute(
           'aria-label',
           `Change ${change.id} of ${page.changes.length}: ${change.type} ${KIND_LABEL[change.blockKind] || change.blockKind} — press Enter to show the diff`,
         );
       }
+      syncMarkFocus();
       updatePos();
+    }
+
+    // Hidden marks are inert, so they leave the tab order too.
+    function syncMarkFocus() {
+      for (const { el: node } of marks) {
+        node.tabIndex = marksOn ? 0 : -1;
+        if (marksOn) node.removeAttribute('aria-disabled');
+        else node.setAttribute('aria-disabled', 'true');
+      }
     }
 
     // ---------------------------------------------------------- popover
@@ -584,6 +627,7 @@
           if (act === 'marks') {
             marksOn = !marksOn;
             document.body.classList.toggle('bai-marks-off', !marksOn);
+            syncMarkFocus();
             if (!marksOn) {
               pinned = null;
               pop.hidden = true;
@@ -637,10 +681,17 @@
     function step(dir) {
       const next = current + dir;
       if (marks.length && next >= 0 && next < marks.length) return jumpTo(next);
-      // At either end, hop to the neighbouring changed page.
+      // At either end, hop to the neighbouring changed page. An unchanged page
+      // is not in the list, so it enters from whichever end the step came from.
       const pages = summary.pages.filter((p) => p.status !== 'deleted');
+      if (!pages.length) return;
       const here = pages.findIndex((p) => p.slug === slug);
-      const target = pages[(here + dir + pages.length) % pages.length];
+      const target =
+        here < 0
+          ? dir > 0
+            ? pages[0]
+            : pages[pages.length - 1]
+          : pages[(here + dir + pages.length) % pages.length];
       if (!target || target.slug === slug)
         return marks.length ? jumpTo(next) : undefined;
       location.href = `./${target.slug}.html#bai-change-${dir > 0 ? '1' : 'last'}`;

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
@@ -199,6 +199,18 @@
           return `<p>${inner}</p>`;
       }
     };
+    // Alt text / caption can change without the bytes changing, so name it.
+    const captionLine = (change) => {
+      const pick =
+        (change.oldCaption || '') !== (change.newCaption || '')
+          ? ['caption', change.oldCaption, change.newCaption]
+          : (change.oldAlt || '') !== (change.newAlt || '')
+            ? ['alt text', change.oldAlt, change.newAlt]
+            : null;
+      if (!pick) return '';
+      const [label, o, n] = pick;
+      return `<div class="bai-popover__caption">${label}: <del class="bai-del">${esc(o || '(none)')}</del> → <ins class="bai-ins">${esc(n || '(none)')}</ins></div>`;
+    };
     const imagePair = (change) => {
       const col = (label, src) =>
         `<div><div class="bai-col-label">${label}</div>${src ? `<img class="bai-popover__img" src="${src}" data-bai-zoom="${change.id}" alt="${label}" />` : '<em>—</em>'}</div>`;
@@ -241,23 +253,69 @@
       return node;
     }
 
+    const listOf = (change) =>
+      change.container === 'ol' ? 'ol' : change.container === 'ul' ? 'ul' : null;
+
+    function wrapPlaceholder(node, change) {
+      const list = listOf(change);
+      if (list) {
+        const holder = document.createElement(list);
+        holder.appendChild(node);
+        return holder;
+      }
+      const table = document.createElement('table');
+      const body = document.createElement('tbody');
+      body.appendChild(node);
+      table.appendChild(body);
+      return table;
+    }
+
+    // A removed <li>/<tr> has to land inside a real list / table, so it either
+    // joins the neighbouring one or brings its own.
+    function placeRemoved(node, change) {
+      const after = blockEl(change.insertAfter);
+      const list = listOf(change);
+      const needsHolder = list || change.container === 'table';
+      if (!after) {
+        section.prepend(needsHolder ? wrapPlaceholder(node, change) : node);
+        return;
+      }
+      if (!needsHolder) {
+        // A plain block cannot sit inside a list or table — go after the whole one.
+        const host = after.closest('li, tr') ? after.closest('ul, ol, table') : null;
+        return void (host || after).after(node);
+      }
+      const tag = after.tagName;
+      if ((list && tag === 'LI') || (change.container === 'table' && tag === 'TR')) {
+        return void after.after(node);
+      }
+      const next = after.nextElementSibling;
+      if (list && next && (next.tagName === 'UL' || next.tagName === 'OL')) {
+        return void next.prepend(node);
+      }
+      if (change.container === 'table' && next && next.tagName === 'TABLE') {
+        return void (next.tBodies[0] || next).prepend(node);
+      }
+      after.after(wrapPlaceholder(node, change));
+    }
+
     function apply() {
       document.body.classList.add('bai-pr-preview');
       document.body.classList.toggle('bai-marks-off', !marksOn);
       marks = [];
       if (page.status !== 'modified' || !section) return;
+      // Consecutive removals share an anchor; each follows the previous one so
+      // they keep their source order instead of stacking up reversed.
+      const lastAt = new Map();
       for (const change of page.changes) {
         let node;
         if (change.type === 'removed') {
           node = placeholderFor(change);
-          const after = blockEl(change.insertAfter);
-          if (after) {
-            // An <li>/<tr> placeholder must stay inside its list / table.
-            if (change.blockKind === 'table-row' && after.tagName !== 'TR') {
-              const table = after.querySelector('table') || after;
-              table.after(node);
-            } else after.after(node);
-          } else section.prepend(node);
+          const key = change.insertAfter == null ? -1 : change.insertAfter;
+          const prev = lastAt.get(key);
+          if (prev) prev.after(node);
+          else placeRemoved(node, change);
+          lastAt.set(key, node);
         } else {
           node = blockEl(change.anchor);
           if (!node) continue;
@@ -272,6 +330,14 @@
           ? -1
           : 1,
       );
+      for (const { change, el: node } of marks) {
+        node.tabIndex = 0;
+        node.setAttribute('role', 'button');
+        node.setAttribute(
+          'aria-label',
+          `Change ${change.id} of ${page.changes.length}: ${change.type} ${KIND_LABEL[change.blockKind] || change.blockKind} — press Enter to show the diff`,
+        );
+      }
       updatePos();
     }
 
@@ -306,6 +372,8 @@
     };
 
     function autoMode(change) {
+      // Inline shows nothing when only markup moved — the two columns do.
+      if (change.formattingOnly) return 'sbs';
       if (modeOverride) return modeOverride;
       const w = change.words || 0;
       if (
@@ -323,10 +391,13 @@
       let modeHtml = '';
       let body = '';
       if (change.blockKind === 'image') {
-        body = imagePair(change);
+        body = imagePair(change) + captionLine(change);
       } else if (type === 'modified') {
         const mode = autoMode(change);
-        modeHtml = `<span class="bai-popover__mode"><button data-mode="inline" aria-pressed="${mode === 'inline'}">Inline</button><button data-mode="sbs" aria-pressed="${mode === 'sbs'}">Side by side</button></span>`;
+        const noInline = change.formattingOnly
+          ? ' disabled title="A formatting-only change has no inline marks"'
+          : '';
+        modeHtml = `<span class="bai-popover__mode"><button data-mode="inline" aria-pressed="${mode === 'inline'}"${noInline}>Inline</button><button data-mode="sbs" aria-pressed="${mode === 'sbs'}">Side by side</button></span>`;
         body =
           mode === 'inline'
             ? wrapInline(change, change.diffHtml)
@@ -548,6 +619,8 @@
       current = (i + marks.length) % marks.length;
       const target = marks[current].el;
       target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      // Keyboard users land on the change itself, not back at the badge.
+      target.focus({ preventScroll: true });
       if (flash) {
         document
           .querySelectorAll('.bai-flash')
@@ -621,7 +694,21 @@
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       // Physical key codes, so the shortcuts survive an active IME.
       const code = e.code || '';
-      if (code === 'BracketLeft') step(-1);
+      if (code === 'Enter' || code === 'Space') {
+        const t =
+          e.target instanceof Element
+            ? e.target.closest('[data-bai-change]')
+            : null;
+        if (!t || !marksOn) return;
+        e.preventDefault();
+        if (pinned === t) {
+          pinned = null;
+          pop.hidden = true;
+        } else {
+          pinned = t;
+          show(t);
+        }
+      } else if (code === 'BracketLeft') step(-1);
       else if (code === 'BracketRight') step(1);
       else if (code === 'KeyV') {
         const c = activeChange();
@@ -647,10 +734,9 @@
     apply();
     const m = location.hash.match(/^#bai-change-(\d+|last)$/);
     if (m && marks.length) {
-      const i =
-        m[1] === 'last'
-          ? marks.length - 1
-          : Math.max(0, Math.min(marks.length - 1, Number(m[1]) - 1));
+      // Resolve by change id, the number Copy ref and the popover both show.
+      const byId = marks.findIndex((x) => String(x.change.id) === m[1]);
+      const i = m[1] === 'last' ? marks.length - 1 : byId >= 0 ? byId : 0;
       setTimeout(() => jumpTo(i), 50);
     }
   }

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
@@ -7,26 +7,29 @@
  * a 404 on either leaves the page untouched.
  */
 (() => {
-  'use strict';
+  "use strict";
 
   const script =
-    document.currentScript || document.querySelector('script[data-page]');
+    document.currentScript || document.querySelector("script[data-page]");
   const slug =
     (script && script.dataset.page) ||
-    location.pathname.split('/').pop().replace(/\.html$/, '');
-  const segs = location.pathname.split('/');
+    location.pathname
+      .split("/")
+      .pop()
+      .replace(/\.html$/, "");
+  const segs = location.pathname.split("/");
   const lang = segs[segs.length - 2];
 
   const KIND_LABEL = {
-    paragraph: 'paragraph',
-    heading: 'heading',
-    'list-item': 'list item',
-    'table-row': 'table row',
-    image: 'image',
-    code: 'code block',
-    'admonition-title': 'admonition',
-    summary: 'summary',
-    other: 'block',
+    paragraph: "paragraph",
+    heading: "heading",
+    "list-item": "list item",
+    "table-row": "table row",
+    image: "image",
+    code: "code block",
+    "admonition-title": "admonition",
+    summary: "summary",
+    other: "block",
   };
 
   const $ = (sel, root = document) => root.querySelector(sel);
@@ -36,19 +39,19 @@
     if (html != null) e.innerHTML = html;
     return e;
   };
-  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;');
+  const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;");
 
   // Inline / side-by-side choice, remembered across pages.
   let modeOverride = null;
   try {
-    modeOverride = localStorage.getItem('bai-pr-preview:mode') || null;
+    modeOverride = localStorage.getItem("bai-pr-preview:mode") || null;
   } catch {
     /* private mode */
   }
   const setMode = (m) => {
     modeOverride = m;
     try {
-      localStorage.setItem('bai-pr-preview:mode', m);
+      localStorage.setItem("bai-pr-preview:mode", m);
     } catch {
       /* private mode */
     }
@@ -56,9 +59,11 @@
 
   Promise.all([
     fetch(`./${slug}.changes.json`).then((r) =>
-      r.ok ? r.json() : { status: 'unchanged', changes: [], counts: { total: 0 } },
+      r.ok
+        ? r.json()
+        : { status: "unchanged", changes: [], counts: { total: 0 } },
     ),
-    fetch('../changes-manifest.json').then((r) => (r.ok ? r.json() : null)),
+    fetch("../changes-manifest.json").then((r) => (r.ok ? r.json() : null)),
   ])
     .then(([page, manifest]) => {
       if (manifest) init(page, manifest);
@@ -68,7 +73,7 @@
     });
 
   function init(page, manifest) {
-    const section = $('section.chapter');
+    const section = $("section.chapter");
     let marks = [];
     let current = -1;
     let marksOn = true;
@@ -78,17 +83,19 @@
     // channel directory) so it survives new pushes to the same PR.
     const scope = (() => {
       const p = location.pathname;
-      const i = p.indexOf('/docs/');
+      const i = p.indexOf("/docs/");
       if (i >= 0) return p.slice(0, i + 6);
-      const parts = p.split('/');
+      const parts = p.split("/");
       parts.pop();
       parts.pop();
-      return `${parts.join('/')}/`;
+      return `${parts.join("/")}/`;
     })();
     const storeKey = (l, s) => `bai-pr-viewed:${scope}:${l}/${s}`;
     const readViewed = (l, s) => {
       try {
-        return new Set(JSON.parse(localStorage.getItem(storeKey(l, s)) || '[]'));
+        return new Set(
+          JSON.parse(localStorage.getItem(storeKey(l, s)) || "[]"),
+        );
       } catch {
         return new Set();
       }
@@ -113,7 +120,7 @@
       else viewed.delete(change.fingerprint);
       writeViewed(lang, slug, viewed);
       const m = marks.find((x) => x.change === change);
-      if (m) m.el.classList.toggle('bai-viewed', on);
+      if (m) m.el.classList.toggle("bai-viewed", on);
       updatePos();
       if (!panel.hidden) renderPanel();
     }
@@ -133,22 +140,22 @@
         `[docs-preview] ${lang}/${slug} · change ${change.id}/${page.changes.length} · ${change.type} ${KIND_LABEL[change.blockKind] || change.blockKind}`,
       ];
       lines.push(
-        `- file: ${page.sourcePath || `${lang}/${slug}/${slug}.md`}${change.line ? `:${change.line}` : ''}`,
+        `- file: ${page.sourcePath || `${lang}/${slug}/${slug}.md`}${change.line ? `:${change.line}` : ""}`,
       );
       if (change.section)
         lines.push(
-          `- section: "${change.section.text}"${change.section.id ? ` (#${change.section.id})` : ''}`,
+          `- section: "${change.section.text}"${change.section.id ? ` (#${change.section.id})` : ""}`,
         );
       lines.push(`- page: ${pageUrl()}#bai-change-${change.id}`);
-      if (change.blockKind === 'image') {
+      if (change.blockKind === "image") {
         lines.push(
-          `- image: ${change.newText || change.oldText} (${change.type === 'modified' ? 'replaced' : change.type})`,
+          `- image: ${change.newText || change.oldText} (${change.type === "modified" ? "replaced" : change.type})`,
         );
       } else {
         if (change.oldText) lines.push(`- old: ${change.oldText}`);
         if (change.newText) lines.push(`- new: ${change.newText}`);
       }
-      return lines.join('\n');
+      return lines.join("\n");
     };
     const pageSummaryText = () =>
       [
@@ -157,27 +164,27 @@
         `- page: ${pageUrl()}`,
         ...page.changes.map((c) => {
           const body = c.newText || c.oldText;
-          return `${isViewed(c) ? '[x]' : '[ ]'} #${c.id} ${c.type} ${KIND_LABEL[c.blockKind] || c.blockKind}${c.line ? ` (line ${c.line})` : ''}${c.section ? ` — ${c.section.text}` : ''}: ${body.slice(0, 100)}${body.length > 100 ? '…' : ''}`;
+          return `${isViewed(c) ? "[x]" : "[ ]"} #${c.id} ${c.type} ${KIND_LABEL[c.blockKind] || c.blockKind}${c.line ? ` (line ${c.line})` : ""}${c.section ? ` — ${c.section.text}` : ""}: ${body.slice(0, 100)}${body.length > 100 ? "…" : ""}`;
         }),
-      ].join('\n');
+      ].join("\n");
     async function copy(text, btn) {
       try {
         await navigator.clipboard.writeText(text);
       } catch {
-        const ta = el('textarea');
+        const ta = el("textarea");
         ta.value = text;
         document.body.appendChild(ta);
         ta.select();
-        document.execCommand('copy');
+        document.execCommand("copy");
         ta.remove();
       }
       if (btn) {
         const old = btn.textContent;
-        btn.textContent = 'Copied';
-        btn.classList.add('bai-copied');
+        btn.textContent = "Copied";
+        btn.classList.add("bai-copied");
         setTimeout(() => {
           btn.textContent = old;
-          btn.classList.remove('bai-copied');
+          btn.classList.remove("bai-copied");
         }, 1200);
       }
     }
@@ -187,13 +194,13 @@
       idx == null || idx < 0 ? null : $(`[data-bai-block="${idx}"]`);
     const wrapInline = (change, inner) => {
       switch (change.blockKind) {
-        case 'table-row':
+        case "table-row":
           return `<table><tbody><tr>${inner}</tr></tbody></table>`;
-        case 'list-item':
+        case "list-item":
           return `<ul><li>${inner}</li></ul>`;
-        case 'code':
+        case "code":
           return `<pre>${inner}</pre>`;
-        case 'heading':
+        case "heading":
           return `<${change.tag}>${inner}</${change.tag}>`;
         default:
           return `<p>${inner}</p>`;
@@ -202,28 +209,28 @@
     // Caption, alt text, title and size can all change without the bytes.
     const captionLine = (change) => {
       const facets = [];
-      const differs = (a, b) => (a || '') !== (b || '');
+      const differs = (a, b) => (a || "") !== (b || "");
       if (differs(change.oldCaption, change.newCaption))
-        facets.push(['caption', change.oldCaption, change.newCaption]);
+        facets.push(["caption", change.oldCaption, change.newCaption]);
       else if (differs(change.oldAlt, change.newAlt))
-        facets.push(['alt text', change.oldAlt, change.newAlt]);
+        facets.push(["alt text", change.oldAlt, change.newAlt]);
       if (differs(change.oldTitle, change.newTitle))
-        facets.push(['title', change.oldTitle, change.newTitle]);
+        facets.push(["title", change.oldTitle, change.newTitle]);
       if (differs(change.oldStyle, change.newStyle))
-        facets.push(['size', change.oldStyle, change.newStyle]);
-      if (!facets.length) return '';
+        facets.push(["size", change.oldStyle, change.newStyle]);
+      if (!facets.length) return "";
       const rows = facets
         .map(
           ([label, o, n]) =>
-            `<div>${label}: <del class="bai-del">${esc(o || '(none)')}</del> → <ins class="bai-ins">${esc(n || '(none)')}</ins></div>`,
+            `<div>${label}: <del class="bai-del">${esc(o || "(none)")}</del> → <ins class="bai-ins">${esc(n || "(none)")}</ins></div>`,
         )
-        .join('');
+        .join("");
       return `<div class="bai-popover__caption">${rows}</div>`;
     };
     const imagePair = (change) => {
       const col = (label, src) =>
-        `<div><div class="bai-col-label">${label}</div>${src ? `<img class="bai-popover__img" src="${src}" data-bai-zoom="${change.id}" alt="${label}" />` : '<em>—</em>'}</div>`;
-      return `<div class="bai-popover__sbs">${col('Old', change.oldImage)}${col('New', change.newImage)}</div>`;
+        `<div><div class="bai-col-label">${label}</div>${src ? `<img class="bai-popover__img" src="${src}" data-bai-zoom="${change.id}" alt="${label}" />` : "<em>—</em>"}</div>`;
+      return `<div class="bai-popover__sbs">${col("Old", change.oldImage)}${col("New", change.newImage)}</div>`;
     };
 
     function placeholderFor(change) {
@@ -232,38 +239,42 @@
           ? `${change.oldText.slice(0, 140)}…`
           : change.oldText;
       let node;
-      if (change.blockKind === 'table-row') {
+      if (change.blockKind === "table-row") {
         node = el(
-          'tr',
-          'bai-removed-placeholder',
+          "tr",
+          "bai-removed-placeholder",
           `<td colspan="20"><span class="bai-removed-text">${esc(short)}</span></td>`,
         );
-      } else if (change.blockKind === 'image') {
+      } else if (change.blockKind === "image") {
         node = el(
-          'figure',
-          'bai-removed-placeholder',
+          "figure",
+          "bai-removed-placeholder",
           `<span class="bai-removed-text">${esc(change.oldText)}</span>`,
         );
       } else {
         const tag =
-          change.blockKind === 'list-item'
-            ? 'li'
-            : change.blockKind === 'heading'
+          change.blockKind === "list-item"
+            ? "li"
+            : change.blockKind === "heading"
               ? change.tag
-              : 'div';
+              : "div";
         node = el(
           tag,
-          'bai-removed-placeholder',
+          "bai-removed-placeholder",
           `<span class="bai-removed-text">${esc(short)}</span>`,
         );
       }
       node.dataset.baiChange = change.id;
-      node.dataset.baiType = 'removed';
+      node.dataset.baiType = "removed";
       return node;
     }
 
     const listOf = (change) =>
-      change.container === 'ol' ? 'ol' : change.container === 'ul' ? 'ul' : null;
+      change.container === "ol"
+        ? "ol"
+        : change.container === "ul"
+          ? "ul"
+          : null;
 
     function wrapPlaceholder(node, change) {
       const list = listOf(change);
@@ -272,8 +283,8 @@
         holder.appendChild(node);
         return holder;
       }
-      const table = document.createElement('table');
-      const body = document.createElement('tbody');
+      const table = document.createElement("table");
+      const body = document.createElement("tbody");
       body.appendChild(node);
       table.appendChild(body);
       return table;
@@ -284,7 +295,7 @@
     // placed, which is what the next placeholder for this anchor follows.
     function placeRemoved(node, change, after, adopt) {
       const list = listOf(change);
-      const needsHolder = list || change.container === 'table';
+      const needsHolder = list || change.container === "table";
       if (!after) {
         const outer = needsHolder ? wrapPlaceholder(node, change) : node;
         section.prepend(outer);
@@ -292,21 +303,26 @@
       }
       if (!needsHolder) {
         // A plain block cannot sit inside a list or table — go after the whole one.
-        const host = after.closest('li, tr') ? after.closest('ul, ol, table') : null;
+        const host = after.closest("li, tr")
+          ? after.closest("ul, ol, table")
+          : null;
         (host || after).after(node);
         return node;
       }
       const tag = after.tagName;
-      if ((list && tag === 'LI') || (change.container === 'table' && tag === 'TR')) {
+      if (
+        (list && tag === "LI") ||
+        (change.container === "table" && tag === "TR")
+      ) {
         after.after(node);
-        return after.closest('ul, ol, table') || node;
+        return after.closest("ul, ol, table") || node;
       }
       const next = adopt ? after.nextElementSibling : null;
       if (list && next && next.tagName === list.toUpperCase()) {
         next.prepend(node);
         return next;
       }
-      if (change.container === 'table' && next && next.tagName === 'TABLE') {
+      if (change.container === "table" && next && next.tagName === "TABLE") {
         (next.tBodies[0] || next).prepend(node);
         return next;
       }
@@ -322,22 +338,22 @@
       if (!parent) return false;
       const list = listOf(change);
       if (list) return parent.tagName === list.toUpperCase();
-      if (change.container === 'table')
-        return ['TBODY', 'THEAD', 'TFOOT', 'TABLE'].includes(parent.tagName);
-      return !prevNode.closest('ul, ol, table');
+      if (change.container === "table")
+        return ["TBODY", "THEAD", "TFOOT", "TABLE"].includes(parent.tagName);
+      return !prevNode.closest("ul, ol, table");
     }
 
     function apply() {
-      document.body.classList.add('bai-pr-preview');
-      document.body.classList.toggle('bai-marks-off', !marksOn);
+      document.body.classList.add("bai-pr-preview");
+      document.body.classList.toggle("bai-marks-off", !marksOn);
       marks = [];
-      if (page.status !== 'modified' || !section) return;
+      if (page.status !== "modified" || !section) return;
       // Consecutive removals share an anchor; each follows the previous one so
       // they keep their source order instead of stacking up reversed.
       const lastAt = new Map();
       for (const change of page.changes) {
         let node;
-        if (change.type === 'removed') {
+        if (change.type === "removed") {
           node = placeholderFor(change);
           const key = change.insertAfter == null ? -1 : change.insertAfter;
           const prev = lastAt.get(key);
@@ -356,7 +372,7 @@
           node.dataset.baiChange = change.id;
           node.dataset.baiType = change.type;
         }
-        node.classList.toggle('bai-viewed', isViewed(change));
+        node.classList.toggle("bai-viewed", isViewed(change));
         marks.push({ change, el: node });
       }
       marks.sort((a, b) =>
@@ -365,9 +381,9 @@
           : 1,
       );
       for (const { change, el: node } of marks) {
-        node.setAttribute('role', 'button');
+        node.setAttribute("role", "button");
         node.setAttribute(
-          'aria-label',
+          "aria-label",
           `Change ${change.id} of ${page.changes.length}: ${change.type} ${KIND_LABEL[change.blockKind] || change.blockKind} — press Enter to show the diff`,
         );
       }
@@ -379,13 +395,13 @@
     function syncMarkFocus() {
       for (const { el: node } of marks) {
         node.tabIndex = marksOn ? 0 : -1;
-        if (marksOn) node.removeAttribute('aria-disabled');
-        else node.setAttribute('aria-disabled', 'true');
+        if (marksOn) node.removeAttribute("aria-disabled");
+        else node.setAttribute("aria-disabled", "true");
       }
     }
 
     // ---------------------------------------------------------- popover
-    const pop = el('div', 'bai-popover');
+    const pop = el("div", "bai-popover");
     pop.hidden = true;
     document.body.appendChild(pop);
     let pinned = null;
@@ -402,7 +418,7 @@
       (current >= 0 && marks[current] ? marks[current].change : null);
 
     let toastTimer = 0;
-    const toast = el('div', 'bai-toast');
+    const toast = el("div", "bai-toast");
     toast.hidden = true;
     document.body.appendChild(toast);
     const showToast = (text) => {
@@ -416,77 +432,79 @@
 
     function autoMode(change) {
       // Inline shows nothing when only markup moved — the two columns do.
-      if (change.formattingOnly) return 'sbs';
+      if (change.formattingOnly) return "sbs";
       if (modeOverride) return modeOverride;
       const w = change.words || 0;
       if (
-        change.blockKind === 'table-row' ||
-        change.blockKind === 'list-item' ||
-        change.blockKind === 'code'
+        change.blockKind === "table-row" ||
+        change.blockKind === "list-item" ||
+        change.blockKind === "code"
       )
-        return w > 40 ? 'sbs' : 'inline';
-      return w > 120 ? 'sbs' : 'inline';
+        return w > 40 ? "sbs" : "inline";
+      return w > 120 ? "sbs" : "inline";
     }
 
     function render(change) {
       const type = change.type;
       const kind = KIND_LABEL[change.blockKind] || change.blockKind;
-      let modeHtml = '';
-      let body = '';
-      if (change.blockKind === 'image') {
+      let modeHtml = "";
+      let body = "";
+      if (change.blockKind === "image") {
         body = imagePair(change) + captionLine(change);
-      } else if (type === 'modified') {
+      } else if (type === "modified") {
         const mode = autoMode(change);
         const noInline = change.formattingOnly
           ? ' disabled title="A formatting-only change has no inline marks"'
-          : '';
-        modeHtml = `<span class="bai-popover__mode"><button data-mode="inline" aria-pressed="${mode === 'inline'}"${noInline}>Inline</button><button data-mode="sbs" aria-pressed="${mode === 'sbs'}">Side by side</button></span>`;
+          : "";
+        modeHtml = `<span class="bai-popover__mode"><button data-mode="inline" aria-pressed="${mode === "inline"}"${noInline}>Inline</button><button data-mode="sbs" aria-pressed="${mode === "sbs"}">Side by side</button></span>`;
         body =
-          mode === 'inline'
+          mode === "inline"
             ? wrapInline(change, change.diffHtml)
             : `<div class="bai-popover__sbs"><div class="bai-col--old"><div class="bai-col-label">Old</div>${wrapInline(change, change.oldHtml)}</div><div class="bai-col--new"><div class="bai-col-label">New</div>${wrapInline(change, change.newHtml)}</div></div>`;
-      } else if (type === 'added') {
+      } else if (type === "added") {
         body = `<div class="bai-popover__sbs bai-popover__sbs--single"><div class="bai-col--new"><div class="bai-col-label">New</div>${wrapInline(change, change.newHtml)}</div></div>`;
       } else {
         body = `<div class="bai-popover__sbs bai-popover__sbs--single"><div class="bai-col--old"><div class="bai-col-label">Old</div>${wrapInline(change, change.oldHtml)}</div></div>`;
       }
       const note = change.formattingOnly
-        ? ' · formatting / link change'
+        ? " · formatting / link change"
         : change.similarity != null
           ? ` · ${Math.round(change.similarity * 100)}% similar`
-          : '';
-      const file = page.sourcePath ? page.sourcePath.split('/').pop() : '';
-      const where = `${file}${change.line ? `:${change.line}` : ''}${change.section ? ` · ${esc(change.section.text)}` : ''}`;
+          : "";
+      const file = page.sourcePath ? page.sourcePath.split("/").pop() : "";
+      const where = `${file}${change.line ? `:${change.line}` : ""}${change.section ? ` · ${esc(change.section.text)}` : ""}`;
       pop.innerHTML =
         `<div class="bai-popover__head">` +
         `<span class="bai-popover__type bai-popover__type--${type}">${type}</span>` +
         `<span class="bai-popover__kind">${kind}${note}</span>` +
         `<span class="bai-popover__spacer"></span>${modeHtml}` +
         `<button class="bai-popover__btn" data-copy title="Copy a reference to this change (file:line, section, link, old/new)">Copy ref</button>` +
-        `<label class="bai-popover__viewed" title="Mark as viewed (v)"><input type="checkbox" data-viewed ${isViewed(change) ? 'checked' : ''}/> Viewed</label>` +
+        `<label class="bai-popover__viewed" title="Mark as viewed (v)"><input type="checkbox" data-viewed ${isViewed(change) ? "checked" : ""}/> Viewed</label>` +
         `</div><div class="bai-popover__body">${body}</div>` +
-        `<div class="bai-popover__hint"><span class="bai-popover__where">#${change.id} · ${where}</span>${change.blockKind === 'image' ? 'Click an image to enlarge · ' : ''}Click the block to pin · <kbd>c</kbd> copy ref · <kbd>v</kbd> viewed · Esc to close</div>`;
-      pop.querySelectorAll('[data-mode]').forEach((b) =>
-        b.addEventListener('click', () => {
+        `<div class="bai-popover__hint"><span class="bai-popover__where">#${change.id} · ${where}</span>${change.blockKind === "image" ? "Click an image to enlarge · " : ""}Click the block to pin · <kbd>n</kbd> / <kbd>p</kbd> next / previous change · <kbd>c</kbd> copy ref · <kbd>v</kbd> viewed · Esc to close</div>`;
+      pop.querySelectorAll("[data-mode]").forEach((b) =>
+        b.addEventListener("click", () => {
           setMode(b.dataset.mode);
           render(change);
         }),
       );
       pop
-        .querySelectorAll('[data-bai-zoom]')
-        .forEach((img) => img.addEventListener('click', () => lightbox(change)));
-      $('[data-copy]', pop).addEventListener('click', (e) =>
+        .querySelectorAll("[data-bai-zoom]")
+        .forEach((img) =>
+          img.addEventListener("click", () => lightbox(change)),
+        );
+      $("[data-copy]", pop).addEventListener("click", (e) =>
         copy(refText(change), e.currentTarget),
       );
-      $('[data-viewed]', pop).addEventListener('change', (e) =>
+      $("[data-viewed]", pop).addEventListener("change", (e) =>
         setViewed(change, e.target.checked),
       );
     }
 
     function position(target) {
       const r = target.getBoundingClientRect();
-      pop.style.left = '0px';
-      pop.style.top = '0px';
+      pop.style.left = "0px";
+      pop.style.top = "0px";
       const pw = pop.offsetWidth;
       const ph = pop.offsetHeight;
       const left = Math.min(Math.max(8, r.left), window.innerWidth - pw - 8);
@@ -510,9 +528,9 @@
       pop.hidden = true;
     }
 
-    document.addEventListener('mouseover', (e) => {
+    document.addEventListener("mouseover", (e) => {
       if (!marksOn || !(e.target instanceof Element)) return;
-      const t = e.target.closest('[data-bai-change]');
+      const t = e.target.closest("[data-bai-change]");
       if (t) {
         hovered = t;
         clearTimeout(hideTimer);
@@ -520,21 +538,25 @@
         if (!pinned) hoverTimer = setTimeout(() => show(t), 120);
         return;
       }
-      if (e.target.closest('.bai-popover')) clearTimeout(hideTimer);
+      if (e.target.closest(".bai-popover")) clearTimeout(hideTimer);
     });
-    document.addEventListener('mouseout', (e) => {
+    document.addEventListener("mouseout", (e) => {
       if (!(e.target instanceof Element)) return;
-      if (e.target.closest('[data-bai-change]') || e.target.closest('.bai-popover')) {
+      if (
+        e.target.closest("[data-bai-change]") ||
+        e.target.closest(".bai-popover")
+      ) {
         clearTimeout(hoverTimer);
         clearTimeout(hideTimer);
         hideTimer = setTimeout(hide, 220);
       }
     });
-    document.addEventListener('click', (e) => {
+    document.addEventListener("click", (e) => {
       if (!(e.target instanceof Element)) return;
-      if (e.target.closest('.bai-popover') || e.target.closest('.bai-nav')) return;
-      const t = e.target.closest('[data-bai-change]');
-      if (marksOn && t && !e.target.closest('a')) {
+      if (e.target.closest(".bai-popover") || e.target.closest(".bai-nav"))
+        return;
+      const t = e.target.closest("[data-bai-change]");
+      if (marksOn && t && !e.target.closest("a")) {
         if (pinned === t) {
           pinned = null;
           pop.hidden = true;
@@ -552,11 +574,11 @@
 
     function lightbox(change) {
       const box = el(
-        'div',
-        'bai-lightbox',
-        `<div class="bai-lightbox__pair"><div>Old<br><img src="${change.oldImage || ''}" alt="Old" /></div><div>New<br><img src="${change.newImage || ''}" alt="New" /></div></div>`,
+        "div",
+        "bai-lightbox",
+        `<div class="bai-lightbox__pair"><div>Old<br><img src="${change.oldImage || ""}" alt="Old" /></div><div>New<br><img src="${change.newImage || ""}" alt="New" /></div></div>`,
       );
-      box.addEventListener('click', () => box.remove());
+      box.addEventListener("click", () => box.remove());
       document.body.appendChild(box);
     }
 
@@ -565,68 +587,69 @@
       totals: { pages: 0, changes: 0 },
       pages: [],
     };
-    const nav = el('div', 'bai-nav');
+    const nav = el("div", "bai-nav");
     nav.innerHTML =
       `<div class="bai-nav__panel" hidden></div>` +
       `<div class="bai-nav__badge"><strong>${summary.totals.pages} pages · ${summary.totals.changes} changes</strong>` +
       `<span class="bai-nav__pos"></span>` +
-      `<button data-nav="prev" title="Previous change ([)">‹</button>` +
-      `<button data-nav="next" title="Next change (])">›</button>` +
+      `<button data-nav="prev" title="Previous change (p) — wraps to the previous changed page">‹</button>` +
+      `<button data-nav="next" title="Next change (n) — wraps to the next changed page">›</button>` +
       `<button data-nav="panel" title="Changed pages">☰</button></div>`;
     document.body.appendChild(nav);
-    const panel = $('.bai-nav__panel', nav);
-    const posEl = $('.bai-nav__pos', nav);
+    const panel = $(".bai-nav__panel", nav);
+    const posEl = $(".bai-nav__pos", nav);
     const pageIdx = summary.pages.findIndex((p) => p.slug === slug);
 
     function renderPanel() {
       const rows = summary.pages
         .map((p, i) => {
           const tag =
-            p.status === 'new'
+            p.status === "new"
               ? '<span class="bai-nav__tag bai-nav__tag--new">NEW</span>'
-              : p.status === 'deleted'
+              : p.status === "deleted"
                 ? '<span class="bai-nav__tag bai-nav__tag--deleted">DELETED</span>'
-                : '';
+                : "";
           const v = viewedCountOf(p);
           const count =
-            p.status === 'modified'
-              ? `<span class="bai-nav__count${v === p.counts.total ? ' bai-nav__count--done' : ''}" title="viewed / total">${v}/${p.counts.total}</span>`
-              : '';
+            p.status === "modified"
+              ? `<span class="bai-nav__count${v === p.counts.total ? " bai-nav__count--done" : ""}" title="viewed / total">${v}/${p.counts.total}</span>`
+              : "";
           const inner = `${tag}<span class="bai-nav__title">${esc(p.title)}</span>${count}`;
           // A deleted page has no copy in this build, so it is not a link.
-          if (p.status === 'deleted')
+          if (p.status === "deleted")
             return `<div class="bai-nav__row bai-nav__row--deleted">${inner}</div>`;
-          return `<a class="bai-nav__row${i === pageIdx ? ' bai-nav__row--current' : ''}" href="./${p.slug}.html#bai-change-1">${inner}</a>`;
+          return `<a class="bai-nav__row${i === pageIdx ? " bai-nav__row--current" : ""}" href="./${p.slug}.html#bai-change-1">${inner}</a>`;
         })
-        .join('');
+        .join("");
       const langs = Object.entries(manifest.langs)
         .map(([l, s]) => {
           const target = s.pages.some((p) => p.slug === slug)
             ? slug
-            : s.pages.find((p) => p.status !== 'deleted')?.slug || slug;
-          return `<a class="${l === lang ? 'bai-nav__lang--current' : ''}" href="../${l}/${target}.html">${l} · ${s.totals.changes}</a>`;
+            : s.pages.find((p) => p.status !== "deleted")?.slug || slug;
+          return `<a class="${l === lang ? "bai-nav__lang--current" : ""}" href="../${l}/${target}.html">${l} · ${s.totals.changes}</a>`;
         })
-        .join('');
+        .join("");
       const actions =
         `<div class="bai-nav__actions">` +
         (marks.length
           ? `<button data-act="copy-page">Copy page summary</button><button data-act="all-viewed">Mark all viewed</button><button data-act="reset-viewed">Reset</button>`
-          : '') +
-        `<button data-act="marks">${marksOn ? 'Hide marks' : 'Show marks'}</button></div>`;
+          : "") +
+        `<button data-act="marks">${marksOn ? "Hide marks" : "Show marks"}</button></div>`;
       const stale = staleViewed
-        ? `<div class="bai-nav__stale">${staleViewed} change${staleViewed > 1 ? 's' : ''} you had viewed ${staleViewed > 1 ? 'have' : 'has'} changed since — shown as unviewed again</div>`
-        : '';
+        ? `<div class="bai-nav__stale">${staleViewed} change${staleViewed > 1 ? "s" : ""} you had viewed ${staleViewed > 1 ? "have" : "has"} changed since — shown as unviewed again</div>`
+        : "";
       panel.innerHTML =
-        `<div class="bai-nav__section">Changed pages${manifest.label ? ` — ${esc(manifest.label)}` : ''}</div>` +
+        `<div class="bai-nav__section">Changed pages${manifest.label ? ` — ${esc(manifest.label)}` : ""}</div>` +
         `${rows || '<div class="bai-nav__row"><em>No page changed</em></div>'}${stale}${actions}` +
         `<div class="bai-nav__section">Languages</div><div class="bai-nav__lang">${langs}</div>`;
-      panel.querySelectorAll('[data-act]').forEach((b) =>
-        b.addEventListener('click', (e) => {
+      panel.querySelectorAll("[data-act]").forEach((b) =>
+        b.addEventListener("click", (e) => {
           const act = b.dataset.act;
-          if (act === 'copy-page') return copy(pageSummaryText(), e.currentTarget);
-          if (act === 'marks') {
+          if (act === "copy-page")
+            return copy(pageSummaryText(), e.currentTarget);
+          if (act === "marks") {
             marksOn = !marksOn;
-            document.body.classList.toggle('bai-marks-off', !marksOn);
+            document.body.classList.toggle("bai-marks-off", !marksOn);
             syncMarkFocus();
             if (!marksOn) {
               pinned = null;
@@ -635,9 +658,9 @@
             return renderPanel();
           }
           for (const m of marks) {
-            if (act === 'all-viewed') viewed.add(m.change.fingerprint);
+            if (act === "all-viewed") viewed.add(m.change.fingerprint);
             else viewed.delete(m.change.fingerprint);
-            m.el.classList.toggle('bai-viewed', act === 'all-viewed');
+            m.el.classList.toggle("bai-viewed", act === "all-viewed");
           }
           writeViewed(lang, slug, viewed);
           updatePos();
@@ -649,41 +672,52 @@
     function updatePos() {
       const v = marks.filter((m) => isViewed(m.change)).length;
       posEl.textContent = marks.length
-        ? `${current < 0 ? '–' : current + 1} / ${marks.length}${v ? ` · ${v} viewed` : ''}`
-        : page.status === 'new'
-          ? 'new page'
-          : 'no marks';
+        ? `${current < 0 ? "–" : current + 1} / ${marks.length}${v ? ` · ${v} viewed` : ""}`
+        : page.status === "new"
+          ? "new page"
+          : "no marks";
       posEl.classList.toggle(
-        'bai-nav__pos--done',
+        "bai-nav__pos--done",
         marks.length > 0 && v === marks.length,
       );
     }
-    function jumpTo(i, flash = true) {
+    // `open` pins the popover on the target, so keyboard navigation reads like
+    // a continuous hover; the scroll is instant then, so the popover lands right.
+    function jumpTo(i, flash = true, open = false) {
       if (!marks.length) return;
       current = (i + marks.length) % marks.length;
       const target = marks[current].el;
-      target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      target.scrollIntoView({
+        block: "center",
+        behavior: open ? "auto" : "smooth",
+      });
       // Keyboard users land on the change itself, not back at the badge.
       target.focus({ preventScroll: true });
+      if (open && marksOn) {
+        pinned = target;
+        show(target);
+      }
       if (flash) {
         document
-          .querySelectorAll('.bai-flash')
-          .forEach((n) => n.classList.remove('bai-flash', 'bai-flash--fade'));
-        target.classList.add('bai-flash');
-        setTimeout(() => target.classList.add('bai-flash--fade'), 900);
+          .querySelectorAll(".bai-flash")
+          .forEach((n) => n.classList.remove("bai-flash", "bai-flash--fade"));
+        target.classList.add("bai-flash");
+        setTimeout(() => target.classList.add("bai-flash--fade"), 900);
         setTimeout(
-          () => target.classList.remove('bai-flash', 'bai-flash--fade'),
+          () => target.classList.remove("bai-flash", "bai-flash--fade"),
           2200,
         );
       }
       updatePos();
     }
+    const LAND_KEY = "bai-pr-preview:open-on-land";
     function step(dir) {
       const next = current + dir;
-      if (marks.length && next >= 0 && next < marks.length) return jumpTo(next);
+      if (marks.length && next >= 0 && next < marks.length)
+        return jumpTo(next, true, true);
       // At either end, hop to the neighbouring changed page. An unchanged page
       // is not in the list, so it enters from whichever end the step came from.
-      const pages = summary.pages.filter((p) => p.status !== 'deleted');
+      const pages = summary.pages.filter((p) => p.status !== "deleted");
       if (!pages.length) return;
       const here = pages.findIndex((p) => p.slug === slug);
       const target =
@@ -693,14 +727,19 @@
             : pages[pages.length - 1]
           : pages[(here + dir + pages.length) % pages.length];
       if (!target || target.slug === slug)
-        return marks.length ? jumpTo(next) : undefined;
-      location.href = `./${target.slug}.html#bai-change-${dir > 0 ? '1' : 'last'}`;
+        return marks.length ? jumpTo(next, true, true) : undefined;
+      try {
+        sessionStorage.setItem(LAND_KEY, "1");
+      } catch {
+        /* private mode */
+      }
+      location.href = `./${target.slug}.html#bai-change-${dir > 0 ? "1" : "last"}`;
     }
-    nav.addEventListener('click', (e) => {
-      const b = e.target.closest('button[data-nav]');
+    nav.addEventListener("click", (e) => {
+      const b = e.target.closest("button[data-nav]");
       if (!b) return;
-      if (b.dataset.nav === 'prev') step(-1);
-      else if (b.dataset.nav === 'next') step(1);
+      if (b.dataset.nav === "prev") step(-1);
+      else if (b.dataset.nav === "next") step(1);
       else {
         renderPanel();
         panel.hidden = !panel.hidden;
@@ -714,21 +753,21 @@
       if (!a) continue;
       a.appendChild(
         el(
-          'span',
+          "span",
           `bai-nav-badge bai-nav-badge--${p.status}`,
-          p.status === 'new'
-            ? 'NEW'
-            : p.status === 'deleted'
-              ? 'DEL'
+          p.status === "new"
+            ? "NEW"
+            : p.status === "deleted"
+              ? "DEL"
               : String(p.counts.total),
         ),
       );
     }
-    if (section && (page.status === 'new' || page.status === 'deleted')) {
+    if (section && (page.status === "new" || page.status === "deleted")) {
       const banner = el(
-        'div',
+        "div",
         `bai-page-banner bai-page-banner--${page.status}`,
-        page.status === 'new'
+        page.status === "new"
           ? `<span class="bai-nav__tag bai-nav__tag--new">NEW</span>This page is added by this PR — everything on it is new, so no block marks are shown.`
           : `<span class="bai-nav__tag bai-nav__tag--deleted">DELETED</span>This page is removed by this PR. It is listed in the change navigator only.`,
       );
@@ -736,19 +775,19 @@
     }
 
     // ---------------------------------------------------------- shortcuts
-    document.addEventListener('keydown', (e) => {
+    document.addEventListener("keydown", (e) => {
       if (
         e.target instanceof Element &&
-        e.target.closest('input, textarea, select, [contenteditable]')
+        e.target.closest("input, textarea, select, [contenteditable]")
       )
         return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       // Physical key codes, so the shortcuts survive an active IME.
-      const code = e.code || '';
-      if (code === 'Enter' || code === 'Space') {
+      const code = e.code || "";
+      if (code === "Enter" || code === "Space") {
         const t =
           e.target instanceof Element
-            ? e.target.closest('[data-bai-change]')
+            ? e.target.closest("[data-bai-change]")
             : null;
         if (!t || !marksOn) return;
         e.preventDefault();
@@ -759,26 +798,30 @@
           pinned = t;
           show(t);
         }
-      } else if (code === 'BracketLeft') step(-1);
-      else if (code === 'BracketRight') step(1);
-      else if (code === 'KeyV') {
+      } else if (code === "KeyP" || code === "BracketLeft") {
+        e.preventDefault();
+        step(-1);
+      } else if (code === "KeyN" || code === "BracketRight") {
+        e.preventDefault();
+        step(1);
+      } else if (code === "KeyV") {
         const c = activeChange();
         if (!c) return;
         e.preventDefault();
         setViewed(c, !isViewed(c));
         if (!pop.hidden) render(c);
         showToast(isViewed(c) ? `#${c.id} viewed` : `#${c.id} unviewed`);
-      } else if (code === 'KeyC') {
+      } else if (code === "KeyC") {
         const c = activeChange();
         if (!c) return;
         e.preventDefault();
-        copy(refText(c), pop.hidden ? null : $('[data-copy]', pop));
+        copy(refText(c), pop.hidden ? null : $("[data-copy]", pop));
         showToast(`Copied ref #${c.id}`);
-      } else if (code === 'Escape') {
+      } else if (code === "Escape") {
         pinned = null;
         pop.hidden = true;
         panel.hidden = true;
-        document.querySelectorAll('.bai-lightbox').forEach((n) => n.remove());
+        document.querySelectorAll(".bai-lightbox").forEach((n) => n.remove());
       }
     });
 
@@ -787,8 +830,15 @@
     if (m && marks.length) {
       // Resolve by change id, the number Copy ref and the popover both show.
       const byId = marks.findIndex((x) => String(x.change.id) === m[1]);
-      const i = m[1] === 'last' ? marks.length - 1 : byId >= 0 ? byId : 0;
-      setTimeout(() => jumpTo(i), 50);
+      const i = m[1] === "last" ? marks.length - 1 : byId >= 0 ? byId : 0;
+      let openOnLand = false;
+      try {
+        openOnLand = sessionStorage.getItem(LAND_KEY) === "1";
+        sessionStorage.removeItem(LAND_KEY);
+      } catch {
+        /* private mode */
+      }
+      setTimeout(() => jumpTo(i, true, openOnLand), 50);
     }
   }
 })();

--- a/packages/backend.ai-webui-docs/package.json
+++ b/packages/backend.ai-webui-docs/package.json
@@ -27,6 +27,7 @@
     "build:web:ko": "pnpm run build:toolkit && docs-toolkit build:web --lang ko",
     "build:web:optimized": "pnpm run build:toolkit && docs-toolkit build:web --lang all --optimize-images",
     "build:web:en:optimized": "pnpm run build:toolkit && docs-toolkit build:web --lang en --optimize-images",
+    "diff:web": "pnpm run build:toolkit && docs-toolkit diff:web",
     "serve:web": "pnpm run build:toolkit && portless run --name docs-web --force -- sh -c 'docs-toolkit serve:web --lang en --port $PORT'",
     "serve:web:ko": "pnpm run build:toolkit && portless run --name docs-web --force -- sh -c 'docs-toolkit serve:web --lang ko --port $PORT'",
     "serve:web:ja": "pnpm run build:toolkit && portless run --name docs-web --force -- sh -c 'docs-toolkit serve:web --lang ja --port $PORT'",


### PR DESCRIPTION
Resolves #9530 (FR-3879)

Per-PR static preview of the user manual site with the PR's changes marked on the live pages — the docs counterpart of the Storybook preview (FR-3659). Designed on the wayfinder map #9532 (FR-3881): the mark style was picked from a prototype (#9533), the diff method from a prototype + research (#9534), and the build/publish shape in #9535.

## What a reviewer gets

On any PR touching `packages/backend.ai-webui-docs/**` or `packages/backend.ai-docs-toolkit/**`, the PR Analysis Report gains a **📖 Docs Preview** section linking to `https://lablup.github.io/backend.ai-webui/pr/<n>/docs/next/<lang>/` with, per built language, the changed pages, their change counts and a deep link to the first change. On the preview itself:

- **Marks.** Every changed markdown block (paragraph, heading, list item, table row, image, code block, admonition title) is highlighted — yellow = modified, green = added, dashed orange border — a removed block leaves a red dashed placeholder; a NEW page gets a banner, a DELETED page is listed in the navigator.
- **Hover view.** Word-level inline diff (deletions struck red, insertions underlined green; ko/ja/th segmented with `Intl.Segmenter`), an **Inline / Side by side** toggle remembered in `localStorage` (auto side-by-side for long list items, table rows and code), images as an old/new pair with a lightbox. Click a block to pin, `Esc` closes.
- **Navigator.** Bottom-right badge `N pages · M changes · i / n`, `‹ ›` steps through changes and hops across pages, `☰` lists the changed pages with `viewed/total`, NEW / DELETED tags and per-language totals; the sidebar carries per-page counts.
- **Viewed.** GitHub's per-file "Viewed", per block: checkbox or `v`. Stored in `localStorage` under a content fingerprint of the change, so a change edited by a later push comes back unviewed and the panel says how many viewed changes have changed since. **Mark all viewed** / **Reset** in the panel.
- **Copy ref** (button or `c`) copies an AI-pasteable reference — `lang/page · change n/N · type kind`, `file: <md path>:<line>`, section, deep link, old/new text; **Copy page summary** copies the page's list with `[x]`/`[ ]` state. `n` / `p` step to the next / previous change — across pages, wrapping from the first change of the first changed page to the last change of the last — and open its popover. Shortcuts match physical key codes, so they work with a Korean/Japanese IME active.

## How it works

**`docs-toolkit diff:web --base <dist> --head <dist> [--lang en,ko] [--label …]`** (new, `packages/backend.ai-docs-toolkit/src/web-diff.ts`): compares the rendered HTML of two builds at block level — block keys are whitespace-normalized inner HTML (so link/format-only edits count), adjacent delete/insert runs are paired by word similarity, the word diff keeps tags atomic — detects image replacements by file bytes, stamps `data-bai-block` anchors on the head build, writes a `<slug>.changes.json` sidecar per page and `next/changes-manifest.json`, copies the changed base images to `base-images/`, and injects the overlay (`templates/assets/pr-preview.{js,css}`). Production builds never see any of it: the overlay is injected only by `diff:web`. No dependencies added.

**CI.** `pr-preview.yml` gains a `docs` job (a small `changes` job gates both jobs from `git diff --name-only`): it builds the PR's toolkit once, builds the head site for the languages whose `src/<lang>/` changed (toolkit-only / shared-file changes build `en`), swaps in the merge-base `src/` and builds the base with the same toolkit, runs `diff:web`, and uploads `pr-preview-docs-<sha>` (the stamped site) + `pr-preview-docs-analysis` (the manifest). `pr-preview-publish.yml` deploys it to `pr/<n>/docs/` next to the Storybook preview and renders the report section; `pr-preview-cleanup.yml` removes `pr/<n>/` on close as before. Nothing PR-controlled is executed on the privileged side; slugs/titles from the manifest are sanitized before they reach the comment. Footprint: full copies of the built languages only (~50 MB each); a content-addressed shared image pool is a follow-up.

## Verification

- `pnpm --filter backend.ai-docs-toolkit test` — 355 tests, 354 pass, 1 pre-existing skip (41 in `web-diff.test.ts`: block kinds and figure anchoring, pairing threshold, markup-aware keys / `formattingOnly`, `Intl.Segmenter` segmentation with regex fallback, image bytes + old-image copy, fingerprints, line lookup, idempotent re-run, new/deleted pages, manifest totals, image alt/caption keys, renamed-image pairing, balanced diff markup, list/table containers)
- `node --test .github/scripts/pr-preview/*.test.mjs` — 13 tests (language classification, comment rendering for docs-only / Storybook-only / toolkit-only, manifest sanitization)
- `bash .github/scripts/pr-preview/build-docs-preview.sh --base-ref origin/main --languages en --out …` run locally end to end (toolkit build, head + merge-base builds, `diff:web`, `src/` restored)
- `bash scripts/verify.sh` — `=== ALL PASS ===`
- `diff:web` run locally on the real docs range `53fce136f7^..6b1ef56c69` (six docs PRs, en+ko): vfolder 11 / deployment 7 / dashboard 4 / admin_menu 34 changes, matching the markdown diffs
- Report rendered for docs-only, Storybook-only and toolkit-only fixtures
- The `workflow_run` half (publish + comment) only runs from `main`, as with FR-3659 — first verified by the next docs PR after merge.

https://claude.ai/code/session_01H4Tnt7Zp2DKPMYV3oS4tZd
