### PR TITLE
fix(FR-3897): render the vfolder permission code as an inline code tag

### DIFF
--- a/react/src/components/VFolderPermissionCell.tsx
+++ b/react/src/components/VFolderPermissionCell.tsx
@@ -4,7 +4,6 @@
  */
 import { VFolderPermissionCellFragment$key } from '../__generated__/VFolderPermissionCellFragment.graphql';
 import { HStack } from '@astryxdesign/core/Stack';
-import { Text } from '@astryxdesign/core/Text';
 import { BAIText } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { useMemo } from 'react';
@@ -62,7 +61,7 @@ const VFolderPermissionCell: React.FC<VFolderPermissionCellProps> = ({
 
   return (
     <HStack gap={2} {...props}>
-      <Text>{permissionInfo?.label}</Text>
+      <BAIText>{permissionInfo?.label}</BAIText>
       <HStack>
         {_.map(permissionInfo?.icon, (tag) => (
           <BAIText key={tag} code>

--- a/react/src/components/VFolderPermissionCell.tsx
+++ b/react/src/components/VFolderPermissionCell.tsx
@@ -5,6 +5,7 @@
 import { VFolderPermissionCellFragment$key } from '../__generated__/VFolderPermissionCellFragment.graphql';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
+import { BAIText } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -59,20 +60,14 @@ const VFolderPermissionCell: React.FC<VFolderPermissionCellProps> = ({
     };
   }, [permissionProp, vfolderData, t]);
 
-  // PHASE 6 (item 4) — FRONTIER conversion. The external props are unchanged
-  // (`vfolderFrgmt` / `permission`), so the five unmigrated consumers compile
-  // untouched; only the internals move. antd `Typography.Text code` becomes
-  // Astryx `Text type="code"`, and `BAIFlex gap="xs"` becomes `HStack gap={2}`
-  // (BUI `xs` resolves to antd's `sizeXS` = 8px = Astryx step 2 — the Phase-3
-  // corrected mapping, not the token NAME).
   return (
     <HStack gap={2} {...props}>
       <Text>{permissionInfo?.label}</Text>
       <HStack>
         {_.map(permissionInfo?.icon, (tag) => (
-          <Text key={tag} type="code">
+          <BAIText key={tag} code>
             {_.toUpper(tag)}
-          </Text>
+          </BAIText>
         ))}
       </HStack>
     </HStack>

--- a/react/src/components/VFolderPermissionCellV2.tsx
+++ b/react/src/components/VFolderPermissionCellV2.tsx
@@ -5,6 +5,7 @@
 import { VFolderPermissionCellV2Fragment$key } from '../__generated__/VFolderPermissionCellV2Fragment.graphql';
 import { HStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
+import { BAIText } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -54,19 +55,14 @@ const VFolderPermissionCellV2: React.FC<VFolderPermissionCellV2Props> = ({
     };
   }, [vfolderData, t]);
 
-  // Ticket 16 — FRONTIER conversion (same pattern as the V1 cell): the
-  // external props are unchanged, only the internals move. antd
-  // `Typography.Text code` becomes Astryx `Text type="code"`, and
-  // `BAIFlex gap="xs"` becomes `HStack gap={2}` (BUI `xs` = 8px = step 2 by
-  // VALUE, per P9).
   return (
     <HStack gap={2} {...props}>
       <Text>{permissionInfo?.label}</Text>
       <HStack>
         {_.map(permissionInfo?.icon, (tag) => (
-          <Text key={tag} type="code">
+          <BAIText key={tag} code>
             {_.toUpper(tag)}
-          </Text>
+          </BAIText>
         ))}
       </HStack>
     </HStack>

--- a/react/src/components/VFolderPermissionCellV2.tsx
+++ b/react/src/components/VFolderPermissionCellV2.tsx
@@ -4,7 +4,6 @@
  */
 import { VFolderPermissionCellV2Fragment$key } from '../__generated__/VFolderPermissionCellV2Fragment.graphql';
 import { HStack } from '@astryxdesign/core/Stack';
-import { Text } from '@astryxdesign/core/Text';
 import { BAIText } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { useMemo } from 'react';
@@ -57,7 +56,7 @@ const VFolderPermissionCellV2: React.FC<VFolderPermissionCellV2Props> = ({
 
   return (
     <HStack gap={2} {...props}>
-      <Text>{permissionInfo?.label}</Text>
+      <BAIText>{permissionInfo?.label}</BAIText>
       <HStack>
         {_.map(permissionInfo?.icon, (tag) => (
           <BAIText key={tag} code>


### PR DESCRIPTION
Resolves #9573 (FR-3897)

## Problem

The folder invitation card (and the legacy/V2 folder permission cells) show the permission label followed by its code, e.g. `읽기 전용 R`. The `R` / `RW` letters were rendered with Astryx `Text type="code"`, which only switches the font family — no background, border, or padding. A single monospace letter next to a proportional label is indistinguishable from plain text, so the code looked like a stray character appended to the label.

## Fix

Render the letters with `BAIText code` instead. That is the BUI wrapper the other ~30 inline-code call sites already use, and its `.bai-text-code` style reproduces the bordered, muted inline tag antd's `Typography.Text code` produced. Applied to both `VFolderPermissionCell` (invitation card, legacy rows) and `VFolderPermissionCellV2` (folder list) so the two cells stay identical. The migration-era comment blocks in both files were dropped per `comment-density.md`.

## Files

- `react/src/components/VFolderPermissionCell.tsx`
- `react/src/components/VFolderPermissionCellV2.tsx`

## Screenshots

### Folder invitation modal (`VFolderPermissionCell`)
| Before | After |
|--------|-------|
| ![invitation-modal-before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9574/20260910-144903-invitation-modal-before.png) | ![invitation-modal-after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9574/20260910-144903-invitation-modal-after.png) |

### Folder list, Mount Permission column (`VFolderPermissionCellV2`)
| Before | After |
|--------|-------|
| ![folder-list-before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9574/20260910-144903-folder-list-before.png) | ![folder-list-after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9574/20260910-144903-folder-list-after.png) |

The folder list rows are live data. The invitation modal was captured with the invitation-list response stubbed through a Playwright route (two pending invitations, `ro` and `rw`): on the shared test manager every non-admin account is refused vfolder REST calls by RBAC, so no account can actually invite the admin. The modal renders the stubbed rows through the same code path as a live response.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, terminology self-test). Astryx token gate not run: no CSS or `var(--…)` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
