### PR TITLE
fix(FR-3887): widen the minimum image resource limit modal to remove horizontal scroll

### DIFF
--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -134,6 +134,9 @@ const ManageImageResourceLimitModal: React.FC<
       onCancel={() => onRequestClose(false)}
       confirmLoading={isInFlightModifyImageInput}
       centered
+      // 520px default overflows the 2-column NumberInput grid (min-content
+      // ~513px) and forces a horizontal scrollbar (FR-3887).
+      width={640}
       title={t('environment.ModifyMinimumImageResourceLimit')}
       okText={t('button.Save')}
       {...BAIModalProps}


### PR DESCRIPTION
Resolves #9542 (FR-3887)

## Summary

The **Edit Minimum Image Resource Limit** modal kept `BAIModal`'s 520px default width while its fixed 2-column `NumberInput` grid needs ~513px of content (min-content-sized tracks), so the body overflowed its content box and `astryx-layout-content` (`overflow-x: auto`) rendered a horizontal scrollbar, clipping the right-hand inputs.

Set `width={640}` on the modal: the grid now resolves to two equal 284px columns, which fits the widest observed case (4 resource limits including fGPU/GPU unit suffixes) without overflow. The prop is placed before the `...BAIModalProps` spread, so callers can still override it.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- Verified in the browser against a local manager (`http://localhost:8090`) on both a 2-input (cpu/mem) and a 4-input (fGPU/cpu/mem/GPU) image: modal body `scrollWidth == clientWidth` (no horizontal scroll).

## Screenshots

| Before (520px, horizontal scrollbar, clipped inputs) | After (640px, no scroll) |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9543/20260909-095614-modal-before.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9543/20260909-095619-modal-after.png) |
