### PR TITLE
refactor(FR-3903): open user settings in a modal over the current page

### DIFF
--- a/react/scripts/build-search-index.mjs
+++ b/react/scripts/build-search-index.mjs
@@ -94,7 +94,7 @@ const KEY_WITH_DEFAULT_RE =
 const DYN_KEY_RE = /(?:^|[^A-Za-z0-9_$])t\(\s*`([^`\n]*\$\{[^`\n]*)`/g;
 
 /** URL params that behave like a page-level tab strip (FR-3267 patterns A-i/A-ii). */
-const TAB_PARAMS = ['tab'];
+const TAB_PARAMS = ['tab', 'settings'];
 const TAB_LIKE_PARAMS = ['type', 'statusCategory', 'mode'];
 
 /** A one-entry tab strip is the page itself — never a separate hit. */
@@ -111,7 +111,40 @@ const SCOPE_PARAMS = ['projectName'];
  * labels built by `_.map` over an object — no enum to read statically, while
  * its two admin twins use enum parsers and are detected normally.
  */
+/**
+ * The settings surface is a modal driven by `?settings=` over any page, so the
+ * `/usersettings` route element is only a redirect shim. Point the crawl at the
+ * modal so the palette still finds the settings it owns.
+ */
+const ROUTE_COMPONENT_OVERRIDES = {
+  '/usersettings': ['react/src/components/UserSettingsModal.tsx'],
+};
+
+/**
+ * Tab a route's settings belong to, when the tab strip and `<SettingList>` sit
+ * in different files so `settingTabKeyOf` cannot pair them. The settings modal
+ * splits them: the category rail lives in `UserSettingsModal`, the groups in
+ * `UserSettingsGeneralPane`.
+ */
+const SETTING_TAB_OVERRIDES = {
+  '/usersettings': 'general',
+};
+
 const TAB_OVERRIDES = {
+  '/usersettings': [
+    { param: 'settings', key: 'general', labelKey: 'userSettings.General' },
+    { param: 'settings', key: 'logs', labelKey: 'userSettings.Logs' },
+    {
+      param: 'settings',
+      key: 'login-sessions',
+      labelKey: 'userSettings.LoginSessions',
+    },
+    {
+      param: 'settings',
+      key: 'login-history',
+      labelKey: 'userSettings.LoginHistory',
+    },
+  ],
   '/project/:projectName/data': [
     { param: 'statusCategory', key: 'active', labelKey: 'data.Active' },
     {
@@ -716,7 +749,12 @@ export function parseRoutes() {
       }
 
       const elNode = propOf(obj, 'element') ?? propOf(obj, 'Component');
-      const comps = elNode ? collectComponents(elNode, compFile) : [];
+      const override = ROUTE_COMPONENT_OVERRIDES[indexed];
+      const comps = override
+        ? override.map((r) => path.join(ROOT, r))
+        : elNode
+          ? collectComponents(elNode, compFile)
+          : [];
 
       if (handle.menuKey || handle.labelKey || handle.title) {
         const isShim =
@@ -934,7 +972,7 @@ export async function buildEntries() {
       labelKey: e.labelKey,
       component: e.components.map(rel),
       tabs: applyTabOverrides(e.path, dedupeTabs(tabs)),
-      settings: dedupeSettings(settings),
+      settings: applySettingTabOverride(e.path, dedupeSettings(settings)),
       keyMap,
       dynamicKeys: [...dynamicKeys].sort(byString),
     });
@@ -966,6 +1004,12 @@ function dedupeSettings(settings) {
     (a, b) =>
       byString(a.key, b.key) || byString(a.groupId ?? '', b.groupId ?? ''),
   );
+}
+
+function applySettingTabOverride(routePath, settings) {
+  const tab = SETTING_TAB_OVERRIDES[routePath];
+  if (!tab) return settings;
+  return settings.map((s) => (s.tab === null ? { ...s, tab } : s));
 }
 
 function applyTabOverrides(routePath, tabs) {

--- a/react/src/components/GlobalSearchPalette/buildHits.test.ts
+++ b/react/src/components/GlobalSearchPalette/buildHits.test.ts
@@ -136,13 +136,13 @@ describe('buildHits', () => {
     expect(hit?.label).toBe('User Session History');
   });
 
-  it('targets a setting item through ?tab=&setting=', () => {
+  it('targets a setting item through ?settings=&setting=', () => {
     const hit = _.find(build(), {
       id: 'setting:/usersettings#userSettings.AutoLogout',
     });
     expect(hit?.target).toEqual({
       path: '/usersettings',
-      search: { tab: 'general', setting: 'userSettings.AutoLogout' },
+      search: { settings: 'general', setting: 'userSettings.AutoLogout' },
     });
     expect(hit?.breadcrumbKeys).toEqual([
       'webui.menu.Settings&Logs',

--- a/react/src/components/GlobalSearchPalette/buildHits.ts
+++ b/react/src/components/GlobalSearchPalette/buildHits.ts
@@ -110,14 +110,24 @@ export interface BuildHitsParams {
   fallbackGroup?: string;
 }
 
+const tabOf = (
+  entry: SearchIndexEntry,
+  tabKey: string | undefined,
+): SearchIndexTab | undefined =>
+  tabKey ? _.find(entry.tabs, (tab) => tab.key === tabKey) : undefined;
+
 const tabLabelKeyOf = (
   entry: SearchIndexEntry,
   tabKey: string | undefined,
-): string | undefined =>
-  tabKey
-    ? _.find(entry.tabs, (tab) => tab.param === 'tab' && tab.key === tabKey)
-        ?.labelKey
-    : undefined;
+): string | undefined => tabOf(entry, tabKey)?.labelKey;
+
+const tabTargetSearchOf = (
+  entry: SearchIndexEntry,
+  tabKey: string | undefined,
+): Record<string, string> => {
+  const tab = tabOf(entry, tabKey);
+  return tab ? { [tab.param]: tab.key } : {};
+};
 
 const makeTabHit = (
   entry: SearchIndexEntry,
@@ -164,7 +174,7 @@ const makeSettingHit = (
   target: {
     path,
     search: {
-      ...(setting.tab ? { tab: setting.tab } : {}),
+      ...tabTargetSearchOf(entry, setting.tab),
       setting: setting.key,
     },
   },

--- a/react/src/components/GlobalSearchPalette/searchIndex.test.ts
+++ b/react/src/components/GlobalSearchPalette/searchIndex.test.ts
@@ -81,10 +81,10 @@ describe('generated search index', () => {
 
   it('finds at least the inventoried tabs and setting items', () => {
     const tabPages = index.entries.filter((e) =>
-      e.tabs.some((t) => t.param === 'tab'),
+      e.tabs.some((t) => t.labelKey),
     );
     const tabKeys = index.entries.reduce(
-      (a, e) => a + e.tabs.filter((t) => t.param === 'tab').length,
+      (a, e) => a + e.tabs.filter((t) => t.labelKey).length,
       0,
     );
     const allTabs = index.entries.flatMap((e) => e.tabs);

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -282,7 +282,14 @@ const SettingList: React.FC<SettingPageProps> = ({
   return (
     <>
       <BAIFlex direction="column" gap={'md'} align="stretch">
-        <BAIFlex justify="start" gap={'xs'} wrap="wrap">
+        {/* Wrapping only where the row is narrow (the settings modal's pane);
+            the full-width admin pages keep the single-row layout the search
+            field's `width="100%"` was sized against. */}
+        <BAIFlex
+          justify="start"
+          gap={'xs'}
+          wrap={hideGroupNav ? 'wrap' : 'nowrap'}
+        >
           {!!showSearchBar && (
             <TextInput
               label={t('settings.SearchPlaceholder')}

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -196,8 +196,10 @@ const SettingList: React.FC<SettingPageProps> = ({
 
   // `?setting=` arrival only fires for an item that is actually on screen: the
   // nav view below `md` and a selected group both hide items the filter kept.
-  const renderedSettingItems =
-    isNarrow && narrowView === 'nav'
+  // `hideGroupNav` has neither — every group is stacked at every width.
+  const renderedSettingItems = hideGroupNav
+    ? _.flatMap(filteredSettingGroups, 'settingItems')
+    : isNarrow && narrowView === 'nav'
       ? []
       : activeTabKey === ALL_NAV_KEY
         ? _.flatMap(filteredSettingGroups, 'settingItems')

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -70,6 +70,12 @@ interface SettingPageProps {
   primaryButton?: ReactNode;
   extraButton?: ReactNode;
   onReset?: () => void;
+  /**
+   * Drop the group nav column and render every group stacked. For hosts that
+   * already own a category rail — the user-settings modal — where a second
+   * `LayoutPanel` would be a nav inside a nav and a `Layout` inside a `Layout`.
+   */
+  hideGroupNav?: boolean;
 }
 
 const GroupSettingItems: React.FC<
@@ -129,6 +135,7 @@ const SettingList: React.FC<SettingPageProps> = ({
   primaryButton,
   extraButton,
   onReset,
+  hideGroupNav = false,
 }) => {
   'use memo';
 
@@ -239,23 +246,26 @@ const SettingList: React.FC<SettingPageProps> = ({
     </BAIFlex>
   );
 
+  const allGroupsPane =
+    totalItemCount > 0 ? (
+      <BAIFlex direction="column" align="stretch" gap={'xl'}>
+        {_.map(filteredSettingGroups, (group) => (
+          <GroupSettingItems
+            data-testid={group?.['data-testid']}
+            key={group.title}
+            group={group}
+            hideEmpty
+            arrivalTitle={arrivalTitle}
+          />
+        ))}
+      </BAIFlex>
+    ) : (
+      <EmptyState title={t('settings.NoChangesToDisplay')} isCompact />
+    );
+
   const settingsPane =
     activeTabKey === ALL_NAV_KEY ? (
-      totalItemCount > 0 ? (
-        <BAIFlex direction="column" align="stretch" gap={'xl'}>
-          {_.map(filteredSettingGroups, (group) => (
-            <GroupSettingItems
-              data-testid={group?.['data-testid']}
-              key={group.title}
-              group={group}
-              hideEmpty
-              arrivalTitle={arrivalTitle}
-            />
-          ))}
-        </BAIFlex>
-      ) : (
-        <EmptyState title={t('settings.NoChangesToDisplay')} isCompact />
-      )
+      allGroupsPane
     ) : activeGroup && activeGroup.settingItems.length > 0 ? (
       <BAIFlex direction="column" align="stretch" gap={'xl'}>
         <GroupSettingItems
@@ -272,7 +282,7 @@ const SettingList: React.FC<SettingPageProps> = ({
   return (
     <>
       <BAIFlex direction="column" gap={'md'} align="stretch">
-        <BAIFlex justify="start" gap={'xs'}>
+        <BAIFlex justify="start" gap={'xs'} wrap="wrap">
           {!!showSearchBar && (
             <TextInput
               label={t('settings.SearchPlaceholder')}
@@ -310,7 +320,9 @@ const SettingList: React.FC<SettingPageProps> = ({
           )}
           {primaryButton}
         </BAIFlex>
-        {isNarrow && narrowView === 'nav' ? (
+        {hideGroupNav ? (
+          allGroupsPane
+        ) : isNarrow && narrowView === 'nav' ? (
           navList
         ) : (
           <Layout

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -5,7 +5,6 @@
 import { App } from '../app-shim';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { ShellScriptType } from '../pages/UserSettingsPage';
 import BAICodeEditor from './BAICodeEditor';
 import BAIFormItem from './BAIFormItem';
 import { Button } from '@astryxdesign/core/Button';
@@ -33,6 +32,8 @@ type UserConfigScript = {
   permission: string;
   data: string;
 };
+
+export type ShellScriptType = 'bootstrap' | 'userconfig' | undefined;
 
 interface BootstrapScriptEditModalProps extends BAIModalProps {
   onRequestClose: (success?: boolean) => void;

--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { UserDropdownMenuQuery } from '../__generated__/UserDropdownMenuQuery.graphql';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import {
   useCurrentUserInfo,
   useCurrentUserRole,
@@ -14,6 +14,7 @@ import { useBAIBreakpoint } from '../theme-shim';
 import AboutBackendAIModal from './AboutBackendAIModal';
 import DownloadModal from './DownloadModal';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
+import { useUserSettingsModal } from './UserSettingsModalOpener';
 import {
   DropdownMenu,
   type DropdownMenuOption,
@@ -77,7 +78,8 @@ const UserDropdownMenu: React.FC<{
 
   const userRole = useCurrentUserRole();
 
-  const webuiNavigate = useWebUINavigate();
+  // The settings surface is a modal over the current page, not a route.
+  const { open: openUserSettings } = useUserSettingsModal();
   const { isTOTPSupported } = useTOTPSupported();
 
   const [fetchKey, updateFetchKey] = useFetchKey();
@@ -154,14 +156,14 @@ const UserDropdownMenu: React.FC<{
       label: t('webui.menu.Preferences'),
       icon: <Settings size="1em" />,
       onClick: () => {
-        webuiNavigate('/usersettings?tab=general');
+        openUserSettings('general');
       },
     },
     {
       label: t('webui.menu.LogsErrors'),
       icon: <FileText size="1em" />,
       onClick: () => {
-        webuiNavigate('/usersettings?tab=logs');
+        openUserSettings('logs');
       },
     },
     (baiClient._config.allowAppDownloadPanel ||

--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -32,7 +32,6 @@ import {
   ShieldCheck,
   CircleAlert,
   Lock,
-  FileText,
   LogOut,
   Settings,
   Download,
@@ -157,13 +156,6 @@ const UserDropdownMenu: React.FC<{
       icon: <Settings size="1em" />,
       onClick: () => {
         openUserSettings('general');
-      },
-    },
-    {
-      label: t('webui.menu.LogsErrors'),
-      icon: <FileText size="1em" />,
-      onClick: () => {
-        openUserSettings('logs');
       },
     },
     (baiClient._config.allowAppDownloadPanel ||

--- a/react/src/components/UserSettingsGeneralPane.tsx
+++ b/react/src/components/UserSettingsGeneralPane.tsx
@@ -1,21 +1,13 @@
 /**
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
- */
-import type { LoginHistoryQuery as LoginHistoryQueryType } from '../__generated__/LoginHistoryQuery.graphql';
-import type { LoginSessionQuery as LoginSessionQueryType } from '../__generated__/LoginSessionQuery.graphql';
+
+ The General category of the user-settings modal. Lifted out of the former
+ `UserSettingsPage` unchanged — same setting groups, same `data-testid`s, same
+ child modals — so the move from page to modal stays a UI change only.
+*/
 import { App } from '../app-shim';
-import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import ErrorLogList from '../components/ErrorLogList';
-import LoginHistory, { LoginHistoryQuery } from '../components/LoginHistory';
-import LoginSession, { LoginSessionQuery } from '../components/LoginSession';
-import MyKeypairInfoModalLegacy from '../components/MyKeypairInfoModalLegacy';
-import MyKeypairManagementModal from '../components/MyKeypairManagementModal';
-import SSHKeypairManagementModal from '../components/SSHKeypairManagementModal';
-import SettingList, { SettingGroup } from '../components/SettingList';
-import ShellScriptEditModal from '../components/ShellScriptEditModal';
-import ThemeAccentColorPicker from '../components/ThemeAccentColorPicker';
-import { useSuspendedBackendaiClient, useTabQuerySnapshot } from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import {
   useBAISettingGeneralState,
   useBAISettingUserState,
@@ -25,73 +17,29 @@ import {
   useCustomThemeConfig,
 } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
+import MyKeypairInfoModalLegacy from './MyKeypairInfoModalLegacy';
+import MyKeypairManagementModal from './MyKeypairManagementModal';
+import SSHKeypairManagementModal from './SSHKeypairManagementModal';
+import SettingList, { SettingGroup } from './SettingList';
+import ShellScriptEditModal, { ShellScriptType } from './ShellScriptEditModal';
+import ThemeAccentColorPicker from './ThemeAccentColorPicker';
 import { Button } from '@astryxdesign/core/Button';
 import {
-  BAISkeleton,
-  BAICard,
   filterOutEmpty,
   useSessionStorageState,
   useToggle,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Settings } from 'lucide-react';
-import { parseAsStringLiteral } from 'nuqs';
-import { Suspense, useEffect, useEffectEvent, useState } from 'react';
+import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useQueryLoader } from 'react-relay';
 
-export type ShellScriptType = 'bootstrap' | 'userconfig' | undefined;
-
-const tabParser = parseAsStringLiteral([
-  'general',
-  'logs',
-  'login-sessions',
-  'login-history',
-]).withDefault('general');
-
-const UserPreferencesPage = () => {
+const UserSettingsGeneralPane = () => {
   'use memo';
 
   const { t } = useTranslation();
   const { message } = App.useApp();
   const baiClient = useSuspendedBackendaiClient();
-  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
-
-  const [loginSessionQueryRef, loadLoginSessionQuery] =
-    useQueryLoader<LoginSessionQueryType>(LoginSessionQuery);
-  const [loginHistoryQueryRef, loadLoginHistoryQuery] =
-    useQueryLoader<LoginHistoryQueryType>(LoginHistoryQuery);
-  // Lazily fetch a tab's data only once it becomes active (covers both a tab
-  // click and a direct `?tab=...` URL restore), so neither query runs while the
-  // General/Logs tabs are shown.
-  const ensureActiveTabQueryLoaded = useEffectEvent(() => {
-    if (currentTab === 'login-sessions' && !loginSessionQueryRef) {
-      loadLoginSessionQuery(
-        {
-          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
-          limit: 10,
-          offset: 0,
-        },
-        { fetchPolicy: 'store-and-network' },
-      );
-    }
-    if (currentTab === 'login-history' && !loginHistoryQueryRef) {
-      loadLoginHistoryQuery(
-        {
-          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
-          limit: 10,
-          offset: 0,
-        },
-        { fetchPolicy: 'store-and-network' },
-      );
-    }
-  });
-  useEffect(
-    function loadActiveTabQueryOnActivation() {
-      ensureActiveTabQueryLoaded();
-    },
-    [currentTab],
-  );
 
   const { themeMode, setThemeMode } = useThemeMode();
   const {
@@ -517,70 +465,13 @@ const UserPreferencesPage = () => {
 
   return (
     <>
-      <BAICard
-        activeTabKey={currentTab}
-        onTabChange={onTabChange}
-        tabList={[
-          {
-            key: 'general',
-            label: t('userSettings.General'),
-          },
-          {
-            key: 'logs',
-            label: t('userSettings.Logs'),
-          },
-          {
-            key: 'login-sessions',
-            label: t('userSettings.LoginSessions'),
-          },
-          {
-            key: 'login-history',
-            label: t('userSettings.LoginHistory'),
-          },
-        ]}
-      >
-        <Suspense fallback={<BAISkeleton />}>
-          {currentTab === 'general' && (
-            <BAIErrorBoundary>
-              <SettingList
-                settingGroups={settingGroups}
-                showChangedOptionFilter
-                showResetButton
-                showSearchBar
-              />
-            </BAIErrorBoundary>
-          )}
-          {currentTab === 'logs' && (
-            <BAIErrorBoundary>
-              <ErrorLogList />
-            </BAIErrorBoundary>
-          )}
-          {currentTab === 'login-sessions' && (
-            <BAIErrorBoundary>
-              {loginSessionQueryRef ? (
-                <LoginSession
-                  queryRef={loginSessionQueryRef}
-                  onReload={loadLoginSessionQuery}
-                />
-              ) : (
-                <BAISkeleton />
-              )}
-            </BAIErrorBoundary>
-          )}
-          {currentTab === 'login-history' && (
-            <BAIErrorBoundary>
-              {loginHistoryQueryRef ? (
-                <LoginHistory
-                  queryRef={loginHistoryQueryRef}
-                  onReload={loadLoginHistoryQuery}
-                />
-              ) : (
-                <BAISkeleton />
-              )}
-            </BAIErrorBoundary>
-          )}
-        </Suspense>
-      </BAICard>
+      <SettingList
+        settingGroups={settingGroups}
+        showChangedOptionFilter
+        showResetButton
+        showSearchBar
+        hideGroupNav
+      />
       {baiClient?.supports('my-keypairs') ? (
         <MyKeypairManagementModal
           open={isOpenSSHKeypairInfoModal}
@@ -612,4 +503,4 @@ const UserPreferencesPage = () => {
   );
 };
 
-export default UserPreferencesPage;
+export default UserSettingsGeneralPane;

--- a/react/src/components/UserSettingsModal.tsx
+++ b/react/src/components/UserSettingsModal.tsx
@@ -1,0 +1,286 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ The user-settings surface, as a dialog over whatever page is underneath
+ (`UserSettingsModalOpener` owns the `?settings=` param that drives it).
+
+ Composition follows Astryx's `settings-dialog` template: `BAIDialog` with
+ `padding={0}` holding one `Layout` whose `start` slot is the category rail and
+ whose `content` scrolls. `BAIModal` is not usable here because it already owns
+ a `Layout`, and Astryx forbids nesting one inside another.
+*/
+import type { LoginHistoryQuery as LoginHistoryQueryType } from '../__generated__/LoginHistoryQuery.graphql';
+import type { LoginSessionQuery as LoginSessionQueryType } from '../__generated__/LoginSessionQuery.graphql';
+import {
+  USER_SETTINGS_CATEGORIES,
+  type UserSettingsCategory,
+} from '../helper/userSettingsModal';
+import { useBAIBreakpoint } from '../theme-shim';
+import BAIErrorBoundary from './BAIErrorBoundary';
+import ErrorLogList from './ErrorLogList';
+import LoginHistory, { LoginHistoryQuery } from './LoginHistory';
+import LoginSession, { LoginSessionQuery } from './LoginSession';
+import UserSettingsGeneralPane from './UserSettingsGeneralPane';
+import WEBUIHelpButton from './WEBUIHelpButton';
+import { Button } from '@astryxdesign/core/Button';
+import { DialogHeader } from '@astryxdesign/core/Dialog';
+import { Divider } from '@astryxdesign/core/Divider';
+import { Icon } from '@astryxdesign/core/Icon';
+import { Layout, LayoutContent, LayoutPanel } from '@astryxdesign/core/Layout';
+import { List, ListItem } from '@astryxdesign/core/List';
+import { VStack } from '@astryxdesign/core/Stack';
+import { BAIDialog, BAISkeleton } from 'backend.ai-ui';
+import {
+  ArrowLeft,
+  ChevronRight,
+  History,
+  MonitorSmartphone,
+  ScrollText,
+  SlidersHorizontal,
+} from 'lucide-react';
+import React, {
+  CSSProperties,
+  Suspense,
+  useEffect,
+  useEffectEvent,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryLoader } from 'react-relay';
+
+// Astryx's dialog surface is `height: fit-content`, so `maxHeight` alone leaves
+// nothing owning a scrollport — the rail and the pane need a resolved height.
+const DIALOG_HEIGHT: CSSProperties = { height: '85vh' };
+
+// The header rides along the scrolling pane; Astryx has no sticky prop for it.
+const HEADER_STICKY: CSSProperties = {
+  position: 'sticky',
+  top: 0,
+  backgroundColor: 'var(--color-background-surface)',
+  zIndex: 1,
+};
+
+// 1100 matches `MyKeypairManagementModal`, the widest dialog opened from here,
+// so a child never overhangs its parent. Minus the rail it still leaves the
+// pane above `ErrorLogList`'s eight-column minimum.
+const DIALOG_WIDTH = 'min(1100px, 92vw)';
+const NAV_PANEL_WIDTH = 240;
+
+const CATEGORY_ICONS: Record<
+  UserSettingsCategory,
+  React.ComponentProps<typeof Icon>['icon']
+> = {
+  general: SlidersHorizontal,
+  logs: ScrollText,
+  'login-sessions': MonitorSmartphone,
+  'login-history': History,
+};
+
+const CATEGORY_LABEL_KEYS: Record<UserSettingsCategory, string> = {
+  general: 'userSettings.General',
+  logs: 'userSettings.Logs',
+  'login-sessions': 'userSettings.LoginSessions',
+  'login-history': 'userSettings.LoginHistory',
+};
+
+export interface UserSettingsModalProps {
+  category: UserSettingsCategory;
+  onCategoryChange: (category: UserSettingsCategory) => void;
+  onRequestClose: () => void;
+}
+
+const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
+  category,
+  onCategoryChange,
+  onRequestClose,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  // RESPONSIVE-POLICY R3 — the theme-shim hook, never Astryx `useMediaQuery`.
+  const { md } = useBAIBreakpoint();
+  const isNarrow = !md;
+  const [narrowView, setNarrowView] = useState<'nav' | 'detail'>('detail');
+
+  const [loginSessionQueryRef, loadLoginSessionQuery] =
+    useQueryLoader<LoginSessionQueryType>(LoginSessionQuery);
+  const [loginHistoryQueryRef, loadLoginHistoryQuery] =
+    useQueryLoader<LoginHistoryQueryType>(LoginHistoryQuery);
+  // Lazily fetch a category's data only once it becomes active (covers both a
+  // rail click and a direct `?settings=...` URL restore), so neither query runs
+  // while the General/Logs categories are shown.
+  const ensureActiveCategoryQueryLoaded = useEffectEvent(() => {
+    if (category === 'login-sessions' && !loginSessionQueryRef) {
+      loadLoginSessionQuery(
+        {
+          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+          limit: 10,
+          offset: 0,
+        },
+        { fetchPolicy: 'store-and-network' },
+      );
+    }
+    if (category === 'login-history' && !loginHistoryQueryRef) {
+      loadLoginHistoryQuery(
+        {
+          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+          limit: 10,
+          offset: 0,
+        },
+        { fetchPolicy: 'store-and-network' },
+      );
+    }
+  });
+  useEffect(
+    function loadActiveCategoryQueryOnActivation() {
+      ensureActiveCategoryQueryLoaded();
+    },
+    [category],
+  );
+
+  // Narrow drill-down: picking a category in the rail reveals its pane, the
+  // back button returns to the rail (same idiom as `SettingList`).
+  const selectCategory = (next: UserSettingsCategory) => {
+    setNarrowView('detail');
+    onCategoryChange(next);
+  };
+
+  const categoryNav = (
+    <VStack gap={2}>
+      <List density="spacious">
+        <ListItem
+          label={t(CATEGORY_LABEL_KEYS.general)}
+          startContent={<Icon icon={CATEGORY_ICONS.general} size="sm" />}
+          endContent={
+            isNarrow ? (
+              <Icon icon={ChevronRight} size="sm" color="secondary" />
+            ) : undefined
+          }
+          isSelected={!isNarrow && category === 'general'}
+          onClick={() => selectCategory('general')}
+        />
+      </List>
+      <Divider />
+      <List density="spacious">
+        {USER_SETTINGS_CATEGORIES.filter((key) => key !== 'general').map(
+          (key) => (
+            <ListItem
+              key={key}
+              label={t(CATEGORY_LABEL_KEYS[key])}
+              startContent={<Icon icon={CATEGORY_ICONS[key]} size="sm" />}
+              endContent={
+                isNarrow ? (
+                  <Icon icon={ChevronRight} size="sm" color="secondary" />
+                ) : undefined
+              }
+              isSelected={!isNarrow && category === key}
+              onClick={() => selectCategory(key)}
+            />
+          ),
+        )}
+      </List>
+    </VStack>
+  );
+
+  const pane =
+    category === 'general' ? (
+      <UserSettingsGeneralPane />
+    ) : category === 'logs' ? (
+      <ErrorLogList />
+    ) : category === 'login-sessions' ? (
+      loginSessionQueryRef ? (
+        <LoginSession
+          queryRef={loginSessionQueryRef}
+          onReload={loadLoginSessionQuery}
+        />
+      ) : (
+        <BAISkeleton />
+      )
+    ) : loginHistoryQueryRef ? (
+      <LoginHistory
+        queryRef={loginHistoryQueryRef}
+        onReload={loadLoginHistoryQuery}
+      />
+    ) : (
+      <BAISkeleton />
+    );
+
+  const showNavOnly = isNarrow && narrowView === 'nav';
+
+  return (
+    <BAIDialog
+      isOpen
+      onOpenChange={(next) => {
+        if (!next) onRequestClose();
+      }}
+      variant={isNarrow ? 'fullscreen' : 'standard'}
+      width={DIALOG_WIDTH}
+      maxHeight="85vh"
+      padding={0}
+      purpose="form"
+      style={isNarrow ? undefined : DIALOG_HEIGHT}
+      // The dialog's accessible name would otherwise be derived from whichever
+      // heading renders first inside it, which changes per category.
+      aria-label={t('webui.menu.Settings&Logs')}
+      data-testid="user-settings-modal"
+    >
+      <Layout
+        height="fill"
+        start={
+          isNarrow ? undefined : (
+            <LayoutPanel
+              width={NAV_PANEL_WIDTH}
+              hasDivider
+              padding={3}
+              role="navigation"
+              label={t('webui.menu.Settings')}
+            >
+              {categoryNav}
+            </LayoutPanel>
+          )
+        }
+        content={
+          <LayoutContent isScrollable padding={4}>
+            <VStack gap={4}>
+              <VStack style={HEADER_STICKY}>
+                <DialogHeader
+                  title={
+                    showNavOnly
+                      ? t('webui.menu.Settings&Logs')
+                      : t(CATEGORY_LABEL_KEYS[category])
+                  }
+                  hasDivider={false}
+                  onOpenChange={(next) => {
+                    if (!next) onRequestClose();
+                  }}
+                  startContent={
+                    isNarrow && !showNavOnly ? (
+                      <Button
+                        label={t('webui.menu.GoBack')}
+                        variant="ghost"
+                        size="sm"
+                        isIconOnly
+                        icon={<Icon icon={ArrowLeft} size="sm" />}
+                        onClick={() => setNarrowView('nav')}
+                      />
+                    ) : undefined
+                  }
+                  endContent={<WEBUIHelpButton />}
+                />
+              </VStack>
+              {showNavOnly ? (
+                categoryNav
+              ) : (
+                <BAIErrorBoundary>
+                  <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
+                </BAIErrorBoundary>
+              )}
+            </VStack>
+          </LayoutContent>
+        }
+      />
+    </BAIDialog>
+  );
+};
+
+export default UserSettingsModal;

--- a/react/src/components/UserSettingsModal.tsx
+++ b/react/src/components/UserSettingsModal.tsx
@@ -5,10 +5,6 @@
  The user-settings surface, as a dialog over whatever page is underneath
  (`UserSettingsModalOpener` owns the `?settings=` param that drives it).
 
- Composition follows Astryx's `settings-dialog` template: `BAIDialog` with
- `padding={0}` holding one `Layout` whose `start` slot is the category rail and
- whose `content` scrolls. `BAIModal` is not usable here because it already owns
- a `Layout`, and Astryx forbids nesting one inside another.
 */
 import type { LoginHistoryQuery as LoginHistoryQueryType } from '../__generated__/LoginHistoryQuery.graphql';
 import type { LoginSessionQuery as LoginSessionQueryType } from '../__generated__/LoginSessionQuery.graphql';
@@ -24,18 +20,12 @@ import LoginSession, { LoginSessionQuery } from './LoginSession';
 import UserSettingsGeneralPane from './UserSettingsGeneralPane';
 import WEBUIHelpButton from './WEBUIHelpButton';
 import { Button } from '@astryxdesign/core/Button';
-import { DialogHeader } from '@astryxdesign/core/Dialog';
 import { Divider } from '@astryxdesign/core/Divider';
 import { Icon } from '@astryxdesign/core/Icon';
-import {
-  Layout,
-  LayoutContent,
-  LayoutHeader,
-  LayoutPanel,
-} from '@astryxdesign/core/Layout';
 import { List, ListItem } from '@astryxdesign/core/List';
-import { VStack } from '@astryxdesign/core/Stack';
-import { BAIDialog, BAISkeleton } from 'backend.ai-ui';
+import { HStack, VStack } from '@astryxdesign/core/Stack';
+import { Text } from '@astryxdesign/core/Text';
+import { BAIModal, BAISkeleton } from 'backend.ai-ui';
 import {
   ArrowLeft,
   ChevronRight,
@@ -54,9 +44,13 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { useQueryLoader } from 'react-relay';
 
-// Astryx's dialog surface is `height: fit-content`, so `maxHeight` alone leaves
-// nothing owning a scrollport — the rail and the pane need a resolved height.
-const DIALOG_HEIGHT: CSSProperties = { height: '85vh' };
+// Astryx's dialog surface is `height: fit-content`, so the rail and the pane
+// need a resolved height before either can own a scrollport. `dvh` so mobile
+// browser chrome does not push the bottom edge off-screen.
+const DIALOG_INSET_BLOCK = 'var(--spacing-12)';
+const DIALOG_HEIGHT_VALUE = `calc(100dvh - ${DIALOG_INSET_BLOCK} * 2)`;
+const DIALOG_HEIGHT: CSSProperties = { height: DIALOG_HEIGHT_VALUE };
+const BODY_FILL: CSSProperties = { height: '100%', minHeight: 0 };
 
 // 1100 matches `MyKeypairManagementModal`, the widest dialog opened from here,
 // so a child never overhangs its parent. Minus the rail it still leaves the
@@ -205,83 +199,81 @@ const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const showNavOnly = isNarrow && narrowView === 'nav';
 
   return (
-    <BAIDialog
-      isOpen
-      onOpenChange={(next) => {
-        if (!next) onRequestClose();
-      }}
+    <BAIModal
+      open
+      onCancel={onRequestClose}
+      // The rail names the open category, so the bar names the surface; below
+      // `md` the rail is gone and the bar carries the category.
+      title={
+        <HStack gap={2} vAlign="center">
+          {isNarrow && !showNavOnly ? (
+            <Button
+              label={t('webui.menu.GoBack')}
+              variant="ghost"
+              size="sm"
+              isIconOnly
+              icon={<Icon icon={ArrowLeft} size="sm" />}
+              onClick={() => setNarrowView('nav')}
+            />
+          ) : null}
+          <Text weight="semibold">
+            {isNarrow && !showNavOnly
+              ? t(CATEGORY_LABEL_KEYS[category])
+              : t('webui.menu.Settings&Logs')}
+          </Text>
+          {/* The page's own help button is behind the mask while this is open. */}
+          <WEBUIHelpButton />
+        </HStack>
+      }
+      footer={null}
       variant={isNarrow ? 'fullscreen' : 'standard'}
       width={DIALOG_WIDTH}
-      maxHeight="85vh"
-      padding={0}
-      purpose="form"
+      // Astryx caps a standard dialog at 75dvh; raise it so `style.height` wins.
+      maxHeight={DIALOG_HEIGHT_VALUE}
+      // `purpose="form"` in Astryx terms: Escape closes, the backdrop does not.
+      maskClosable={false}
       style={isNarrow ? undefined : DIALOG_HEIGHT}
-      // The dialog's accessible name would otherwise be derived from whichever
-      // heading renders first inside it, which changes per category.
+      styles={{ body: BODY_FILL }}
+      // The accessible name would otherwise come from the title, which changes
+      // per category below `md`.
       aria-label={t('webui.menu.Settings&Logs')}
       data-testid="user-settings-modal"
     >
-      <Layout
-        height="fill"
-        header={
-          <LayoutHeader hasDivider>
-            <DialogHeader
-              // The rail names the open category, so the bar names the surface;
-              // below `md` the rail is gone and the bar carries the category.
-              title={
-                isNarrow && !showNavOnly
-                  ? t(CATEGORY_LABEL_KEYS[category])
-                  : t('webui.menu.Settings&Logs')
-              }
-              hasDivider={false}
-              onOpenChange={(next) => {
-                if (!next) onRequestClose();
-              }}
-              startContent={
-                isNarrow && !showNavOnly ? (
-                  <Button
-                    label={t('webui.menu.GoBack')}
-                    variant="ghost"
-                    size="sm"
-                    isIconOnly
-                    icon={<Icon icon={ArrowLeft} size="sm" />}
-                    onClick={() => setNarrowView('nav')}
-                  />
-                ) : undefined
-              }
-              endContent={<WEBUIHelpButton />}
-            />
-          </LayoutHeader>
-        }
-        start={
-          isNarrow ? undefined : (
-            <LayoutPanel
+      {/* `BAIModal` already owns the dialog's one `Layout`, so the rail is a
+          stack beside the pane rather than a second `LayoutPanel`. */}
+      <HStack height="100%" align="stretch">
+        {isNarrow ? null : (
+          <>
+            <VStack
+              as="nav"
               width={NAV_PANEL_WIDTH}
-              hasDivider
-              padding={3}
-              role="navigation"
-              label={t('webui.menu.Settings')}
+              isScrollable
+              paddingInlineEnd={3}
             >
               {categoryNav}
-            </LayoutPanel>
-          )
-        }
-        content={
-          <LayoutContent isScrollable padding={4}>
-            {showNavOnly ? (
-              categoryNav
-            ) : (
-              // Keyed so a failed category does not latch the whole surface:
-              // the page this replaced mounted one boundary per tab, which
-              // switching tabs unmounted.
-              <BAIErrorBoundary key={category}>
-                <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
-              </BAIErrorBoundary>
-            )}
-          </LayoutContent>
-        }
-      />
-    </BAIDialog>
+            </VStack>
+            <Divider orientation="vertical" />
+          </>
+        )}
+        <VStack
+          width="100%"
+          isScrollable
+          paddingInlineStart={isNarrow ? 0 : 4}
+          paddingBlockEnd={2}
+        >
+          {showNavOnly ? (
+            categoryNav
+          ) : (
+            // Keyed so a failed category does not latch the whole surface: the
+            // page this replaced mounted one boundary per tab, which switching
+            // tabs unmounted.
+            <BAIErrorBoundary key={category}>
+              <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
+            </BAIErrorBoundary>
+          )}
+        </VStack>
+      </HStack>
+    </BAIModal>
   );
 };
 

--- a/react/src/components/UserSettingsModal.tsx
+++ b/react/src/components/UserSettingsModal.tsx
@@ -61,7 +61,7 @@ const HEADER_STICKY: CSSProperties = {
   position: 'sticky',
   top: 0,
   paddingInline: 'var(--spacing-4)',
-  paddingBlockStart: 'var(--spacing-4)',
+  paddingBlock: 'var(--spacing-4) var(--spacing-2)',
   backgroundColor: 'var(--color-background-surface)',
   zIndex: 1,
 };
@@ -69,6 +69,11 @@ const HEADER_STICKY: CSSProperties = {
 const PANE_INSET: CSSProperties = {
   paddingInline: 'var(--spacing-4)',
   paddingBlockEnd: 'var(--spacing-4)',
+  // Its own stacking context, so a pane's internal layering — BAITable's pinned
+  // column and sticky header cells reach z-index 3 — cannot outrank the header
+  // bar above it.
+  position: 'relative',
+  zIndex: 0,
 };
 
 // 1100 matches `MyKeypairManagementModal`, the widest dialog opened from here,
@@ -282,7 +287,10 @@ const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                 {showNavOnly ? (
                   categoryNav
                 ) : (
-                  <BAIErrorBoundary>
+                  // Keyed so a failed category does not latch the whole
+                  // surface: the page this replaced mounted one boundary per
+                  // tab, which switching tabs unmounted.
+                  <BAIErrorBoundary key={category}>
                     <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
                   </BAIErrorBoundary>
                 )}

--- a/react/src/components/UserSettingsModal.tsx
+++ b/react/src/components/UserSettingsModal.tsx
@@ -27,7 +27,12 @@ import { Button } from '@astryxdesign/core/Button';
 import { DialogHeader } from '@astryxdesign/core/Dialog';
 import { Divider } from '@astryxdesign/core/Divider';
 import { Icon } from '@astryxdesign/core/Icon';
-import { Layout, LayoutContent, LayoutPanel } from '@astryxdesign/core/Layout';
+import {
+  Layout,
+  LayoutContent,
+  LayoutHeader,
+  LayoutPanel,
+} from '@astryxdesign/core/Layout';
 import { List, ListItem } from '@astryxdesign/core/List';
 import { VStack } from '@astryxdesign/core/Stack';
 import { BAIDialog, BAISkeleton } from 'backend.ai-ui';
@@ -52,29 +57,6 @@ import { useQueryLoader } from 'react-relay';
 // Astryx's dialog surface is `height: fit-content`, so `maxHeight` alone leaves
 // nothing owning a scrollport — the rail and the pane need a resolved height.
 const DIALOG_HEIGHT: CSSProperties = { height: '85vh' };
-
-// The header rides along the scrolling pane; Astryx has no sticky prop for it.
-// The pane's own inset lives on these two blocks rather than on `LayoutContent`,
-// so the stuck bar covers the full width and nothing scrolls through the gap a
-// `padding`ed scrollport would leave above it.
-const HEADER_STICKY: CSSProperties = {
-  position: 'sticky',
-  top: 0,
-  paddingInline: 'var(--spacing-4)',
-  paddingBlock: 'var(--spacing-4) var(--spacing-2)',
-  backgroundColor: 'var(--color-background-surface)',
-  zIndex: 1,
-};
-
-const PANE_INSET: CSSProperties = {
-  paddingInline: 'var(--spacing-4)',
-  paddingBlockEnd: 'var(--spacing-4)',
-  // Its own stacking context, so a pane's internal layering — BAITable's pinned
-  // column and sticky header cells reach z-index 3 — cannot outrank the header
-  // bar above it.
-  position: 'relative',
-  zIndex: 0,
-};
 
 // 1100 matches `MyKeypairManagementModal`, the widest dialog opened from here,
 // so a child never overhangs its parent. Minus the rail it still leaves the
@@ -241,6 +223,36 @@ const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     >
       <Layout
         height="fill"
+        header={
+          <LayoutHeader hasDivider>
+            <DialogHeader
+              // The rail names the open category, so the bar names the surface;
+              // below `md` the rail is gone and the bar carries the category.
+              title={
+                isNarrow && !showNavOnly
+                  ? t(CATEGORY_LABEL_KEYS[category])
+                  : t('webui.menu.Settings&Logs')
+              }
+              hasDivider={false}
+              onOpenChange={(next) => {
+                if (!next) onRequestClose();
+              }}
+              startContent={
+                isNarrow && !showNavOnly ? (
+                  <Button
+                    label={t('webui.menu.GoBack')}
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    icon={<Icon icon={ArrowLeft} size="sm" />}
+                    onClick={() => setNarrowView('nav')}
+                  />
+                ) : undefined
+              }
+              endContent={<WEBUIHelpButton />}
+            />
+          </LayoutHeader>
+        }
         start={
           isNarrow ? undefined : (
             <LayoutPanel
@@ -255,47 +267,17 @@ const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           )
         }
         content={
-          <LayoutContent isScrollable padding={0}>
-            <VStack gap={4}>
-              <VStack style={HEADER_STICKY}>
-                <DialogHeader
-                  title={
-                    showNavOnly
-                      ? t('webui.menu.Settings&Logs')
-                      : t(CATEGORY_LABEL_KEYS[category])
-                  }
-                  hasDivider={false}
-                  onOpenChange={(next) => {
-                    if (!next) onRequestClose();
-                  }}
-                  startContent={
-                    isNarrow && !showNavOnly ? (
-                      <Button
-                        label={t('webui.menu.GoBack')}
-                        variant="ghost"
-                        size="sm"
-                        isIconOnly
-                        icon={<Icon icon={ArrowLeft} size="sm" />}
-                        onClick={() => setNarrowView('nav')}
-                      />
-                    ) : undefined
-                  }
-                  endContent={<WEBUIHelpButton />}
-                />
-              </VStack>
-              <VStack style={PANE_INSET}>
-                {showNavOnly ? (
-                  categoryNav
-                ) : (
-                  // Keyed so a failed category does not latch the whole
-                  // surface: the page this replaced mounted one boundary per
-                  // tab, which switching tabs unmounted.
-                  <BAIErrorBoundary key={category}>
-                    <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
-                  </BAIErrorBoundary>
-                )}
-              </VStack>
-            </VStack>
+          <LayoutContent isScrollable padding={4}>
+            {showNavOnly ? (
+              categoryNav
+            ) : (
+              // Keyed so a failed category does not latch the whole surface:
+              // the page this replaced mounted one boundary per tab, which
+              // switching tabs unmounted.
+              <BAIErrorBoundary key={category}>
+                <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
+              </BAIErrorBoundary>
+            )}
           </LayoutContent>
         }
       />

--- a/react/src/components/UserSettingsModal.tsx
+++ b/react/src/components/UserSettingsModal.tsx
@@ -54,11 +54,21 @@ import { useQueryLoader } from 'react-relay';
 const DIALOG_HEIGHT: CSSProperties = { height: '85vh' };
 
 // The header rides along the scrolling pane; Astryx has no sticky prop for it.
+// The pane's own inset lives on these two blocks rather than on `LayoutContent`,
+// so the stuck bar covers the full width and nothing scrolls through the gap a
+// `padding`ed scrollport would leave above it.
 const HEADER_STICKY: CSSProperties = {
   position: 'sticky',
   top: 0,
+  paddingInline: 'var(--spacing-4)',
+  paddingBlockStart: 'var(--spacing-4)',
   backgroundColor: 'var(--color-background-surface)',
   zIndex: 1,
+};
+
+const PANE_INSET: CSSProperties = {
+  paddingInline: 'var(--spacing-4)',
+  paddingBlockEnd: 'var(--spacing-4)',
 };
 
 // 1100 matches `MyKeypairManagementModal`, the widest dialog opened from here,
@@ -240,7 +250,7 @@ const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           )
         }
         content={
-          <LayoutContent isScrollable padding={4}>
+          <LayoutContent isScrollable padding={0}>
             <VStack gap={4}>
               <VStack style={HEADER_STICKY}>
                 <DialogHeader
@@ -268,13 +278,15 @@ const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   endContent={<WEBUIHelpButton />}
                 />
               </VStack>
-              {showNavOnly ? (
-                categoryNav
-              ) : (
-                <BAIErrorBoundary>
-                  <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
-                </BAIErrorBoundary>
-              )}
+              <VStack style={PANE_INSET}>
+                {showNavOnly ? (
+                  categoryNav
+                ) : (
+                  <BAIErrorBoundary>
+                    <Suspense fallback={<BAISkeleton />}>{pane}</Suspense>
+                  </BAIErrorBoundary>
+                )}
+              </VStack>
             </VStack>
           </LayoutContent>
         }

--- a/react/src/components/UserSettingsModalOpener.test.tsx
+++ b/react/src/components/UserSettingsModalOpener.test.tsx
@@ -1,0 +1,163 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ The history contract is the modal's main acceptance criterion and it lives in
+ the nuqs adapter's hands, so it is pinned here rather than left to a manual
+ pass: opening pushes (Back closes), switching category and closing replace.
+*/
+import { forgetNonSettingsLocation } from '../helper/userSettingsModal';
+import UserSettingsModalOpener, {
+  useUserSettingsModal,
+} from './UserSettingsModalOpener';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NuqsAdapter } from 'nuqs/adapters/react-router/v6';
+import {
+  RouterProvider,
+  createBrowserRouter,
+  useLocation,
+} from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({}),
+  };
+});
+
+vi.mock('../hooks/useWebUIMenuItems', () => ({
+  useWebUIMenuItems: () => ({ defaultMenuPath: '/start' }),
+}));
+
+// The modal itself is `React.lazy` and pulls in Relay, the settings panes and
+// the whole Astryx dialog stack; the contract under test is the URL, not the
+// dialog, so it is stubbed down to its close button.
+vi.mock('./UserSettingsModal', () => ({
+  default: ({
+    category,
+    onCategoryChange,
+    onRequestClose,
+  }: {
+    category: string;
+    onCategoryChange: (next: string) => void;
+    onRequestClose: () => void;
+  }) => (
+    <div data-testid="modal">
+      <span data-testid="category">{category}</span>
+      <button onClick={() => onCategoryChange('logs')}>to logs</button>
+      <button onClick={onRequestClose}>close</button>
+    </div>
+  ),
+}));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+};
+
+const OpenButton = () => {
+  const { open } = useUserSettingsModal();
+  return <button onClick={() => open('general')}>open settings</button>;
+};
+
+// A browser router over jsdom's own history, so push / replace / Back behave as
+// they do in the app — `createMemoryRouter` keeps a private stack the nuqs
+// adapter does not pop from.
+const renderApp = () => {
+  window.history.replaceState(null, '', '/session?tab=running');
+  const router = createBrowserRouter([
+    {
+      path: '*',
+      element: (
+        <>
+          <LocationProbe />
+          <OpenButton />
+          <UserSettingsModalOpener />
+        </>
+      ),
+    },
+  ]);
+  render(
+    <NuqsAdapter defaultOptions={{ shallow: false }}>
+      <RouterProvider router={router} />
+    </NuqsAdapter>,
+  );
+  return { router };
+};
+
+describe('UserSettingsModalOpener history contract', () => {
+  beforeEach(() => {
+    forgetNonSettingsLocation();
+  });
+
+  it('stays closed until the param appears', () => {
+    renderApp();
+    expect(screen.queryByTestId('modal')).toBeNull();
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/session?tab=running',
+    );
+  });
+
+  it("opens over the current page, keeping the page's own query string", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await user.click(screen.getByText('open settings'));
+
+    expect(await screen.findByTestId('modal')).toBeInTheDocument();
+    expect(screen.getByTestId('category')).toHaveTextContent('general');
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/session?tab=running&settings=general',
+    );
+  });
+
+  it('closes on Back, because opening pushed', async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await user.click(screen.getByText('open settings'));
+    await screen.findByTestId('modal');
+
+    window.history.back();
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('modal')).toBeNull();
+    });
+  });
+
+  it('replaces on a category switch, so Back still closes in one press', async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await user.click(screen.getByText('open settings'));
+    await screen.findByTestId('modal');
+    await user.click(screen.getByText('to logs'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('category')).toHaveTextContent('logs');
+    });
+
+    window.history.back();
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('modal')).toBeNull();
+    });
+  });
+
+  it('drops the param on close, replacing so no entry is left behind', async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await user.click(screen.getByText('open settings'));
+    await screen.findByTestId('modal');
+    await user.click(screen.getByText('close'));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('modal')).toBeNull();
+    });
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/session?tab=running',
+    );
+  });
+});

--- a/react/src/components/UserSettingsModalOpener.tsx
+++ b/react/src/components/UserSettingsModalOpener.tsx
@@ -1,0 +1,88 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  coerceUserSettingsCategory,
+  rememberNonSettingsLocation,
+  USER_SETTINGS_PARAM,
+  USER_SETTINGS_ROUTE,
+  type UserSettingsCategory,
+} from '../helper/userSettingsModal';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useWebUIMenuItems } from '../hooks/useWebUIMenuItems';
+import { parseAsString, useQueryState } from 'nuqs';
+import React, { Suspense, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const UserSettingsModal = React.lazy(() => import('./UserSettingsModal'));
+
+// Category switches and closing replace history so Back closes the modal in one
+// press; `useUserSettingsModal` opts into push for the opening transition.
+const settingsParam = parseAsString.withOptions({ history: 'replace' });
+
+/**
+ * Mounts the user-settings modal app-wide and drives it from `?settings=`, so
+ * it opens over the current page instead of navigating to one.
+ */
+const UserSettingsModalOpener = () => {
+  'use memo';
+  // Mounted above the route tree, so without this gate a `?settings=` URL would
+  // paint a dialog over the login screen.
+  useSuspendedBackendaiClient();
+
+  const location = useLocation();
+  const navigate = useWebUINavigate();
+  const { defaultMenuPath } = useWebUIMenuItems();
+  const [rawCategory, setRawCategory] = useQueryState(
+    USER_SETTINGS_PARAM,
+    settingsParam,
+  );
+  const category = coerceUserSettingsCategory(rawCategory);
+
+  useEffect(
+    function trackBackgroundLocation() {
+      rememberNonSettingsLocation(location);
+    },
+    [location],
+  );
+
+  const close = () => {
+    // A cold deep link leaves the modal over an empty shell; closing there has
+    // to land on a real page.
+    if (location.pathname === USER_SETTINGS_ROUTE) {
+      navigate(defaultMenuPath, { replace: true });
+      return;
+    }
+    setRawCategory(null);
+  };
+
+  // `BAIDialog` keeps its children mounted while closed, so the gate is here:
+  // no Relay loaders and no chunk fetch until the modal is actually open.
+  if (category === null) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <UserSettingsModal
+        category={category}
+        onCategoryChange={(next) => setRawCategory(next)}
+        onRequestClose={close}
+      />
+    </Suspense>
+  );
+};
+
+export default UserSettingsModalOpener;
+
+/** Entry point for in-app triggers. Pushes, so Back closes the modal. */
+export const useUserSettingsModal = () => {
+  const [, setRawCategory] = useQueryState(
+    USER_SETTINGS_PARAM,
+    parseAsString.withOptions({ history: 'push' }),
+  );
+
+  return {
+    open: (category: UserSettingsCategory = 'general') =>
+      setRawCategory(category),
+  };
+};

--- a/react/src/components/UserSettingsModalOpener.tsx
+++ b/react/src/components/UserSettingsModalOpener.tsx
@@ -4,9 +4,9 @@
  */
 import {
   coerceUserSettingsCategory,
+  isUserSettingsPath,
   rememberNonSettingsLocation,
   USER_SETTINGS_PARAM,
-  USER_SETTINGS_ROUTE,
   type UserSettingsCategory,
 } from '../helper/userSettingsModal';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
@@ -50,7 +50,7 @@ const UserSettingsModalOpener = () => {
   const close = () => {
     // A cold deep link leaves the modal over an empty shell; closing there has
     // to land on a real page.
-    if (location.pathname === USER_SETTINGS_ROUTE) {
+    if (isUserSettingsPath(location.pathname)) {
       navigate(defaultMenuPath, { replace: true });
       return;
     }

--- a/react/src/components/UserSettingsModalOpener.tsx
+++ b/react/src/components/UserSettingsModalOpener.tsx
@@ -76,6 +76,7 @@ export default UserSettingsModalOpener;
 
 /** Entry point for in-app triggers. Pushes, so Back closes the modal. */
 export const useUserSettingsModal = () => {
+  'use memo';
   const [, setRawCategory] = useQueryState(
     USER_SETTINGS_PARAM,
     parseAsString.withOptions({ history: 'push' }),

--- a/react/src/components/UserSettingsRouteRedirect.test.tsx
+++ b/react/src/components/UserSettingsRouteRedirect.test.tsx
@@ -1,0 +1,95 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  forgetNonSettingsLocation,
+  rememberNonSettingsLocation,
+} from '../helper/userSettingsModal';
+import UserSettingsRouteRedirect from './UserSettingsRouteRedirect';
+import { render, screen } from '@testing-library/react';
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryRouter,
+  useLocation,
+} from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    // `WebUINavigate` only calls this to wait for the client.
+    useSuspendedBackendaiClient: () => ({}),
+  };
+});
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+};
+
+// The probe sits in a layout route so it also reports locations that resolve
+// back to `/usersettings` itself (the cold-deep-link case).
+const renderAt = (initialEntry: string) => {
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <>
+            <LocationProbe />
+            <Outlet />
+          </>
+        ),
+        children: [
+          { path: '/usersettings', element: <UserSettingsRouteRedirect /> },
+          { path: '*', element: null },
+        ],
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+  return render(<RouterProvider router={router} />);
+};
+
+describe('UserSettingsRouteRedirect', () => {
+  beforeEach(() => {
+    forgetNonSettingsLocation();
+  });
+
+  it('converts a cold `?tab=` deep link into the settings param on its own route', async () => {
+    renderAt('/usersettings?tab=logs');
+    expect(await screen.findByTestId('location')).toHaveTextContent(
+      '/usersettings?settings=logs',
+    );
+  });
+
+  it('defaults a bare visit to the general category', async () => {
+    renderAt('/usersettings');
+    expect(await screen.findByTestId('location')).toHaveTextContent(
+      '/usersettings?settings=general',
+    );
+  });
+
+  it('reopens over the tracked background page, keeping its query string', async () => {
+    rememberNonSettingsLocation({
+      pathname: '/session',
+      search: '?tab=running',
+    });
+    renderAt('/usersettings?tab=logs');
+    expect(await screen.findByTestId('location')).toHaveTextContent(
+      '/session?tab=running&settings=logs',
+    );
+  });
+
+  it('renders nothing once the param is already present, so it cannot loop', async () => {
+    renderAt('/usersettings?settings=general');
+    // Unchanged location: the opener owns the modal from here.
+    expect(await screen.findByTestId('location')).toHaveTextContent(
+      '/usersettings?settings=general',
+    );
+  });
+});

--- a/react/src/components/UserSettingsRouteRedirect.test.tsx
+++ b/react/src/components/UserSettingsRouteRedirect.test.tsx
@@ -78,6 +78,8 @@ describe('UserSettingsRouteRedirect', () => {
     rememberNonSettingsLocation({
       pathname: '/session',
       search: '?tab=running',
+      hash: '',
+      state: null,
     });
     renderAt('/usersettings?tab=logs');
     expect(await screen.findByTestId('location')).toHaveTextContent(

--- a/react/src/components/UserSettingsRouteRedirect.tsx
+++ b/react/src/components/UserSettingsRouteRedirect.tsx
@@ -1,0 +1,50 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  buildUserSettingsSearch,
+  coerceUserSettingsCategory,
+  peekNonSettingsLocation,
+  USER_SETTINGS_PARAM,
+  USER_SETTINGS_ROUTE,
+} from '../helper/userSettingsModal';
+import WebUINavigate from './WebUINavigate';
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Route element for `/usersettings`. The settings UI is a modal now, so this
+ * only converts the legacy `?tab=` deep link into the `?settings=` param and
+ * hands off to `UserSettingsModalOpener`.
+ *
+ * When a background page was visited in this session the modal reopens over it;
+ * on a cold load it stays on `/usersettings` rather than pulling in the default
+ * page, so an external deep link paints the dialog immediately.
+ */
+const UserSettingsRouteRedirect: React.FC = () => {
+  'use memo';
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  // Already converted — the opener owns it from here, so redirecting again
+  // would loop.
+  if (params.get(USER_SETTINGS_PARAM)) return null;
+
+  const category = coerceUserSettingsCategory(params.get('tab')) ?? 'general';
+  const background = peekNonSettingsLocation();
+  const target = background
+    ? {
+        pathname: background.pathname,
+        search: buildUserSettingsSearch(background.search, category),
+      }
+    : {
+        pathname: USER_SETTINGS_ROUTE,
+        search: buildUserSettingsSearch('', category),
+      };
+
+  // `replace`: a push would make Back bounce through here and reopen the modal.
+  return <WebUINavigate to={target} replace />;
+};
+
+export default UserSettingsRouteRedirect;

--- a/react/src/components/UserSettingsRouteRedirect.tsx
+++ b/react/src/components/UserSettingsRouteRedirect.tsx
@@ -32,19 +32,24 @@ const UserSettingsRouteRedirect: React.FC = () => {
   if (params.get(USER_SETTINGS_PARAM)) return null;
 
   const category = coerceUserSettingsCategory(params.get('tab')) ?? 'general';
+  // `hash` and `state` travel with the background: the session list keeps its
+  // already-fetched detail fragment in `state`, and dropping it puts the drawer
+  // back on its fetch fallback.
   const background = peekNonSettingsLocation();
   const target = background
     ? {
         pathname: background.pathname,
         search: buildUserSettingsSearch(background.search, category),
+        hash: background.hash,
       }
     : {
         pathname: USER_SETTINGS_ROUTE,
         search: buildUserSettingsSearch('', category),
+        hash: location.hash,
       };
 
   // `replace`: a push would make Back bounce through here and reopen the modal.
-  return <WebUINavigate to={target} replace />;
+  return <WebUINavigate to={target} state={background?.state} replace />;
 };
 
 export default UserSettingsRouteRedirect;

--- a/react/src/generated/searchIndex.json
+++ b/react/src/generated/searchIndex.json
@@ -5026,22 +5026,22 @@
       "labelKey": "webui.menu.Settings&Logs",
       "tabs": [
         {
-          "param": "tab",
+          "param": "settings",
           "key": "general",
           "labelKey": "userSettings.General"
         },
         {
-          "param": "tab",
+          "param": "settings",
           "key": "login-history",
           "labelKey": "userSettings.LoginHistory"
         },
         {
-          "param": "tab",
+          "param": "settings",
           "key": "login-sessions",
           "labelKey": "userSettings.LoginSessions"
         },
         {
-          "param": "tab",
+          "param": "settings",
           "key": "logs",
           "labelKey": "userSettings.Logs"
         }
@@ -5357,6 +5357,7 @@
         "userSettings.SSHKeypairGenerationWarning",
         "userSettings.UserConfigScript",
         "webui.menu.GoBack",
+        "webui.menu.Help",
         "webui.menu.Settings"
       ]
     }

--- a/react/src/helper/userSettingsModal.test.ts
+++ b/react/src/helper/userSettingsModal.test.ts
@@ -83,10 +83,15 @@ describe('background location tracking', () => {
     rememberNonSettingsLocation({
       pathname: '/session',
       search: '?tab=running',
+      hash: '#top',
+      state: { drawerFrgmt: 'cached' },
     });
     expect(peekNonSettingsLocation()).toEqual({
       pathname: '/session',
       search: '?tab=running',
+      hash: '#top',
+      // Kept so reopening over the page does not drop its prefetched data.
+      state: { drawerFrgmt: 'cached' },
     });
   });
 
@@ -94,11 +99,23 @@ describe('background location tracking', () => {
     'ignores the settings route itself (%s)',
     (pathname) => {
       forgetNonSettingsLocation();
-      rememberNonSettingsLocation({ pathname: '/session', search: '' });
-      rememberNonSettingsLocation({ pathname, search: '?tab=logs' });
+      rememberNonSettingsLocation({
+        pathname: '/session',
+        search: '',
+        hash: '',
+        state: null,
+      });
+      rememberNonSettingsLocation({
+        pathname,
+        search: '?tab=logs',
+        hash: '',
+        state: null,
+      });
       expect(peekNonSettingsLocation()).toEqual({
         pathname: '/session',
         search: '',
+        hash: '',
+        state: null,
       });
     },
   );

--- a/react/src/helper/userSettingsModal.test.ts
+++ b/react/src/helper/userSettingsModal.test.ts
@@ -1,0 +1,83 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  buildUserSettingsSearch,
+  coerceUserSettingsCategory,
+  forgetNonSettingsLocation,
+  peekNonSettingsLocation,
+  rememberNonSettingsLocation,
+  USER_SETTINGS_ROUTE,
+} from './userSettingsModal';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('coerceUserSettingsCategory', () => {
+  it('treats an absent param as closed', () => {
+    expect(coerceUserSettingsCategory(null)).toBeNull();
+    expect(coerceUserSettingsCategory(undefined)).toBeNull();
+    expect(coerceUserSettingsCategory('')).toBeNull();
+  });
+
+  it('passes every known category through', () => {
+    expect(coerceUserSettingsCategory('general')).toBe('general');
+    expect(coerceUserSettingsCategory('logs')).toBe('logs');
+    expect(coerceUserSettingsCategory('login-sessions')).toBe('login-sessions');
+    expect(coerceUserSettingsCategory('login-history')).toBe('login-history');
+  });
+
+  it('falls back to general for an unknown value, as the old tab parser did', () => {
+    expect(coerceUserSettingsCategory('bogus')).toBe('general');
+  });
+});
+
+describe('buildUserSettingsSearch', () => {
+  it("keeps the page's own query string, including its tab", () => {
+    expect(buildUserSettingsSearch('?tab=running&order=name', 'logs')).toBe(
+      '?tab=running&order=name&settings=logs',
+    );
+  });
+
+  it('builds a search from nothing', () => {
+    expect(buildUserSettingsSearch('', 'general')).toBe('?settings=general');
+  });
+
+  it('overwrites an existing category', () => {
+    expect(buildUserSettingsSearch('?settings=logs', 'login-history')).toBe(
+      '?settings=login-history',
+    );
+  });
+});
+
+describe('background location tracking', () => {
+  beforeEach(() => {
+    forgetNonSettingsLocation();
+  });
+
+  it('starts empty so a cold load can be detected', () => {
+    expect(peekNonSettingsLocation()).toBeNull();
+  });
+
+  it('remembers a normal page', () => {
+    rememberNonSettingsLocation({
+      pathname: '/session',
+      search: '?tab=running',
+    });
+    expect(peekNonSettingsLocation()).toEqual({
+      pathname: '/session',
+      search: '?tab=running',
+    });
+  });
+
+  it('ignores the settings route itself', () => {
+    rememberNonSettingsLocation({ pathname: '/session', search: '' });
+    rememberNonSettingsLocation({
+      pathname: USER_SETTINGS_ROUTE,
+      search: '?tab=logs',
+    });
+    expect(peekNonSettingsLocation()).toEqual({
+      pathname: '/session',
+      search: '',
+    });
+  });
+});

--- a/react/src/helper/userSettingsModal.test.ts
+++ b/react/src/helper/userSettingsModal.test.ts
@@ -6,6 +6,7 @@ import {
   buildUserSettingsSearch,
   coerceUserSettingsCategory,
   forgetNonSettingsLocation,
+  isUserSettingsPath,
   peekNonSettingsLocation,
   rememberNonSettingsLocation,
   USER_SETTINGS_ROUTE,
@@ -49,6 +50,26 @@ describe('buildUserSettingsSearch', () => {
   });
 });
 
+describe('isUserSettingsPath', () => {
+  // React Router matches the route case-insensitively and with a trailing
+  // slash, so the guards that read `location.pathname` have to as well.
+  it.each([
+    '/usersettings',
+    '/usersettings/',
+    '/UserSettings',
+    '/USERSETTINGS//',
+  ])('recognises %s', (pathname) => {
+    expect(isUserSettingsPath(pathname)).toBe(true);
+  });
+
+  it.each(['/usersettings2', '/admin/usersettings', '/session', '/'])(
+    'rejects %s',
+    (pathname) => {
+      expect(isUserSettingsPath(pathname)).toBe(false);
+    },
+  );
+});
+
 describe('background location tracking', () => {
   beforeEach(() => {
     forgetNonSettingsLocation();
@@ -69,15 +90,16 @@ describe('background location tracking', () => {
     });
   });
 
-  it('ignores the settings route itself', () => {
-    rememberNonSettingsLocation({ pathname: '/session', search: '' });
-    rememberNonSettingsLocation({
-      pathname: USER_SETTINGS_ROUTE,
-      search: '?tab=logs',
-    });
-    expect(peekNonSettingsLocation()).toEqual({
-      pathname: '/session',
-      search: '',
-    });
-  });
+  it.each([USER_SETTINGS_ROUTE, '/UserSettings', '/usersettings/'])(
+    'ignores the settings route itself (%s)',
+    (pathname) => {
+      forgetNonSettingsLocation();
+      rememberNonSettingsLocation({ pathname: '/session', search: '' });
+      rememberNonSettingsLocation({ pathname, search: '?tab=logs' });
+      expect(peekNonSettingsLocation()).toEqual({
+        pathname: '/session',
+        search: '',
+      });
+    },
+  );
 });

--- a/react/src/helper/userSettingsModal.ts
+++ b/react/src/helper/userSettingsModal.ts
@@ -58,16 +58,26 @@ export const isUserSettingsPath = (pathname: string): boolean =>
  * Last location that was not the settings route, so the redirect shim can put
  * the modal back over the page the user was actually looking at. A cache, not
  * state: `null` simply means "cold load".
+ *
+ * `hash` and `state` ride along because dropping them silently degrades the
+ * page underneath — the session list carries its already-fetched detail
+ * fragment in `state` (`ComputeSessionListPage`), so losing it puts the drawer
+ * back on its fetch fallback.
  */
-let lastNonSettingsLocation: { pathname: string; search: string } | null = null;
+export type NonSettingsLocation = Pick<
+  Location,
+  'pathname' | 'search' | 'hash' | 'state'
+>;
 
-export const rememberNonSettingsLocation = (
-  location: Pick<Location, 'pathname' | 'search'>,
-) => {
+let lastNonSettingsLocation: NonSettingsLocation | null = null;
+
+export const rememberNonSettingsLocation = (location: NonSettingsLocation) => {
   if (isUserSettingsPath(location.pathname)) return;
   lastNonSettingsLocation = {
     pathname: location.pathname,
     search: location.search,
+    hash: location.hash,
+    state: location.state,
   };
 };
 

--- a/react/src/helper/userSettingsModal.ts
+++ b/react/src/helper/userSettingsModal.ts
@@ -46,6 +46,15 @@ export const buildUserSettingsSearch = (
 };
 
 /**
+ * React Router matches paths case-insensitively and tolerates a trailing slash,
+ * while `location.pathname` keeps whatever the URL spelled. Comparing raw would
+ * let `/UserSettings` slip past both guards below and trap the modal in a
+ * close -> shim -> reopen loop.
+ */
+export const isUserSettingsPath = (pathname: string): boolean =>
+  pathname.replace(/\/+$/, '').toLowerCase() === USER_SETTINGS_ROUTE;
+
+/**
  * Last location that was not the settings route, so the redirect shim can put
  * the modal back over the page the user was actually looking at. A cache, not
  * state: `null` simply means "cold load".
@@ -55,7 +64,7 @@ let lastNonSettingsLocation: { pathname: string; search: string } | null = null;
 export const rememberNonSettingsLocation = (
   location: Pick<Location, 'pathname' | 'search'>,
 ) => {
-  if (location.pathname === USER_SETTINGS_ROUTE) return;
+  if (isUserSettingsPath(location.pathname)) return;
   lastNonSettingsLocation = {
     pathname: location.pathname,
     search: location.search,

--- a/react/src/helper/userSettingsModal.ts
+++ b/react/src/helper/userSettingsModal.ts
@@ -1,0 +1,69 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type { Location } from 'react-router-dom';
+
+/**
+ * User settings live in a modal that opens over whatever page the user is on,
+ * driven by this query param. `/usersettings` survives only as a redirect shim
+ * for the legacy `?tab=` deep links (`UserSettingsRouteRedirect`).
+ */
+export const USER_SETTINGS_PARAM = 'settings';
+export const USER_SETTINGS_ROUTE = '/usersettings';
+
+export const USER_SETTINGS_CATEGORIES = [
+  'general',
+  'logs',
+  'login-sessions',
+  'login-history',
+] as const;
+
+export type UserSettingsCategory = (typeof USER_SETTINGS_CATEGORIES)[number];
+
+/** Absent means closed; present-but-unknown falls back to the first category. */
+export const coerceUserSettingsCategory = (
+  raw: string | null | undefined,
+): UserSettingsCategory | null =>
+  raw == null || raw === ''
+    ? null
+    : (USER_SETTINGS_CATEGORIES as ReadonlyArray<string>).includes(raw)
+      ? (raw as UserSettingsCategory)
+      : 'general';
+
+/**
+ * Merge the category into a page's search string. The page's own `tab` is left
+ * alone — it belongs to the page underneath, and the help button reads the
+ * category rather than `tab` while the modal is open.
+ */
+export const buildUserSettingsSearch = (
+  search: string,
+  category: UserSettingsCategory,
+): string => {
+  const params = new URLSearchParams(search);
+  params.set(USER_SETTINGS_PARAM, category);
+  return `?${params.toString()}`;
+};
+
+/**
+ * Last location that was not the settings route, so the redirect shim can put
+ * the modal back over the page the user was actually looking at. A cache, not
+ * state: `null` simply means "cold load".
+ */
+let lastNonSettingsLocation: { pathname: string; search: string } | null = null;
+
+export const rememberNonSettingsLocation = (
+  location: Pick<Location, 'pathname' | 'search'>,
+) => {
+  if (location.pathname === USER_SETTINGS_ROUTE) return;
+  lastNonSettingsLocation = {
+    pathname: location.pathname,
+    search: location.search,
+  };
+};
+
+export const peekNonSettingsLocation = () => lastNonSettingsLocation;
+
+export const forgetNonSettingsLocation = () => {
+  lastNonSettingsLocation = null;
+};

--- a/react/src/hooks/useHelpURL.ts
+++ b/react/src/hooks/useHelpURL.ts
@@ -4,6 +4,10 @@
  */
 import { useCurrentLanguage } from '../components/DefaultProviders';
 import { resolveHelpDocPath } from '../helper/helpAnchors';
+import {
+  coerceUserSettingsCategory,
+  USER_SETTINGS_PARAM,
+} from '../helper/userSettingsModal';
 import { useWebUILocation } from './index';
 import { useCurrentMenuKey } from './useRouteScope';
 
@@ -31,8 +35,15 @@ export const useHelpURL = (): string => {
   // Scope-aware menu key (route handle): under `/admin/<feature>` and
   // `/project/:name/<feature>` the first pathname segment is the scope prefix,
   // so the lookup uses the matched route's menu key, not the pathname.
-  const matchingKey = useCurrentMenuKey() || '';
-  const activeTab = new URLSearchParams(location.search).get('tab');
+  const routeMenuKey = useCurrentMenuKey() || '';
+  const searchParams = new URLSearchParams(location.search);
+  // An open settings modal covers whatever page is underneath, so it owns the
+  // help target — otherwise the "?" would answer for the page behind it.
+  const settingsCategory = coerceUserSettingsCategory(
+    searchParams.get(USER_SETTINGS_PARAM),
+  );
+  const matchingKey = settingsCategory ? 'usersettings' : routeMenuKey;
+  const activeTab = settingsCategory ?? searchParams.get('tab');
 
   return manualURL + resolveHelpDocPath(matchingKey, activeTab);
 };

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -1402,11 +1402,7 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     // route survives only to convert legacy `?tab=` deep links into it.
     path: '/usersettings',
     handle: { labelKey: 'webui.menu.Settings&Logs' },
-    element: (
-      <Suspense fallback={<BAISkeleton rows={4} />}>
-        <UserSettingsRouteRedirect />
-      </Suspense>
-    ),
+    element: <UserSettingsRouteRedirect />,
   },
   {
     path: '/logs',

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -20,6 +20,7 @@ import RouteAccessGuard from './components/RouteAccessGuard';
 import RouteErrorBoundary from './components/RouteErrorBoundary';
 import { STokenLoginBoundary } from './components/STokenLoginBoundary';
 import StorageHostFetchErrorBoundary from './components/StorageHostFetchErrorBoundary';
+import UserSettingsRouteRedirect from './components/UserSettingsRouteRedirect';
 import WebUINavigate from './components/WebUINavigate';
 import { persistPostLoginState } from './helper/loginSessionAuth';
 import { useSuspendedBackendaiClient } from './hooks';
@@ -66,7 +67,6 @@ const AdminDashboardPage = React.lazy(
 );
 const EnvironmentPage = React.lazy(() => import('./pages/EnvironmentPage'));
 const MyEnvironmentPage = React.lazy(() => import('./pages/MyEnvironmentPage'));
-const UserSettingsPage = React.lazy(() => import('./pages/UserSettingsPage'));
 const SessionLauncherPage = React.lazy(
   () => import('./pages/SessionLauncherPage'),
 );
@@ -82,6 +82,9 @@ const FolderInvitationResponseModalOpener = React.lazy(
 );
 const FileUploadManager = React.lazy(
   () => import('./components/FileUploadManager'),
+);
+const UserSettingsModalOpener = React.lazy(
+  () => import('./components/UserSettingsModalOpener'),
 );
 
 const DeploymentListPage = React.lazy(
@@ -1395,11 +1398,13 @@ export const mainLayoutChildRoutes: RouteObject[] = [
   },
   // --- Global, no-prefix, unchanged ---
   {
+    // The settings surface is a modal now (`UserSettingsModalOpener`); this
+    // route survives only to convert legacy `?tab=` deep links into it.
     path: '/usersettings',
     handle: { labelKey: 'webui.menu.Settings&Logs' },
     element: (
       <Suspense fallback={<BAISkeleton rows={4} />}>
-        <UserSettingsPage />
+        <UserSettingsRouteRedirect />
       </Suspense>
     ),
   },
@@ -1718,6 +1723,14 @@ export const routes: RouteObject[] = [
               </ErrorBoundaryWithNullFallback>
               <ErrorBoundaryWithNullFallback>
                 <FileUploadManager />
+              </ErrorBoundaryWithNullFallback>
+            </Suspense>
+            {/* Its own boundary: the opener suspends on the client, and
+                sharing the block above would unmount `FileUploadManager`
+                and drop in-flight uploads. */}
+            <Suspense fallback={null}>
+              <ErrorBoundaryWithNullFallback>
+                <UserSettingsModalOpener />
               </ErrorBoundaryWithNullFallback>
             </Suspense>
           </STokenGuard>


### PR DESCRIPTION
Resolves #9595 (FR-3903)

`/usersettings` was a full page: opening Preferences meant navigating away from
whatever you were doing. It is now a modal that opens over the current page,
with a category rail on the left and the selected pane on the right.

## URL contract

`?settings=general | logs | login-sessions | login-history` on the **current**
location drives it. Opening pushes a history entry so Back closes it in one
press; switching category and closing replace, so the modal adds no history
noise. Refresh restores the open category over the same page.

`/usersettings` stays a real route as a shim that converts the legacy `?tab=`
deep links onto the param — it cannot be deleted, because `ContainerCommitModal`
stores `to: '/usersettings?tab=logs'` as a string inside a notification. With a
background page tracked it reopens over that page; on a cold load it stays on
`/usersettings` rather than pulling in the default page, so an external deep
link paints the dialog immediately (measured below).

## Composition

`BAIModal` owns the dialog and its header. Astryx forbids nesting `Layout`, and
`BAIModal` already owns the dialog's one, so the rail is an `HStack` beside the
pane rather than a second `LayoutPanel`. The surface leaves a `--spacing-12`
gutter above and below, with `maxHeight` raised past Astryx's 75dvh cap.

Below `md` the dialog goes fullscreen, the rail becomes a drill-down, and the
header carries the category name and a back button.

`SettingList` gained `hideGroupNav`: it renders its own `Layout` + nav rail,
which would be a nav inside a nav here.

## No functional regression

Every setting, its `data-testid`, every conditional gate (`allowThemeMode`,
`isThemePreviewMode`, `globalThis.isElectron`, `supports('my-keypairs')`), the
notification-permission flow, the `langChanged` event, the per-tab query loaders
and the child modals moved across unchanged. The pane's error boundary is keyed
by category, matching the per-tab boundary the page used to mount.

Two things the move broke and this PR repairs:

- The **global search index** crawls route elements, so the shim left the
  palette with none of the 19 settings. The generator now crawls the modal,
  declares the `?settings=` categories the way the data page's `statusCategory`
  already is, and names the tab the groups belong to (the rail and the groups no
  longer share a file, so `settingTabKeyOf` cannot pair them). Regenerated index
  is identical apart from `param: tab` → `settings`.
- The **help button** resolves against the route menu key, which would answer
  for the page behind the modal. An open modal now owns the help target.

The "Logs / Errors" shortcut is gone from the user dropdown — Preferences opens
the same modal and Logs is one click away in its rail.

## Verification

- `bash scripts/verify.sh` — `=== ALL PASS ===`
- 177 unit tests pass, 23 of them new: `userSettingsModal.test.ts` (category
  coercion, search merging, background-location tracking, path matching) and
  `UserSettingsRouteRedirect.test.tsx` (cold / tracked / already-converted).
- Live browser probes on a real cluster: all four categories, Esc, Back, legacy
  and cold deep links, nested child modals (SSH keypair, both shell scripts, the
  reset confirm) stacking and dismissing topmost-first, narrow drill-down, dark
  mode.
- `navigateTo(page, 'usersettings')` → the General pane's `items-my-keypair-info`
  Config button visible in **6.8 s** against the e2e spec's 10 s budget (Vite dev
  build, three runs: 6783 / 6764 / 6841 ms).

A four-lens adversarial review over the diff raised 29 claims; 19 did not
survive refutation. Four of the rest were real and are fixed here — most
notably `/UserSettings` (a case variant, which React Router matches) trapping
the modal in a close → shim → reopen loop with the page behind it inert.

## Not in this PR

The user manual still describes a page with four tabs. Its `#user-settings` /
`#general-tab` / `#logs-tab` headings are the help button's anchors and must
stay byte-identical, so the docs pass is a separate change.

Known trade-offs: the breadcrumb no longer shows Settings (correct for an
overlay); `?settings=` leaks into a copied URL while open; after closing, one
Back press is a no-op because opening pushed and closing replaced.
