### PR TITLE
fix(FR-3901): use relative brandImage paths in the Storybook theme

### DIFF
--- a/packages/backend.ai-ui/.storybook/BackendAITheme.ts
+++ b/packages/backend.ai-ui/.storybook/BackendAITheme.ts
@@ -19,7 +19,7 @@ const commonStorybookTheme = {
 export const storybookLightTheme = create({
   base: 'light',
   ...commonStorybookTheme,
-  brandImage: '/backend.ai-logo-dark.svg',
+  brandImage: 'backend.ai-logo-dark.svg',
 
   // Primary colors
   colorPrimary: '#FF7A00',
@@ -51,7 +51,7 @@ export const storybookLightTheme = create({
 export const storybookDarkTheme = create({
   base: 'dark',
   ...commonStorybookTheme,
-  brandImage: '/backend.ai-logo.svg',
+  brandImage: 'backend.ai-logo.svg',
 
   // Primary colors
   colorPrimary: '#FF9D00',


### PR DESCRIPTION
Resolves #9591 (FR-3901)

## Summary

On the per-PR Storybook preview published to GitHub Pages (`https://lablup.github.io/backend.ai-webui/pr/<n>/storybook/`), the Backend.AI logo in the sidebar header did not render: the browser requested `https://lablup.github.io/backend.ai-logo-dark.svg` and got a 404. The manager theme in `packages/backend.ai-ui/.storybook/BackendAITheme.ts` set `brandImage` to root-absolute paths, which resolve against the origin root and lose the `/backend.ai-webui/pr/<n>/storybook/` subpath. The local `storybook dev` server masked the bug because it serves from the origin root.

## Changes

- `packages/backend.ai-ui/.storybook/BackendAITheme.ts`: `brandImage` for the light theme is now `backend.ai-logo-dark.svg` and for the dark theme `backend.ai-logo.svg` (leading slash dropped), so both resolve against the manager document URL the same way `preview-head.html` already references `fonts/roboto/roboto.css`.

No other Storybook asset reference is root-absolute. The SVGs are still copied by `staticDirs` to the build root, so `.../storybook/backend.ai-logo-dark.svg` already exists on the deployed site; only the reference was wrong. The local dev server keeps working since its base is the origin root.

## Verification

- `bash scripts/verify.sh`: `=== ALL PASS ===` (Relay, search index, lint, format, TypeScript and the remaining gates).
- `pnpm run build-storybook` in `packages/backend.ai-ui`: the build succeeds, both SVGs land at the build root, the built manager bundle references `backend.ai-logo-dark.svg` / `backend.ai-logo.svg` relatively, and no `"/backend.ai-logo` reference remains anywhere in the output.
- Not verified here: the live GitHub Pages PR preview. The `pr-preview-publish.yml` run for this PR is the end-to-end check.

<!-- fw-dev-server-url -->
🔗 **Dev server**: http://fr-3901-pr9593.seungwon.10-82-0-159.sslip.io
<!-- /fw-dev-server-url -->