### PR TITLE
feat(FR-3898): collect per-change review comments on the docs PR preview and copy them at once

### DIFF
--- a/packages/backend.ai-docs-toolkit/README.md
+++ b/packages/backend.ai-docs-toolkit/README.md
@@ -163,7 +163,7 @@ Notes:
 - `build:web --strict` (default) fails the build on broken links; `--no-strict` downgrades them to warnings.
 - `build:web --optimize-images` generates `.webp` variants for PNGs over 50 KB and wraps them in `<picture>`; `--optimize-images-avif` adds `.avif` variants. Both require the optional `sharp` peer dependency.
 - Default ports: `preview` → `3456`, `preview:html` → `3457`, `serve:web` → `3458`.
-- `diff:web` compares two `dist/web` roots at markdown-block level and writes into the head build: a `<slug>.changes.json` sidecar per page, a `changes-manifest.json` per channel, `base-images/` copies of the replaced images, and the `pr-preview` overlay that marks the changed blocks in the browser. `--json` prints the manifest to stdout (the summary then goes to stderr).
+- `diff:web` compares two `dist/web` roots at markdown-block level and writes into the head build: a `<slug>.changes.json` sidecar per page, a `changes-manifest.json` per channel, `base-images/` copies of the replaced images, and the `pr-preview` overlay that marks the changed blocks in the browser. The overlay's popover takes a comment per change (kept in the browser's `localStorage`, scoped to the deployment); the change navigator copies every comment of the preview — reference block plus quoted note, in reading order — as one PR comment. `--json` prints the manifest to stdout (the summary then goes to stderr).
 
 ## Agent Template System
 

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
@@ -397,6 +397,10 @@
   border-color: var(--bai-focus);
   color: var(--bai-focus);
 }
+.bai-nav__badge button.bai-nav__comments:hover {
+  background: var(--bai-focus);
+  color: #fff;
+}
 .bai-nav__badge button.bai-nav__comments[hidden] { display: none; }
 .bai-nav__badge button.bai-nav__comments.bai-copied {
   background: var(--bai-add);

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css
@@ -106,6 +106,25 @@
   pointer-events: none;
 }
 
+/* commented: the same badge in the accent colour; both states share it */
+.bai-pr-preview [data-bai-change].bai-commented::after {
+  content: "✎ comment";
+  position: absolute;
+  top: -12px;
+  right: -6px;
+  font: 600 10px/1 system-ui, sans-serif;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--bai-focus);
+  padding: 2px 6px;
+  border-radius: 999px;
+  pointer-events: none;
+}
+.bai-pr-preview [data-bai-change].bai-viewed.bai-commented::after {
+  content: "✓ viewed · ✎ comment";
+  background: var(--bai-focus);
+}
+
 /* ---------- marks hidden ---------- */
 .bai-marks-off [data-bai-change] {
   background: none !important;
@@ -113,7 +132,8 @@
   outline: none !important;
   cursor: auto;
 }
-.bai-marks-off [data-bai-change].bai-viewed::after { content: none; }
+.bai-marks-off [data-bai-change].bai-viewed::after,
+.bai-marks-off [data-bai-change].bai-commented::after { content: none; }
 .bai-marks-off .bai-removed-placeholder { display: none !important; }
 
 /* Marks are reachable by Tab, so the focus ring must beat `marks off`. */
@@ -209,6 +229,31 @@
   user-select: none;
 }
 .bai-popover__viewed input { margin: 0; accent-color: var(--bai-add); }
