### PR TITLE
fix(FR-3892): skip auto-diagnostics queries for non-superadmin users

### DIFF
--- a/react/src/hooks/useAutoDiagnostics.ts
+++ b/react/src/hooks/useAutoDiagnostics.ts
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useSuspendedBackendaiClient } from '.';
 import type { DiagnosticResult } from '../types/diagnostics';
 import { useCspDiagnostics } from './useCspDiagnostics';
 import { useEndpointDiagnostics } from './useEndpointDiagnostics';
@@ -29,20 +28,17 @@ export function useDiagnosticsBadgeSeverity(): BadgeSeverity {
 }
 
 /**
- * Hook that runs a subset of critical diagnostic checks after login
- * and exposes the highest severity via a Jotai atom for the sidebar badge.
+ * Hook that runs the critical diagnostic checks after login and exposes the
+ * highest severity via a Jotai atom for the sidebar badge.
  *
- * - Only runs for superadmin users.
- * - Runs asynchronously and does NOT block the login flow.
- * - Reuses the existing diagnostics hooks for consistency with the diagnostics page.
+ * Mount only for superadmins (`AutoDiagnosticsEffect` in routes.tsx gates
+ * this) — the underlying hooks issue superadmin-scoped requests
+ * (e.g. `storage_volume_list`) as soon as they run (FR-3892).
  */
 export function useAutoDiagnostics(): void {
   'use memo';
 
   const setDiagnosticsBadgeSeverity = useSetAtom(diagnosticsBadgeSeverityAtom);
-  const baiClient = useSuspendedBackendaiClient();
-
-  const isSuperAdmin: boolean = !!baiClient?.is_superadmin;
 
   // Reuse existing diagnostics hooks to avoid duplicating API requests
   const { results: endpointResults } = useEndpointDiagnostics();
@@ -50,38 +46,23 @@ export function useAutoDiagnostics(): void {
   const configResults = useWebServerConfigDiagnostics();
   const storageResults = useStorageProxyDiagnostics();
 
-  // Compute critical results by filtering results from the shared hooks
-  const criticalResults: DiagnosticResult[] = (() => {
-    if (!isSuperAdmin) return [];
+  const allResults: DiagnosticResult[] = [
+    ...endpointResults,
+    ...cspResults,
+    ...configResults,
+    ...storageResults,
+  ];
 
-    const allResults: DiagnosticResult[] = [
-      ...endpointResults,
-      ...cspResults,
-      ...configResults,
-      ...storageResults,
-    ];
-
-    return allResults.filter(
-      (r) => r.severity === 'critical' || r.severity === 'warning',
-    );
-  })();
-
-  // Determine the highest severity: critical > warning > null
-  const highestSeverity: BadgeSeverity = (() => {
-    if (criticalResults.some((r) => r.severity === 'critical')) {
-      return 'critical';
-    }
-    if (criticalResults.some((r) => r.severity === 'warning')) {
-      return 'warning';
-    }
-    return null;
-  })();
+  // Highest severity wins: critical > warning > null
+  const highestSeverity: BadgeSeverity = allResults.some(
+    (r) => r.severity === 'critical',
+  )
+    ? 'critical'
+    : allResults.some((r) => r.severity === 'warning')
+      ? 'warning'
+      : null;
 
   useEffect(() => {
-    if (!isSuperAdmin) {
-      setDiagnosticsBadgeSeverity(null);
-      return;
-    }
     setDiagnosticsBadgeSeverity(highestSeverity);
-  }, [isSuperAdmin, highestSeverity, setDiagnosticsBadgeSeverity]);
+  }, [highestSeverity, setDiagnosticsBadgeSeverity]);
 }

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -23,7 +23,10 @@ import StorageHostFetchErrorBoundary from './components/StorageHostFetchErrorBou
 import WebUINavigate from './components/WebUINavigate';
 import { persistPostLoginState } from './helper/loginSessionAuth';
 import { useSuspendedBackendaiClient } from './hooks';
