### PR TITLE
fix(FR-3893): align invited-folder items and drop the stray last divider

### DIFF
--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -39,10 +39,8 @@ import { useTranslation } from 'react-i18next';
 
 const styles = stylex.create({
   item: {
-    // Top-align the icon/actions with the folder name instead of the whole
-    // multi-row block, and re-suppress the last item's divider with a longhand
-    // — Astryx's own :last-child uses the shorthand, which its always-on
-    // longhands out-rank in StyleX priority (FR-3893).
+    // Astryx ListItem's :last-child divider suppression is a shorthand that
+    // loses to its own longhands in StyleX — re-suppress it here (FR-3893).
     alignItems: 'flex-start',
     borderBlockEndWidth: {
       default: borderVars['--border-width'],

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -22,6 +22,11 @@ import { List, ListItem } from '@astryxdesign/core/List';
 import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { HStack } from '@astryxdesign/core/Stack';
 import {
+  borderVars,
+  typeScaleVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import * as stylex from '@stylexjs/stylex';
+import {
   BAIMetadataList,
   BAIModal,
   type BAIModalProps,
@@ -31,6 +36,24 @@ import * as _ from 'lodash-es';
 import { FolderIcon } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const styles = stylex.create({
+  item: {
+    // Top-align the icon/actions with the folder name instead of the whole
+    // multi-row block, and re-suppress the last item's divider with a longhand
+    // — Astryx's own :last-child uses the shorthand, which its always-on
+    // longhands out-rank in StyleX priority (FR-3893).
+    alignItems: 'flex-start',
+    borderBlockEndWidth: {
+      default: borderVars['--border-width'],
+      ':last-child': 0,
+    },
+  },
+  // Center the 1em icon on the label's first line (Astryx list-marker trick).
+  icon: {
+    marginTop: `calc((1em * ${typeScaleVars['--text-body-leading']} - 1em) / 2)`,
+  },
+});
 
 interface FolderInvitationResponseModalProps extends Omit<
   BAIModalProps,
@@ -62,7 +85,8 @@ const FolderInvitationResponseModal: React.FC<
     <ListItem
       key={item.id}
       label={item.vfolder_name ?? ''}
-      startContent={<FolderIcon size="1em" />}
+      xstyle={styles.item}
+      startContent={<FolderIcon size="1em" {...stylex.props(styles.icon)} />}
       description={
         <BAIMetadataList columns="single">
           <MetadataListItem label={t('data.From')}>


### PR DESCRIPTION
Resolves #9558 (FR-3893)

## What & why

The invited-folder modal (`FolderInvitationResponseModal`) had two visual defects:

1. **Stray divider under the last item** — Astryx `ListItem`'s `hasDividers` draws the divider with always-on longhands (`borderBlockEndWidth/Style/Color`) and turns it off on `:last-child` with the `border-block-end` **shorthand**. StyleX ranks longhands above shorthands, so the suppression never wins and the last item keeps its 1px rule, leaving a stray line above the modal's bottom edge.
2. **Misaligned item layout** — Astryx `Item` defaults to `align-items: center`, so the folder icon (and the Accept/Decline buttons) sat vertically centered against the whole three-row block, visually attaching the icon to the "From" row instead of the folder name.

The fix is a call-site `xstyle`:

- re-suppresses the last item's divider with a `:last-child` **longhand** (`borderBlockEndWidth: 0`), keeping the 1px rule *between* items;
- switches the item root to `flex-start` and nudges the 1em icon down by `calc((1em * --text-body-leading − 1em) / 2)` so it centers on the label's first text line — the same technique Astryx's own list markers use.

## Measured before/after (live dev server, mocked single invitation)

| Property | Before | After |
|---|---|---|
| last `li` `border-block-end-width` (light & dark) | `1px solid` | `0px` |
| icon centerY − label centerY | **+28.0px** (centered on row 2) | **+1.6px** (on the label line) |
| between-item divider (2-item case) | 1px | 1px (unchanged) |
| `pageerror` count (light/dark passes) | 0 | 0 |

Horizontal alignment was measured as already correct (label `left` 516 = metadata rows `left` 516, before and after); the reported horizontal offset was the perceptual effect of the icon hugging the second row.

## Screenshots

| Before (dark, as reported) | After (dark) |
|---|---|
| ![before-dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9562/20260909-081442-fr3893-before-dark.png) | ![after-dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9562/20260909-081442-fr3893-after-dark.png) |

| Before (light) | After (light) |
|---|---|
| ![before-light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9562/20260909-081442-fr3893-before-light.png) | ![after-light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9562/20260909-081442-fr3893-after-light.png) |

Two-invitation case (divider kept between items, none at the bottom):

![after-multi](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9562/20260909-081442-fr3893-after-multi.png)

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → 137 files / **2318 tests passed**
- `pnpm --filter backend.ai-ui exec vitest run` → 78 files / **2052 passed, 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → the only 2 findings (`--bai-dialog-z` in `BAIDialog.css` / `BAIDrawerPortal.css`) are pre-existing on `main` in files this PR does not touch.

## Residue

- The root cause (shorthand `:last-child` suppression losing to longhands) lives in `@astryxdesign/core` `ListItem.withDivider`, so **`ImageInstallModal`'s `List hasDividers`** carries the same latent last-item divider; not fixed here to keep the diff scoped to the reported modal.
- With `flex-start`, the Accept/Decline buttons now align with the folder-name row instead of the block center — deliberate, matching the icon alignment the report asked for.
- Icon-to-label optical centering lands within 1.6px of exact (line-height rounding); not worth further correction.