+.bai-popover__comment { padding: 8px 12px 0; }
+.bai-popover__comment textarea {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 28px;
+  max-height: 160px;
+  resize: none;
+  overflow-y: auto;
+  border: 1px solid var(--bai-pop-border);
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 4px 8px;
+}
+.bai-popover__comment textarea::placeholder { opacity: 0.55; }
+.bai-popover__comment textarea:not(:placeholder-shown) { border-color: var(--bai-focus); }
+.bai-popover__comment textarea:focus {
+  outline: none;
+  border-color: var(--bai-focus);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
 .bai-popover__where {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   margin-right: 10px;
@@ -344,6 +389,20 @@
   color: #fff;
   border-color: var(--bai-focus);
 }
+.bai-nav__badge button.bai-nav__comments {
+  width: auto;
+  padding: 0 10px;
+  font-size: 12px;
+  white-space: nowrap;
+  border-color: var(--bai-focus);
+  color: var(--bai-focus);
+}
+.bai-nav__badge button.bai-nav__comments[hidden] { display: none; }
+.bai-nav__badge button.bai-nav__comments.bai-copied {
+  background: var(--bai-add);
+  border-color: var(--bai-add);
+  color: #fff;
+}
 .bai-nav__pos {
   min-width: 5.5em;
   text-align: center;
@@ -398,6 +457,7 @@ a.bai-nav__row:hover { background: var(--bai-row-hover); }
   font-variant-numeric: tabular-nums;
 }
 .bai-nav__count--done { background: var(--bai-add); color: #fff; }
+.bai-nav__count--note { background: var(--bai-focus); color: #fff; }
 .bai-nav__actions {
   display: flex;
   gap: 6px;

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
@@ -189,6 +189,162 @@
       }
     }
 
+    // ---------------------------------------------------------- comments
+    // Review notes typed on a change. Kept per page under the same scope as
+    // `viewed`; the navigator copies them all as one PR comment (ref + quote).
+    const COMMENT_PREFIX = `bai-pr-comment:${scope}:`;
+    const commentKey = (l, s) => `${COMMENT_PREFIX}${l}/${s}`;
+    const commentKeys = () => {
+      const keys = [];
+      try {
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i);
+          if (k && k.startsWith(COMMENT_PREFIX)) keys.push(k);
+        }
+      } catch {
+        /* private mode */
+      }
+      return keys;
+    };
+    const readComments = (l, s) => {
+      try {
+        const v = JSON.parse(localStorage.getItem(commentKey(l, s)) || "{}");
+        return v && typeof v === "object" && !Array.isArray(v) ? v : {};
+      } catch {
+        return {};
+      }
+    };
+    const writeComments = (l, s, obj) => {
+      try {
+        if (Object.keys(obj).length)
+          localStorage.setItem(commentKey(l, s), JSON.stringify(obj));
+        else localStorage.removeItem(commentKey(l, s));
+      } catch {
+        /* private mode */
+      }
+    };
+    let comments = readComments(lang, slug);
+    const commentOf = (change) =>
+      (comments[change.fingerprint] && comments[change.fingerprint].text) || "";
+    function setComment(change, text) {
+      if (text.trim()) {
+        comments[change.fingerprint] = {
+          id: change.id,
+          text,
+          ref: refText(change),
+          at: Date.now(),
+        };
+      } else {
+        delete comments[change.fingerprint];
+      }
+      writeComments(lang, slug, comments);
+      const m = marks.find((x) => x.change === change);
+      if (m) m.el.classList.toggle("bai-commented", !!text.trim());
+      updateCommentBadge();
+      if (!panel.hidden) renderPanel();
+    }
+    const commentCountOf = (l, s) =>
+      Object.keys(l === lang && s === slug ? comments : readComments(l, s))
+        .length;
+    // Every comment in this preview in reading order — manifest languages,
+    // their pages as listed, then change id. A block the manifest no longer
+    // has (or a page it no longer lists) is stale: still copied, with a note.
+    function allComments() {
+      const langs = manifest.langs || {};
+      const langOrder = Object.keys(langs);
+      const pagesSeen = new Map();
+      for (const k of commentKeys()) {
+        const rel = k.slice(COMMENT_PREFIX.length);
+        const cut = rel.indexOf("/");
+        if (cut > 0)
+          pagesSeen.set(rel, [rel.slice(0, cut), rel.slice(cut + 1)]);
+      }
+      pagesSeen.set(`${lang}/${slug}`, [lang, slug]);
+      const out = [];
+      for (const [l, s] of pagesSeen.values()) {
+        const pages = langs[l] ? langs[l].pages : [];
+        const pi = pages.findIndex((p) => p.slug === s);
+        const info = pi >= 0 ? pages[pi] : null;
+        const entries =
+          l === lang && s === slug ? comments : readComments(l, s);
+        for (const [fp, e] of Object.entries(entries)) {
+          if (!e || typeof e.text !== "string" || !e.text.trim()) continue;
+          out.push({
+            lang: l,
+            slug: s,
+            id: Number(e.id) || 0,
+            ref: e.ref || `[docs-preview] ${l}/${s}`,
+            text: e.text,
+            stale:
+              !info ||
+              (Array.isArray(info.fingerprints) &&
+                !info.fingerprints.includes(fp)),
+            li:
+              langOrder.indexOf(l) < 0
+                ? langOrder.length
+                : langOrder.indexOf(l),
+            pi: pi < 0 ? pages.length : pi,
+          });
+        }
+      }
+      return out.sort(
+        (a, b) =>
+          a.li - b.li ||
+          a.lang.localeCompare(b.lang) ||
+          a.pi - b.pi ||
+          a.slug.localeCompare(b.slug) ||
+          a.id - b.id,
+      );
+    }
+    const quote = (text) =>
+      text
+        .replace(/\s+$/, "")
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    const STALE_NOTE =
+      "- note: the block changed after this comment was written";
+    const commentsText = () =>
+      allComments()
+        .map(
+          (c) =>
+            `${c.ref}${c.stale ? `\n${STALE_NOTE}` : ""}\n${quote(c.text)}`,
+        )
+        .join("\n\n");
+    const refWithComment = (change) => {
+      const text = commentOf(change);
+      return text.trim()
+        ? `${refText(change)}\n${quote(text)}`
+        : refText(change);
+    };
+    function clearComments() {
+      if (!allComments().length) return;
+      if (!window.confirm("Remove every comment saved for this preview?"))
+        return;
+      try {
+        commentKeys().forEach((k) => localStorage.removeItem(k));
+      } catch {
+        /* private mode */
+      }
+      comments = {};
+      for (const m of marks) m.el.classList.remove("bai-commented");
+      const ta = $("[data-comment]", pop);
+      if (ta) ta.value = "";
+      updateCommentBadge();
+      renderPanel();
+    }
+    // Another tab of the same preview may have edited the notes.
+    window.addEventListener("storage", (e) => {
+      if (!e.key || !e.key.startsWith(COMMENT_PREFIX)) return;
+      if (e.key === commentKey(lang, slug)) {
+        comments = readComments(lang, slug);
+        for (const m of marks)
+          m.el.classList.toggle("bai-commented", !!commentOf(m.change));
+      }
+      updateCommentBadge();
+      if (!panel.hidden) renderPanel();
+    });
+
     // ---------------------------------------------------------- marks
     const blockEl = (idx) =>
       idx == null || idx < 0 ? null : $(`[data-bai-block="${idx}"]`);
