### PR TITLE
test: e2e auto-heal 2026-09-11

### DIFF
--- a/e2e/auth/forgot-password.spec.ts
+++ b/e2e/auth/forgot-password.spec.ts
@@ -598,7 +598,9 @@ test.describe('Change password page', () => {
 
       // 3. Click Update and verify the password mismatch error notification
       await page.getByRole('button', { name: 'Update' }).click();
-      await expect(page.getByText('Password mismatch')).toBeVisible({
+      await expect(
+        toastRegion(page).getByText('Password mismatch'),
+      ).toBeVisible({
         timeout: 10_000,
       });
 

--- a/e2e/chat/chat-sync.spec.ts
+++ b/e2e/chat/chat-sync.spec.ts
@@ -244,9 +244,10 @@ test.describe(
         'true',
         { timeout: 10000 },
       );
+      // An unscoped getByText also matches a hidden node with the same label.
       await expect(
-        secondChatCardHeader.getByText('gpt-mock-model-b'),
-      ).toBeVisible({ timeout: 10000 });
+        secondChatCardHeader.getByRole('button', { name: 'Select Model' }),
+      ).toContainText('gpt-mock-model-b', { timeout: 10000 });
 
       // Verify both panes have sync ON
       await expect(getSyncToggle(page, 0).first()).toBeVisible({

--- a/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
+++ b/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
@@ -18,7 +18,15 @@ import {
   profileModal,
   usersTabButton,
 } from '../utils/user-profile-util';
-import test, { expect } from '@playwright/test';
+import test, { expect, type Page } from '@playwright/test';
+
+// PowerSearch has no submit button: clicking the quoted free-text suggestion
+// commits the filter (same as AdminModelCardPage.applyNameFilter()).
+async function applyEmailFilter(page: Page, email: string): Promise<void> {
+  const searchBar = page.getByRole('combobox', { name: 'Search filters' });
+  await searchBar.fill(email);
+  await page.getByRole('option', { name: new RegExp(`^"${email}"$`) }).click();
+}
 
 // Generate unique identifiers for this test run
 const TEST_RUN_ID = Date.now().toString(36);
@@ -205,14 +213,7 @@ test.describe.serial(
       await page.getByText('Active', { exact: true }).click();
 
       // Use the filter to search for this specific user's email.
-      // BAIPropertyFilter renders Input.Search inside AutoComplete; in antd v6
-      // the aria-label on Input.Search is dropped from the underlying input,
-      // so target the input directly via the .ant-input-search wrapper.
-      const filterValueInput = page
-        .locator('.ant-input-search input[type="search"]')
-        .first();
-      await filterValueInput.fill(EMAIL);
-      await page.getByRole('button', { name: 'search' }).click();
+      await applyEmailFilter(page, EMAIL);
 
       // 3. Check if the user is in the Active list
       const userRow = page.getByRole('row').filter({ hasText: EMAIL });
@@ -234,10 +235,12 @@ test.describe.serial(
         // 3b. Deactivate the user — confirm the Popconfirm that appears
         await expect(userRow).toBeVisible();
         await clickRowAction(page, userRow, 'Deactivate');
-        const deactivatePopconfirm = page.locator('.ant-popconfirm');
+        const deactivatePopconfirm = page.getByRole('dialog', {
+          name: 'Deactivate',
+        });
         await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
         await deactivatePopconfirm
-          .getByRole('button', { name: 'Deactivate' })
+          .getByRole('button', { name: 'Deactivate', exact: true })
           .click();
         await expect(userRow).toBeHidden({ timeout: 10000 });
       }
@@ -249,11 +252,7 @@ test.describe.serial(
       await expect(usersTabButton(page)).toBeVisible();
 
       // Apply the same email filter on the Inactive tab
-      const inactiveFilterInput = page
-        .locator('.ant-input-search input[type="search"]')
-        .first();
-      await inactiveFilterInput.fill(EMAIL);
-      await page.getByRole('button', { name: 'search' }).click();
+      await applyEmailFilter(page, EMAIL);
 
       // Wait for the filtered Inactive table to load and show this specific user
       await expect(page.getByRole('cell', { name: EMAIL })).toBeVisible({
@@ -262,15 +261,15 @@ test.describe.serial(
 
       const inactiveUserRow = page.getByRole('row').filter({ hasText: EMAIL });
       await inactiveUserRow.getByRole('checkbox').click();
-      // Wait for the selection action bar to appear, then click the purge button.
-      // The purge button uses DeleteFilled icon (accessible name "delete").
-      // Scope to the first "delete" button (the header purge button); the row-level
-      // per-row delete action also uses "delete" aria-label and would cause strict
-      // mode violation if unscoped.
+      // Both bulk-toolbar IconButtons are named "Action"; key on the trash icon
+      // (name: 'delete' would hit the row-level "Permanently Delete" buttons).
       await expect(page.getByText(/\d+ selected/)).toBeVisible({
         timeout: 5000,
       });
-      await page.getByRole('button', { name: 'delete' }).first().click();
+      await page
+        .getByRole('button', { name: 'Action', exact: true })
+        .filter({ has: page.locator('svg.lucide-trash2') })
+        .click();
 
       const purgeModal = new PurgeUsersModal(page);
       await purgeModal.waitForVisible();

--- a/e2e/user-profile/user-profile.spec.ts
+++ b/e2e/user-profile/user-profile.spec.ts
@@ -14,7 +14,13 @@ import {
   createDisposableUser,
   profileModal,
 } from '../utils/user-profile-util';
-import test, { expect } from '@playwright/test';
+import test, { expect, type Page } from '@playwright/test';
+
+// Astryx also renders each toast into a screen-reader announcer, so an
+// unscoped getByText() matches twice.
+function toastRegion(page: Page) {
+  return page.getByRole('region', { name: 'Notifications' });
+}
 
 // These tests edit the logged-in account's own profile — full name, password,
 // and the **Allowed Client IP** allowlist. Running them as the shared
@@ -161,11 +167,12 @@ test.describe(
           '192.168.0.0/16',
         ]);
 
+        // Each tag renders as a "Remove {cidr}" button
         await expect(
-          formItem.locator('.ant-tag').filter({ hasText: '10.20.30.0/24' }),
+          formItem.getByRole('button', { name: 'Remove 10.20.30.0/24' }),
         ).toBeVisible();
         await expect(
-          formItem.locator('.ant-tag').filter({ hasText: '192.168.0.0/16' }),
+          formItem.getByRole('button', { name: 'Remove 192.168.0.0/16' }),
         ).toBeVisible();
 
         await profileModal(page)
@@ -173,7 +180,7 @@ test.describe(
           .click();
       });
 
-      test('Invalid IP/CIDR entries are highlighted in red', async ({
+      test('Invalid IP/CIDR entries are flagged with a validation error', async ({
         page,
         request,
       }) => {
@@ -184,18 +191,18 @@ test.describe(
 
         await addIpTags(profileModal(page), ['not-an-ip']);
 
-        const redTag = formItem
-          .locator('.ant-tag')
-          .filter({ hasText: 'not-an-ip' });
-        await expect(redTag).toBeVisible();
-        await expect(redTag).toHaveClass(/ant-tag-red/);
+        // The tokenizer keeps the entry; the field's validator names it.
+        await expect(
+          formItem.getByRole('button', { name: 'Remove not-an-ip' }),
+        ).toBeVisible();
+        await expect(formItem.getByText('Invalid IP: not-an-ip')).toBeVisible();
 
         await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
           .click();
       });
 
-      test('Mixed valid and invalid IPs show correct tag colors', async ({
+      test('Mixed valid and invalid IPs flag only the invalid entry', async ({
         page,
         request,
       }) => {
@@ -210,23 +217,15 @@ test.describe(
           '10.0.0.0/8',
         ]);
 
-        const validTag = formItem
-          .locator('.ant-tag')
-          .filter({ hasText: '192.168.1.1' });
-        await expect(validTag).toBeVisible();
-        await expect(validTag).not.toHaveClass(/ant-tag-red/);
+        for (const ip of ['192.168.1.1', 'invalid-ip', '10.0.0.0/8']) {
+          await expect(
+            formItem.getByRole('button', { name: `Remove ${ip}` }),
+          ).toBeVisible();
+        }
 
-        const invalidTag = formItem
-          .locator('.ant-tag')
-          .filter({ hasText: 'invalid-ip' });
-        await expect(invalidTag).toBeVisible();
-        await expect(invalidTag).toHaveClass(/ant-tag-red/);
-
-        const cidrTag = formItem
-          .locator('.ant-tag')
-          .filter({ hasText: '10.0.0.0/8' });
-        await expect(cidrTag).toBeVisible();
-        await expect(cidrTag).not.toHaveClass(/ant-tag-red/);
+        const error = formItem.getByText(/^Invalid IP:/);
+        await expect(error).toBeVisible();
+        await expect(error).toHaveText('Invalid IP: invalid-ip');
 
         await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
@@ -241,23 +240,16 @@ test.describe(
 
         await addIpTags(profileModal(page), ['192.168.1.1']);
 
-        const tag = formItem
-          .locator('.ant-tag')
-          .filter({ hasText: '192.168.1.1' });
-        await expect(tag).toBeVisible();
+        // Each token carries a remove button named "Remove {ip}"
+        const removeButton = formItem.getByRole('button', {
+          name: 'Remove 192.168.1.1',
+        });
+        await expect(removeButton).toBeVisible();
 
-        // to-astryx final-B: was `.anticon-close` — a per-glyph class from
-        // `@ant-design/icons` that nothing in this app renders any more (the
-        // first-party icon shim emits `bai-icon`, and it never emitted
-        // glyph-specific names at all). The allowed-client-IP control is an
-        // Astryx `Tokenizer`; each token carries a real remove button whose
-        // accessible name is `Remove <value>` (measured on the live profile
-        // modal), so target that instead of any class.
-        // NOTE: the `.ant-tag` selectors still in this file are equally stale
-        // and belong to the separate `.ant-*` selector migration.
-        await tag.getByRole('button', { name: /^Remove / }).click();
+        await removeButton.click();
 
-        await expect(tag).toBeHidden();
+        await expect(removeButton).toBeHidden();
+        await expect(formItem.getByText('192.168.1.1')).toBeHidden();
 
         await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
@@ -301,7 +293,7 @@ test.describe(
         await modal.getByRole('button', { name: 'Update' }).click();
 
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
 
         // Cleanup: clear allowed IPs
@@ -311,7 +303,7 @@ test.describe(
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
       });
 
@@ -333,7 +325,7 @@ test.describe(
         await modal.getByRole('button', { name: 'Update' }).click();
 
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
 
         // Cleanup: clear allowed IPs
@@ -343,7 +335,7 @@ test.describe(
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
       });
 
@@ -361,7 +353,7 @@ test.describe(
         await addIpTags(profileModal(page), [currentIp]);
         await modal.getByRole('button', { name: 'Update' }).click();
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
 
         // Reopen and remove all IPs
@@ -371,13 +363,15 @@ test.describe(
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
 
         // Verify IPs are cleared
         await openProfileModal(page);
         const formItem = getAllowedClientIpFormItem(profileModal(page));
-        await expect(formItem.locator('.ant-tag')).toHaveCount(0);
+        await expect(
+          formItem.getByRole('button', { name: /^Remove / }),
+        ).toHaveCount(0);
 
         await profileModal(page)
           .getByRole('button', { name: 'Cancel' })
@@ -398,7 +392,7 @@ test.describe(
 
         const modal = profileModal(page);
 
-        const fullNameInput = modal.locator('input#full_name');
+        const fullNameInput = modal.getByRole('textbox', { name: 'Full Name' });
         const originalName = await fullNameInput.inputValue();
 
         const testName = `E2E Test User ${Date.now().toString(36)}`;
@@ -408,24 +402,28 @@ test.describe(
         await modal.getByRole('button', { name: 'Update' }).click();
 
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
 
         // Reopen and verify the name was saved
         await openProfileModal(page);
         const updatedName = await profileModal(page)
-          .locator('input#full_name')
+          .getByRole('textbox', { name: 'Full Name' })
           .inputValue();
         expect(updatedName).toBe(testName);
 
         // Cleanup: restore original name
-        await profileModal(page).locator('input#full_name').clear();
-        await profileModal(page).locator('input#full_name').fill(originalName);
+        await profileModal(page)
+          .getByRole('textbox', { name: 'Full Name' })
+          .clear();
+        await profileModal(page)
+          .getByRole('textbox', { name: 'Full Name' })
+          .fill(originalName);
         await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
       });
 
@@ -439,7 +437,7 @@ test.describe(
         const modal = profileModal(page);
         const currentIp = await getCurrentClientIp(page);
 
-        const fullNameInput = modal.locator('input#full_name');
+        const fullNameInput = modal.getByRole('textbox', { name: 'Full Name' });
         const originalName = await fullNameInput.inputValue();
         const testName = `E2E Combined ${Date.now().toString(36)}`;
 
@@ -451,30 +449,34 @@ test.describe(
         await modal.getByRole('button', { name: 'Update' }).click();
 
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
 
         // Reopen and verify both changes were saved
         await openProfileModal(page);
         const savedName = await profileModal(page)
-          .locator('input#full_name')
+          .getByRole('textbox', { name: 'Full Name' })
           .inputValue();
         expect(savedName).toBe(testName);
 
         const savedFormItem = getAllowedClientIpFormItem(profileModal(page));
         await expect(
-          savedFormItem.locator('.ant-tag').filter({ hasText: currentIp }),
+          savedFormItem.getByRole('button', { name: `Remove ${currentIp}` }),
         ).toBeVisible();
 
         // Cleanup: restore original name and clear IPs
-        await profileModal(page).locator('input#full_name').clear();
-        await profileModal(page).locator('input#full_name').fill(originalName);
+        await profileModal(page)
+          .getByRole('textbox', { name: 'Full Name' })
+          .clear();
+        await profileModal(page)
+          .getByRole('textbox', { name: 'Full Name' })
+          .fill(originalName);
         await removeAllIpTags(profileModal(page));
         await profileModal(page)
           .getByRole('button', { name: 'Update' })
           .click();
         await expect(
-          page.getByText('Profile has been successfully updated.'),
+          toastRegion(page).getByText('Profile has been successfully updated.'),
         ).toBeVisible({ timeout: 10000 });
       });
     });
@@ -492,11 +494,17 @@ test.describe(
 
         const modal = profileModal(page);
 
-        await expect(modal.locator('input#password')).toBeVisible();
-        await expect(modal.locator('input#passwordConfirm')).toBeVisible();
+        await expect(
+          modal.getByRole('textbox', { name: 'New Password', exact: true }),
+        ).toBeVisible();
+        await expect(
+          modal.getByRole('textbox', { name: 'New password (again)' }),
+        ).toBeVisible();
 
         // "Original password" field should NOT be present
-        await expect(modal.locator('input#originalPassword')).toHaveCount(0);
+        await expect(
+          modal.getByRole('textbox', { name: /original password/i }),
+        ).toHaveCount(0);
 
         await modal.getByRole('button', { name: 'Cancel' }).click();
       });
@@ -507,7 +515,9 @@ test.describe(
 
         const modal = profileModal(page);
 
-        await modal.locator('input#password').fill('123');
+        await modal
+          .getByRole('textbox', { name: 'New Password', exact: true })
+          .fill('123');
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -522,8 +532,12 @@ test.describe(
 
         const modal = profileModal(page);
 
-        await modal.locator('input#password').fill('NewPass1!');
-        await modal.locator('input#passwordConfirm').fill('DifferentPass2!');
+        await modal
+          .getByRole('textbox', { name: 'New Password', exact: true })
+          .fill('NewPass1!');
+        await modal
+          .getByRole('textbox', { name: 'New password (again)' })
+          .fill('DifferentPass2!');
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -543,7 +557,9 @@ test.describe(
 
         const modal = profileModal(page);
 
-        await modal.locator('input#password').fill('NewPass1!');
+        await modal
+          .getByRole('textbox', { name: 'New Password', exact: true })
+          .fill('NewPass1!');
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -571,7 +587,7 @@ test.describe(
         await modal.getByRole('button', { name: 'Update' }).click();
 
         await expect(
-          page.getByText('There are no changes to update.'),
+          toastRegion(page).getByText('There are no changes to update.'),
         ).toBeVisible({ timeout: 5000 });
       });
 
@@ -581,7 +597,7 @@ test.describe(
 
         const modal = profileModal(page);
 
-        const fullNameInput = modal.locator('input#full_name');
+        const fullNameInput = modal.getByRole('textbox', { name: 'Full Name' });
         const originalName = await fullNameInput.inputValue();
 
         await fullNameInput.clear();
@@ -594,13 +610,13 @@ test.describe(
         // Reopen and verify nothing changed
         await openProfileModal(page);
         const restoredName = await profileModal(page)
-          .locator('input#full_name')
+          .getByRole('textbox', { name: 'Full Name' })
           .inputValue();
         expect(restoredName).toBe(originalName);
 
         const formItem = getAllowedClientIpFormItem(profileModal(page));
         await expect(
-          formItem.locator('.ant-tag').filter({ hasText: '10.0.0.1' }),
+          formItem.getByRole('button', { name: 'Remove 10.0.0.1' }),
         ).toHaveCount(0);
 
         await profileModal(page)

--- a/e2e/user-profile/user-profile.spec.ts
+++ b/e2e/user-profile/user-profile.spec.ts
@@ -134,12 +134,12 @@ test.describe(
 
         await addIpTags(profileModal(page), ['192.168.1.1', '10.0.0.1']);
 
-        // Verify tags are created
+        // Verify tags are created (each renders as a "Remove {ip}" button)
         await expect(
-          formItem.locator('.ant-tag').filter({ hasText: '192.168.1.1' }),
+          formItem.getByRole('button', { name: 'Remove 192.168.1.1' }),
         ).toBeVisible();
         await expect(
-          formItem.locator('.ant-tag').filter({ hasText: '10.0.0.1' }),
+          formItem.getByRole('button', { name: 'Remove 10.0.0.1' }),
         ).toBeVisible();
 
         await profileModal(page)

--- a/e2e/user/bulk-user-creation.spec.ts
+++ b/e2e/user/bulk-user-creation.spec.ts
@@ -383,8 +383,11 @@ test.describe(
           // 5. Verify the "Number of users" spinner shows the default value 1
           await expect(modal.getUserCountInput()).toHaveValue('1');
 
-          // 6. Verify the Decrease Value button is disabled at value 1
-          await expect(modal.getDecreaseValueButton()).toBeDisabled();
+          // 6. Verify the count cannot go below 1 (the input exposes min=1)
+          await expect(modal.getUserCountInput()).toHaveAttribute(
+            'aria-valuemin',
+            '1',
+          );
 
           // 7. Fill in "Email prefix (before @)"
           await modal.fillEmailPrefix(EMAIL_PREFIX);
@@ -399,7 +402,7 @@ test.describe(
           // 11. Click "OK" and wait for success message
           await modal.submit();
           await expect(
-            page.locator('.ant-message').getByText(/Successfully created/),
+            toastRegion(page).getByText(/Successfully created/),
           ).toBeVisible({ timeout: 30000 });
 
           // 11b. A successful bulk create reveals the generated keypairs in a
@@ -430,8 +433,10 @@ test.describe(
             .locator('.bai-name-action-cell-actions button')
             .nth(2)
             .click();
-          const popconfirm = page.locator('.ant-popconfirm');
-          await popconfirm.getByRole('button', { name: 'Deactivate' }).click();
+          const popconfirm = page.getByRole('dialog', { name: 'Deactivate' });
+          await popconfirm
+            .getByRole('button', { name: 'Deactivate', exact: true })
+            .click();
           await expect(userRow).toBeHidden({ timeout: 10000 });
 
           // 15. Switch to Inactive tab and verify the user appears there

--- a/e2e/user/bulk-user-creation.spec.ts
+++ b/e2e/user/bulk-user-creation.spec.ts
@@ -9,6 +9,20 @@ import {
 } from '../utils/user-profile-util';
 import test, { expect, type Page } from '@playwright/test';
 
+// Astryx also renders each toast into a screen-reader announcer, so an
+// unscoped getByText() matches twice.
+function toastRegion(page: Page) {
+  return page.getByRole('region', { name: 'Notifications' });
+}
+
+// Both bulk-toolbar IconButtons are named "Action"; a name: 'delete' match hits
+// the row-level "Permanently Delete" buttons instead, so key on the trash icon.
+function bulkPurgeButton(page: Page) {
+  return page
+    .getByRole('button', { name: 'Action', exact: true })
+    .filter({ has: page.locator('svg.lucide-trash2') });
+}
+
 // Generate unique identifiers for this test run to avoid conflicts
 const TEST_RUN_ID = Date.now().toString(36);
 const EMAIL_SUFFIX = 'lablup.com';
@@ -42,8 +56,10 @@ async function cleanupBulkCreatedUsers(
         .locator('.bai-name-action-cell-actions button')
         .nth(2)
         .click();
-      const popconfirm = page.locator('.ant-popconfirm');
-      await popconfirm.getByRole('button', { name: 'Deactivate' }).click();
+      const popconfirm = page.getByRole('dialog', { name: 'Deactivate' });
+      await popconfirm
+        .getByRole('button', { name: 'Deactivate', exact: true })
+        .click();
       await expect(userRow).toBeHidden({ timeout: 10000 });
     }
   }
@@ -71,9 +87,7 @@ async function cleanupBulkCreatedUsers(
   }
 
   if (hasInactiveUsers) {
-    // The purge button uses <DeleteFilled /> icon whose aria-label is "delete".
-    // Use .first() to target the header bulk-delete button, not row-level purge buttons.
-    await page.getByRole('button', { name: 'delete' }).first().click();
+    await bulkPurgeButton(page).click();
     const purgeModal = new PurgeUsersModal(page);
     await purgeModal.waitForVisible();
     await purgeModal.confirmDeletion();
@@ -213,7 +227,7 @@ test.describe(
           // 12. Click "OK" and wait for success message
           await modal.submit();
           await expect(
-            page.locator('.ant-message').getByText(/Successfully created/),
+            toastRegion(page).getByText(/Successfully created/),
           ).toBeVisible({ timeout: 30000 });
 
           // 13. A successful bulk create reveals the generated keypairs in a
@@ -245,9 +259,11 @@ test.describe(
               .locator('.bai-name-action-cell-actions button')
               .nth(2)
               .click();
-            const popconfirm = page.locator('.ant-popconfirm');
+            const popconfirm = page.getByRole('dialog', {
+              name: 'Deactivate',
+            });
             await popconfirm
-              .getByRole('button', { name: 'Deactivate' })
+              .getByRole('button', { name: 'Deactivate', exact: true })
               .click();
             await expect(userRow).toBeHidden({ timeout: 10000 });
           }
@@ -269,9 +285,7 @@ test.describe(
           }
 
           // 18. Click the purge (trash bin) button.
-          // The purge button uses <DeleteFilled /> icon whose aria-label is "delete".
-          // Use .first() to target the header bulk-delete button, not row-level purge buttons.
-          await page.getByRole('button', { name: 'delete' }).first().click();
+          await bulkPurgeButton(page).click();
 
           // 19. Confirm permanent deletion in the purge modal
           const purgeModal = new PurgeUsersModal(page);
@@ -433,9 +447,7 @@ test.describe(
           await inactiveRow.getByRole('checkbox').click();
 
           // 17. Click the purge (trash bin) button.
-          // The purge button uses <DeleteFilled /> icon whose aria-label is "delete".
-          // Use .first() to target the header bulk-delete button, not row-level purge buttons.
-          await page.getByRole('button', { name: 'delete' }).first().click();
+          await bulkPurgeButton(page).click();
 
           // 18. Confirm permanent deletion in the purge modal
           const purgeModal = new PurgeUsersModal(page);

--- a/e2e/utils/classes/user/BulkCreateUserModal.ts
+++ b/e2e/utils/classes/user/BulkCreateUserModal.ts
@@ -98,13 +98,6 @@ export class BulkCreateUserModal {
     return this.modal.getByRole('button', { name: 'Close' });
   }
 
-  /**
-   * Get the Decrease Value button on the user count spinner
-   */
-  getDecreaseValueButton(): Locator {
-    return this.modal.getByRole('button', { name: 'Decrease Value' });
-  }
-
   // =====================
   // Form Field Actions
   // =====================

--- a/e2e/utils/user-profile-util.ts
+++ b/e2e/utils/user-profile-util.ts
@@ -133,19 +133,9 @@ export async function removeAllIpTags(container: Locator) {
   const formItem = getAllowedClientIpFormItem(container);
   const selectInput = formItem.getByRole('combobox');
   await selectInput.click();
-  // Backspace removes the last selected tag in an antd Select. Keep pressing
-  // until none remain, with a safety cap so a stuck DOM can't cause an infinite
-  // loop. The cap is generous enough for any realistic Allowed Client IP list.
-  //
-  // The Allowed Client IP field uses a custom `tagRender` (see
-  // UserProfileSettingModal.tsx / UserSettingModal.tsx) that renders each
-  // selected value as a plain antd `<Tag>` (`.ant-tag`) instead of the
-  // default `.ant-select-selection-item` markup. Using the default selector
-  // here made `tags.count()` always resolve to 0, so the loop exited before
-  // ever pressing Backspace — a silent no-op that left the form untouched,
-  // caused the "no changes" message instead of a real update, and left the
-  // modal open (blocking any subsequent reopen click).
-  const tags = formItem.locator('.ant-tag');
+  // Backspace removes the last tag; each tag renders as a "Remove {ip}"
+  // button. The safety cap stops a stuck DOM from looping forever.
+  const tags = formItem.getByRole('button', { name: /^Remove /i });
   for (let safety = 0; safety < 100; safety++) {
     const remaining = await tags.count();
     if (remaining === 0) break;


### PR DESCRIPTION
Produced by the daily webui digest auto-heal (2026-09-11). Every test below was triaged as test-side locator drift and re-run against `webui-nightly` after the fix. It passes. No app source changed.

## Healed (verified re-pass)

| Spec | Test | Mechanism |
|---|---|---|
| `e2e/auth/forgot-password.spec.ts` | User cannot submit when passwords do not match | `Password mismatch` toast scoped to the Notifications region. The Astryx announcer node made an unscoped `getByText` match twice. |
| `e2e/chat/chat-sync.spec.ts` | Sending a message from one synced pane triggers send in all other synced panes | Model name asserted on the `Select Model` button, not through an unscoped `getByText` that hit two nodes. |
| `e2e/user/bulk-user-creation.spec.ts` | Admin can bulk create multiple users | `.ant-message` → Notifications region. `.ant-popconfirm` → `getByRole('dialog', { name: 'Deactivate' })`. Bulk purge button now keyed on the trash icon: `name: 'delete'` + `.first()` matched a row-level "Permanently Delete" button, which purged the wrong row. |
| `e2e/user-profile/user-profile.spec.ts` | User can add valid IP addresses as tags | `.ant-tag` → the tokenizer's `Remove {ip}` buttons. |
| `e2e/user-profile/user-ip-restriction-enforcement.spec.ts` (+ `e2e/utils/user-profile-util.ts`) | Admin can clean up: remove IP restriction and delete test user | `.ant-input-search` → PowerSearch suggestion commit. `.ant-popconfirm` → dialog role. Same bulk-purge fix as above. `removeAllIpTags()` counted `.ant-tag` (always 0, so a silent no-op) and now counts `Remove {ip}` buttons. Whole serial suite verified. |

Exhausted: none.

## Notes
- `e2e/user-profile/user-profile.spec.ts:151` ("User can add valid CIDR ranges as tags") still uses the same `.ant-tag` pattern. It was out of scope today and is left for the next run.
- The bulk-selection toolbar's IconButtons both have the accessible name "Action", with no label per icon. That is an a11y gap in the app, not in the tests.
- No reviewers requested: none of the healed failures traces to a PR in the window.
- Report: `/home/ubuntu/e2e-digest-reports/report-2026-09-11.md` (digest runner host)

## Second pass (2026-09-11, re-run against `webui-nightly`)

Re-ran the five healed specs. All five healed tests pass. Two other tests in the same files failed, so the rest of those files was healed too.

| Spec | Test | Mechanism |
|---|---|---|
| `e2e/user/bulk-user-creation.spec.ts` | Admin can bulk create a single user | The `Number of users` input is an Astryx number input with no stepper buttons, so the `Decrease Value` assertion checked a control that no longer exists; it asserts `aria-valuemin="1"` instead. Same `.ant-message` / `.ant-popconfirm` fixes as the multi-user test. |
| `e2e/user-profile/user-profile.spec.ts` | User can add valid CIDR ranges as tags · User can remove an IP tag · User can clear all allowed client IPs | Remaining `.ant-tag` selectors → the tokenizer's `Remove {ip}` buttons. |
| `e2e/user-profile/user-profile.spec.ts` | Invalid IP/CIDR entries are flagged with a validation error (was "highlighted in red") · Mixed valid and invalid IPs flag only the invalid entry (was "show correct tag colors") | The per-tag red highlight was dropped on purpose in the Astryx migration (`UserSettingModal.tsx`); every token is `data-color="default"` and the field's validator renders `Invalid IP: {entries}`. The tests now assert that message. |
| `e2e/user-profile/user-profile.spec.ts` | Password fields are present without original password field · Weak password is rejected · Mismatch passwords are rejected · Password confirm is required · Modal cancel does not save changes | `input#full_name` / `input#password` / `input#passwordConfirm` → `getByRole('textbox', { name })`. |
| `e2e/user-profile/user-profile.spec.ts` | No-change submission shows info message | Toast scoped to the Notifications region (announcer double match). The success toasts are scoped the same way. |

Result of the second pass: `bulk-user-creation.spec.ts` 4/4 pass; `user-profile.spec.ts` 13/18 pass.

**Not healed — app/backend failure.** The five remaining `user-profile.spec.ts` failures (`Validation passes when current client IP is included`, `... within a CIDR range`, `User can clear all allowed client IPs`, `User can update full name successfully`, `... full name and allowed client IP together`) all fail at the same step: a regular user pressing **Update** on *My Account Information*. The manager (`10.82.130.172:8090`) rejects the `updateUserV2` mutation:

```
Insufficient permission to perform this operation.
(User <id> lacks permission <Permission.UPDATE: 2> on user <same id>)
code: role_create_forbidden
```

The same flow succeeds as the superadmin. A freshly created regular user cannot update their own profile, which looks like an RBAC gap (compare BA-7726, keypair 403 for users created after the RBAC migration). Those tests keep the correct locators and will pass once the backend allows self-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

