### PR TITLE
fix(FR-3894): align the deployment More menu to the trigger's end edge

### DIFF
--- a/react/src/components/DeploymentBasicInfoCard.tsx
+++ b/react/src/components/DeploymentBasicInfoCard.tsx
@@ -303,8 +303,6 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
               >
                 {t('button.Edit')}
               </BAIButton>
-              {/* PILOT-DECISION: antd menu-item `danger: true` (red tint on
-                  the Delete entry) has no DropdownMenu equivalent — dropped. */}
               <DropdownMenu
                 button={{
                   label: t('button.More'),
@@ -312,10 +310,16 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
                   isIconOnly: true,
                 }}
                 hasChevron={false}
+                // The trigger sits at the card's right edge: with the default
+                // start alignment the panel gets only the strip between the
+                // button and the viewport and clips its label (FR-3894).
+                placement="below"
+                alignment="end"
                 items={[
                   {
                     label: t('deployment.DeleteDeployment'),
                     icon: <Trash2 size="1em" />,
+                    variant: 'destructive',
                     isDisabled:
                       isDeploymentInStoppedCategory(deploymentStatus) ||
                       isInFlightDeleteMutation,


### PR DESCRIPTION
Resolves #9563 (FR-3894)

applied test server: https://fr-3893-pr9562-align-invited-folder.seungwon.10-82-0-159.sslip.io/

## Summary

On the Deployment detail page the More (⋮) menu in the header action group rendered its only item, **Delete deployment**, clipped to a single glyph, with the panel hanging off the right edge of the trigger.

## Mechanism

`DropdownMenu` defaults to `alignment="start"`, which Astryx resolves to `position-area: self-end span-self-end`: the panel's inline-start edge is pinned to the trigger's inline-start edge, and its containing block becomes the strip between that edge and the viewport's right edge. For the rightmost header button that strip is ~80px at 1440px wide. The panel has `width: fit-content`, so it *shrinks into* that strip instead of overflowing it, which is why the `flip-inline` entry in `position-try-fallbacks` never fires. The label then wraps and the item's ellipsis clipping hides everything past the first glyph.

`alignment="end"` (with an explicit `placement="below"`) flips the area to `span-self-start`, so the panel grows leftward and its end edge sits on the trigger's end edge — the same pairing the other rightmost menus in the app already use (`AdminUserManagement`, `SFTPServerButtonV2`, `BAIFetchKeyButton`).

While here, the Delete item takes `variant: 'destructive'`. The `PILOT-DECISION` note that DropdownMenu had no equivalent for antd's `danger` menu item was stale — Astryx renders a destructive item's label and icon in the error colour — so the note is gone and the tint is back.

## Measured (live dev server, Chromium 1440×900, ko locale)

| | Before | After |
|---|---|---|
| Trigger rect | x 1360, w 32 | x 1360, w 32 |
| Panel rect | x 1360, w **64** | x 1279, w **113** (right edge = trigger right edge, 1392) |
| `position-area` | `self-end span-self-end` | `self-end span-self-start` |
| Item scrollWidth / clientWidth | 56 / 56 (label wrapped, clipped) | 105 / 105 (full label) |
| Dark mode | identical numbers | identical numbers |
| `pageerror` count | 0 | 0 |

Dark mode was measured with `document.documentElement.dataset.theme === 'dark'` asserted.

## Screenshots

| Before (light) | After (light) | After (dark) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9564/20260909-092117-before-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9564/20260909-092122-after-light.png) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9564/20260909-092128-after-dark.png) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → 137 files, 2318 tests passed
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on two pre-existing findings in `BAIDialog.css` / `BAIDrawerPortal.css` (`var(--bai-dialog-z)` fallback); neither file is touched here and the touched file reports 0 findings.
- No `packages/backend.ai-ui/src` change, so the BUI build/vitest were not re-run.

## Residue

Other `DropdownMenu` triggers that are not at a right edge (`DeploymentRevisionHistoryTab`, `FileBrowserButtonV2`, `ShellScriptEditModal`, `ImportNotebookForm`, `SessionLauncherPage`) keep the default start alignment; they were not measured in this PR. The underlying fit-content-vs-fallback interaction lives in Astryx's `useLayer` and is not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