@@ -373,6 +529,7 @@
           node.dataset.baiType = change.type;
         }
         node.classList.toggle("bai-viewed", isViewed(change));
+        node.classList.toggle("bai-commented", !!commentOf(change));
         marks.push({ change, el: node });
       }
       marks.sort((a, b) =>
@@ -478,10 +635,12 @@
         `<span class="bai-popover__type bai-popover__type--${type}">${type}</span>` +
         `<span class="bai-popover__kind">${kind}${note}</span>` +
         `<span class="bai-popover__spacer"></span>${modeHtml}` +
-        `<button class="bai-popover__btn" data-copy title="Copy a reference to this change (file:line, section, link, old/new)">Copy ref</button>` +
+        `<button class="bai-popover__btn" data-copy title="Copy a reference to this change (file:line, section, link, old/new) with your comment">Copy ref</button>` +
         `<label class="bai-popover__viewed" title="Mark as viewed (v)"><input type="checkbox" data-viewed ${isViewed(change) ? "checked" : ""}/> Viewed</label>` +
-        `</div><div class="bai-popover__body">${body}</div>` +
-        `<div class="bai-popover__hint"><span class="bai-popover__where">#${change.id} · ${where}</span>${change.blockKind === "image" ? "Click an image to enlarge · " : ""}Click the block to pin · <kbd>n</kbd> / <kbd>p</kbd> next / previous change · <kbd>c</kbd> copy ref · <kbd>v</kbd> viewed · Esc to close</div>`;
+        `</div>` +
+        `<div class="bai-popover__comment"><textarea data-comment rows="1" placeholder="Comment on this change — collected for one PR comment (m)" aria-label="Review comment for this change">${esc(commentOf(change))}</textarea></div>` +
+        `<div class="bai-popover__body">${body}</div>` +
+        `<div class="bai-popover__hint"><span class="bai-popover__where">#${change.id} · ${where}</span>${change.blockKind === "image" ? "Click an image to enlarge · " : ""}Click the block to pin · <kbd>n</kbd> / <kbd>p</kbd> next / previous change · <kbd>c</kbd> copy ref · <kbd>m</kbd> comment · <kbd>v</kbd> viewed · Esc to close</div>`;
       pop.querySelectorAll("[data-mode]").forEach((b) =>
         b.addEventListener("click", () => {
           setMode(b.dataset.mode);
@@ -494,11 +653,36 @@
           img.addEventListener("click", () => lightbox(change)),
         );
       $("[data-copy]", pop).addEventListener("click", (e) =>
-        copy(refText(change), e.currentTarget),
+        copy(refWithComment(change), e.currentTarget),
       );
       $("[data-viewed]", pop).addEventListener("change", (e) =>
         setViewed(change, e.target.checked),
       );
+      const ta = $("[data-comment]", pop);
+      ta.addEventListener("focus", () => {
+        // Typing has to outlive the hover: pin the popover on its block.
+        const m = marks.find((x) => x.change === change);
+        if (m) pinned = m.el;
+      });
+      ta.addEventListener("input", () => {
+        setComment(change, ta.value);
+        fitComment();
+      });
+      ta.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          ta.blur();
+        }
+      });
+      fitComment();
+    }
+
+    // Grow the note box with its text; the popover body scrolls, not the box.
+    function fitComment() {
+      const ta = $("[data-comment]", pop);
+      if (!ta) return;
+      ta.style.height = "auto";
+      ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
     }
 
     function position(target) {
@@ -520,6 +704,7 @@
       updatePos();
       render(change);
       pop.hidden = false;
+      fitComment();
       position(target);
     }
     function hide() {
@@ -592,13 +777,22 @@
       `<div class="bai-nav__panel" hidden></div>` +
       `<div class="bai-nav__badge"><strong>${summary.totals.pages} pages · ${summary.totals.changes} changes</strong>` +
       `<span class="bai-nav__pos"></span>` +
+      `<button data-nav="comments" class="bai-nav__comments" title="Copy every comment in this preview as one PR comment" hidden></button>` +
       `<button data-nav="prev" title="Previous change (p) — wraps to the previous changed page">‹</button>` +
       `<button data-nav="next" title="Next change (n) — wraps to the next changed page">›</button>` +
       `<button data-nav="panel" title="Changed pages">☰</button></div>`;
     document.body.appendChild(nav);
     const panel = $(".bai-nav__panel", nav);
     const posEl = $(".bai-nav__pos", nav);
+    const commentsBtn = $('[data-nav="comments"]', nav);
     const pageIdx = summary.pages.findIndex((p) => p.slug === slug);
+
+    function updateCommentBadge() {
+      const n = allComments().length;
+      commentsBtn.hidden = n === 0;
+      commentsBtn.textContent = `✎ Copy ${n} comment${n === 1 ? "" : "s"}`;
+    }
+    updateCommentBadge();
 
     function renderPanel() {
       const rows = summary.pages
@@ -614,7 +808,11 @@
             p.status === "modified"
               ? `<span class="bai-nav__count${v === p.counts.total ? " bai-nav__count--done" : ""}" title="viewed / total">${v}/${p.counts.total}</span>`
               : "";
-          const inner = `${tag}<span class="bai-nav__title">${esc(p.title)}</span>${count}`;
+          const k = commentCountOf(lang, p.slug);
+          const notes = k
+            ? `<span class="bai-nav__count bai-nav__count--note" title="comments">✎ ${k}</span>`
+            : "";
+          const inner = `${tag}<span class="bai-nav__title">${esc(p.title)}</span>${count}${notes}`;
           // A deleted page has no copy in this build, so it is not a link.
           if (p.status === "deleted")
             return `<div class="bai-nav__row bai-nav__row--deleted">${inner}</div>`;
@@ -629,15 +827,24 @@
           return `<a class="${l === lang ? "bai-nav__lang--current" : ""}" href="../${l}/${target}.html">${l} · ${s.totals.changes}</a>`;
         })
         .join("");
