### PR TITLE
fix(FR-3896): count only page/component feats as R5 manual gaps

### DIFF
--- a/.claude/skills/release-train-prep/SKILL.md
+++ b/.claude/skills/release-train-prep/SKILL.md
@@ -146,7 +146,8 @@ Top-level fields:
 | `undeclared[]` | flags used but never declared, i.e. permanently `false` |
 | `risks.noE2E[]` | `{pr, fr, subject, ui[]}` — UI changed, no e2e changed |
 | `risks.destructive[]` | `{pr, fr, subject, destructive[]}` — irreversible-flow files |
-| `risks.noDocs[]` | `{pr, fr, subject}` — user-visible `feat:` with no manual change |
+| `risks.noDocs[]` | `{pr, fr, subject}` — `feat:` that changed a page or component (`react/src/pages|components`, `Dev*` files excluded) with no manual change |
+| `risks.noDocsSkipped[]` | `{pr, fr, subject, reason}` — `feat:` with UI files the script set aside (`dev-tooling`, `library-only`, `no-page-surface`). Debugging only — answers "why was #N not flagged?"; the digest never counts or lists them, they already appear under 새 기능 |
 | `i18n[]` | `{file, addedCount, missing[], placeholder[]}` per locale file |
 
 ### 3. Render the HTML
@@ -170,6 +171,13 @@ file-level caution.
 **5** items and append `외 N건` when there are more. For R3, do not list 40 locale
 files — collapse to the shape (`대부분의 언어에서 placeholder N개 / 누락 M개`) and
 name only the outliers.
+
+**`외 N건` is a size fold, nothing else.** It means "N more of the same kind that
+did not fit", so the reader can ask for them and get a list of equals. An item
+you drop for a *reason* — not manual material, not user-facing, a false positive
+— is never folded into it: either leave it out entirely (the script already
+does this for R5) or name it with its reason. The rc.4 thread had to ask what
+"외 4건" were because a triage was hiding inside a fold.
 
 **HTML safety**: escape `&`, `<`, `>`, `"`, `'` in every string taken from the JSON
 (PR subjects, file paths, flag names) before inserting it. Emit only `<b>`, `<i>`,
@@ -216,6 +224,7 @@ Template:
 
 <b>📖 매뉴얼 미반영</b> — {n}건<br/>
 <ul><li><a href="{prUrl}">#{pr}</a> {subject}</li></ul>
+{외 N건}
 <hr/>
 <i>🤖 scripts/release-risk-report.mjs · 결함 목록이 아니라 QA 확인 항목입니다</i>
 ```
@@ -235,6 +244,11 @@ How each special section is written:
   field; a correctly annotated usage is not news. When `gating.gaps` is empty,
   keep the section as the single line `⚙️ 버전 게이팅 누락 — 없음 ✅`: for a
   go/no-go reader, "checked and clean" and "not checked" must not look the same.
+- **매뉴얼 미반영 (R5)**: `risks.noDocs[]` is the list and the heading count is
+  its length. Feats the script set aside (`risks.noDocsSkipped[]`: dev tooling,
+  library-only, no page surface) are not counted and not mentioned — they are
+  already in 새 기능 and the commit list. If one of them does deserve a manual
+  entry, fix `isManualFacing` in the script rather than editing the digest.
 
 Drop any other section whose count is 0 rather than printing an empty heading.
 If every section is empty, post a single line saying the range has no risk
@@ -306,8 +320,15 @@ every step below is described, not executed. Steps, in order:
    never doubled:
 
    ```bash
