### PR TITLE
fix(FR-3733): put the BAIText expand link inline at the end of the text

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIText.css
+++ b/packages/backend.ai-ui/src/components/BAIText.css
@@ -171,8 +171,9 @@
   word-break: break-word;
 }
 
-/* The expand link inline at the end of the text (antd `operationUnit`). */
-.bai-text-content > .bai-text-expand {
+/* The expand link inline at the end of the text (antd `operationUnit`).
+   Descendant, not child: the measuring probe's clone must match too. */
+.bai-text-content .bai-text-expand {
   margin-inline-start: var(--spacing-1);
   white-space: nowrap;
 }

--- a/packages/backend.ai-ui/src/components/BAIText.css
+++ b/packages/backend.ai-ui/src/components/BAIText.css
@@ -161,12 +161,20 @@
   white-space: nowrap;
 }
 
-/* rows: N — `-webkit-line-clamp` is set inline (the value is dynamic). */
+/* rows: N — `-webkit-line-clamp` is set inline (the value is dynamic). Under
+   `expandable` the box shows a measured prefix + `…` + the link, and the clamp
+   stays on as the net for a prefix that still spills. */
 .bai-text-content-clamp {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   white-space: normal;
   word-break: break-word;
+}
+
+/* The expand link inline at the end of the text (antd `operationUnit`). */
+.bai-text-content > .bai-text-expand {
+  margin-inline-start: var(--spacing-1);
+  white-space: nowrap;
 }
 
 /* `expandable` opened: show everything, wrapping. Selector matches the row

--- a/packages/backend.ai-ui/src/components/BAIText.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIText.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Inline text with the antd Typography.Text prop surface and structure, rendered on Astryx tokens: one span that inherits the surrounding font size, plus the semantic colors, the strong/italic/underline/delete decorations, the code, keyboard and mark boxes, CSS truncation (single or multi-line) with an optional tooltip and an expand link, and a copy-to-clipboard control. With ellipsis or copyable the span becomes an inline-flex row holding the clamp box and the controls, so the text still measures its own overflow. Its strings (the copy label, the expand and collapse links) are translated through useBAIi18n. Remaining props are standard HTML attributes and land on the root span.',
+      'Inline text with the antd Typography.Text prop surface and structure, rendered on Astryx tokens: one span that inherits the surrounding font size, plus the semantic colors, the strong/italic/underline/delete decorations, the code, keyboard and mark boxes, CSS truncation (single or multi-line) with an optional tooltip and an expand link that ends the text itself, and a copy-to-clipboard control. With ellipsis or copyable the span becomes an inline-flex row holding the clamp box and the controls, so the text still measures its own overflow. Its strings (the copy label, the expand and collapse links) are translated through useBAIi18n. Remaining props are standard HTML attributes and land on the root span.',
     bestPractices: [
       {
         guidance: true,
@@ -124,7 +124,7 @@ export const docs = {
       name: 'ellipsis',
       type: 'boolean | BAITextEllipsisConfig',
       description:
-        'Clamps the text. true clamps to one line; the object form takes rows for a multi-line clamp, tooltip to reveal the full value on hover, expandable to append an expand and collapse link, and onExpand to observe it.',
+        'Clamps the text. true clamps to one line; the object form takes rows for a multi-line clamp, tooltip to reveal the full value on hover, expandable to end the text with an expand and collapse link (a multi-line clamp is measured so the link fits on the last visible line), and onExpand to observe it.',
     },
     {
       name: 'copyable',

--- a/packages/backend.ai-ui/src/components/BAIText.doc.ts
+++ b/packages/backend.ai-ui/src/components/BAIText.doc.ts
@@ -16,7 +16,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Inline text with the antd Typography.Text prop surface and structure, rendered on Astryx tokens: one span that inherits the surrounding font size, plus the semantic colors, the strong/italic/underline/delete decorations, the code, keyboard and mark boxes, CSS truncation (single or multi-line) with an optional tooltip and an expand link that ends the text itself, and a copy-to-clipboard control. With ellipsis or copyable the span becomes an inline-flex row holding the clamp box and the controls, so the text still measures its own overflow. Its strings (the copy label, the expand and collapse links) are translated through useBAIi18n. Remaining props are standard HTML attributes and land on the root span.',
+      'Inline text with the antd Typography.Text prop surface and structure, rendered on Astryx tokens: one span that inherits the surrounding font size, plus the semantic colors, the strong/italic/underline/delete decorations, the code, keyboard and mark boxes, CSS truncation (single or multi-line) with an optional tooltip and an expand link that ends the text itself (beside the box for keyboard, whose Kbd cannot be sliced), and a copy-to-clipboard control. With ellipsis or copyable the span becomes an inline-flex row holding the clamp box and the controls, so the text still measures its own overflow. Its strings (the copy label, the expand and collapse links) are translated through useBAIi18n. Remaining props are standard HTML attributes and land on the root span.',
     bestPractices: [
       {
         guidance: true,
@@ -124,7 +124,7 @@ export const docs = {
       name: 'ellipsis',
       type: 'boolean | BAITextEllipsisConfig',
       description:
-        'Clamps the text. true clamps to one line; the object form takes rows for a multi-line clamp, tooltip to reveal the full value on hover, expandable to end the text with an expand and collapse link (a multi-line clamp is measured so the link fits on the last visible line), and onExpand to observe it.',
+        'Clamps the text. true clamps to one line; the object form takes rows for a multi-line clamp, tooltip to reveal the full value on hover, expandable to end the text with an expand and collapse link (a multi-line clamp is measured so the link fits on the last visible line; with keyboard the link sits beside the box instead), and onExpand to observe it.',
     },
     {
       name: 'copyable',

--- a/packages/backend.ai-ui/src/components/BAIText.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.stories.tsx
@@ -446,7 +446,7 @@ export const ExpandableEllipsis: Story = {
     docs: {
       description: {
         story:
-          'Expandable ellipsis allows users to toggle between truncated and full text views. Click the "Expand" link to show full content and "Collapse" to hide it. Works with both single and multi-line ellipsis.',
+          'Expandable ellipsis allows users to toggle between truncated and full text views. The "Expand" link ends the text itself: after the `…` on the last clamped line (a multi-line clamp is measured in JS so the link fits on that line, as antd did) and after the last word once expanded, where it reads "Collapse". A single-line clamp clips in CSS and keeps the link right after the clipped box.',
       },
     },
   },

--- a/packages/backend.ai-ui/src/components/BAIText.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.test.tsx
@@ -388,6 +388,47 @@ describe('BAIText ellipsis', () => {
     }
   });
 
+  it('never cuts a multi-line clamp inside a surrogate pair', () => {
+    const rect = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        const height = Math.ceil((this.textContent?.length ?? 0) / 10) * 20;
+        return { height } as DOMRect;
+      });
+    try {
+      render(
+        <BAIText ellipsis={{ rows: 2, expandable: true }}>
+          {`${'a'.repeat(12)}😀${'b'.repeat(20)}`}
+        </BAIText>,
+      );
+      const box = expandLink('Expand').parentElement as HTMLElement;
+      // 13 units would split the emoji, so the cut steps back to 12.
+      expect(box.textContent).toBe(`${'a'.repeat(12)}…Expand`);
+      expect(box.textContent).not.toContain('\uFFFD');
+    } finally {
+      rect.mockRestore();
+    }
+  });
+
+  it('keeps a keyboard clamp on CSS with the link beside the box', () => {
+    setOverflow(true);
+    render(
+      <BAIText
+        data-testid="t"
+        keyboard
+        ellipsis={{ rows: 2, expandable: true }}
+      >
+        shift+F5
+      </BAIText>,
+    );
+    const root = screen.getByTestId('t');
+    const box = root.querySelector('.bai-text-content') as HTMLElement;
+    const link = expandLink('Expand');
+    expect(box.querySelector('.astryx-kbd')).not.toBeNull();
+    expect(box).not.toContainElement(link);
+    expect(link.parentElement).toBe(root);
+  });
+
   it('follows BUI i18next for the expand link', async () => {
     setOverflow(true);
     await act(async () => {

--- a/packages/backend.ai-ui/src/components/BAIText.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.test.tsx
@@ -388,6 +388,46 @@ describe('BAIText ellipsis', () => {
     }
   });
 
+  it('shrinks the cut until a styled prefix fits the rendered box', () => {
+    // The probe reads plain text (ten characters per line), but the rendered
+    // box counts <strong> text double, so the first cut of 13 still spills.
+    const weighted = (el: Element) =>
+      Array.from(el.childNodes).reduce((sum, node) => {
+        const length = node.textContent?.length ?? 0;
+        return sum + (node.nodeName === 'STRONG' ? length * 2 : length);
+      }, 0);
+    const rect = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        const height = Math.ceil((this.textContent?.length ?? 0) / 10) * 20;
+        return { height } as DOMRect;
+      });
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return Math.ceil(weighted(this) / 10) * 20;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get: () => 40,
+    });
+    try {
+      render(
+        <BAIText ellipsis={{ rows: 2, expandable: true }}>
+          <strong>{'b'.repeat(30)}</strong>
+        </BAIText>,
+      );
+      const box = expandLink('Expand').parentElement as HTMLElement;
+      // 13 → 11 → 9 → 8 → 7 → 6: the first prefix whose doubled width plus
+      // `…Expand` fits two lines.
+      expect(box.querySelector('strong')?.textContent).toBe('b'.repeat(6));
+      expect(box.textContent).toBe(`${'b'.repeat(6)}…Expand`);
+    } finally {
+      rect.mockRestore();
+    }
+  });
+
   it('never cuts a multi-line clamp inside a surrogate pair', () => {
     const rect = vi
       .spyOn(Element.prototype, 'getBoundingClientRect')

--- a/packages/backend.ai-ui/src/components/BAIText.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.test.tsx
@@ -297,6 +297,97 @@ describe('BAIText ellipsis', () => {
     expect(screen.getByText('long')).toHaveClass('bai-text-content-clamp');
   });
 
+  // The link ends the text (antd): beside a CSS-clipped single line, inside
+  // the box after `…` on a multi-line clamp and after the last word once
+  // expanded (FR-3733). Astryx `Link` wraps its label, so address the link
+  // element by class.
+  const expandLink = (label: string) =>
+    screen.getByText(label).closest('.bai-text-expand') as HTMLElement;
+
+  it('keeps the Expand link beside a single-line clip box', () => {
+    setOverflow(true);
+    render(
+      <BAIText data-testid="t" ellipsis={{ expandable: true }}>
+        long
+      </BAIText>,
+    );
+    const box = screen.getByText('long');
+    const link = expandLink('Expand');
+    expect(box).not.toContainElement(link);
+    expect(link.parentElement).toBe(screen.getByTestId('t'));
+  });
+
+  it('puts the Expand link inside a multi-line clamp box', () => {
+    setOverflow(true);
+    render(<BAIText ellipsis={{ rows: 2, expandable: true }}>long</BAIText>);
+    expect(screen.getByText('long')).toContainElement(expandLink('Expand'));
+  });
+
+  it('puts the Collapse link after the last word once expanded', () => {
+    setOverflow(true);
+    render(<BAIText ellipsis={{ expandable: true }}>long</BAIText>);
+    fireEvent.click(screen.getByText('Expand'));
+    const box = screen.getByText('long');
+    const link = expandLink('Collapse');
+    expect(box).toContainElement(link);
+    expect(box.lastElementChild).toBe(link);
+  });
+
+  it('cuts a multi-line clamp so `…` and the link fit on the last line', () => {
+    // A layout stand-in: every line holds ten characters and is 20px tall.
+    const rect = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        const height = Math.ceil((this.textContent?.length ?? 0) / 10) * 20;
+        return { height } as DOMRect;
+      });
+    try {
+      render(
+        <BAIText ellipsis={{ rows: 2, expandable: true }}>
+          {'a'.repeat(30)}
+        </BAIText>,
+      );
+      const link = expandLink('Expand');
+      const box = link.parentElement as HTMLElement;
+      // 13 chars + `…` + "Expand" = 20 chars = two lines.
+      expect(box.textContent).toBe(`${'a'.repeat(13)}…Expand`);
+      expect(box).toHaveClass('bai-text-content-clamp');
+
+      fireEvent.click(link);
+      expect(expandLink('Collapse').parentElement?.textContent).toBe(
+        `${'a'.repeat(30)}Collapse`,
+      );
+      fireEvent.click(screen.getByText('Collapse'));
+      expect(expandLink('Expand').parentElement?.textContent).toBe(
+        `${'a'.repeat(13)}…Expand`,
+      );
+    } finally {
+      rect.mockRestore();
+    }
+  });
+
+  it('slices a multi-line clamp through styled children', () => {
+    const rect = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        const height = Math.ceil((this.textContent?.length ?? 0) / 10) * 20;
+        return { height } as DOMRect;
+      });
+    try {
+      render(
+        <BAIText ellipsis={{ rows: 2, expandable: true }}>
+          {'a'.repeat(8)}
+          <strong>{'b'.repeat(22)}</strong>
+        </BAIText>,
+      );
+      const box = expandLink('Expand').parentElement as HTMLElement;
+      expect(box.textContent).toBe(`${'a'.repeat(8)}${'b'.repeat(5)}…Expand`);
+      expect(box.querySelector('strong')?.textContent).toBe('b'.repeat(5));
+    } finally {
+      rect.mockRestore();
+    }
+  });
+
   it('follows BUI i18next for the expand link', async () => {
     setOverflow(true);
     await act(async () => {

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -11,9 +11,13 @@
 
    plain          <span.bai-text>children</span>
    ellipsis/copy  <span.bai-text.bai-text-row>
-                    <span.bai-text-content>children</span>   the clamp box
-                    [Tooltip]  [Expand]  [Copy]
+                    <span.bai-text-content>children [… Expand]</span>
+                    [Tooltip]  [Expand: single-line clip only]  [Copy]
                   </span>
+
+ The expand link ends the text itself (antd): after `…` on the last clamped
+ line — measured in JS for `rows > 1` (FR-3733) — and after the last word
+ once expanded. Only a CSS-clipped single line keeps it beside the box.
 
  The component owns its span rather than rendering Astryx `Text`: `Text`
  paints its own type scale and colour, turns `display: block` under
@@ -152,6 +156,183 @@ const resolveTooltipContent = (
   return tooltip as ReactNode;
 };
 
+const ELLIPSIS = '…';
+
+/** The first `length` characters of `nodes` as `nodeToText` counts them. */
+const sliceNodes = (nodes: ReactNode[], length: number): ReactNode[] => {
+  const out: ReactNode[] = [];
+  let remaining = length;
+  for (const node of nodes) {
+    if (remaining <= 0) break;
+    if (typeof node === 'string' || typeof node === 'number') {
+      const text = String(node);
+      out.push(text.length <= remaining ? node : text.slice(0, remaining));
+      remaining -= text.length;
+    } else if (React.isValidElement<{ children?: ReactNode }>(node)) {
+      const textLength = nodeToText(node).length;
+      out.push(
+        textLength <= remaining
+          ? node
+          : React.cloneElement(
+              node,
+              undefined,
+              ...sliceNodes(
+                React.Children.toArray(node.props.children),
+                remaining,
+              ),
+            ),
+      );
+      remaining -= textLength;
+    }
+  }
+  return out;
+};
+
+interface ClampMeasure {
+  overflow: boolean;
+  /** Characters of the text shown before `…` and the link; `null` = all. */
+  cut: number | null;
+}
+
+const NO_CLAMP: ClampMeasure = { overflow: false, cut: null };
+
+/**
+ * antd's JS ellipsis: a hidden probe in the box finds, by binary search, the
+ * longest prefix that leaves room for `…` and the expand link on line `rows`.
+ * The link is measured as a clone of the rendered one, so the first pass only
+ * reports the overflow and the cut follows once the link exists.
+ */
+const measureClamp = (
+  box: HTMLElement,
+  rows: number,
+  text: string,
+): ClampMeasure => {
+  const probe = document.createElement('span');
+  const boxStyle = getComputedStyle(box);
+  const width =
+    box.clientWidth -
+    (parseFloat(boxStyle.paddingLeft) || 0) -
+    (parseFloat(boxStyle.paddingRight) || 0);
+  Object.assign(probe.style, {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    display: 'block',
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
+    width: `${width}px`,
+  } satisfies Partial<CSSStyleDeclaration>);
+  probe.setAttribute('aria-hidden', 'true');
+  box.appendChild(probe);
+  try {
+    probe.textContent = '\u00a0';
+    const lineHeight = probe.getBoundingClientRect().height;
+    if (!lineHeight) {
+      // No layout engine (jsdom): the clamped scrollHeight is all there is.
+      return {
+        overflow: box.scrollHeight > box.clientHeight + 1,
+        cut: null,
+      };
+    }
+    const limit = (rows + 0.5) * lineHeight;
+    probe.textContent = text;
+    if (probe.getBoundingClientRect().height <= limit) return NO_CLAMP;
+    const link = box.querySelector('.bai-text-expand');
+    if (!link) return { overflow: true, cut: null };
+    const fits = (length: number) => {
+      probe.replaceChildren(
+        document.createTextNode(text.slice(0, length) + ELLIPSIS),
+        link.cloneNode(true),
+      );
+      return probe.getBoundingClientRect().height <= limit;
+    };
+    let low = 0;
+    let high = text.length - 1;
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      if (fits(mid)) low = mid;
+      else high = mid - 1;
+    }
+    return { overflow: true, cut: low };
+  } finally {
+    probe.remove();
+  }
+};
+
+/** Whether the content of a clamp box is taller than the box itself. */
+const contentOverflows = (element: HTMLElement) => {
+  // `-webkit-line-clamp` can report the clamped height as scrollHeight, so
+  // measure the content itself as well.
+  let contentHeight = element.scrollHeight;
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    contentHeight = Math.max(
+      contentHeight,
+      range.getBoundingClientRect().height,
+    );
+    range.detach();
+  } catch {
+    // No Range layout (jsdom): the clamped scrollHeight is all there is.
+    contentHeight = element.scrollHeight;
+  }
+  return contentHeight > element.clientHeight + 1;
+};
+
+/**
+ * The multi-line expandable clamp, re-measured on resize, on new text and
+ * once the link is in the DOM. If the rendered prefix still spills (styled
+ * inline children measure wider than their plain text) the cut shrinks by a
+ * tenth until it fits.
+ */
+const useMeasuredClamp = (
+  ref: React.RefObject<HTMLElement | null>,
+  enabled: boolean,
+  rows: number,
+  text: string,
+  linkLabel: string,
+): ClampMeasure => {
+  'use memo';
+  const [measure, setMeasure] = useState<ClampMeasure>(NO_CLAMP);
+  const hasLink = measure.overflow;
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!enabled || !element) {
+      setMeasure(NO_CLAMP);
+      return;
+    }
+    const check = () => {
+      const next = measureClamp(element, rows, text);
+      setMeasure((prev) =>
+        prev.overflow === next.overflow && prev.cut === next.cut ? prev : next,
+      );
+    };
+    check();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(check);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref, enabled, rows, text, linkLabel, hasLink]);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    const { cut } = measure;
+    if (!enabled || !element || cut === null || cut === 0) return;
+    if (contentOverflows(element)) {
+      setMeasure({
+        overflow: true,
+        cut: cut - Math.max(1, Math.ceil(cut / 10)),
+      });
+    }
+  }, [ref, enabled, measure]);
+
+  return measure;
+};
+
 /**
  * Overflow of the clamp box, re-measured on resize and on new children — a
  * fixed-width cell whose value changes does not resize, so a ResizeObserver
@@ -170,26 +351,11 @@ const useOverflow = (
     const element = ref.current;
     if (!enabled || !element) return;
     const check = () => {
-      if (rows === 1) {
-        setIsOverflowing(element.scrollWidth > element.clientWidth);
-        return;
-      }
-      // `-webkit-line-clamp` can report the clamped height as scrollHeight, so
-      // measure the content itself as well.
-      let contentHeight = element.scrollHeight;
-      try {
-        const range = document.createRange();
-        range.selectNodeContents(element);
-        contentHeight = Math.max(
-          contentHeight,
-          range.getBoundingClientRect().height,
-        );
-        range.detach();
-      } catch {
-        // No Range layout (jsdom): the clamped scrollHeight is all there is.
-        contentHeight = element.scrollHeight;
-      }
-      setIsOverflowing(contentHeight > element.clientHeight + 1);
+      setIsOverflowing(
+        rows === 1
+          ? element.scrollWidth > element.clientWidth
+          : contentOverflows(element),
+      );
     };
     check();
     if (typeof ResizeObserver === 'undefined') return;
@@ -308,13 +474,38 @@ const BAIText: React.FC<BAITextProps> = ({
   const expandable = ellipsisConfig?.expandable ?? false;
   const tooltipContent = resolveTooltipContent(ellipsis, children);
 
+  // antd wrapped the children in the matching element; the box treatment
+  // rides on it, and under `ellipsis` it is also the clamp box. `keyboard`
+  // is Astryx `Kbd`, which takes the children's text as its `keys` spec.
+  const ContentTag = code ? 'code' : mark ? 'mark' : 'span';
+  const boxClassName = code
+    ? 'bai-text-code'
+    : mark
+      ? 'bai-text-mark'
+      : undefined;
+  const content = keyboard ? <Kbd keys={nodeToText(children)} /> : children;
+
+  // A multi-line expandable clamp is measured in JS so `…` and the link end
+  // the last visible line; a single line clips in CSS with the link after it.
+  const isMeasured = !!ellipsis && expandable && rows > 1 && !isExpanded;
+  const expandLabel = isExpanded
+    ? t('general.button.Collapse')
+    : t('general.button.Expand');
   const contentRef = useRef<HTMLElement | null>(null);
-  const isOverflowing = useOverflow(
+  const clamp = useMeasuredClamp(
     contentRef,
-    !!ellipsis && !isExpanded,
+    isMeasured,
+    rows,
+    nodeToText(content),
+    expandLabel,
+  );
+  const cssOverflow = useOverflow(
+    contentRef,
+    !!ellipsis && !isExpanded && !isMeasured,
     rows,
     children,
   );
+  const isOverflowing = isMeasured ? clamp.overflow : cssOverflow;
 
   const rootClassName = classNames(
     'bai-text',
@@ -336,17 +527,6 @@ const BAIText: React.FC<BAITextProps> = ({
     className,
   );
 
-  // antd wrapped the children in the matching element; the box treatment
-  // rides on it, and under `ellipsis` it is also the clamp box. `keyboard`
-  // is Astryx `Kbd`, which takes the children's text as its `keys` spec.
-  const ContentTag = code ? 'code' : mark ? 'mark' : 'span';
-  const boxClassName = code
-    ? 'bai-text-code'
-    : mark
-      ? 'bai-text-mark'
-      : undefined;
-  const content = keyboard ? <Kbd keys={nodeToText(children)} /> : children;
-
   if (!ellipsis && !copyable) {
     return (
       <span {...restProps} className={rootClassName} style={style}>
@@ -364,6 +544,20 @@ const BAIText: React.FC<BAITextProps> = ({
     setIsExpanded(next);
     ellipsisConfig?.onExpand?.(e, { expanded: next });
   };
+
+  const expandLink =
+    expandable && (isOverflowing || isExpanded) ? (
+      <Link className="bai-text-expand" onClick={handleExpand}>
+        {expandLabel}
+      </Link>
+    ) : null;
+  // Inline after the text (antd), except on a CSS-clipped single line where
+  // the box would clip it.
+  const isLinkInline = isExpanded || rows > 1;
+  const visibleContent =
+    isMeasured && clamp.cut !== null
+      ? [...sliceNodes(React.Children.toArray(content), clamp.cut), ELLIPSIS]
+      : content;
 
   return (
     <span
@@ -384,7 +578,8 @@ const BAIText: React.FC<BAITextProps> = ({
             : undefined
         }
       >
-        {content}
+        {visibleContent}
+        {isLinkInline ? expandLink : null}
       </ContentTag>
       {tooltipContent !== undefined && isOverflowing && !isExpanded ? (
         <Tooltip
@@ -394,13 +589,7 @@ const BAIText: React.FC<BAITextProps> = ({
           content={<span className="bai-text-tooltip">{tooltipContent}</span>}
         />
       ) : null}
-      {expandable && (isOverflowing || isExpanded) ? (
-        <Link className="bai-text-expand" onClick={handleExpand}>
-          {isExpanded
-            ? t('general.button.Collapse')
-            : t('general.button.Expand')}
-        </Link>
-      ) : null}
+      {isLinkInline ? null : expandLink}
       {copyable ? (
         <CopyControl copyable={copyable}>{children}</CopyControl>
       ) : null}

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -340,10 +340,10 @@ const useMeasuredClamp = (
     if (contentOverflows(element)) {
       setMeasure({
         overflow: true,
-        cut: cut - Math.max(1, Math.ceil(cut / 10)),
+        cut: toCodePointBoundary(text, cut - Math.max(1, Math.ceil(cut / 10))),
       });
     }
-  }, [ref, enabled, measure]);
+  }, [ref, enabled, text, measure]);
 
   return measure;
 };

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -158,7 +158,16 @@ const resolveTooltipContent = (
 
 const ELLIPSIS = '…';
 
-/** The first `length` characters of `nodes` as `nodeToText` counts them. */
+/** `index` moved back one unit when it would split a surrogate pair. */
+const toCodePointBoundary = (text: string, index: number) => {
+  const code = text.charCodeAt(index - 1);
+  return code >= 0xd800 && code <= 0xdbff ? index - 1 : index;
+};
+
+/**
+ * The first `length` UTF-16 units of `nodes` as `nodeToText` counts them,
+ * never cutting inside a surrogate pair.
+ */
 const sliceNodes = (nodes: ReactNode[], length: number): ReactNode[] => {
   const out: ReactNode[] = [];
   let remaining = length;
@@ -166,7 +175,11 @@ const sliceNodes = (nodes: ReactNode[], length: number): ReactNode[] => {
     if (remaining <= 0) break;
     if (typeof node === 'string' || typeof node === 'number') {
       const text = String(node);
-      out.push(text.length <= remaining ? node : text.slice(0, remaining));
+      out.push(
+        text.length <= remaining
+          ? node
+          : text.slice(0, toCodePointBoundary(text, remaining)),
+      );
       remaining -= text.length;
     } else if (React.isValidElement<{ children?: ReactNode }>(node)) {
       const textLength = nodeToText(node).length;
@@ -244,7 +257,9 @@ const measureClamp = (
     if (!link) return { overflow: true, cut: null };
     const fits = (length: number) => {
       probe.replaceChildren(
-        document.createTextNode(text.slice(0, length) + ELLIPSIS),
+        document.createTextNode(
+          text.slice(0, toCodePointBoundary(text, length)) + ELLIPSIS,
+        ),
         link.cloneNode(true),
       );
       return probe.getBoundingClientRect().height <= limit;
@@ -256,7 +271,7 @@ const measureClamp = (
       if (fits(mid)) low = mid;
       else high = mid - 1;
     }
-    return { overflow: true, cut: low };
+    return { overflow: true, cut: toCodePointBoundary(text, low) };
   } finally {
     probe.remove();
   }
@@ -487,7 +502,10 @@ const BAIText: React.FC<BAITextProps> = ({
 
   // A multi-line expandable clamp is measured in JS so `…` and the link end
   // the last visible line; a single line clips in CSS with the link after it.
-  const isMeasured = !!ellipsis && expandable && rows > 1 && !isExpanded;
+  // `Kbd` takes its text as the `keys` prop, which cannot be sliced, so it
+  // keeps the CSS clamp with the link beside the box.
+  const isMeasured =
+    !!ellipsis && expandable && rows > 1 && !isExpanded && !keyboard;
   const expandLabel = isExpanded
     ? t('general.button.Collapse')
     : t('general.button.Expand');
@@ -551,9 +569,9 @@ const BAIText: React.FC<BAITextProps> = ({
         {expandLabel}
       </Link>
     ) : null;
-  // Inline after the text (antd), except on a CSS-clipped single line where
-  // the box would clip it.
-  const isLinkInline = isExpanded || rows > 1;
+  // Inline after the text (antd), except beside a CSS-clipped box, which
+  // would clip it.
+  const isLinkInline = isExpanded || isMeasured;
   const visibleContent =
     isMeasured && clamp.cut !== null
       ? [...sliceNodes(React.Children.toArray(content), clamp.cut), ELLIPSIS]


### PR DESCRIPTION
Resolves #9194 (FR-3733)

## Summary

`BAIText` with `ellipsis={{ expandable: true }}` rendered the Expand / Collapse link as a vertically centred flex sibling of the clamp box (the structure FR-1462 introduced and FR-3726 / #9177 restored). antd's native `Typography.Text ellipsis={{ expandable }}` placed the link inline at the end of the text: right after the `…` on the last clamped line, and after the last word once expanded. This PR moves the link to that placement.

## Changes

- **Expanded (any `rows`)**: the Collapse link renders inside the content box after the children, so it follows the last word instead of floating at the vertical centre of the block.
- **Multi-line clamp (`rows > 1`)**: measured in JS as antd did. A hidden probe appended inside the box finds, by binary search on the plain text, the longest prefix that leaves room for `…` and a clone of the rendered link on line `rows`. The children are then sliced to that prefix (`sliceNodes`, which descends into nested elements and keeps their structure), followed by `…` and the link. Overflow for this path is decided from the full text so the sliced render cannot flip it back and unmount the link. The link is measured as a clone of the real one, so the first pass only reports the overflow and the cut follows in the next layout effect once the link exists (synchronous, before paint). `-webkit-line-clamp` stays on as the net for a prefix whose styled inline children measure wider than their plain text; a post-render check shrinks the cut by a tenth until it fits.
- **Single-line clamp (`rows: 1`)**: still CSS `text-overflow: ellipsis`, with the link right after the clip box (inside the `nowrap` box it would be clipped).
- `useOverflow` shares its clamped-content measurement with the new path through `contentOverflows`.
- Cuts never split a surrogate pair: the probe prefix, the returned cut and `sliceNodes` step a mid-pair index back one unit, so an emoji at the boundary is dropped instead of rendered as U+FFFD.
- `keyboard` stays on the CSS clamp with the link beside the box: `Kbd` takes the text as its `keys` prop, which cannot be sliced.
- CSS: the inline link gets `margin-inline-start: var(--spacing-1)` and `white-space: nowrap` (the antd `operationUnit` gap). The rule is a descendant selector so the probe's clone of the link measures with the same styles.
- Storybook `Text/BAIText → ExpandableEllipsis` description and `BAIText.doc.ts` describe the new placement.

## Tests

- `packages/backend.ai-ui/src/components/BAIText.test.tsx`: eight new cases. The link sits beside a single-line clip box, inside a multi-line clamp box, and after the last word once expanded. A `getBoundingClientRect` stand-in (ten characters per line, 20px tall) asserts the measured cut (`13 chars + … + Expand` on two lines), the expand / collapse round trip, slicing through a `<strong>` child, and a cut that would split an emoji stepping back to the code-point boundary. A rendered box that counts `<strong>` text double shows the post-render correction shrinking the cut (13 → 6) until the styled prefix fits. A `keyboard` clamp keeps the link beside the box.

## Verification

- `pnpm exec vitest run src/components/BAIText.test.tsx` in `packages/backend.ai-ui`: 45 passed.
- `bash scripts/verify.sh`: `=== ALL PASS ===`.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict`: no new findings.
- Not done in this run: a browser check of the measured cut against real layout. Storybook `Text/BAIText → ExpandableEllipsis` is the place to look at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- fw-dev-server-url -->
🔗 **Dev server**: http://fr-3733-pr9601.seungwon.10-82-0-159.sslip.io
<!-- /fw-dev-server-url -->