+      const all = allComments();
+      const staleComments = all.filter((c) => c.stale).length;
       const actions =
         `<div class="bai-nav__actions">` +
         (marks.length
           ? `<button data-act="copy-page">Copy page summary</button><button data-act="all-viewed">Mark all viewed</button><button data-act="reset-viewed">Reset</button>`
           : "") +
+        (all.length
+          ? `<button data-act="copy-comments">Copy ${all.length} comment${all.length === 1 ? "" : "s"}</button><button data-act="clear-comments">Clear comments</button>`
+          : "") +
         `<button data-act="marks">${marksOn ? "Hide marks" : "Show marks"}</button></div>`;
-      const stale = staleViewed
-        ? `<div class="bai-nav__stale">${staleViewed} change${staleViewed > 1 ? "s" : ""} you had viewed ${staleViewed > 1 ? "have" : "has"} changed since — shown as unviewed again</div>`
-        : "";
+      const stale =
+        (staleViewed
+          ? `<div class="bai-nav__stale">${staleViewed} change${staleViewed > 1 ? "s" : ""} you had viewed ${staleViewed > 1 ? "have" : "has"} changed since — shown as unviewed again</div>`
+          : "") +
+        (staleComments
+          ? `<div class="bai-nav__stale">${staleComments} comment${staleComments > 1 ? "s" : ""} refer${staleComments > 1 ? "" : "s"} to a block that changed since — copied with a note</div>`
+          : "");
       panel.innerHTML =
         `<div class="bai-nav__section">Changed pages${manifest.label ? ` — ${esc(manifest.label)}` : ""}</div>` +
         `${rows || '<div class="bai-nav__row"><em>No page changed</em></div>'}${stale}${actions}` +