-   $FW_JIRA search "project = FR AND summary ~ \"Final Train\" AND summary ~ \"$VERSION\"" --limit 5
+   $FW_JIRA search "project = FR AND summary ~ \"Final Train\" ORDER BY created DESC" --limit 10 \
+     | grep -iF "$VERSION"
    ```
+
+   List the recent trains and match the version string yourself. Do NOT put
+   the version into the JQL: `summary ~ "26.9.0"` is a tokenized text search
+   and returned nothing for FR-3663 "Final Train to v26.9.0" on 2026-09-09 —
+   a `--train` run that trusted it would have created a second Story. The
+   grep also catches the `vWebUI 26.9.0` and bare `26.9.0` spellings alike.
 
    On a hit, skip creation, use the existing key, and say so in the reply.
 

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -897,8 +897,7 @@ function renderMarkdown(report) {
     !undeclared.length &&
     !i18n.length &&
     !risks.destructive.length &&
-    !risks.noDocs.length &&
-    !risks.noDocsSkipped.length
+    !risks.noDocs.length
   ) {
     L.push('No risk signals in this range.');
     L.push('');

--- a/scripts/release-risk-report.mjs
+++ b/scripts/release-risk-report.mjs
@@ -11,7 +11,7 @@
  *   R2  new manager feature gate                -> needs a two-manager pass
  *   R3  i18n keys added but not translated      -> ships raw keys / English
  *   R4  destructive-flow file touched           -> re-verify the typed confirm
- *   R5  user-visible feat with no manual change -> docs gap
+ *   R5  feat on a page/component, no manual change -> docs gap
  *
  * Usage:
  *   node scripts/release-risk-report.mjs --from v26.8.1 [--to HEAD] [--out FILE] [--json]
@@ -158,6 +158,16 @@ const BUI_NON_RUNTIME =
 // assets directly, so a style-only commit is still a UI change.
 const UI_EXT = /\.(tsx?|css|scss|svg|png)$/;
 
+// Dev-only surfaces ship in the bundle but are not product UI
+// (DevReviewRouteLabel, DevApiEndpointMismatchAlert).
+const isDevTooling = (f) => /^Dev[A-Z]/.test(f.split('/').pop());
+
+// What the user manual documents: host-app pages and components. Wiring
+// (routes.tsx), hooks and the backend.ai-ui library are not manual material
+// on their own.
+const isManualFacing = (f) =>
+  /^react\/src\/(pages|components)\//.test(f) && !isDevTooling(f);
+
 export function classify(files) {
   const ui = files.filter(
     (f) =>
@@ -171,6 +181,7 @@ export function classify(files) {
   );
   return {
     ui,
+    manualFacing: ui.filter(isManualFacing),
     // Executable tests only: e2e/ also holds docs and plans (e.g. the
     // coverage report), and touching those is not test coverage.
     e2e: files.filter(
@@ -184,6 +195,19 @@ export function classify(files) {
     ),
     destructive: ui.filter((f) => DESTRUCTIVE_NAME.test(f.split('/').pop())),
   };
+}
+
+/**
+ * Why a `feat` with UI files is not an R5 manual gap, or null when it is one.
+ * The reason is a JSON-only debugging aid ("why was #N not flagged?"); the
+ * digest neither counts nor mentions skipped feats.
+ */
+export function manualGapSkipReason(classified) {
+  if (classified.manualFacing.length) return null;
+  if (classified.ui.some(isDevTooling)) return 'dev-tooling';
+  if (!classified.ui.some((f) => f.startsWith('react/src/')))
+    return 'library-only';
+  return 'no-page-surface';
 }
 
 /**
@@ -861,7 +885,7 @@ function renderMarkdown(report) {
 
   section(
     'R5 — User-visible feature with no manual change',
-    'A `feat:` that changed the UI but not the user manual. Confirm the manual does not need it.',
+    'A `feat:` that changed a page or component but not the user manual. Confirm the manual does not need it.',
     risks.noDocs,
     (c) => `- [ ] ${link(c)} ${c.subject.replace(/\s*\(#\d+\)$/, '')}`,
   );
@@ -873,7 +897,8 @@ function renderMarkdown(report) {
     !undeclared.length &&
     !i18n.length &&
     !risks.destructive.length &&
-    !risks.noDocs.length
+    !risks.noDocs.length &&
+    !risks.noDocsSkipped.length
   ) {
     L.push('No risk signals in this range.');
     L.push('');
@@ -941,13 +966,20 @@ function main() {
       (c) => c.classified.ui.length > 0 && c.classified.e2e.length === 0,
     ),
     destructive: commits.filter((c) => c.classified.destructive.length > 0),
-    noDocs: commits.filter(
-      (c) =>
-        c.type === 'feat' &&
-        c.classified.ui.length > 0 &&
-        c.classified.docs.length === 0,
-    ),
+    noDocs: [],
+    noDocsSkipped: [],
   };
+  for (const c of commits) {
+    if (
+      c.type !== 'feat' ||
+      c.classified.ui.length === 0 ||
+      c.classified.docs.length > 0
+    )
+      continue;
+    const reason = manualGapSkipReason(c.classified);
+    if (reason) risks.noDocsSkipped.push({ ...c, reason });
+    else risks.noDocs.push(c);
+  }
 
   const versionMap = readFeatureVersionMap(args.to);
   const used = usedFeatureFlags(args.to);
@@ -988,6 +1020,7 @@ function main() {
                 subject: c.subject,
                 ui: c.classified.ui,
                 destructive: c.classified.destructive,
+                ...(c.reason ? { reason: c.reason } : {}),
               })),
             ]),
           ),

--- a/scripts/release-risk-report.test.ts
+++ b/scripts/release-risk-report.test.ts
@@ -9,6 +9,7 @@ import {
   extractSupportsUsages,
   flatten,
   hasDestructiveContract,
+  manualGapSkipReason,
   parseArgs,
   parseFeatureVersionMap,
 } from './release-risk-report.mjs';