-import { useAutoDiagnostics } from './hooks/useAutoDiagnostics';
+import {
+  diagnosticsBadgeSeverityAtom,
+  useAutoDiagnostics,
+} from './hooks/useAutoDiagnostics';
 import { useBAISettingUserState } from './hooks/useBAISetting';
 import { useCurrentProjectValue } from './hooks/useCurrentProject';
 import { LogoutEventHandler } from './hooks/useLogout';
@@ -45,7 +48,7 @@ import { toProjectContext } from './types/projectContext';
 import { BAISkeleton, BAIFlex, BAICard } from 'backend.ai-ui';
 import { useSetAtom } from 'jotai';
 import { parseAsString, useQueryStates } from 'nuqs';
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteObject, useParams } from 'react-router-dom';
 
@@ -1420,11 +1423,26 @@ export const mainLayoutChildRoutes: RouteObject[] = [
 ];
 
 /**
- * Component that runs auto-diagnostics checks after login and shows
- * a notification if any critical issues are detected.
- * Wraps the hook in a Suspense boundary so it won't block rendering.
+ * Runs auto-diagnostics after login, superadmin only — the diagnostics hooks
+ * fire superadmin-scoped requests (e.g. storage_volume_list) as soon as they
+ * run, so non-superadmins must not mount the runner (FR-3892).
  */
 const AutoDiagnosticsEffect = () => {
+  'use memo';
+  const baiClient = useSuspendedBackendaiClient();
+  const setDiagnosticsBadgeSeverity = useSetAtom(diagnosticsBadgeSeverityAtom);
+  const isSuperAdmin = !!baiClient?.is_superadmin;
+
+  useEffect(() => {
+    if (!isSuperAdmin) {
+      setDiagnosticsBadgeSeverity(null);
+    }
+  }, [isSuperAdmin, setDiagnosticsBadgeSeverity]);
+
+  return isSuperAdmin ? <AutoDiagnosticsRunner /> : null;
+};
+
+const AutoDiagnosticsRunner = () => {
   useAutoDiagnostics();
   return null;
 };

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -1443,6 +1443,7 @@ const AutoDiagnosticsEffect = () => {
 };
 
 const AutoDiagnosticsRunner = () => {
+  'use memo';
   useAutoDiagnostics();
   return null;
 };


### PR DESCRIPTION
Resolves #9557 (FR-3892)

## Problem

`useAutoDiagnostics` (mounted via `AutoDiagnosticsEffect` in `react/src/routes.tsx`) called the four diagnostics hooks — endpoint, CSP, web-server config, and `useStorageProxyDiagnostics` — unconditionally for every logged-in user. The superadmin check was applied only when filtering results and writing the sidebar badge atom, so the underlying requests (e.g. the `storage_volume_list` GraphQL query) were still sent right after every regular-user login. The manager rejected them and `ErrorBoundaryWithNullFallback` swallowed the error — invisible in the UI, but wasted traffic and a needless permission error on every login.

## Fix

Gate at the mount point so the hooks are never called for non-superadmins:

- `AutoDiagnosticsEffect` now reads `is_superadmin` itself and renders an inner `AutoDiagnosticsRunner` (which calls `useAutoDiagnostics`) only when the user is a superadmin. For non-superadmins it mounts nothing and resets `diagnosticsBadgeSeverityAtom` to `null`, preserving the badge-reset behavior the hook previously handled (e.g. re-login as a different user in the same tab).
- `useAutoDiagnostics` drops its now-redundant internal `is_superadmin` branch — the hooks it composes never run for non-superadmins anymore — and its doc comment states the caller must gate mounting.

The `/diagnostics` page itself was already gated with `access: 'superadmin'` and is untouched.

## How to test

1. Log in as a **regular (non-superadmin) user** with the browser DevTools Network tab open.
2. Confirm no `useStorageProxyDiagnosticsQuery` GraphQL request goes out after login (filter the Network tab by `graphql` and check the request payloads — previously this query fired on every login and was rejected by the manager).
3. Log in as a **superadmin** and confirm auto-diagnostics still runs: the query goes out and the sidebar diagnostics badge appears when there are warning/critical findings.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, terminology)