@@ -647,6 +854,9 @@
           const act = b.dataset.act;
           if (act === "copy-page")
             return copy(pageSummaryText(), e.currentTarget);
+          if (act === "copy-comments")
+            return copy(commentsText(), e.currentTarget);
+          if (act === "clear-comments") return clearComments();
           if (act === "marks") {
             marksOn = !marksOn;
             document.body.classList.toggle("bai-marks-off", !marksOn);
@@ -740,6 +950,7 @@
       if (!b) return;
       if (b.dataset.nav === "prev") step(-1);
       else if (b.dataset.nav === "next") step(1);
+      else if (b.dataset.nav === "comments") copy(commentsText(), b);
       else {
         renderPanel();
         panel.hidden = !panel.hidden;
@@ -815,8 +1026,20 @@
         const c = activeChange();
         if (!c) return;
         e.preventDefault();
-        copy(refText(c), pop.hidden ? null : $("[data-copy]", pop));
+        copy(refWithComment(c), pop.hidden ? null : $("[data-copy]", pop));
         showToast(`Copied ref #${c.id}`);
+      } else if (code === "KeyM") {
+        const c = activeChange();
+        const m = c && marks.find((x) => x.change === c);
+        if (!m || !marksOn) return;
+        e.preventDefault();
+        pinned = m.el;
+        show(m.el);
+        const ta = $("[data-comment]", pop);
+        if (ta) {
+          ta.focus();
+          ta.setSelectionRange(ta.value.length, ta.value.length);
+        }
       } else if (code === "Escape") {
         pinned = null;
         pop.hidden = true;

--- a/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js
@@ -669,7 +669,9 @@
         fitComment();
       });
       ta.addEventListener("keydown", (e) => {
-        if (e.key === "Escape") {
+        const done = e.key === "Enter" && (e.metaKey || e.ctrlKey);
+        if (e.key === "Escape" || done) {
+          e.preventDefault();
           e.stopPropagation();
           ta.blur();
         }


### PR DESCRIPTION
Resolves #9582 (FR-3898)

> [!WARNING]
> **Review harness:** this PR changes only the toolkit overlay, so its own docs preview has no content change to mark. Use the preview of the stacked test PR #9586 — <https://lablup.github.io/backend.ai-webui/pr/9586/docs/next/en/> (`ko` for the Korean change) — which is built with this PR's toolkit against throwaway docs edits. **Merge only this PR; close #9586 without merging** once this one lands.

## Summary

Reviewers of a docs PR currently paste one **Copy ref** block per change into a PR comment, add their instruction to each, and mention `@copilot` (e.g. https://github.com/lablup/backend.ai-webui/pull/9576#issuecomment-5614031417). This PR lets them write those instructions on the diff preview itself and copy them all at once.

- **Comment box in the change popover**, under the `MODIFIED / ADDED / REMOVED` header. A commented block carries a `✎ comment` badge (shares the badge with `✓ viewed`).
- **`✎ Copy N comments`** in the change navigator bar, plus `Copy N comments` / `Clear comments` in the panel. The copy is every comment of the preview — all pages and languages — as ref block + quoted note, in reading order, ready to paste as one PR comment.
- Comments are kept in `localStorage` under the same deployment scope as the Viewed state (`bai-pr-comment:<scope>:<lang>/<slug>`, keyed by change fingerprint), so they survive re-deploys of the same PR. A comment whose block changed since is flagged in the panel and copied with a note instead of being dropped.
- `Copy ref` and the `c` shortcut include the change's own comment; `m` focuses the comment box of the active change; Escape or Cmd/Ctrl+Enter in the box blurs it, a second Escape closes the popover.

No server or account linking: only text reaches the clipboard.

Copied output for three comments on two pages:

```
[docs-preview] en/about · change 1/1 · added paragraph
- file: packages/backend.ai-docs-toolkit-example/src/en/about.md:3
- section: "About" (#about-about)
- page: http://127.0.0.1:8765/next/en/about.html#bai-change-1
- new: About page sentence added for the multi-page copy test.
> Third note, on the about page.

[docs-preview] en/features · change 1/2 · modified paragraph
- file: packages/backend.ai-docs-toolkit-example/src/en/features.md:3
- section: "Features" (#features-features)
- page: http://127.0.0.1:8765/next/en/features.html#bai-change-1
- old: This chapter walks through the content blocks the toolkit knows how to render, so you can copy any of them straight into your own pages.
- new: This chapter walks through the content blocks the toolkit knows how to render, so you can copy any of them straight into your own pages. This sentence was added by the local preview test.
> Please shorten this sentence.

[docs-preview] en/features · change 2/2 · added paragraph
- file: packages/backend.ai-docs-toolkit-example/src/en/features.md:6
- section: "Features" (#features-features)
- page: http://127.0.0.1:8765/next/en/features.html#bai-change-2
- new: A brand-new paragraph inserted for the FR-3898 comment test.
> Drop this paragraph.
> It duplicates the intro.
```

## Screenshots

| Comment box in the change popover | Navigator: per-page counts, Copy / Clear comments |
|---|---|
| ![popover with comment box](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9584/20260910-064637-popover-comment-box.png) | ![navigator with comments](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-9584/20260910-064643-navigator-copy-comments.png) |

## Files

- `packages/backend.ai-docs-toolkit/templates/assets/pr-preview.js` — comment state, popover box, navigator button, panel actions, `m` shortcut
- `packages/backend.ai-docs-toolkit/templates/assets/pr-preview.css` — comment badge, textarea, navigator button, per-page count
- `packages/backend.ai-docs-toolkit/README.md` — one sentence on the overlay

## Verification

- `pnpm --filter backend.ai-docs-toolkit test` — 361 pass, 1 skipped
- Playwright script against a local `diff:web` build of the example package: comment → badge → reload persistence → `m` shortcut → second page → copy-all order and format → stale notice and note → clear. All checks pass.
- `bash scripts/verify.sh` — `=== ALL PASS ===`

## Checklist

- [ ] 1. Open a docs PR preview, click a changed block, type a comment and confirm the block shows `✎ comment` and the bar shows `✎ Copy 1 comment`.
- [ ] 2. Comment on a change of another page (or language), press `✎ Copy N comments` and confirm the paste contains every comment as ref block + `> note`.
- [ ] 3. Reload the page and confirm the comments are still there; open the panel and confirm `Clear comments` removes them after the confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwdW4R9BF2LErrPzuyKgRq


