### PR TITLE
fix(FR-3895): render tooltip line breaks and center the help icon on Information rows

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIMetadataList.css
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.css
@@ -67,9 +67,27 @@
 }
 
 /* A side-label dt stretches to its grid row and Astryx centers it, so it
-   drifts off a multi-line value's first line — pin it to the top (FR-3667). */
+   drifts off a multi-line value's first line (FR-3667). Baseline alignment
+   still packs the flex line to the top, and it makes the LABEL TEXT the dt's
+   baseline — with flex-start the first item, i.e. the icon slot, supplied a
+   synthesized one, which pulled the value off the label by ~2px. */
 .bai-metadata-list > dl > dt {
-  align-items: flex-start;
+  align-items: baseline;
+}
+
+/* The icon slot has no text baseline, so it opts out of the baseline group
+   and centers itself on the first label line instead. `BAIMetadataListItem`
+   marks a node label so it is never mistaken for the slot. */
+.bai-metadata-list
+  > dl
+  > dt
+  > span:first-child:not(.bai-metadata-list-item__label) {
+  align-self: flex-start;
+  height: 1lh;
+}
+
+.bai-metadata-list-item__label {
+  display: contents;
 }
 
 .bai-metadata-list--bordered {

--- a/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
+++ b/packages/backend.ai-ui/src/components/BAIMetadataList.tsx
@@ -90,8 +90,18 @@ export const BAIMetadataListItem: React.FC<BAIMetadataListItemProps> = ({
   ...metadataListItemProps
 }) => {
   'use memo';
+  // The marker keeps the icon-slot rule in BAIMetadataList.css off a node label.
+  const markedLabel =
+    typeof label === 'string' ? (
+      label
+    ) : (
+      <span className="bai-metadata-list-item__label">{label}</span>
+    );
   return (
-    <MetadataListItem {...metadataListItemProps} label={label as string} />
+    <MetadataListItem
+      {...metadataListItemProps}
+      label={markedLabel as string}
+    />
   );
 };
 

--- a/react/src/components/DescriptionLabel.tsx
+++ b/react/src/components/DescriptionLabel.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { newLineToBrElement } from '../helper';
 import { BAIQuestionIconWithTooltip } from 'backend.ai-ui';
 import React from 'react';
 
@@ -16,7 +17,7 @@ const DescriptionLabel: React.FC<{
   subtitle?: string | null;
 }> = ({ subtitle }) => {
   if (!subtitle) return null;
-  return <BAIQuestionIconWithTooltip title={subtitle} />;
+  return <BAIQuestionIconWithTooltip title={newLineToBrElement(subtitle)} />;
 };
 
 export default DescriptionLabel;

--- a/react/src/components/Information.tsx
+++ b/react/src/components/Information.tsx
@@ -147,9 +147,6 @@ const Information: React.FC<InformationProps> = () => {
           <MetadataListItem
             label={t('information.RedisVersion')}
             icon={
-              // PILOT-DECISION: `newLineToBrElement` produced a `<br/>`-joined
-              // ReactNode; the tooltip icon's `title` is plain `string`
-              // (P2), so the line-break formatting is dropped here.
               <DescriptionLabel subtitle={t('information.DescRedisVersion')} />
             }
           >


### PR DESCRIPTION
Resolves #9569 (FR-3895)

## Summary

- **Tooltip line breaks.** `DescriptionLabel` passed the raw i18n string to the help tooltip, so the `<br/>` inside `information.DescLicenseType` / `DescRedisVersion` rendered literally. It now runs the string through `newLineToBrElement`, restoring the line-break formatting the antd-era version had (and dropping the PILOT-DECISION note in `Information.tsx` that recorded the loss).
- **Help icon and value alignment on side-label rows.** In a side-label `BAIMetadataList`, the `dt` was pinned to `align-items: flex-start` (FR-3667). With an icon in the slot, the icon hugged the top of the 24px cell (about 3.5px above the label text), and because the icon slot has no text baseline, the `dt`'s baseline was synthesized from the icon's bottom edge, so the value column drifted about 2px off the rows without an icon. The `dt` now aligns on `baseline` (a stretched multi-line row still packs the flex line to the top, so FR-3667's fix holds), and the icon slot opts out of the baseline group with `align-self: flex-start; height: 1lh` so it centers on the first label line. `BAIMetadataListItem` wraps a node label in a `display: contents` marker span so the icon-slot selector cannot mistake a label element for the slot. This is in the shared BUI wrapper, so every side-label list with an `icon` (also `UserInfoModal`'s warning icon) gets the same correction.

## Measured

Information page, Chromium, light theme. Icon center and value center relative to the label text's center; the no-icon reference row (API version) reads +1.5px for its value.

| Row | Before (icon / value) | After (icon / value) |
|---|---|---|
| Docker version … Expiration (badge value) | -3.5px / -0.5px | +0.5px / +1.5px |
| Uses SSL, Validation (glyph value) | -3.5px / -1.8px | +0.5px / +0.3px |

## Screenshots

| Before | After |
|--------|-------|
| ![before-tooltip](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9570/20260910-012013-before-tooltip.png) | ![after-tooltip](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9570/20260910-012021-after-tooltip.png) |
| ![before-component](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9570/20260910-012029-before-component.png) | ![after-component](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9570/20260910-012037-after-component.png) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → ok (BUI source changed)
- `pnpm --filter backend.ai-ui exec vitest run src/components/BAIMetadataList.test.tsx` → 2 passed
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → only the pre-existing `BAIDrawerPortal.css` finding; this PR adds no `var()`

## Test plan

- [ ] Information page: hover the License Type and Redis version help icons; the tooltip shows a real line break, no `<br/>` text.
- [ ] Information page: the `?` icons sit on the label text's center line and the value badges line up with the rows that have no icon.
- [ ] Deployment revision detail (two-column side labels): labels still top-align with a multi-line value.
- [ ] Data page folder detail (path row uses a node label): unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwoUzEfKZGEEM5Fdr8hJ7a
