### PR TITLE
test: e2e auto-heal 2026-09-10

### DIFF
--- a/e2e/admin-model-card/admin-model-card-sort-refresh.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-sort-refresh.spec.ts
@@ -3,6 +3,7 @@
 import { AdminModelCardPage } from '../utils/classes/AdminModelCardPage';
 import {
   deleteForeverAndVerifyFromTrash,
+  getSortableColumnHeader,
   loginAsAdmin,
   moveToTrashAndVerify,
   webuiEndpoint,
@@ -98,7 +99,7 @@ test.describe(
       await adminModelCardPage.waitForTableLoad();
 
       // Click the "Name" column header to sort ascending
-      await page.getByRole('columnheader', { name: 'Name' }).click();
+      await getSortableColumnHeader(page, 'Name').click();
 
       // Verify the URL contains an ascending sort order
       await expect(page).toHaveURL(/order=name/);
@@ -109,7 +110,7 @@ test.describe(
       });
 
       // Verify the sort indicator shows ascending
-      const nameHeader = page.getByRole('columnheader', { name: 'Name' });
+      const nameHeader = getSortableColumnHeader(page, 'Name');
       await expect(nameHeader).toBeVisible();
     });
 
@@ -124,7 +125,7 @@ test.describe(
       await adminModelCardPage.waitForTableLoad();
 
       // Click Name header once (ascending), then again (descending)
-      const nameHeader = page.getByRole('columnheader', { name: 'Name' });
+      const nameHeader = getSortableColumnHeader(page, 'Name');
       await nameHeader.click();
       await nameHeader.click();
 
@@ -175,11 +176,11 @@ test.describe(
       await adminModelCardPage.waitForTableLoad();
 
       // Sort by Name ascending
-      await page.getByRole('columnheader', { name: 'Name' }).click();
+      await getSortableColumnHeader(page, 'Name').click();
       await expect(page).toHaveURL(/order=name/);
 
       // Switch to sort by Created At
-      await page.getByRole('columnheader', { name: 'Created At' }).click();
+      await getSortableColumnHeader(page, 'Created At').click();
       await expect(page).toHaveURL(/order=createdAt/);
       await expect(page).not.toHaveURL(/order=name/);
 

--- a/e2e/admin-model-card/admin-model-card-sort-refresh.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-sort-refresh.spec.ts
@@ -146,10 +146,9 @@ test.describe(
       );
       await adminModelCardPage.waitForTableLoad();
 
-      // Click the "Created At" column header to sort
-      const createdAtHeader = page.getByRole('columnheader', {
-        name: 'Created At',
-      });
+      // Click the "Created At" column header to sort. The sorter overrides the
+      // header's accessible name ("Sort by createdAt"), so match by text.
+      const createdAtHeader = getSortableColumnHeader(page, 'Created At');
       await createdAtHeader.click();
 
       // Verify the URL reflects the sort

--- a/e2e/admin-model-card/admin-model-card-url-state.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-url-state.spec.ts
@@ -89,17 +89,20 @@ test.describe(
       await page.goto(currentURL);
       await adminModelCardPage.waitForTableLoad();
 
-      // Verify the filter chip is visible (filter persisted from URL). PowerSearch's
-      // chip-remove button is named "Remove <Field>: <operator>" (no value suffix
-      // on this page); the value itself renders as adjoining chip text.
-      await expect(
-        page.getByRole('button', { name: 'Remove Name: contains' }),
-      ).toBeVisible();
-
-      // Verify the filtered results are shown
-      await expect(adminModelCardPage.getPaginationInfo()).toContainText(
-        'items',
+      // Verify the filter chip carries the value that came back from the URL.
+      // PowerSearch names the remove button "Remove <Field>: <operator>" only —
+      // the value is a sibling span, so assert the enclosing token pill.
+      const filterChipRemove = page.getByRole('button', {
+        name: 'Remove Name: contains',
+      });
+      await expect(filterChipRemove).toBeVisible();
+      await expect(filterChipRemove.locator('xpath=..')).toContainText(
+        testCardName,
       );
+
+      // Verify the filter is actually applied: only the target row is listed
+      await expect(adminModelCardPage.getRowByName(testCardName)).toBeVisible();
+      await expect(adminModelCardPage.getDataRows()).toHaveCount(1);
     });
 
     // 10.2 Sort order is persisted in the URL query parameters

--- a/e2e/admin-model-card/admin-model-card-url-state.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-url-state.spec.ts
@@ -3,6 +3,7 @@
 import { AdminModelCardPage } from '../utils/classes/AdminModelCardPage';
 import {
   deleteForeverAndVerifyFromTrash,
+  getSortableColumnHeader,
   loginAsAdmin,
   moveToTrashAndVerify,
   webuiEndpoint,
@@ -88,16 +89,11 @@ test.describe(
       await page.goto(currentURL);
       await adminModelCardPage.waitForTableLoad();
 
-      // Verify the filter chip is visible (filter persisted from URL)
-      const filterChipPattern = new RegExp(
-        `Name.*${testCardName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
-      );
+      // Verify the filter chip is visible (filter persisted from URL). PowerSearch's
+      // chip-remove button is named "Remove <Field>: <operator>" (no value suffix
+      // on this page); the value itself renders as adjoining chip text.
       await expect(
-        page
-          .getByRole('status')
-          .filter({ hasText: filterChipPattern })
-          .or(page.locator('.ant-tag').filter({ hasText: filterChipPattern }))
-          .first(),
+        page.getByRole('button', { name: 'Remove Name: contains' }),
       ).toBeVisible();
 
       // Verify the filtered results are shown
@@ -117,7 +113,7 @@ test.describe(
       await adminModelCardPage.waitForTableLoad();
 
       // Click the "Name" column to sort ascending
-      await page.getByRole('columnheader', { name: 'Name' }).click();
+      await getSortableColumnHeader(page, 'Name').click();
       await expect(page).toHaveURL(/order=name/);
 
       const sortedURL = page.url();

--- a/e2e/admin-model-card/admin-model-card-url-state.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-url-state.spec.ts
@@ -149,7 +149,12 @@ test.describe(
         // page of model store cards on the target cluster. Seeding more model
         // cards is an infra task — until then the test skips with an auditable
         // reason.
-        const nextButton = page.getByRole('button', { name: 'right' });
+        //
+        // Astryx `Pagination` names the arrow "Go to next page" (not the antd
+        // icon name "right").
+        const nextButton = page.getByRole('button', {
+          name: 'Go to next page',
+        });
         const isNextEnabled = await nextButton.isEnabled();
         test.skip(
           !isNextEnabled,
@@ -161,10 +166,13 @@ test.describe(
         // Use the URL as the source of truth for the active page
         await expect(page).toHaveURL(/current=2/);
 
-        // Verify page 2 pagination item is active
+        // Verify page 2 is active: Astryx marks the current page button with
+        // `aria-current="page"`.
         await expect(
-          page.getByRole('listitem', { name: '2' }).first(),
-        ).toBeVisible();
+          page
+            .getByRole('navigation', { name: 'Pagination' })
+            .locator('[aria-current="page"]'),
+        ).toHaveText('2');
 
         const page2URL = page.url();
 

--- a/e2e/global-search/global-search-palette.spec.ts
+++ b/e2e/global-search/global-search-palette.spec.ts
@@ -117,9 +117,13 @@ test.describe(
       await resultRow(page, 'Registries').click();
 
       await expect(page).toHaveURL(/\/admin\/environment\?.*tab=registry/);
-      await expect(page.getByRole('tab', { selected: true })).toContainText(
-        'Registries',
-      );
+      // Astryx `TabList` renders plain buttons in a `nav[aria-label="Tabs"]`,
+      // not ARIA `tab`s — the active one carries `aria-current="true"`.
+      await expect(
+        page
+          .getByRole('navigation', { name: 'Tabs' })
+          .getByRole('button', { name: 'Registries' }),
+      ).toHaveAttribute('aria-current', 'true');
     });
 
     test('user can select a setting hit and arrive on the highlighted item', async ({

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -66,8 +66,13 @@ test.describe.serial(
           .locator('.bai-name-action-cell-actions button')
           .nth(2)
           .click();
-        const popconfirm = page.locator('.ant-popconfirm');
-        await popconfirm.getByRole('button', { name: 'Deactivate' }).click();
+        // BAINameActionCell's popConfirm renders as an Astryx Popover with
+        // role="dialog", labeled by the action's title ("Deactivate"), not
+        // the confirm copy inside it ("Deactivate user").
+        const popconfirm = page.getByRole('dialog', { name: 'Deactivate' });
+        await popconfirm
+          .getByRole('button', { name: 'Deactivate', exact: true })
+          .click();
         // Wait for user to disappear from the Active list
         await expect(userRow).toBeHidden({ timeout: 10000 });
       }
@@ -234,12 +239,16 @@ test.describe.serial(
         .nth(2)
         .click();
 
-      // 6. Verify popconfirm dialog appears
-      const popconfirm = page.locator('.ant-popconfirm');
-      await expect(popconfirm.getByText('Deactivate User')).toBeVisible();
+      // 6. Verify popconfirm dialog appears. BAINameActionCell's popConfirm
+      // renders as an Astryx Popover with role="dialog", labeled by the
+      // action's title ("Deactivate") — not the antd `.ant-popconfirm` class.
+      const popconfirm = page.getByRole('dialog', { name: 'Deactivate' });
+      await expect(popconfirm).toBeVisible();
 
       // 7. Confirm deactivation
-      await popconfirm.getByRole('button', { name: 'Deactivate' }).click();
+      await popconfirm
+        .getByRole('button', { name: 'Deactivate', exact: true })
+        .click();
 
       // 8. Verify user disappears from Active users list
       await expect(page.getByRole('row').filter({ hasText: EMAIL })).toBeHidden(
@@ -279,12 +288,14 @@ test.describe.serial(
         .nth(2)
         .click();
 
-      // 6. Verify popconfirm dialog appears
-      const popconfirm = page.locator('.ant-popconfirm');
-      await expect(popconfirm.getByText('Activate User')).toBeVisible();
+      // 6. Verify popconfirm dialog appears (Astryx Popover, role="dialog").
+      const popconfirm = page.getByRole('dialog', { name: 'Activate' });
+      await expect(popconfirm).toBeVisible();
 
       // 7. Confirm activation
-      await popconfirm.getByRole('button', { name: 'Activate' }).click();
+      await popconfirm
+        .getByRole('button', { name: 'Activate', exact: true })
+        .click();
 
       // 8. Verify user disappears from Inactive users list
       await expect(page.getByRole('row').filter({ hasText: EMAIL })).toBeHidden(
@@ -326,8 +337,10 @@ test.describe.serial(
         .locator('.bai-name-action-cell-actions button')
         .nth(2)
         .click();
-      const popconfirm = page.locator('.ant-popconfirm');
-      await popconfirm.getByRole('button', { name: 'Deactivate' }).click();
+      const popconfirm = page.getByRole('dialog', { name: 'Deactivate' });
+      await popconfirm
+        .getByRole('button', { name: 'Deactivate', exact: true })
+        .click();
       // Wait for user to disappear from Active list before switching filters
       await expect(userRow).toBeHidden({ timeout: 10000 });
 

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -373,9 +373,12 @@ test.describe.serial(
       // so we cannot verify the email directly in the modal for a single-user deletion.
       await purgeModal.confirmDeletion();
 
-      // 12. Verify success message appears
+      // 12. Verify success message appears. The toast text is rendered twice
+      // (notification stack + screen-reader announcer), so scope to the stack.
       await expect(
-        page.getByText(/Permanently deleted \d+ out of \d+ users/),
+        page
+          .getByRole('region', { name: 'Notifications' })
+          .getByText(/Permanently deleted \d+ out of \d+ users/),
       ).toBeVisible({ timeout: 10000 });
 
       // 13. Verify user completely disappears from inactive users list

--- a/e2e/utils/classes/AdminModelCardPage.ts
+++ b/e2e/utils/classes/AdminModelCardPage.ts
@@ -34,9 +34,12 @@ export class AdminModelCardPage {
   }
 
   getDataRows(): Locator {
-    return this.page.locator(
-      'tbody tr:not(.ant-table-measure-row):not(.ant-table-placeholder)',
-    );
+    // Astryx `Table`'s empty state is a real `<tr>` ("No data to display"),
+    // not a dead antd `.ant-table-placeholder` row — filter by the row
+    // checkbox that only real data rows carry.
+    return this.page
+      .locator('tbody tr')
+      .filter({ has: this.page.getByRole('checkbox') });
   }
 
   private escapeRegExp(value: string): string {
@@ -73,23 +76,25 @@ export class AdminModelCardPage {
     return this.page.getByRole('combobox', { name: 'Search' });
   }
 
-  getFilterSearchButton(): Locator {
-    return this.page.getByRole('button', { name: 'search' });
+  getFilterSearchResultOption(value: string): Locator {
+    return this.page.getByRole('option', {
+      name: new RegExp(`^"${this.escapeRegExp(value)}"$`),
+    });
   }
 
   async applyNameFilter(value: string): Promise<void> {
+    // PowerSearch has no submit button — typing opens a quoted free-text
+    // suggestion, and clicking it commits the condition.
     await this.getFilterSearchInput().fill(value);
-    await this.getFilterSearchButton().click();
+    await this.getFilterSearchResultOption(value).click();
     await this.page.waitForURL(new RegExp(`filter=`));
   }
 
   async clearFilter(): Promise<void> {
-    // The filter chip's close affordance is a button labeled "Close" (not an
-    // icon-only `img` role) as of the row-action UI refresh in FR-3331.
-    const closeButton = this.page
-      .getByRole('button', { name: 'Close' })
-      .first();
-    await closeButton.click();
+    // PowerSearch's chip-remove button is named "Remove <Field>: <operator>",
+    // so "Clear all" is the stable target regardless of which field/operator
+    // was applied.
+    await this.page.getByRole('button', { name: 'Clear all' }).click();
   }
 
   // ── Row actions ──────────────────────────────────────────────────────────

--- a/e2e/utils/classes/user/PurgeUsersModal.ts
+++ b/e2e/utils/classes/user/PurgeUsersModal.ts
@@ -111,7 +111,12 @@ export class PurgeUsersModal {
    * Get the Delete button
    */
   getDeleteButton(): Locator {
-    return this.modal.getByRole('button', { name: 'Delete' });
+    // The confirm input's clear button is also named "... Permanently Delete",
+    // so match the OK button's label exactly.
+    return this.modal.getByRole('button', {
+      name: 'Permanently Delete',
+      exact: true,
+    });
   }
 
   /**


### PR DESCRIPTION
Produced automatically by the **daily digest auto-heal** (2026-09-10 run). Every
change is test-side only — no `react/` or `packages/` source is touched — and each
healed test was re-run against the nightly environment before this PR existed.

## Why these five specs

Today's run was the **first successful full suite since 2026-09-07** (09-08 → 09-10-run1
all aborted on preflight: the test webserver `10.82.0.6:8090` was refusing connections).
So this failure set covers six days of merges, and triage classified 11 of 92 failures
as test-side drift. These are the five highest-leverage ones.

| Mechanism | What actually changed in the app | Specs |
|---|---|---|
| `BAIGraphQLPropertyFilter` is Astryx `PowerSearch` now | No submit button (`getByRole('button', {name:'search'})` is dead); the search icon is decorative. Typing opens a quoted free-text suggestion, and clicking it commits the condition. Chip removal is `Remove <Field>: <operator>` / `Clear all`. The empty state is a real `<tr>`, not an antd placeholder row. | `admin-model-card-filter`, `admin-model-card-url-state` |
| A sorter overrides its column header's accessible name | `getByRole('columnheader', {name: 'Name'})` matches 2 elements (strict-mode violation) because the sort button's `aria-label` ("Sort by …") becomes part of the name. Switched to the existing `getSortableColumnHeader()` helper, the same fix #9405 applied to `admin-model-card-page-load`. | `admin-model-card-sort-refresh`, `admin-model-card-url-state` |
| Astryx `TabList` renders nav buttons, not ARIA tabs | `role="tab"` / `aria-selected` only appear when the parent `TabList` is explicitly given `role="tablist"`, which no call site does. The active tab carries `aria-current="true"` inside `nav[aria-label="Tabs"]` — the pattern already used by `preset-crud`, `rbac-role-detail`, `my-environment`. | `global-search-palette` |
| `BAINameActionCell`'s `popConfirm` is an Astryx `Popover` | `.ant-popconfirm` no longer exists; the confirm is `role="dialog"` labeled by the action's title. | `user-crud` |

`global-search-palette.spec.ts` is worth a note: it is a **brand-new spec** (landed in
#8864 this window) that was written against the ARIA-tab shape, so it missed the earlier
heal passes for the same mechanism rather than regressing.

## Healed (verified re-pass)

- `admin-model-card/admin-model-card-filter.spec.ts` — all 3 tests
- `admin-model-card/admin-model-card-sort-refresh.spec.ts` — all 5 tests (the Created At sort was healed in the follow-up, see below)
- `admin-model-card/admin-model-card-url-state.spec.ts` — all 3 tests (pagination persistence healed in the follow-up, see below)
- `global-search/global-search-palette.spec.ts` — "select a tab hit and land on the deep-linked tab"
- `user/user-crud.spec.ts` — all 6 tests ("deactivate" / "reactivate" by the popconfirm change; the purge test healed in the follow-up, see below)

## Follow-up: the three failures first triaged as app-side were drift too

A re-run of these five specs against nightly (2026-09-10, after the first two
commits) showed `createModelCard()` getting through in `beforeEach`, so the two
model-card tests first filed as "blocked upstream" actually die on plain locator
drift — and the purge test deferred as "separate" is two more strict-mode
violations of the same shape. All three are healed in the third commit:

| Test | What actually changed in the app | Fix |
|---|---|---|
| `admin-model-card-sort-refresh` "sort by Created At" | The sorter overrides the header's accessible name (`Sort by createdAt`), so `getByRole('columnheader', { name: 'Created At' })` never matches. | `getSortableColumnHeader(page, 'Created At')`, same as the Name-sort tests. |
| `admin-model-card-url-state` "persist pagination state" | Astryx `Pagination` names the arrow `Go to next page` (not antd's `right`) and marks the current page with `aria-current="page"` — there is no active `listitem`. | Target the arrow by its new name and assert the `aria-current` button inside `navigation[name="Pagination"]` reads `2`. |
| `user-crud` "deactivate and permanently delete (purge)" | `PurgeUsersModal.getDeleteButton()` (`name: 'Delete'`) also matches the confirm input's clear button (`Clear Please type "Permanently Delete".`). After that, the success toast text is rendered twice — notification stack + screen-reader announcer — so the unscoped `getByText` is a second strict-mode violation. | Match the OK button as `Permanently Delete` exactly; scope the toast assertion to the `Notifications` region (the `toastRegion()` pattern from `registry.spec.ts`). |

The `PurgeUsersModal` fix also serves `bulk-user-creation.spec.ts` and
`password-expiry.spec.ts`, which share the page object.

One flake seen once and not reproduced: "reactivate an inactive user" failed a
single time with nightly stuck on the `Loading components...` splash for the
whole 30 s; it passed on the three re-runs that followed, so nothing changed.

## Verification

`bash scripts/verify.sh` — Relay, Search index, Lint, Format, TypeScript all **PASS**.
One pre-existing unrelated failure: `Astryx theme build` cannot resolve `backend.ai-ui`
because `packages/backend.ai-ui/dist` has never been built in this checkout. It fails
identically on a pristine `main` and is untouched by this PR (the whole diff is `e2e/*.ts`).

Report doc: `~/e2e-digest-reports/report-2026-09-10-run2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Copilot review

One finding, valid, fixed in the follow-up commit: the rewritten filter-chip assertion
had stopped verifying the persisted *value* (`Remove Name: contains` is the same button
name for every Name/contains token, and the `items` pagination text passes on an
unfiltered table too). It now asserts the enclosing token pill contains `testCardName`
and that exactly the target row is listed. Re-verified green. Thread replied and resolved.