@@ -210,6 +211,64 @@ describe('release risk report', () => {
       expect(c.e2e).toHaveLength(1);
       expect(c.docs).toHaveLength(1);
       expect(c.i18n).toHaveLength(1);
+    });
+
+    it('narrows manualFacing to pages and components, minus Dev* files', () => {
+      const c = classify([
+        'react/src/pages/DataPage.tsx',
+        'react/src/components/FolderCreateModal.tsx',
+        'react/src/components/DevReviewRouteLabel.tsx',
+        'react/src/routes.tsx',
+        'react/src/hooks/useFoo.ts',
+        'packages/backend.ai-ui/src/components/BAICard.tsx',
+      ]);
+      expect(c.ui).toHaveLength(6);
+      expect(c.manualFacing).toEqual([
+        'react/src/pages/DataPage.tsx',
+        'react/src/components/FolderCreateModal.tsx',
+      ]);
+    });
+  });
+
+  describe('manualGapSkipReason', () => {
+    it('keeps a feat that touches a page or component', () => {
+      expect(
+        manualGapSkipReason(classify(['react/src/pages/DataPage.tsx'])),
+      ).toBeNull();
+    });
+
+    it('skips the review overlay: Dev* component plus route wiring', () => {
+      // #9536 / #9368 / #9337 in the v26.9.0-rc.4 range.
+      expect(
+        manualGapSkipReason(
+          classify([
+            'react/src/ambient.d.ts',
+            'react/src/components/DevReviewRouteLabel.tsx',
+            'react/src/routes.tsx',
+          ]),
+        ),
+      ).toBe('dev-tooling');
+    });
+
+    it('skips a backend.ai-ui-only feat', () => {
+      // #9464 in the v26.9.0-rc.4 range.
+      expect(
+        manualGapSkipReason(
+          classify([
+            'packages/backend.ai-ui/src/components/BAIInteractiveLoginButton.tsx',
+            'packages/backend.ai-ui/src/hooks/useBAIInteractiveLogin.ts',
+            'packages/backend.ai-ui/src/locale/en.json',
+          ]),
+        ),
+      ).toBe('library-only');
+    });
+
+    it('skips a host-side feat with no page surface', () => {
+      expect(
+        manualGapSkipReason(
+          classify(['react/src/hooks/useFoo.ts', 'react/src/routes.tsx']),
+        ),
+      ).toBe('no-page-surface');
     });
   });
 


### PR DESCRIPTION
Resolves #9571 (FR-3896)

## Summary

The release risk report's R5 ("user-visible `feat:` with no manual change") counted any `feat` that touched a runtime file under `react/src/` or `packages/backend.ai-ui/src/`. In the v26.9.0-rc.4 digest 4 of the 9 hits were not manual material — three review-overlay feats that touched only `DevReviewRouteLabel.tsx` + `routes.tsx` (#9536, #9368, #9337) and one `backend.ai-ui`-only hook (#9464) — and the digest folded them into "외 N건", so the thread had to ask what they were.

- `classify()` now exposes `manualFacing`: `react/src/pages|components` minus `Dev*`-prefixed files (the dev-only convention: `DevReviewRouteLabel`, `DevApiEndpointMismatchAlert`). R5 requires at least one such file.
- Feats set aside are neither counted nor mentioned in the report or the digest — they already appear under 새 기능 and in the commit list. The JSON keeps them as `risks.noDocsSkipped[]` with a `reason` (`dev-tooling` / `library-only` / `no-page-surface`) purely as a debugging aid ("why was #N not flagged?").
- `release-train-prep` skill: "외 N건" is defined as a size-only fold (an item dropped for a reason is left out, never folded); the `--train` duplicate scan lists recent "Final Train" stories and greps the version instead of `summary ~ "<version>"`, which is a tokenized text search and returned nothing for FR-3663 "Final Train to v26.9.0".

## Verification

- `pnpm exec vitest run scripts/release-risk-report.test.ts` — 35 passed (4 new: `manualFacing` narrowing, and `manualGapSkipReason` on the exact file sets of #9536/#9368/#9337, #9464, and a hooks-only feat).
- `node scripts/release-risk-report.mjs --from v26.9.0-rc.3 --to v26.9.0-rc.4` — R5 is now the 5 real gaps (#9398, #6227, #9070, #9249, #9189); skipped: #9536, #9368, #9337 (dev-tooling), #9464 (library-only). R1 and hotspots unchanged (65 / Deployment 10).
- `bash scripts/verify.sh` — `=== ALL PASS ===` (after `pnpm --filter backend.ai-ui build` in the fresh worktree; the first run failed only at "Astryx theme build" because the workspace package had no `dist/` yet).
- `scripts/` and `.claude/` are outside lint-staged and the ESLint config; the 9 ESLint findings on the `.mjs` (`process` undefined, unused destructure) pre-date this change and are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5e7Xai7poA5hM2A1b8GhF
